### PR TITLE
chore: remove redundant base_branches from CodeRabbit config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -8,8 +8,6 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    base_branches:
-      - main
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary
- Remove `base_branches: [main]` from `.coderabbit.yml` -- redundant when main is the default branch

Flagged by CodeRabbit on sydlexius/stillwater#736.

Generated with [Claude Code](https://claude.com/claude-code)