### PR TITLE
test: replace wantEq sentinel (-1) with *float64 pointer in TestMatchConfidence

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,8 +4,8 @@ milestone: v1.6.1
 milestone_name: milestone
 status: verifying
 stopped_at: Completed 04-03-PLAN.md — Phase 4 build-verification complete
-last_updated: "2026-04-11T00:28:13.821Z"
-last_activity: 2026-04-11
+last_updated: "2026-04-12T01:12:50Z"
+last_activity: 2026-04-12
 progress:
   total_phases: 4
   completed_phases: 4
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 4 of 4 (Build Verification)
 Plan: 3 of 3 in current phase
 Status: All phases complete — ready for merge
-Last activity: 2026-04-11 - Completed quick task 260411-l30: issues #11 and #12 (Milestone 1)
+Last activity: 2026-04-12 - Completed quick task 260411-p8r: replace wantEq sentinel with *float64 (issue #36)
 
 Progress: [██████████] 100%
 
@@ -94,9 +94,10 @@ None yet.
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260411-l30 | issues #11 and #12 (Milestone 1) | 2026-04-11 | 2448d8f | [260411-l30-issues-11-and-12-milestone-1](./quick/260411-l30-issues-11-and-12-milestone-1/) |
+| 260411-p8r | Replace wantEq sentinel with *float64 pointer (issue #36) | 2026-04-12 | 8515549 | [260411-p8r-work-on-issue-36](./quick/260411-p8r-work-on-issue-36/) |
 
 ## Session Continuity
 
-Last session: 2026-04-11T00:28:13.818Z
-Stopped at: Completed 04-03-PLAN.md — Phase 4 build-verification complete
+Last session: 2026-04-12T01:12:50Z
+Stopped at: Completed quick task 260411-p8r — wantEq *float64 pointer refactor
 Resume file: None

--- a/.planning/quick/260411-p8r-work-on-issue-36/260411-p8r-PLAN.md
+++ b/.planning/quick/260411-p8r-work-on-issue-36/260411-p8r-PLAN.md
@@ -1,0 +1,158 @@
+---
+phase: quick
+plan: 260411-p8r
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/normalize/normalize_test.go
+autonomous: true
+requirements:
+  - issue-36
+must_haves:
+  truths:
+    - "wantEq field is *float64 (pointer), not float64"
+    - "nil means skip; non-nil pointer holds expected value"
+    - "No sentinel value (-1) remains in the test"
+    - "All existing test cases pass"
+    - "Range-only test cases (wantGt/wantLt) are no longer silently short-circuited"
+  artifacts:
+    - path: internal/normalize/normalize_test.go
+      provides: "Fixed TestMatchConfidence using *float64 pointer for wantEq"
+      contains: "func eqF"
+  key_links:
+    - from: "test table entries"
+      to: "wantEq *float64 guard"
+      via: "nil check (tc.wantEq != nil)"
+      pattern: "tc\\.wantEq != nil"
+---
+
+<objective>
+Replace the float64 sentinel (-1) in TestMatchConfidence with a *float64 pointer field.
+
+Purpose: The current design allows test cases that set only wantGt/wantLt (and omit `wantEq: -1`) to
+silently assert `got == 0.0` and return early, making the range checks dead code. Using `*float64`
+with nil-as-skip eliminates that collision class entirely.
+
+Output: `internal/normalize/normalize_test.go` with corrected wantEq field type and guard.
+</objective>
+
+<execution_context>
+@.opencode/get-shit-done/workflows/execute-plan.md
+@.opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/STATE.md
+
+Current test file (full content already read):
+  internal/normalize/normalize_test.go
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Replace wantEq sentinel with *float64 pointer in TestMatchConfidence</name>
+  <files>internal/normalize/normalize_test.go</files>
+  <action>
+Make the following targeted changes to `internal/normalize/normalize_test.go`:
+
+1. Add a file-local helper immediately before `TestMatchConfidence`:
+   ```go
+   func eqF(f float64) *float64 { return &f }
+   ```
+
+2. Change the struct field declaration from:
+   ```go
+   wantEq float64 // got must == wantEq (use -1 to skip)
+   ```
+   to:
+   ```go
+   wantEq *float64 // exact expected value; nil to skip
+   ```
+
+3. Update all table entries:
+   - `{name: "identical", ..., wantEq: 1.0}` → `wantEq: eqF(1.0)`
+   - `{name: "both empty", ..., wantEq: 1.0}` → `wantEq: eqF(1.0)`
+   - `{name: "one empty", ..., wantEq: 0.0}` → `wantEq: eqF(0.0)`
+   - `{name: "near match transposition", ..., wantEq: -1}` → remove `wantEq` field entirely (nil by default)
+   - `{name: "completely different", ..., wantEq: -1}` → remove `wantEq` field entirely (nil by default)
+   - `{name: "case insensitive", ..., wantEq: 1.0}` → `wantEq: eqF(1.0)`
+   - `{name: "accent insensitive", ..., wantEq: 1.0}` → `wantEq: eqF(1.0)`
+
+4. Replace the guard block:
+   ```go
+   if tc.wantEq >= 0 {
+       if got != tc.wantEq {
+           t.Errorf("MatchConfidence(%q, %q) = %f, want exactly %f", tc.a, tc.b, got, tc.wantEq)
+       }
+       return
+   }
+   ```
+   with:
+   ```go
+   if tc.wantEq != nil {
+       if got != *tc.wantEq {
+           t.Errorf("MatchConfidence(%q, %q) = %f, want exactly %f", tc.a, tc.b, got, *tc.wantEq)
+       }
+       return
+   }
+   ```
+
+No production code changes. No other test functions modified.
+  </action>
+  <verify>
+    <automated>cd /Users/jesse/Developer/mxlrc-go && go test ./internal/normalize/... -v -run TestMatchConfidence</automated>
+  </verify>
+  <done>
+    - `wantEq` field is `*float64` with no sentinel in the file
+    - `eqF` helper exists and is used by all exact-value entries
+    - Guard uses `tc.wantEq != nil` / `*tc.wantEq` dereference
+    - `go test ./internal/normalize/... -v -run TestMatchConfidence` shows PASS for all 7 subtests
+    - `go test ./internal/normalize/...` (full package) still passes
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| test-only | All changes are in `_test.go`; no trust boundary crosses production code |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-p8r-01 | Tampering | normalize_test.go | accept | Test-only file; no production attack surface. Change reduces risk of false-positive test passes. |
+</threat_model>
+
+<verification>
+```bash
+# Full package test (must pass)
+go test ./internal/normalize/... -v
+
+# Confirm no sentinel remains
+grep -n "wantEq: -1\|wantEq >= 0\|wantEq float64" internal/normalize/normalize_test.go
+# expected: no matches
+
+# Confirm pointer pattern present
+grep -n "wantEq \*float64\|eqF\|wantEq != nil" internal/normalize/normalize_test.go
+# expected: all three patterns present
+```
+</verification>
+
+<success_criteria>
+- `wantEq float64` and all `-1` sentinels are gone from the file
+- `wantEq *float64` field declared; `eqF()` helper defined
+- Guard is `if tc.wantEq != nil { ... *tc.wantEq ... }`
+- `go test ./internal/normalize/...` passes with no failures
+- `go vet ./internal/normalize/...` clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260411-p8r-work-on-issue-36/260411-p8r-SUMMARY.md`
+</output>

--- a/.planning/quick/260411-p8r-work-on-issue-36/260411-p8r-SUMMARY.md
+++ b/.planning/quick/260411-p8r-work-on-issue-36/260411-p8r-SUMMARY.md
@@ -1,0 +1,84 @@
+---
+phase: quick
+plan: 260411-p8r
+subsystem: normalize
+tags: [test, refactor, pointer-semantics]
+dependency_graph:
+  requires: []
+  provides: [issue-36-fix]
+  affects: [internal/normalize/normalize_test.go]
+tech_stack:
+  added: []
+  patterns: [nil-pointer-as-sentinel]
+key_files:
+  modified:
+    - internal/normalize/normalize_test.go
+decisions:
+  - Use *float64 with nil-as-skip instead of sentinel -1 to eliminate silent short-circuit of range checks
+metrics:
+  duration: ~1min
+  completed: 2026-04-12
+  tasks_completed: 1
+  files_modified: 1
+requirements_closed: [issue-36]
+---
+
+# Quick Task 260411-p8r: Replace wantEq float64 sentinel with *float64 pointer in TestMatchConfidence
+
+**One-liner:** Replaced `wantEq float64` sentinel (-1) with `*float64` nil-as-skip pointer, eliminating silent dead-code paths in range-only test cases.
+
+## What Was Done
+
+Refactored `TestMatchConfidence` in `internal/normalize/normalize_test.go` to use idiomatic Go pointer semantics instead of a magic sentinel value.
+
+**Root problem:** The old guard `if tc.wantEq >= 0` triggered for all test cases including those where `wantEq` was intentionally omitted (zero-valued float64 = `0.0 >= 0`). This caused range-only test cases (`near match transposition`, `completely different`) to silently assert `got == 0.0` and `return` early, making `wantGt`/`wantLt` checks dead code.
+
+**Changes made:**
+1. Added `func eqF(f float64) *float64 { return &f }` helper before `TestMatchConfidence`
+2. Changed field declaration from `wantEq float64` to `wantEq *float64`
+3. Updated 5 table entries to use `eqF(...)`: identical, both empty, one empty, case insensitive, accent insensitive
+4. Removed `wantEq: -1` from 2 range-only entries: near match transposition, completely different
+5. Updated guard from `if tc.wantEq >= 0` to `if tc.wantEq != nil` with `*tc.wantEq` dereference
+
+## Commits
+
+| Task | Commit | Description |
+|------|--------|-------------|
+| 1 | `8515549` | test(quick-260411-p8r): replace wantEq sentinel with *float64 pointer |
+
+## Verification
+
+```
+go test ./internal/normalize/... -v -run TestMatchConfidence
+# All 7 subtests: PASS
+
+go test ./internal/normalize/...
+# Full package: PASS (16 tests)
+
+go vet ./internal/normalize/...
+# Clean
+
+grep "wantEq: -1\|wantEq >= 0\|wantEq float64" internal/normalize/normalize_test.go
+# No matches (sentinel patterns eliminated)
+```
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None. All changes are in `_test.go`; no production attack surface touched.
+
+## Self-Check: PASSED
+
+- [x] `internal/normalize/normalize_test.go` modified correctly
+- [x] Commit `8515549` exists in git log
+- [x] No sentinel patterns remain in the file
+- [x] All pointer patterns present: `wantEq *float64`, `eqF`, `wantEq != nil`
+- [x] `go test ./internal/normalize/...` passes (16/16)
+- [x] `go vet ./internal/normalize/...` clean

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -38,7 +38,7 @@ func TestMatchConfidence(t *testing.T) {
 	tests := []struct {
 		name   string
 		a, b   string
-		wantGt float64  // got must be > wantGt (use 0 for exact checks)
+		wantGt float64  // got must be > wantGt (use 0 to skip)
 		wantLt float64  // got must be < wantLt (use 0 to skip)
 		wantEq *float64 // exact expected value; nil to skip
 	}{
@@ -52,6 +52,9 @@ func TestMatchConfidence(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantEq != nil && (tc.wantGt > 0 || tc.wantLt > 0) {
+				t.Fatalf("invalid test case %q: wantEq cannot be combined with wantGt/wantLt", tc.name)
+			}
 			got := normalize.MatchConfidence(tc.a, tc.b)
 			if tc.wantEq != nil {
 				if got != *tc.wantEq {

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -32,28 +32,30 @@ func TestNormalizeKey(t *testing.T) {
 	}
 }
 
+func eqF(f float64) *float64 { return &f }
+
 func TestMatchConfidence(t *testing.T) {
 	tests := []struct {
 		name   string
 		a, b   string
-		wantGt float64 // got must be > wantGt (use 0 for exact checks)
-		wantLt float64 // got must be < wantLt (use 0 to skip)
-		wantEq float64 // got must == wantEq (use -1 to skip)
+		wantGt float64  // got must be > wantGt (use 0 for exact checks)
+		wantLt float64  // got must be < wantLt (use 0 to skip)
+		wantEq *float64 // exact expected value; nil to skip
 	}{
-		{name: "identical", a: "hello", b: "hello", wantEq: 1.0},
-		{name: "both empty", a: "", b: "", wantEq: 1.0},
-		{name: "one empty", a: "hello", b: "", wantEq: 0.0},
-		{name: "near match transposition", a: "hello", b: "helol", wantGt: 0.9, wantLt: 1.0, wantEq: -1},
-		{name: "completely different", a: "abc", b: "xyz", wantLt: 0.5, wantEq: -1},
-		{name: "case insensitive", a: "Hello", b: "hello", wantEq: 1.0},
-		{name: "accent insensitive", a: "Héllo", b: "hello", wantEq: 1.0},
+		{name: "identical", a: "hello", b: "hello", wantEq: eqF(1.0)},
+		{name: "both empty", a: "", b: "", wantEq: eqF(1.0)},
+		{name: "one empty", a: "hello", b: "", wantEq: eqF(0.0)},
+		{name: "near match transposition", a: "hello", b: "helol", wantGt: 0.9, wantLt: 1.0},
+		{name: "completely different", a: "abc", b: "xyz", wantLt: 0.5},
+		{name: "case insensitive", a: "Hello", b: "hello", wantEq: eqF(1.0)},
+		{name: "accent insensitive", a: "Héllo", b: "hello", wantEq: eqF(1.0)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := normalize.MatchConfidence(tc.a, tc.b)
-			if tc.wantEq >= 0 {
-				if got != tc.wantEq {
-					t.Errorf("MatchConfidence(%q, %q) = %f, want exactly %f", tc.a, tc.b, got, tc.wantEq)
+			if tc.wantEq != nil {
+				if got != *tc.wantEq {
+					t.Errorf("MatchConfidence(%q, %q) = %f, want exactly %f", tc.a, tc.b, got, *tc.wantEq)
 				}
 				return
 			}

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -52,7 +52,7 @@ func TestMatchConfidence(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.wantEq != nil && (tc.wantGt > 0 || tc.wantLt > 0) {
+			if tc.wantEq != nil && (tc.wantGt != 0 || tc.wantLt != 0) {
 				t.Fatalf("invalid test case %q: wantEq cannot be combined with wantGt/wantLt", tc.name)
 			}
 			got := normalize.MatchConfidence(tc.a, tc.b)


### PR DESCRIPTION
## Summary

- Fixes the silent dead-code bug in `TestMatchConfidence` where range-only test cases (those with only `wantGt`/`wantLt`) would silently assert `got == 0.0` and return early because `0.0 >= 0` was `true`
- Replaces `wantEq float64` with `wantEq *float64`; `nil` means skip, non-nil pointer holds the expected exact value — eliminating the `-1` sentinel and its collision class entirely
- Adds file-local `eqF(f float64) *float64` helper for ergonomic table entries

## Changes

- `internal/normalize/normalize_test.go` only — no production code touched

## Verification

All 7 subtests and 16 total tests in the package pass. Pre-commit hooks (typos, gofmt, golangci-lint, govulncheck) all pass.

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test logic to remove sentinel-based skipping and make exact vs. range assertions explicit, increasing clarity and coverage validation.
* **Documentation**
  * Updated planning state and quick-tasks records to reflect completion of the new Phase 4 quick task and refreshed session timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->