### PR TITLE
chore: track A debt cleanup (pragma tests, pointer sentinels, nolint reason)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,7 @@ func applyEnvOverrides(cfg *Config) {
 	if v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			slog.Warn("env var is invalid; using current value", "var", cooldownVar, "value", v, "current", cfg.API.Cooldown) //nolint:gosec // G706: env var value echoed to structured log field; no format-string injection risk
+			slog.Warn("env var is invalid; using current value", "var", cooldownVar, "value", v, "current", cfg.API.Cooldown) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.Cooldown = n
 		}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -17,7 +17,11 @@ func TestOpen_CreatesDatabaseAndAppliesMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer func() { _ = sqlDB.Close() }()
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
 
 	// Verify expected tables were created by the migration.
 	tables := []string{"libraries", "scan_results", "lyrics_cache", "work_queue", "api_keys"}
@@ -44,7 +48,11 @@ func TestOpen_WALModeEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer func() { _ = sqlDB.Close() }()
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
 
 	var mode string
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode); err != nil {
@@ -64,7 +72,11 @@ func TestOpen_ForeignKeysEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer func() { _ = sqlDB.Close() }()
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
 
 	var enabled int
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&enabled); err != nil {
@@ -85,7 +97,11 @@ func TestOpen_BusyTimeoutAndSynchronous(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer func() { _ = sqlDB.Close() }()
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
 
 	var busy int
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busy); err != nil {
@@ -123,11 +139,15 @@ func TestOpen_IdempotentMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
-	_ = db1.Close()
+	if err := db1.Close(); err != nil {
+		t.Fatalf("close first db: %v", err)
+	}
 
 	db2, err := Open(ctx, path)
 	if err != nil {
 		t.Fatalf("second Open (idempotency check): %v", err)
 	}
-	_ = db2.Close()
+	if err := db2.Close(); err != nil {
+		t.Fatalf("close second db: %v", err)
+	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -17,7 +17,7 @@ func TestOpen_CreatesDatabaseAndAppliesMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer sqlDB.Close() //nolint:errcheck
+	defer func() { _ = sqlDB.Close() }()
 
 	// Verify expected tables were created by the migration.
 	tables := []string{"libraries", "scan_results", "lyrics_cache", "work_queue", "api_keys"}
@@ -44,7 +44,7 @@ func TestOpen_WALModeEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer sqlDB.Close() //nolint:errcheck
+	defer func() { _ = sqlDB.Close() }()
 
 	var mode string
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode); err != nil {
@@ -64,7 +64,7 @@ func TestOpen_ForeignKeysEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer sqlDB.Close() //nolint:errcheck
+	defer func() { _ = sqlDB.Close() }()
 
 	var enabled int
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&enabled); err != nil {
@@ -85,7 +85,7 @@ func TestOpen_BusyTimeoutAndSynchronous(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer sqlDB.Close() //nolint:errcheck
+	defer func() { _ = sqlDB.Close() }()
 
 	var busy int
 	if err := sqlDB.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busy); err != nil {
@@ -123,11 +123,11 @@ func TestOpen_IdempotentMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
-	db1.Close() //nolint:errcheck
+	_ = db1.Close()
 
 	db2, err := Open(ctx, path)
 	if err != nil {
 		t.Fatalf("second Open (idempotency check): %v", err)
 	}
-	db2.Close() //nolint:errcheck
+	_ = db2.Close()
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -75,6 +75,35 @@ func TestOpen_ForeignKeysEnabled(t *testing.T) {
 	}
 }
 
+// TestOpen_BusyTimeoutAndSynchronous verifies the remaining two pragmas set by
+// Open: busy_timeout=5000ms and synchronous=NORMAL (1).
+func TestOpen_BusyTimeoutAndSynchronous(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "pragmas.db")
+
+	sqlDB, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck
+
+	var busy int
+	if err := sqlDB.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busy); err != nil {
+		t.Fatalf("query busy_timeout: %v", err)
+	}
+	if busy != 5000 {
+		t.Errorf("busy_timeout = %d; want 5000", busy)
+	}
+
+	var sync int
+	if err := sqlDB.QueryRowContext(ctx, "PRAGMA synchronous").Scan(&sync); err != nil {
+		t.Fatalf("query synchronous: %v", err)
+	}
+	if sync != 1 {
+		t.Errorf("synchronous = %d; want 1 (NORMAL)", sync)
+	}
+}
+
 // TestOpen_EmptyPathReturnsError verifies that an empty path is rejected.
 func TestOpen_EmptyPathReturnsError(t *testing.T) {
 	ctx := context.Background()

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -32,27 +32,27 @@ func TestNormalizeKey(t *testing.T) {
 	}
 }
 
-func eqF(f float64) *float64 { return &f }
+func fptr(f float64) *float64 { return &f }
 
 func TestMatchConfidence(t *testing.T) {
 	tests := []struct {
 		name   string
 		a, b   string
-		wantGt float64  // got must be > wantGt (use 0 to skip)
-		wantLt float64  // got must be < wantLt (use 0 to skip)
+		wantGt *float64 // got must be > *wantGt; nil to skip
+		wantLt *float64 // got must be < *wantLt; nil to skip
 		wantEq *float64 // exact expected value; nil to skip
 	}{
-		{name: "identical", a: "hello", b: "hello", wantEq: eqF(1.0)},
-		{name: "both empty", a: "", b: "", wantEq: eqF(1.0)},
-		{name: "one empty", a: "hello", b: "", wantEq: eqF(0.0)},
-		{name: "near match transposition", a: "hello", b: "helol", wantGt: 0.9, wantLt: 1.0},
-		{name: "completely different", a: "abc", b: "xyz", wantLt: 0.5},
-		{name: "case insensitive", a: "Hello", b: "hello", wantEq: eqF(1.0)},
-		{name: "accent insensitive", a: "Héllo", b: "hello", wantEq: eqF(1.0)},
+		{name: "identical", a: "hello", b: "hello", wantEq: fptr(1.0)},
+		{name: "both empty", a: "", b: "", wantEq: fptr(1.0)},
+		{name: "one empty", a: "hello", b: "", wantEq: fptr(0.0)},
+		{name: "near match transposition", a: "hello", b: "helol", wantGt: fptr(0.9), wantLt: fptr(1.0)},
+		{name: "completely different", a: "abc", b: "xyz", wantLt: fptr(0.5)},
+		{name: "case insensitive", a: "Hello", b: "hello", wantEq: fptr(1.0)},
+		{name: "accent insensitive", a: "Héllo", b: "hello", wantEq: fptr(1.0)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.wantEq != nil && (tc.wantGt != 0 || tc.wantLt != 0) {
+			if tc.wantEq != nil && (tc.wantGt != nil || tc.wantLt != nil) {
 				t.Fatalf("invalid test case %q: wantEq cannot be combined with wantGt/wantLt", tc.name)
 			}
 			got := normalize.MatchConfidence(tc.a, tc.b)
@@ -62,11 +62,11 @@ func TestMatchConfidence(t *testing.T) {
 				}
 				return
 			}
-			if tc.wantGt > 0 && got <= tc.wantGt {
-				t.Errorf("MatchConfidence(%q, %q) = %f, want > %f", tc.a, tc.b, got, tc.wantGt)
+			if tc.wantGt != nil && got <= *tc.wantGt {
+				t.Errorf("MatchConfidence(%q, %q) = %f, want > %f", tc.a, tc.b, got, *tc.wantGt)
 			}
-			if tc.wantLt > 0 && got >= tc.wantLt {
-				t.Errorf("MatchConfidence(%q, %q) = %f, want < %f", tc.a, tc.b, got, tc.wantLt)
+			if tc.wantLt != nil && got >= *tc.wantLt {
+				t.Errorf("MatchConfidence(%q, %q) = %f, want < %f", tc.a, tc.b, got, *tc.wantLt)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Bundles the small untracked-debt items from \`.planning/NEXT_STEPS.md\` Track A into one PR.

- **\`internal/db/db_test.go\`** -- add \`TestOpen_BusyTimeoutAndSynchronous\` covering the two pragmas (\`busy_timeout=5000\`, \`synchronous=NORMAL\`) that \`Open\` sets but no test asserted.
- **\`internal/normalize/normalize_test.go\`** -- migrate \`wantGt\`/\`wantLt\` from \`float64\` (0 sentinel meaning "skip") to \`*float64\` (nil sentinel), matching \`wantEq\` from #37. Removes the inability to assert against \`0.0\`. Helper \`eqF\` renamed \`fptr\` since it now serves all three fields.
- **\`internal/config/config.go\`** -- the existing \`//nolint:gosec G706\` directive was flagged in review as "dead" (G706 claimed not to exist), but the linter actually does fire G706 here (log-injection taint analysis on \`os.Getenv\` value). Rewrote the suppression comment to accurately describe the real rule and justification (slog treats the field as a value, not a format string).

Items A2 (\`t.Setenv\` migration) and A4 (guard placement in \`normalize_test.go\`) in the plan were already done in the current tree.

No behavior change. No new dependencies.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [x] \`golangci-lint run\` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test validating database PRAGMA behavior (busy timeout and synchronous mode).
  * Improved confidence-matching tests to use pointer-based expectations for clearer skip/compare semantics.
  * Strengthened test cleanup to explicitly handle database close errors instead of suppressing them.

* **Chores**
  * Clarified internal warning/comment text related to environment-variable parsing/logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->