### PR TITLE
feat(m3): add library scan foundation

### DIFF
--- a/cmd/mxlrcsvc-go/main.go
+++ b/cmd/mxlrcsvc-go/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sydlexius/mxlrcsvc-go/internal/db"
 	"github.com/sydlexius/mxlrcsvc-go/internal/lyrics"
 	"github.com/sydlexius/mxlrcsvc-go/internal/musixmatch"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
 	"github.com/sydlexius/mxlrcsvc-go/internal/scanner"
 )
 
@@ -84,7 +85,7 @@ func run() int {
 		outdir = *args.Outdir
 	}
 
-	inputs := app.NewInputsQueue()
+	inputs := queue.NewInputsQueue()
 	sc := scanner.NewScanner()
 	mode, err := sc.ParseInput(args.Song, outdir, args.Update, args.Upgrade, args.Depth, args.BFS, inputs)
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/sydlexius/mxlrcsvc-go/internal/lyrics"
 	"github.com/sydlexius/mxlrcsvc-go/internal/musixmatch"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
 )
 
 // App owns all processing state and orchestrates the lyrics fetch loop.
 type App struct {
-	inputs   *InputsQueue
-	failed   *InputsQueue
+	inputs   *queue.InputsQueue
+	failed   *queue.InputsQueue
 	fetcher  musixmatch.Fetcher
 	writer   lyrics.Writer
 	mode     string
@@ -26,10 +27,10 @@ type App struct {
 // NewApp creates an App with the given dependencies.
 // The inputs queue should be pre-populated by the scanner.
 // A new failed queue is created internally.
-func NewApp(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *InputsQueue, cooldown int, mode string) *App {
+func NewApp(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) *App {
 	return &App{
 		inputs:   inputs,
-		failed:   NewInputsQueue(),
+		failed:   queue.NewInputsQueue(),
 		fetcher:  fetcher,
 		writer:   writer,
 		mode:     mode,

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -151,3 +151,30 @@ func TestOpen_IdempotentMigrations(t *testing.T) {
 		t.Fatalf("close second db: %v", err)
 	}
 }
+
+// TestOpen_ScanResultsUniqueIndex verifies that the scan result upsert key
+// migration has been applied.
+func TestOpen_ScanResultsUniqueIndex(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan-index.db")
+
+	sqlDB, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	var count int
+	row := sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_scan_results_library_file'")
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("query scan result index: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("scan result unique index count = %d; want 1", count)
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -177,4 +177,40 @@ func TestOpen_ScanResultsUniqueIndex(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("scan result unique index count = %d; want 1", count)
 	}
+
+	var unique int
+	row = sqlDB.QueryRowContext(ctx,
+		"SELECT [unique] FROM pragma_index_list('scan_results') WHERE name = 'idx_scan_results_library_file'")
+	if err := row.Scan(&unique); err != nil {
+		t.Fatalf("query scan result index uniqueness: %v", err)
+	}
+	if unique != 1 {
+		t.Fatalf("scan result index unique = %d; want 1", unique)
+	}
+
+	rows, err := sqlDB.QueryContext(ctx,
+		"SELECT name FROM pragma_index_info('idx_scan_results_library_file') ORDER BY seqno")
+	if err != nil {
+		t.Fatalf("query scan result index columns: %v", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			t.Errorf("close index columns rows: %v", err)
+		}
+	}()
+
+	var cols []string
+	for rows.Next() {
+		var col string
+		if err := rows.Scan(&col); err != nil {
+			t.Fatalf("scan result index column: %v", err)
+		}
+		cols = append(cols, col)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate scan result index columns: %v", err)
+	}
+	if len(cols) != 2 || cols[0] != "library_id" || cols[1] != "file_path" {
+		t.Fatalf("scan result index columns = %v; want [library_id file_path]", cols)
+	}
 }

--- a/internal/db/migrations/003_scan_results_unique.sql
+++ b/internal/db/migrations/003_scan_results_unique.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scan_results_library_file
+    ON scan_results(library_id, file_path);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_scan_results_library_file;
+-- +goose StatementEnd

--- a/internal/db/migrations/003_scan_results_unique.sql
+++ b/internal/db/migrations/003_scan_results_unique.sql
@@ -1,5 +1,12 @@
 -- +goose Up
 -- +goose StatementBegin
+DELETE FROM scan_results
+WHERE id NOT IN (
+    SELECT MAX(id)
+    FROM scan_results
+    GROUP BY library_id, file_path
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_scan_results_library_file
     ON scan_results(library_id, file_path);
 -- +goose StatementEnd

--- a/internal/library/repository.go
+++ b/internal/library/repository.go
@@ -1,0 +1,134 @@
+package library
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+)
+
+// Repo provides CRUD access to configured library roots.
+type Repo struct {
+	db *sql.DB
+}
+
+// New creates a library repository backed by db.
+func New(db *sql.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// Add creates a new library root. Path must be unique.
+func (r *Repo) Add(ctx context.Context, path, name string) (models.Library, error) {
+	path, name, err := validate(path, name)
+	if err != nil {
+		return models.Library{}, err
+	}
+	res, err := r.db.ExecContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?)`,
+		path,
+		name,
+	)
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: add: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: add id: %w", err)
+	}
+	return r.Get(ctx, id)
+}
+
+// List returns all configured library roots in stable ID order.
+func (r *Repo) List(ctx context.Context) (libs []models.Library, retErr error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, path, name, created_at, updated_at FROM libraries ORDER BY id ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("library: list: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("library: close list rows: %w", err)
+		}
+	}()
+
+	for rows.Next() {
+		var lib models.Library
+		if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("library: list scan: %w", err)
+		}
+		libs = append(libs, lib)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("library: list rows: %w", err)
+	}
+	return libs, nil
+}
+
+// Get returns the library root with id. It returns sql.ErrNoRows when not found.
+func (r *Repo) Get(ctx context.Context, id int64) (models.Library, error) {
+	var lib models.Library
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE id = ?`,
+		id,
+	).Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt)
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: get: %w", err)
+	}
+	return lib, nil
+}
+
+// Update changes the path and name for an existing library root.
+func (r *Repo) Update(ctx context.Context, id int64, path, name string) (models.Library, error) {
+	path, name, err := validate(path, name)
+	if err != nil {
+		return models.Library{}, err
+	}
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE libraries SET path = ?, name = ? WHERE id = ?`,
+		path,
+		name,
+		id,
+	)
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: update: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: update rows affected: %w", err)
+	}
+	if affected == 0 {
+		return models.Library{}, fmt.Errorf("library: update missing: %w", sql.ErrNoRows)
+	}
+	return r.Get(ctx, id)
+}
+
+// Remove deletes the library root with id.
+func (r *Repo) Remove(ctx context.Context, id int64) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("library: remove: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("library: remove rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("library: remove missing: %w", sql.ErrNoRows)
+	}
+	return nil
+}
+
+func validate(path, name string) (string, string, error) {
+	path = strings.TrimSpace(path)
+	name = strings.TrimSpace(name)
+	if path == "" {
+		return "", "", fmt.Errorf("library: path must not be empty")
+	}
+	if name == "" {
+		return "", "", fmt.Errorf("library: name must not be empty")
+	}
+	return path, name, nil
+}

--- a/internal/library/repository_test.go
+++ b/internal/library/repository_test.go
@@ -1,0 +1,119 @@
+package library_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/db"
+	"github.com/sydlexius/mxlrcsvc-go/internal/library"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func TestAddGetListUpdateRemove(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	added, err := repo.Add(ctx, "/music/rock", "Rock")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if added.ID == 0 {
+		t.Fatal("Add returned zero ID")
+	}
+	if added.Path != "/music/rock" || added.Name != "Rock" {
+		t.Fatalf("Add returned %+v", added)
+	}
+
+	got, err := repo.Get(ctx, added.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != added {
+		t.Fatalf("Get got %+v; want %+v", got, added)
+	}
+
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0] != added {
+		t.Fatalf("List got %+v; want [%+v]", list, added)
+	}
+
+	updated, err := repo.Update(ctx, added.ID, "/music/jazz", "Jazz")
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.ID != added.ID || updated.Path != "/music/jazz" || updated.Name != "Jazz" {
+		t.Fatalf("Update returned %+v", updated)
+	}
+
+	if err := repo.Remove(ctx, added.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	_, err = repo.Get(ctx, added.ID)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Get after Remove got %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestAdd_RejectsDuplicatePath(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	if _, err := repo.Add(ctx, "/music", "Music"); err != nil {
+		t.Fatalf("Add initial: %v", err)
+	}
+	if _, err := repo.Add(ctx, "/music", "Duplicate"); err == nil {
+		t.Fatal("Add duplicate returned nil error; want constraint error")
+	}
+}
+
+func TestAdd_ValidatesRequiredFields(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	tests := []struct {
+		name string
+		path string
+		lib  string
+	}{
+		{name: "empty path", path: "", lib: "Music"},
+		{name: "empty name", path: "/music", lib: ""},
+		{name: "blank path", path: "  ", lib: "Music"},
+		{name: "blank name", path: "/music", lib: "  "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := repo.Add(ctx, tc.path, tc.lib); err == nil {
+				t.Fatal("Add returned nil error; want validation error")
+			}
+		})
+	}
+}
+
+func TestUpdateRemove_NotFound(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	_, err := repo.Update(ctx, 123, "/music", "Music")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Update missing got %v; want sql.ErrNoRows", err)
+	}
+	err = repo.Remove(ctx, 123)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Remove missing got %v; want sql.ErrNoRows", err)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -48,3 +48,25 @@ type Inputs struct {
 	Outdir   string
 	Filename string
 }
+
+// Library represents a configured music library root.
+type Library struct {
+	ID        int64
+	Path      string
+	Name      string
+	CreatedAt string
+	UpdatedAt string
+}
+
+// ScanResult represents an audio file discovered during a library scan.
+type ScanResult struct {
+	ID        int64
+	LibraryID int64
+	FilePath  string
+	Track     Track
+	Outdir    string
+	Filename  string
+	Status    string
+	CreatedAt string
+	UpdatedAt string
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -51,22 +51,22 @@ type Inputs struct {
 
 // Library represents a configured music library root.
 type Library struct {
-	ID        int64
-	Path      string
-	Name      string
-	CreatedAt string
-	UpdatedAt string
+	ID        int64  `json:"id,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Name      string `json:"name,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
 // ScanResult represents an audio file discovered during a library scan.
 type ScanResult struct {
-	ID        int64
-	LibraryID int64
-	FilePath  string
-	Track     Track
-	Outdir    string
-	Filename  string
-	Status    string
-	CreatedAt string
-	UpdatedAt string
+	ID        int64  `json:"id,omitempty"`
+	LibraryID int64  `json:"library_id,omitempty"`
+	FilePath  string `json:"file_path,omitempty"`
+	Track     Track  `json:"track,omitempty"`
+	Outdir    string `json:"outdir,omitempty"`
+	Filename  string `json:"filename,omitempty"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,4 +1,4 @@
-package app
+package queue
 
 import (
 	"fmt"

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,4 +1,4 @@
-package app
+package queue
 
 import (
 	"testing"

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -1,0 +1,96 @@
+package scan
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+)
+
+const (
+	// StatusPending marks a discovered file that has not been queued yet.
+	StatusPending = "pending"
+	// StatusProcessing marks a discovered file currently being processed.
+	StatusProcessing = "processing"
+	// StatusDone marks a discovered file whose lyrics work completed.
+	StatusDone = "done"
+	// StatusFailed marks a discovered file whose lyrics work failed.
+	StatusFailed = "failed"
+)
+
+// Repo provides persistence for library scan results.
+type Repo struct {
+	db *sql.DB
+}
+
+// New creates a scan result repository backed by db.
+func New(db *sql.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// Upsert stores scan results for a library, keyed by library_id and file_path.
+func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.ScanResult) error {
+	for _, res := range results {
+		status := res.Status
+		if status == "" {
+			status = StatusPending
+		}
+		_, err := r.db.ExecContext(ctx,
+			`INSERT INTO scan_results (library_id, file_path, artist, title, status)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(library_id, file_path) DO UPDATE SET
+                 artist = excluded.artist,
+                 title = excluded.title,
+                 status = excluded.status`,
+			libraryID,
+			res.FilePath,
+			res.Track.ArtistName,
+			res.Track.TrackName,
+			status,
+		)
+		if err != nil {
+			return fmt.Errorf("scan: upsert %s: %w", res.FilePath, err)
+		}
+	}
+	return nil
+}
+
+// ListByLibrary returns persisted scan results for a library in stable ID order.
+func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []models.ScanResult, retErr error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, library_id, file_path, artist, title, status, created_at
+         FROM scan_results
+         WHERE library_id = ?
+         ORDER BY id ASC`,
+		libraryID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan: list by library: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("scan: close list rows: %w", err)
+		}
+	}()
+
+	for rows.Next() {
+		var res models.ScanResult
+		if err := rows.Scan(
+			&res.ID,
+			&res.LibraryID,
+			&res.FilePath,
+			&res.Track.ArtistName,
+			&res.Track.TrackName,
+			&res.Status,
+			&res.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan: list scan: %w", err)
+		}
+		results = append(results, res)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan: list rows: %w", err)
+	}
+	return results, nil
+}

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -31,12 +31,18 @@ func New(db *sql.DB) *Repo {
 
 // Upsert stores scan results for a library, keyed by library_id and file_path.
 func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.ScanResult) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("scan: begin upsert tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	for _, res := range results {
 		status := res.Status
 		if status == "" {
 			status = StatusPending
 		}
-		_, err := r.db.ExecContext(ctx,
+		_, err := tx.ExecContext(ctx,
 			`INSERT INTO scan_results (library_id, file_path, artist, title, status)
              VALUES (?, ?, ?, ?, ?)
              ON CONFLICT(library_id, file_path) DO UPDATE SET
@@ -52,6 +58,9 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 		if err != nil {
 			return fmt.Errorf("scan: upsert %s: %w", res.FilePath, err)
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("scan: commit upsert tx: %w", err)
 	}
 	return nil
 }

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -1,0 +1,139 @@
+package scan_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/db"
+	"github.com/sydlexius/mxlrcsvc-go/internal/library"
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/scan"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func TestRepo_UpsertAndListByLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+
+	results := []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Status:   scan.StatusPending,
+	}}
+	if err := scanRepo.Upsert(ctx, lib.ID, results); err != nil {
+		t.Fatalf("Upsert initial: %v", err)
+	}
+	results[0].Track.TrackName = "Updated Title"
+	results[0].Status = scan.StatusDone
+	if err := scanRepo.Upsert(ctx, lib.ID, results); err != nil {
+		t.Fatalf("Upsert update: %v", err)
+	}
+
+	got, err := scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListByLibrary returned %d results; want 1", len(got))
+	}
+	if got[0].FilePath != "/music/a.mp3" {
+		t.Errorf("FilePath = %q; want /music/a.mp3", got[0].FilePath)
+	}
+	if got[0].Track.TrackName != "Updated Title" {
+		t.Errorf("TrackName = %q; want Updated Title", got[0].Track.TrackName)
+	}
+	if got[0].Status != scan.StatusDone {
+		t.Errorf("Status = %q; want %q", got[0].Status, scan.StatusDone)
+	}
+}
+
+func TestRepo_UpsertDefaultsStatus(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListByLibrary returned %d results; want 1", len(got))
+	}
+	if got[0].Status != scan.StatusPending {
+		t.Fatalf("Status = %q; want %q", got[0].Status, scan.StatusPending)
+	}
+}
+
+func TestRepo_ListByLibrary_IsolatedByLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	if err != nil {
+		t.Fatalf("Add library A: %v", err)
+	}
+	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	if err != nil {
+		t.Fatalf("Add library B: %v", err)
+	}
+	filePath := "/shared/track.mp3"
+	if err := scanRepo.Upsert(ctx, libA.ID, []models.ScanResult{{
+		FilePath: filePath,
+		Track:    models.Track{ArtistName: "Artist A", TrackName: "Title A"},
+	}}); err != nil {
+		t.Fatalf("Upsert library A: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libB.ID, []models.ScanResult{{
+		FilePath: filePath,
+		Track:    models.Track{ArtistName: "Artist B", TrackName: "Title B"},
+	}}); err != nil {
+		t.Fatalf("Upsert library B: %v", err)
+	}
+
+	gotA, err := scanRepo.ListByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary A: %v", err)
+	}
+	gotB, err := scanRepo.ListByLibrary(ctx, libB.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary B: %v", err)
+	}
+	if len(gotA) != 1 || gotA[0].Track.ArtistName != "Artist A" {
+		t.Fatalf("library A results = %+v; want Artist A only", gotA)
+	}
+	if len(gotB) != 1 || gotB[0].Track.ArtistName != "Artist B" {
+		t.Fatalf("library B results = %+v; want Artist B only", gotB)
+	}
+}

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -58,6 +58,9 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 		return fmt.Errorf("scan: list libraries: %w", err)
 	}
 	for _, v := range libs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		results, err := s.Scanner.ScanLibrary(ctx, v.Path, s.Options)
 		if err != nil {
 			return fmt.Errorf("scan: scan library %d: %w", v.ID, err)

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -1,0 +1,108 @@
+package scan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/scanner"
+)
+
+// LibraryLister lists configured library roots.
+type LibraryLister interface {
+	List(ctx context.Context) ([]models.Library, error)
+}
+
+// ResultStore persists scan results.
+type ResultStore interface {
+	Upsert(ctx context.Context, libraryID int64, results []models.ScanResult) error
+}
+
+// LibraryScanner scans a library path.
+type LibraryScanner interface {
+	ScanLibrary(root string, opts scanner.ScanOptions) ([]models.ScanResult, error)
+}
+
+// OnCompleteFunc is called after a library scan has been persisted.
+type OnCompleteFunc func(ctx context.Context, lib models.Library, results []models.ScanResult) error
+
+// Scheduler periodically scans configured libraries and persists results.
+type Scheduler struct {
+	Libraries      LibraryLister
+	Results        ResultStore
+	Scanner        LibraryScanner
+	Options        scanner.ScanOptions
+	Interval       time.Duration
+	MaxRuntime     time.Duration
+	OnScanComplete OnCompleteFunc
+}
+
+// RunOnce scans every configured library exactly once.
+func (s *Scheduler) RunOnce(ctx context.Context) error {
+	if s.Libraries == nil {
+		return fmt.Errorf("scan: scheduler libraries dependency is nil")
+	}
+	if s.Results == nil {
+		return fmt.Errorf("scan: scheduler results dependency is nil")
+	}
+	if s.Scanner == nil {
+		return fmt.Errorf("scan: scheduler scanner dependency is nil")
+	}
+
+	libs, err := s.Libraries.List(ctx)
+	if err != nil {
+		return fmt.Errorf("scan: list libraries: %w", err)
+	}
+	for _, lib := range libs {
+		results, err := s.Scanner.ScanLibrary(lib.Path, s.Options)
+		if err != nil {
+			return fmt.Errorf("scan: scan library %d: %w", lib.ID, err)
+		}
+		for i := range results {
+			results[i].LibraryID = lib.ID
+			if results[i].Status == "" {
+				results[i].Status = StatusPending
+			}
+		}
+		if err := s.Results.Upsert(ctx, lib.ID, results); err != nil {
+			return fmt.Errorf("scan: persist library %d: %w", lib.ID, err)
+		}
+		if s.OnScanComplete != nil {
+			if err := s.OnScanComplete(ctx, lib, results); err != nil {
+				return fmt.Errorf("scan: complete library %d: %w", lib.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Run scans immediately and then repeats at Interval until ctx is canceled or
+// MaxRuntime elapses. If Interval is zero or negative, it performs one scan.
+func (s *Scheduler) Run(ctx context.Context) error {
+	if s.MaxRuntime > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.MaxRuntime)
+		defer cancel()
+	}
+
+	if err := s.RunOnce(ctx); err != nil {
+		return err
+	}
+	if s.Interval <= 0 {
+		return nil
+	}
+
+	ticker := time.NewTicker(s.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := s.RunOnce(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -54,23 +54,23 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("scan: list libraries: %w", err)
 	}
-	for _, lib := range libs {
-		results, err := s.Scanner.ScanLibrary(ctx, lib.Path, s.Options)
+	for _, v := range libs {
+		results, err := s.Scanner.ScanLibrary(ctx, v.Path, s.Options)
 		if err != nil {
-			return fmt.Errorf("scan: scan library %d: %w", lib.ID, err)
+			return fmt.Errorf("scan: scan library %d: %w", v.ID, err)
 		}
 		for i := range results {
-			results[i].LibraryID = lib.ID
+			results[i].LibraryID = v.ID
 			if results[i].Status == "" {
 				results[i].Status = StatusPending
 			}
 		}
-		if err := s.Results.Upsert(ctx, lib.ID, results); err != nil {
-			return fmt.Errorf("scan: persist library %d: %w", lib.ID, err)
+		if err := s.Results.Upsert(ctx, v.ID, results); err != nil {
+			return fmt.Errorf("scan: persist library %d: %w", v.ID, err)
 		}
 		if s.OnScanComplete != nil {
-			if err := s.OnScanComplete(ctx, lib, results); err != nil {
-				return fmt.Errorf("scan: complete library %d: %w", lib.ID, err)
+			if err := s.OnScanComplete(ctx, v, results); err != nil {
+				return fmt.Errorf("scan: complete library %d: %w", v.ID, err)
 			}
 		}
 	}

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -21,7 +21,7 @@ type ResultStore interface {
 
 // LibraryScanner scans a library path.
 type LibraryScanner interface {
-	ScanLibrary(root string, opts scanner.ScanOptions) ([]models.ScanResult, error)
+	ScanLibrary(ctx context.Context, root string, opts scanner.ScanOptions) ([]models.ScanResult, error)
 }
 
 // OnCompleteFunc is called after a library scan has been persisted.
@@ -55,7 +55,7 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 		return fmt.Errorf("scan: list libraries: %w", err)
 	}
 	for _, lib := range libs {
-		results, err := s.Scanner.ScanLibrary(lib.Path, s.Options)
+		results, err := s.Scanner.ScanLibrary(ctx, lib.Path, s.Options)
 		if err != nil {
 			return fmt.Errorf("scan: scan library %d: %w", lib.ID, err)
 		}
@@ -98,7 +98,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-ticker.C:
 			if err := s.RunOnce(ctx); err != nil {
 				return err

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -85,6 +85,9 @@ func (s *Scheduler) Run(ctx context.Context) error {
 		ctx, cancel = context.WithTimeout(ctx, s.MaxRuntime)
 		defer cancel()
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if err := s.RunOnce(ctx); err != nil {
 		return err

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -49,6 +49,9 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 	if s.Scanner == nil {
 		return fmt.Errorf("scan: scheduler scanner dependency is nil")
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	libs, err := s.Libraries.List(ctx)
 	if err != nil {

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -24,16 +24,18 @@ func (f fakeLibraries) List(context.Context) ([]models.Library, error) {
 }
 
 type fakeResults struct {
-	calls     int
+	calls []upsertCall
+	err   error
+}
+
+type upsertCall struct {
 	libraryID int64
 	results   []models.ScanResult
-	err       error
 }
 
 func (f *fakeResults) Upsert(_ context.Context, libraryID int64, results []models.ScanResult) error {
-	f.calls++
-	f.libraryID = libraryID
-	f.results = results
+	cp := append([]models.ScanResult(nil), results...)
+	f.calls = append(f.calls, upsertCall{libraryID: libraryID, results: cp})
 	if f.err != nil {
 		return f.err
 	}
@@ -78,14 +80,14 @@ func TestScheduler_RunOncePersistsAndCallsCallback(t *testing.T) {
 	if err := s.RunOnce(ctx); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
-	if store.calls != 1 {
-		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	if len(store.calls) != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", len(store.calls))
 	}
-	if store.libraryID != 7 {
-		t.Errorf("Upsert libraryID = %d; want 7", store.libraryID)
+	if store.calls[0].libraryID != 7 {
+		t.Errorf("Upsert libraryID = %d; want 7", store.calls[0].libraryID)
 	}
-	if len(store.results) != 1 || store.results[0].Status != scan.StatusPending {
-		t.Errorf("Upsert results = %+v; want one pending result", store.results)
+	if len(store.calls[0].results) != 1 || store.calls[0].results[0].Status != scan.StatusPending {
+		t.Errorf("Upsert results = %+v; want one pending result", store.calls[0].results)
 	}
 	if !called {
 		t.Fatal("OnScanComplete was not called")
@@ -106,8 +108,8 @@ func TestScheduler_RunWithNoIntervalRunsOnce(t *testing.T) {
 	if err := s.Run(ctx); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if store.calls != 1 {
-		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	if len(store.calls) != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", len(store.calls))
 	}
 }
 
@@ -126,8 +128,8 @@ func TestScheduler_RunOnceReturnsContextErrorOnCancellation(t *testing.T) {
 	if err := s.RunOnce(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("RunOnce error = %v; want context.Canceled", err)
 	}
-	if store.calls != 0 {
-		t.Fatalf("Upsert calls = %d; want 0", store.calls)
+	if len(store.calls) != 0 {
+		t.Fatalf("Upsert calls = %d; want 0", len(store.calls))
 	}
 }
 
@@ -147,8 +149,37 @@ func TestScheduler_RunReturnsContextErrorOnCancellation(t *testing.T) {
 	if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run error = %v; want context.Canceled", err)
 	}
-	if store.calls != 0 {
-		t.Fatalf("Upsert calls = %d; want 0", store.calls)
+	if len(store.calls) != 0 {
+		t.Fatalf("Upsert calls = %d; want 0", len(store.calls))
+	}
+}
+
+func TestScheduler_RunOnceReturnsContextErrorBetweenLibraries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &fakeResults{}
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: []models.Library{
+			{ID: 7, Path: "/music/a", Name: "A"},
+			{ID: 8, Path: "/music/b", Name: "B"},
+		}},
+		Results: store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/a.mp3",
+		}}},
+		OnScanComplete: func(context.Context, models.Library, []models.ScanResult) error {
+			cancel()
+			return nil
+		},
+	}
+
+	if err := s.RunOnce(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunOnce error = %v; want context.Canceled", err)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", len(store.calls))
+	}
+	if store.calls[0].libraryID != 7 {
+		t.Fatalf("Upsert libraryID = %d; want 7", store.calls[0].libraryID)
 	}
 }
 

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -1,0 +1,198 @@
+package scan_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/scan"
+	"github.com/sydlexius/mxlrcsvc-go/internal/scanner"
+)
+
+type fakeLibraries struct {
+	libs []models.Library
+	err  error
+}
+
+func (f fakeLibraries) List(context.Context) ([]models.Library, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.libs, nil
+}
+
+type fakeResults struct {
+	calls     int
+	libraryID int64
+	results   []models.ScanResult
+	err       error
+}
+
+func (f *fakeResults) Upsert(_ context.Context, libraryID int64, results []models.ScanResult) error {
+	f.calls++
+	f.libraryID = libraryID
+	f.results = results
+	if f.err != nil {
+		return f.err
+	}
+	return nil
+}
+
+type fakeScanner struct {
+	results []models.ScanResult
+	err     error
+}
+
+func (f fakeScanner) ScanLibrary(string, scanner.ScanOptions) ([]models.ScanResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.results, nil
+}
+
+func TestScheduler_RunOncePersistsAndCallsCallback(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	called := false
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: []models.Library{{ID: 7, Path: "/music", Name: "Music"}}},
+		Results:   store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/a.mp3",
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		}}},
+		OnScanComplete: func(_ context.Context, lib models.Library, results []models.ScanResult) error {
+			called = true
+			if lib.ID != 7 {
+				t.Errorf("callback lib ID = %d; want 7", lib.ID)
+			}
+			if len(results) != 1 || results[0].LibraryID != 7 {
+				t.Errorf("callback results = %+v; want library ID 7", results)
+			}
+			return nil
+		},
+	}
+
+	if err := s.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	}
+	if store.libraryID != 7 {
+		t.Errorf("Upsert libraryID = %d; want 7", store.libraryID)
+	}
+	if len(store.results) != 1 || store.results[0].Status != scan.StatusPending {
+		t.Errorf("Upsert results = %+v; want one pending result", store.results)
+	}
+	if !called {
+		t.Fatal("OnScanComplete was not called")
+	}
+}
+
+func TestScheduler_RunWithNoIntervalRunsOnce(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: []models.Library{{ID: 7, Path: "/music", Name: "Music"}}},
+		Results:   store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/a.mp3",
+		}}},
+	}
+
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	}
+}
+
+func TestScheduler_RunOnceRequiresDependencies(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		s    scan.Scheduler
+	}{
+		{name: "missing libraries", s: scan.Scheduler{}},
+		{name: "missing results", s: scan.Scheduler{Libraries: fakeLibraries{}}},
+		{name: "missing scanner", s: scan.Scheduler{Libraries: fakeLibraries{}, Results: &fakeResults{}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.s.RunOnce(ctx); err == nil {
+				t.Fatal("RunOnce returned nil error; want dependency error")
+			}
+		})
+	}
+}
+
+func TestScheduler_RunOncePropagatesErrors(t *testing.T) {
+	ctx := context.Background()
+	listErr := errors.New("list failed")
+	scanErr := errors.New("scan failed")
+	storeErr := errors.New("store failed")
+	callbackErr := errors.New("callback failed")
+
+	tests := []struct {
+		name string
+		s    scan.Scheduler
+		want error
+	}{
+		{
+			name: "list",
+			s: scan.Scheduler{
+				Libraries: fakeLibraries{err: listErr},
+				Results:   &fakeResults{},
+				Scanner:   fakeScanner{},
+			},
+			want: listErr,
+		},
+		{
+			name: "scan",
+			s: scan.Scheduler{
+				Libraries: fakeLibraries{libs: []models.Library{{ID: 1, Path: "/music"}}},
+				Results:   &fakeResults{},
+				Scanner:   fakeScanner{err: scanErr},
+			},
+			want: scanErr,
+		},
+		{
+			name: "store",
+			s: scan.Scheduler{
+				Libraries: fakeLibraries{libs: []models.Library{{ID: 1, Path: "/music"}}},
+				Results:   &fakeResults{err: storeErr},
+				Scanner: fakeScanner{results: []models.ScanResult{{
+					FilePath: "/music/a.mp3",
+				}}},
+			},
+			want: storeErr,
+		},
+		{
+			name: "callback",
+			s: scan.Scheduler{
+				Libraries: fakeLibraries{libs: []models.Library{{ID: 1, Path: "/music"}}},
+				Results:   &fakeResults{},
+				Scanner: fakeScanner{results: []models.ScanResult{{
+					FilePath: "/music/a.mp3",
+				}}},
+				OnScanComplete: func(context.Context, models.Library, []models.ScanResult) error {
+					return callbackErr
+				},
+			},
+			want: callbackErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.RunOnce(ctx)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("RunOnce error = %v; want wrapping %v", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -143,9 +143,9 @@ func TestScheduler_RunOnceRequiresDependencies(t *testing.T) {
 		{name: "missing scanner", s: scan.Scheduler{Libraries: fakeLibraries{}, Results: &fakeResults{}}},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.s.RunOnce(ctx); err == nil {
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			if err := v.s.RunOnce(ctx); err == nil {
 				t.Fatal("RunOnce returned nil error; want dependency error")
 			}
 		})
@@ -209,11 +209,11 @@ func TestScheduler_RunOncePropagatesErrors(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.s.RunOnce(ctx)
-			if !errors.Is(err, tc.want) {
-				t.Fatalf("RunOnce error = %v; want wrapping %v", err, tc.want)
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			err := v.s.RunOnce(ctx)
+			if !errors.Is(err, v.want) {
+				t.Fatalf("RunOnce error = %v; want wrapping %v", err, v.want)
 			}
 		})
 	}

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -111,6 +111,26 @@ func TestScheduler_RunWithNoIntervalRunsOnce(t *testing.T) {
 	}
 }
 
+func TestScheduler_RunOnceReturnsContextErrorOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &fakeResults{}
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: []models.Library{{ID: 7, Path: "/music", Name: "Music"}}},
+		Results:   store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/a.mp3",
+		}}},
+	}
+
+	cancel()
+	if err := s.RunOnce(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunOnce error = %v; want context.Canceled", err)
+	}
+	if store.calls != 0 {
+		t.Fatalf("Upsert calls = %d; want 0", store.calls)
+	}
+}
+
 func TestScheduler_RunReturnsContextErrorOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &fakeResults{}

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -127,8 +127,8 @@ func TestScheduler_RunReturnsContextErrorOnCancellation(t *testing.T) {
 	if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run error = %v; want context.Canceled", err)
 	}
-	if store.calls != 1 {
-		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	if store.calls != 0 {
+		t.Fatalf("Upsert calls = %d; want 0", store.calls)
 	}
 }
 

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/mxlrcsvc-go/internal/models"
 	"github.com/sydlexius/mxlrcsvc-go/internal/scan"
@@ -44,7 +45,7 @@ type fakeScanner struct {
 	err     error
 }
 
-func (f fakeScanner) ScanLibrary(string, scanner.ScanOptions) ([]models.ScanResult, error) {
+func (f fakeScanner) ScanLibrary(context.Context, string, scanner.ScanOptions) ([]models.ScanResult, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -104,6 +105,27 @@ func TestScheduler_RunWithNoIntervalRunsOnce(t *testing.T) {
 
 	if err := s.Run(ctx); err != nil {
 		t.Fatalf("Run: %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("Upsert calls = %d; want 1", store.calls)
+	}
+}
+
+func TestScheduler_RunReturnsContextErrorOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &fakeResults{}
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: []models.Library{{ID: 7, Path: "/music", Name: "Music"}}},
+		Results:   store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/a.mp3",
+		}}},
+		Interval: time.Hour,
+	}
+
+	cancel()
+	if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v; want context.Canceled", err)
 	}
 	if store.calls != 1 {
 		t.Fatalf("Upsert calls = %d; want 1", store.calls)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/dhowden/tag"
-	"github.com/sydlexius/mxlrcsvc-go/internal/app"
 	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
 )
 
 // supportedFileTypes lists audio file extensions that can have metadata read.
@@ -22,6 +22,14 @@ var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".fla
 
 // Scanner handles parsing input sources and populating the work queue.
 type Scanner struct{}
+
+// ScanOptions controls library directory traversal and queue eligibility.
+type ScanOptions struct {
+	Update   bool
+	Upgrade  bool
+	MaxDepth int
+	BFS      bool
+}
 
 // NewScanner creates a new Scanner.
 func NewScanner() *Scanner {
@@ -44,7 +52,7 @@ func AssertInput(song string) *models.Track {
 }
 
 // GetSongMulti processes multiple "artist,title" pairs into the work queue.
-func (sc *Scanner) GetSongMulti(songList []string, savePath string, songs *app.InputsQueue) {
+func (sc *Scanner) GetSongMulti(songList []string, savePath string, songs *queue.InputsQueue) {
 	for _, song := range songList {
 		track := AssertInput(song)
 		if track == nil {
@@ -56,7 +64,7 @@ func (sc *Scanner) GetSongMulti(songList []string, savePath string, songs *app.I
 }
 
 // GetSongText reads a text file with "artist,title" lines and populates the queue.
-func (sc *Scanner) GetSongText(textFn string, savePath string, songs *app.InputsQueue) error {
+func (sc *Scanner) GetSongText(textFn string, savePath string, songs *queue.InputsQueue) error {
 	f, err := os.Open(textFn) //nolint:gosec // path comes from user CLI argument
 	if err != nil {
 		return fmt.Errorf("opening text file %s: %w", textFn, err)
@@ -75,11 +83,19 @@ func (sc *Scanner) GetSongText(textFn string, savePath string, songs *app.Inputs
 	return nil
 }
 
-// GetSongDir scans a directory for audio files and populates the queue with metadata.
-// update causes existing .lrc files to be re-queued (overwrite synced lyrics).
-// upgrade causes existing .txt files (previously saved as unsynced) to be re-queued
-// so that the tool can check whether synced lyrics are now available and promote them to .lrc.
-func (sc *Scanner) GetSongDir(dir string, songs *app.InputsQueue, update bool, upgrade bool, limit int, depth int, bfs bool) error {
+// ScanLibrary scans a root directory for audio files and returns structured results.
+func (sc *Scanner) ScanLibrary(root string, opts ScanOptions) ([]models.ScanResult, error) {
+	if opts.MaxDepth < 0 {
+		opts.MaxDepth = 0
+	}
+	var results []models.ScanResult
+	if err := sc.scanDir(root, opts, 0, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (sc *Scanner) scanDir(dir string, opts ScanOptions, depth int, results *[]models.ScanResult) error {
 	slog.Info("scanning directory", "path", dir)
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -91,13 +107,13 @@ func (sc *Scanner) GetSongDir(dir string, songs *app.InputsQueue, update bool, u
 		if id1 == id2 {
 			return files[i].Name() < files[j].Name()
 		}
-		return bfs != id1
+		return opts.BFS != id1
 	})
 
 	for _, file := range files {
 		if file.IsDir() {
-			if depth < limit {
-				if err := sc.GetSongDir(filepath.Join(dir, file.Name()), songs, update, upgrade, limit, depth+1, bfs); err != nil {
+			if depth < opts.MaxDepth {
+				if err := sc.scanDir(filepath.Join(dir, file.Name()), opts, depth+1, results); err != nil {
 					return err
 				}
 			}
@@ -125,11 +141,11 @@ func (sc *Scanner) GetSongDir(dir string, songs *app.InputsQueue, update bool, u
 		}
 
 		switch {
-		case lrcExists && !update:
+		case lrcExists && !opts.Update:
 			// Synced lyrics already present and not asked to update -- skip.
 			slog.Debug("skipping file, lyrics exist", "file", file.Name())
 			continue
-		case txtExists && !upgrade && !update && !lrcExists:
+		case txtExists && !opts.Upgrade && !opts.Update && !lrcExists:
 			// Unsynced .txt present and not asked to upgrade or update -- skip.
 			slog.Debug("skipping file, unsynced lyrics exist", "file", file.Name())
 			continue
@@ -154,28 +170,53 @@ func (sc *Scanner) GetSongDir(dir string, songs *app.InputsQueue, update bool, u
 		}
 
 		slog.Debug("adding file", "file", file.Name())
-		song := models.Inputs{
+		*results = append(*results, models.ScanResult{
+			FilePath: filepath.Join(dir, file.Name()),
 			Track:    models.Track{ArtistName: m.Artist(), TrackName: m.Title()},
 			Outdir:   dir,
 			Filename: stem + ".lrc",
-		}
-		songs.Push(song)
+			Status:   "pending",
+		})
+	}
+	return nil
+}
+
+// GetSongDir scans a directory for audio files and populates the queue with metadata.
+// update causes existing .lrc files to be re-queued (overwrite synced lyrics).
+// upgrade causes existing .txt files (previously saved as unsynced) to be re-queued
+// so that the tool can check whether synced lyrics are now available and promote them to .lrc.
+func (sc *Scanner) GetSongDir(dir string, songs *queue.InputsQueue, update bool, upgrade bool, limit int, depth int, bfs bool) error {
+	results, err := sc.ScanLibrary(dir, ScanOptions{
+		Update:   update,
+		Upgrade:  upgrade,
+		MaxDepth: limit - depth,
+		BFS:      bfs,
+	})
+	if err != nil {
+		return err
+	}
+	for _, res := range results {
+		songs.Push(models.Inputs{
+			Track:    res.Track,
+			Outdir:   res.Outdir,
+			Filename: res.Filename,
+		})
 	}
 	return nil
 }
 
 // ParseInput determines the input mode and populates the work queue accordingly.
-func (sc *Scanner) ParseInput(songs []string, outdir string, update bool, upgrade bool, depth int, bfs bool, queue *app.InputsQueue) (string, error) {
+func (sc *Scanner) ParseInput(songs []string, outdir string, update bool, upgrade bool, depth int, bfs bool, inputs *queue.InputsQueue) (string, error) {
 	if len(songs) == 1 {
 		fi, err := os.Stat(songs[0])
 		if err == nil {
 			if !fi.IsDir() {
-				if err := sc.GetSongText(songs[0], outdir, queue); err != nil {
+				if err := sc.GetSongText(songs[0], outdir, inputs); err != nil {
 					return "", err
 				}
 				return "text", nil
 			}
-			if err := sc.GetSongDir(songs[0], queue, update, upgrade, depth, 0, bfs); err != nil {
+			if err := sc.GetSongDir(songs[0], inputs, update, upgrade, depth, 0, bfs); err != nil {
 				return "", err
 			}
 			return "dir", nil
@@ -183,6 +224,6 @@ func (sc *Scanner) ParseInput(songs []string, outdir string, update bool, upgrad
 			return "", fmt.Errorf("checking input path %s: %w", songs[0], err)
 		}
 	}
-	sc.GetSongMulti(songs, outdir, queue)
+	sc.GetSongMulti(songs, outdir, inputs)
 	return "cli", nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"bufio"
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -84,18 +85,21 @@ func (sc *Scanner) GetSongText(textFn string, savePath string, songs *queue.Inpu
 }
 
 // ScanLibrary scans a root directory for audio files and returns structured results.
-func (sc *Scanner) ScanLibrary(root string, opts ScanOptions) ([]models.ScanResult, error) {
+func (sc *Scanner) ScanLibrary(ctx context.Context, root string, opts ScanOptions) ([]models.ScanResult, error) {
 	if opts.MaxDepth < 0 {
 		opts.MaxDepth = 0
 	}
 	var results []models.ScanResult
-	if err := sc.scanDir(root, opts, 0, &results); err != nil {
+	if err := sc.scanDir(ctx, root, opts, 0, &results); err != nil {
 		return nil, err
 	}
 	return results, nil
 }
 
-func (sc *Scanner) scanDir(dir string, opts ScanOptions, depth int, results *[]models.ScanResult) error {
+func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, depth int, results *[]models.ScanResult) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	slog.Info("scanning directory", "path", dir)
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -111,9 +115,12 @@ func (sc *Scanner) scanDir(dir string, opts ScanOptions, depth int, results *[]m
 	})
 
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if file.IsDir() {
 			if depth < opts.MaxDepth {
-				if err := sc.scanDir(filepath.Join(dir, file.Name()), opts, depth+1, results); err != nil {
+				if err := sc.scanDir(ctx, filepath.Join(dir, file.Name()), opts, depth+1, results); err != nil {
 					return err
 				}
 			}
@@ -186,7 +193,7 @@ func (sc *Scanner) scanDir(dir string, opts ScanOptions, depth int, results *[]m
 // upgrade causes existing .txt files (previously saved as unsynced) to be re-queued
 // so that the tool can check whether synced lyrics are now available and promote them to .lrc.
 func (sc *Scanner) GetSongDir(dir string, songs *queue.InputsQueue, update bool, upgrade bool, limit int, depth int, bfs bool) error {
-	results, err := sc.ScanLibrary(dir, ScanOptions{
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{
 		Update:   update,
 		Upgrade:  upgrade,
 		MaxDepth: limit - depth,

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sydlexius/mxlrcsvc-go/internal/app"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
 )
 
 // minimalID3v2 is a minimal ID3v2.3 tag with TIT2 ("Test Title") and TPE1
@@ -101,18 +101,66 @@ func TestGetSongDir_SkipLogic(t *testing.T) {
 				touchFile(t, dir, "track.txt")
 			}
 
-			queue := app.NewInputsQueue()
+			q := queue.NewInputsQueue()
 			sc := NewScanner()
 			// depth=0, limit=100, bfs=false
-			if err := sc.GetSongDir(dir, queue, tc.update, tc.upgrade, 100, 0, false); err != nil {
+			if err := sc.GetSongDir(dir, q, tc.update, tc.upgrade, 100, 0, false); err != nil {
 				t.Fatalf("GetSongDir returned error: %v", err)
 			}
 
-			gotQueue := queue.Len() > 0
+			gotQueue := q.Len() > 0
 			if gotQueue != tc.wantQueue {
 				t.Errorf("update=%v upgrade=%v lrc=%v txt=%v: got enqueued=%v, want enqueued=%v",
 					tc.update, tc.upgrade, tc.lrcExists, tc.txtExists, gotQueue, tc.wantQueue)
 			}
 		})
+	}
+}
+
+func TestScanLibrary_ReturnsStructuredResults(t *testing.T) {
+	dir := t.TempDir()
+	writeAudioFile(t, dir, "track.mp3")
+
+	sc := NewScanner()
+	results, err := sc.ScanLibrary(dir, ScanOptions{MaxDepth: 100})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("ScanLibrary returned %d results; want 1", len(results))
+	}
+	got := results[0]
+	if got.FilePath != filepath.Join(dir, "track.mp3") {
+		t.Errorf("FilePath = %q; want %q", got.FilePath, filepath.Join(dir, "track.mp3"))
+	}
+	if got.Outdir != dir {
+		t.Errorf("Outdir = %q; want %q", got.Outdir, dir)
+	}
+	if got.Filename != "track.lrc" {
+		t.Errorf("Filename = %q; want %q", got.Filename, "track.lrc")
+	}
+	if got.Track.ArtistName != "Test Artist" || got.Track.TrackName != "Test Title" {
+		t.Errorf("Track = %+v; want Test Artist/Test Title", got.Track)
+	}
+	if got.Status != "pending" {
+		t.Errorf("Status = %q; want pending", got.Status)
+	}
+}
+
+func TestScanLibrary_RespectsMaxDepth(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeAudioFile(t, nested, "track.mp3")
+
+	sc := NewScanner()
+	results, err := sc.ScanLibrary(root, ScanOptions{MaxDepth: 0})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("ScanLibrary returned %d results; want 0", len(results))
 	}
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -122,7 +124,7 @@ func TestScanLibrary_ReturnsStructuredResults(t *testing.T) {
 	writeAudioFile(t, dir, "track.mp3")
 
 	sc := NewScanner()
-	results, err := sc.ScanLibrary(dir, ScanOptions{MaxDepth: 100})
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -156,11 +158,22 @@ func TestScanLibrary_RespectsMaxDepth(t *testing.T) {
 	writeAudioFile(t, nested, "track.mp3")
 
 	sc := NewScanner()
-	results, err := sc.ScanLibrary(root, ScanOptions{MaxDepth: 0})
+	results, err := sc.ScanLibrary(context.Background(), root, ScanOptions{MaxDepth: 0})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("ScanLibrary returned %d results; want 0", len(results))
+	}
+}
+
+func TestScanLibrary_RespectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sc := NewScanner()
+	_, err := sc.ScanLibrary(ctx, t.TempDir(), ScanOptions{MaxDepth: 100})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ScanLibrary error = %v; want context.Canceled", err)
 	}
 }


### PR DESCRIPTION
## Summary

- move `InputsQueue` from `internal/app` to lower-level `internal/queue`
- add `internal/library` CRUD repository for configured library roots
- add stateless scanner `ScanLibrary` API returning structured scan results while preserving existing CLI queue behavior
- add `internal/scan` repository and scheduler foundation with scan result upserts and completion callback support
- add scan result uniqueness migration and M3 repository/scheduler coverage

Closes #31
Closes #15
Closes #16
Closes #17
Closes #45

## Test Plan

- `GOCACHE=/tmp/mxlrc-go-build-cache go test -count=1 -coverprofile=/tmp/mxlrc-go-cover.out ./...`
- `GOCACHE=/tmp/mxlrc-go-build-cache go vet ./...`
- `GOCACHE=/tmp/mxlrc-go-build-cache GOLANGCI_LINT_CACHE=/tmp/mxlrc-golangci-cache golangci-lint run ./...`
- pre-commit hooks passed: typos, gofmt, go build, golangci-lint, govulncheck, gitleaks, conventional commit

## Notes

- CLI behavior is preserved: existing directory input still populates the in-memory queue through `GetSongDir`.
- `internal/scanner` no longer imports `internal/app`.
- `Scheduler.OnScanComplete` is the intended future bridge for M5.5 scanner-to-queue integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library management UI/backend (add/list/update/remove) and new models for libraries and scan results.
  * Directory scanning that discovers audio files, extracts metadata, and enqueues scan results.
  * Scan scheduler to run scans once or on an interval with configurable limits and completion callbacks.
  * Scan results store with upsert and per-library listing.

* **Bug Fixes / Data**
  * Enforced uniqueness for scan results (library + file) via migration that removes duplicates and adds a unique index.

* **Tests**
  * Expanded test coverage for DB migration, library & scan repositories, scheduler, and scanner (including scan options, depth, and cancellation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->