### PR TITLE
test: add CLI startup integration coverage

### DIFF
--- a/cmd/mxlrcsvc-go/main.go
+++ b/cmd/mxlrcsvc-go/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -36,19 +37,87 @@ func main() {
 	os.Exit(run())
 }
 
+type appRunner interface {
+	Run(ctx context.Context) error
+}
+
+type runOptions struct {
+	Args       []string
+	Out        io.Writer
+	Context    context.Context
+	LoadDotenv func() error
+	NewFetcher func(token string) musixmatch.Fetcher
+	NewWriter  func() lyrics.Writer
+	NewApp     func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner
+}
+
 // run executes the application and returns an exit code.
 // Using a helper function ensures deferred cleanup (e.g. sqlDB.Close) runs
 // before os.Exit is called, while still producing a non-zero exit on error.
 func run() int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return runWithOptions(runOptions{Context: ctx})
+}
+
+func runWithOptions(opts runOptions) int {
+	rawArgs := opts.Args
+	if rawArgs == nil {
+		rawArgs = os.Args[1:]
+	}
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	loadDotenv := opts.LoadDotenv
+	if loadDotenv == nil {
+		loadDotenv = func() error { return godotenv.Load() }
+	}
+	newFetcher := opts.NewFetcher
+	if newFetcher == nil {
+		newFetcher = func(token string) musixmatch.Fetcher { return musixmatch.NewClient(token) }
+	}
+	newWriter := opts.NewWriter
+	if newWriter == nil {
+		newWriter = func() lyrics.Writer { return lyrics.NewLRCWriter() }
+	}
+	newApp := opts.NewApp
+	if newApp == nil {
+		newApp = func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
+			return app.NewApp(fetcher, writer, inputs, cooldown, mode)
+		}
+	}
+
 	var args Args
-	arg.MustParse(&args)
+	parser, err := arg.NewParser(arg.Config{Program: "mxlrcsvc-go", Out: out}, &args)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 2
+	}
+	if err := parser.Parse(rawArgs); err != nil {
+		if err == arg.ErrHelp {
+			if err := parser.WriteHelpForSubcommand(out); err != nil {
+				_, _ = fmt.Fprintln(out, err)
+				return 2
+			}
+			return 0
+		}
+		if usageErr := parser.WriteUsageForSubcommand(out); usageErr != nil {
+			_, _ = fmt.Fprintln(out, usageErr)
+			return 2
+		}
+		_, _ = fmt.Fprintln(out, err)
+		return 2
+	}
 
 	// Load .env file if present (does NOT overwrite existing env vars).
 	// Error is ignored -- .env file is optional.
-	_ = godotenv.Load()
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	_ = loadDotenv()
 
 	cfg, err := config.Load(args.ConfigPath)
 	if err != nil {
@@ -101,9 +170,9 @@ func run() int {
 		}
 	}
 
-	mx := musixmatch.NewClient(token)
-	w := lyrics.NewLRCWriter()
-	application := app.NewApp(mx, w, inputs, cooldown, mode)
+	mx := newFetcher(token)
+	w := newWriter()
+	application := newApp(mx, w, inputs, cooldown, mode)
 
 	if err := application.Run(ctx); err != nil {
 		slog.Error("application error", "error", err)

--- a/cmd/mxlrcsvc-go/main.go
+++ b/cmd/mxlrcsvc-go/main.go
@@ -135,13 +135,6 @@ func runWithOptions(opts runOptions) int {
 		return 1
 	}
 
-	sqlDB, err := db.Open(ctx, cfg.DB.Path)
-	if err != nil {
-		slog.Error("failed to open database", "error", err)
-		return 1
-	}
-	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
-
 	// Cooldown: explicit CLI flag wins; otherwise use config (which has its own default).
 	cooldown := cfg.API.Cooldown
 	if args.Cooldown != nil {
@@ -169,6 +162,13 @@ func runWithOptions(opts runOptions) int {
 			return 1
 		}
 	}
+
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
 
 	mx := newFetcher(token)
 	w := newWriter()

--- a/cmd/mxlrcsvc-go/main.go
+++ b/cmd/mxlrcsvc-go/main.go
@@ -42,13 +42,13 @@ type appRunner interface {
 }
 
 type runOptions struct {
-	Args       []string
-	Out        io.Writer
-	Context    context.Context
-	LoadDotenv func() error
-	NewFetcher func(token string) musixmatch.Fetcher
-	NewWriter  func() lyrics.Writer
-	NewApp     func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner
+	args       []string
+	out        io.Writer
+	ctx        context.Context
+	loadDotenv func() error
+	newFetcher func(token string) musixmatch.Fetcher
+	newWriter  func() lyrics.Writer
+	newApp     func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner
 }
 
 // run executes the application and returns an exit code.
@@ -58,35 +58,35 @@ func run() int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	return runWithOptions(runOptions{Context: ctx})
+	return runWithOptions(runOptions{ctx: ctx})
 }
 
 func runWithOptions(opts runOptions) int {
-	rawArgs := opts.Args
+	rawArgs := opts.args
 	if rawArgs == nil {
 		rawArgs = os.Args[1:]
 	}
-	out := opts.Out
+	out := opts.out
 	if out == nil {
 		out = os.Stdout
 	}
-	ctx := opts.Context
+	ctx := opts.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	loadDotenv := opts.LoadDotenv
+	loadDotenv := opts.loadDotenv
 	if loadDotenv == nil {
 		loadDotenv = func() error { return godotenv.Load() }
 	}
-	newFetcher := opts.NewFetcher
+	newFetcher := opts.newFetcher
 	if newFetcher == nil {
 		newFetcher = func(token string) musixmatch.Fetcher { return musixmatch.NewClient(token) }
 	}
-	newWriter := opts.NewWriter
+	newWriter := opts.newWriter
 	if newWriter == nil {
 		newWriter = func() lyrics.Writer { return lyrics.NewLRCWriter() }
 	}
-	newApp := opts.NewApp
+	newApp := opts.newApp
 	if newApp == nil {
 		newApp = func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
 			return app.NewApp(fetcher, writer, inputs, cooldown, mode)
@@ -125,13 +125,6 @@ func runWithOptions(opts runOptions) int {
 		return 1
 	}
 
-	sqlDB, err := db.Open(ctx, cfg.DB.Path)
-	if err != nil {
-		slog.Error("failed to open database", "error", err)
-		return 1
-	}
-	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
-
 	// Token precedence: CLI flag > env vars (handled in config.Load) > config file.
 	token := args.Token
 	if token == "" {
@@ -141,6 +134,13 @@ func runWithOptions(opts runOptions) int {
 		slog.Error("no API token provided: use --token flag, MUSIXMATCH_TOKEN env var, MXLRC_API_TOKEN env var, or config file")
 		return 1
 	}
+
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
 
 	// Cooldown: explicit CLI flag wins; otherwise use config (which has its own default).
 	cooldown := cfg.API.Cooldown

--- a/cmd/mxlrcsvc-go/main_test.go
+++ b/cmd/mxlrcsvc-go/main_test.go
@@ -84,16 +84,16 @@ func writeConfig(t *testing.T, token string, cooldown int, outdir string, dbPath
 func runStartup(t *testing.T, args []string, rec *runRecord) int {
 	t.Helper()
 	return runWithOptions(runOptions{
-		Args:       args,
-		LoadDotenv: func() error { return nil },
-		NewFetcher: func(token string) musixmatch.Fetcher {
+		args:       args,
+		loadDotenv: func() error { return nil },
+		newFetcher: func(token string) musixmatch.Fetcher {
 			rec.token = token
 			return &fakeFetcher{rec: rec}
 		},
-		NewWriter: func() lyrics.Writer {
+		newWriter: func() lyrics.Writer {
 			return fakeWriter{}
 		},
-		NewApp: func(_ musixmatch.Fetcher, _ lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
+		newApp: func(_ musixmatch.Fetcher, _ lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
 			rec.appCreated = true
 			rec.cooldown = cooldown
 			rec.mode = mode
@@ -118,15 +118,15 @@ func TestRunWithOptions_HelpDoesNotStartApplication(t *testing.T) {
 	rec := &runRecord{}
 
 	code := runWithOptions(runOptions{
-		Args:       []string{"--help"},
-		Out:        &out,
-		LoadDotenv: func() error { return nil },
-		NewFetcher: func(token string) musixmatch.Fetcher {
+		args:       []string{"--help"},
+		out:        &out,
+		loadDotenv: func() error { return nil },
+		newFetcher: func(token string) musixmatch.Fetcher {
 			rec.token = token
 			return &fakeFetcher{rec: rec}
 		},
-		NewWriter: func() lyrics.Writer { return fakeWriter{} },
-		NewApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
+		newWriter: func() lyrics.Writer { return fakeWriter{} },
+		newApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
 			rec.appCreated = true
 			return fakeRunner{rec: rec}
 		},
@@ -236,8 +236,8 @@ func TestRunWithOptions_MissingTokenFailsBeforeAppRun(t *testing.T) {
 	if rec.findCalls != 0 {
 		t.Fatalf("FindLyrics calls = %d; want 0", rec.findCalls)
 	}
-	if _, err := os.Stat(dbPath); err != nil {
-		t.Fatalf("stat db path: %v", err)
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("stat db path error = %v; want not exist", err)
 	}
 }
 

--- a/cmd/mxlrcsvc-go/main_test.go
+++ b/cmd/mxlrcsvc-go/main_test.go
@@ -83,9 +83,14 @@ func writeConfig(t *testing.T, token string, cooldown int, outdir string, dbPath
 
 func runStartup(t *testing.T, args []string, rec *runRecord) int {
 	t.Helper()
+	return runStartupWithDotenv(t, args, rec, func() error { return nil })
+}
+
+func runStartupWithDotenv(t *testing.T, args []string, rec *runRecord, loadDotenv func() error) int {
+	t.Helper()
 	return runWithOptions(runOptions{
 		args:       args,
-		loadDotenv: func() error { return nil },
+		loadDotenv: loadDotenv,
 		newFetcher: func(token string) musixmatch.Fetcher {
 			rec.token = token
 			return &fakeFetcher{rec: rec}
@@ -189,6 +194,46 @@ func TestRunWithOptions_CLIPrecedenceAndPairInput(t *testing.T) {
 	}
 	if _, err := os.Stat(dbPath); err != nil {
 		t.Fatalf("stat db path: %v", err)
+	}
+}
+
+func TestRunWithOptions_DotenvTokenPrecedence(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	cfg := writeConfig(t, "config-token", 1, filepath.Join(dir, "out"), filepath.Join(dir, "state", "test.db"))
+	loadDotenv := func() error {
+		if os.Getenv("MUSIXMATCH_TOKEN") == "" {
+			t.Setenv("MUSIXMATCH_TOKEN", "dotenv-token")
+		}
+		return nil
+	}
+
+	rec := &runRecord{}
+	code := runStartupWithDotenv(t, []string{"--config", cfg, "Artist,Title"}, rec, loadDotenv)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.token != "dotenv-token" {
+		t.Fatalf("token = %q; want dotenv token", rec.token)
+	}
+
+	t.Setenv("MUSIXMATCH_TOKEN", "env-token")
+	rec = &runRecord{}
+	code = runStartupWithDotenv(t, []string{"--config", cfg, "Artist,Title"}, rec, loadDotenv)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.token != "env-token" {
+		t.Fatalf("token = %q; want env token", rec.token)
+	}
+
+	rec = &runRecord{}
+	code = runStartupWithDotenv(t, []string{"--config", cfg, "--token", "cli-token", "Artist,Title"}, rec, loadDotenv)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.token != "cli-token" {
+		t.Fatalf("token = %q; want CLI token", rec.token)
 	}
 }
 

--- a/cmd/mxlrcsvc-go/main_test.go
+++ b/cmd/mxlrcsvc-go/main_test.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/lyrics"
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/musixmatch"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+)
+
+type runRecord struct {
+	token       string
+	findCalls   int
+	appCreated  bool
+	runCalls    int
+	cooldown    int
+	mode        string
+	inputs      []models.Inputs
+	runErr      error
+	createAppFn func(*runRecord)
+}
+
+type fakeFetcher struct {
+	rec *runRecord
+}
+
+func (f *fakeFetcher) FindLyrics(context.Context, models.Track) (models.Song, error) {
+	f.rec.findCalls++
+	return models.Song{}, errors.New("unexpected lyrics fetch in startup test")
+}
+
+type fakeWriter struct{}
+
+func (fakeWriter) WriteLRC(models.Song, string, string) error {
+	return errors.New("unexpected LRC write in startup test")
+}
+
+type fakeRunner struct {
+	rec *runRecord
+}
+
+func (r fakeRunner) Run(context.Context) error {
+	r.rec.runCalls++
+	return r.rec.runErr
+}
+
+func isolateCLIEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN",
+		"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN",
+		"MXLRC_OUTPUT_DIR", "MXLRC_DB_PATH",
+	} {
+		t.Setenv(v, "")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+}
+
+func writeConfig(t *testing.T, token string, cooldown int, outdir string, dbPath string) string {
+	t.Helper()
+	cfg := filepath.Join(t.TempDir(), "config.toml")
+	content := "[api]\n" +
+		"token = \"" + token + "\"\n" +
+		"cooldown = " + strconv.Itoa(cooldown) + "\n" +
+		"[output]\n" +
+		"dir = \"" + filepath.ToSlash(outdir) + "\"\n" +
+		"[db]\n" +
+		"path = \"" + filepath.ToSlash(dbPath) + "\"\n"
+	if err := os.WriteFile(cfg, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfg
+}
+
+func runStartup(t *testing.T, args []string, rec *runRecord) int {
+	t.Helper()
+	return runWithOptions(runOptions{
+		Args:       args,
+		LoadDotenv: func() error { return nil },
+		NewFetcher: func(token string) musixmatch.Fetcher {
+			rec.token = token
+			return &fakeFetcher{rec: rec}
+		},
+		NewWriter: func() lyrics.Writer {
+			return fakeWriter{}
+		},
+		NewApp: func(_ musixmatch.Fetcher, _ lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
+			rec.appCreated = true
+			rec.cooldown = cooldown
+			rec.mode = mode
+			for !inputs.Empty() {
+				v, err := inputs.Pop()
+				if err != nil {
+					t.Fatalf("pop input: %v", err)
+				}
+				rec.inputs = append(rec.inputs, v)
+			}
+			if rec.createAppFn != nil {
+				rec.createAppFn(rec)
+			}
+			return fakeRunner{rec: rec}
+		},
+	})
+}
+
+func TestRunWithOptions_HelpDoesNotStartApplication(t *testing.T) {
+	isolateCLIEnv(t)
+	var out bytes.Buffer
+	rec := &runRecord{}
+
+	code := runWithOptions(runOptions{
+		Args:       []string{"--help"},
+		Out:        &out,
+		LoadDotenv: func() error { return nil },
+		NewFetcher: func(token string) musixmatch.Fetcher {
+			rec.token = token
+			return &fakeFetcher{rec: rec}
+		},
+		NewWriter: func() lyrics.Writer { return fakeWriter{} },
+		NewApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
+			rec.appCreated = true
+			return fakeRunner{rec: rec}
+		},
+	})
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.appCreated {
+		t.Fatal("app was created; want help to stop before startup")
+	}
+	if !strings.Contains(out.String(), "Usage: mxlrcsvc-go") {
+		t.Fatalf("help output = %q; want usage", out.String())
+	}
+}
+
+func TestRunWithOptions_CLIPrecedenceAndPairInput(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	cfgOut := filepath.Join(dir, "config-out")
+	envOut := filepath.Join(dir, "env-out")
+	cliOut := filepath.Join(dir, "cli-out")
+	dbPath := filepath.Join(dir, "state", "test.db")
+	cfg := writeConfig(t, "config-token", 9, cfgOut, dbPath)
+	t.Setenv("MUSIXMATCH_TOKEN", "env-token")
+	t.Setenv("MXLRC_API_COOLDOWN", "7")
+	t.Setenv("MXLRC_OUTPUT_DIR", envOut)
+
+	rec := &runRecord{}
+	code := runStartup(t, []string{
+		"--config", cfg,
+		"--token", "cli-token",
+		"--cooldown", "0",
+		"--outdir", cliOut,
+		"Artist,Title",
+	}, rec)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.token != "cli-token" {
+		t.Fatalf("token = %q; want CLI token", rec.token)
+	}
+	if rec.cooldown != 0 {
+		t.Fatalf("cooldown = %d; want CLI cooldown 0", rec.cooldown)
+	}
+	if rec.mode != "cli" {
+		t.Fatalf("mode = %q; want cli", rec.mode)
+	}
+	if len(rec.inputs) != 1 {
+		t.Fatalf("inputs = %d; want 1", len(rec.inputs))
+	}
+	got := rec.inputs[0]
+	if got.Track.ArtistName != "Artist" || got.Track.TrackName != "Title" {
+		t.Fatalf("track = %+v; want Artist/Title", got.Track)
+	}
+	if got.Outdir != cliOut {
+		t.Fatalf("outdir = %q; want %q", got.Outdir, cliOut)
+	}
+	if rec.findCalls != 0 {
+		t.Fatalf("FindLyrics calls = %d; want 0", rec.findCalls)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat db path: %v", err)
+	}
+}
+
+func TestRunWithOptions_EnvPrecedenceOverConfig(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	cfgOut := filepath.Join(dir, "config-out")
+	envOut := filepath.Join(dir, "env-out")
+	dbPath := filepath.Join(dir, "state", "test.db")
+	cfg := writeConfig(t, "config-token", 9, cfgOut, dbPath)
+	t.Setenv("MUSIXMATCH_TOKEN", "env-token")
+	t.Setenv("MXLRC_API_COOLDOWN", "7")
+	t.Setenv("MXLRC_OUTPUT_DIR", envOut)
+
+	rec := &runRecord{}
+	code := runStartup(t, []string{"--config", cfg, "Artist,Title"}, rec)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.token != "env-token" {
+		t.Fatalf("token = %q; want env token", rec.token)
+	}
+	if rec.cooldown != 7 {
+		t.Fatalf("cooldown = %d; want env cooldown 7", rec.cooldown)
+	}
+	if len(rec.inputs) != 1 || rec.inputs[0].Outdir != envOut {
+		t.Fatalf("inputs = %+v; want env output dir %q", rec.inputs, envOut)
+	}
+}
+
+func TestRunWithOptions_MissingTokenFailsBeforeAppRun(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state", "test.db")
+	cfg := writeConfig(t, "", 1, filepath.Join(dir, "out"), dbPath)
+
+	rec := &runRecord{}
+	code := runStartup(t, []string{"--config", cfg, "Artist,Title"}, rec)
+	if code == 0 {
+		t.Fatal("run exit code = 0; want failure")
+	}
+	if rec.appCreated {
+		t.Fatal("app was created; want missing token to stop startup before app creation")
+	}
+	if rec.findCalls != 0 {
+		t.Fatalf("FindLyrics calls = %d; want 0", rec.findCalls)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat db path: %v", err)
+	}
+}
+
+func TestRunWithOptions_TextFileInputSetup(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	outdir := filepath.Join(dir, "lyrics")
+	dbPath := filepath.Join(dir, "state", "test.db")
+	cfg := writeConfig(t, "config-token", 1, outdir, dbPath)
+	textFile := filepath.Join(dir, "songs.txt")
+	if err := os.WriteFile(textFile, []byte("Artist A,Title A\nArtist B,Title B\n"), 0o600); err != nil {
+		t.Fatalf("write text input: %v", err)
+	}
+
+	rec := &runRecord{}
+	code := runStartup(t, []string{"--config", cfg, textFile}, rec)
+	if code != 0 {
+		t.Fatalf("run exit code = %d; want 0", code)
+	}
+	if rec.mode != "text" {
+		t.Fatalf("mode = %q; want text", rec.mode)
+	}
+	if len(rec.inputs) != 2 {
+		t.Fatalf("inputs = %d; want 2", len(rec.inputs))
+	}
+	if rec.inputs[0].Track.ArtistName != "Artist A" || rec.inputs[1].Track.TrackName != "Title B" {
+		t.Fatalf("inputs = %+v; want text-file tracks", rec.inputs)
+	}
+	for _, v := range rec.inputs {
+		if v.Outdir != outdir {
+			t.Fatalf("input outdir = %q; want %q", v.Outdir, outdir)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a testable CLI startup helper that preserves production behavior
- cover help, token precedence, temp DB setup, CLI-pair input, and text-file input
- inject fake startup dependencies so tests do not call Musixmatch

## Tests
- go test -count=1 ./cmd/mxlrcsvc-go
- go test -count=1 ./...
- golangci-lint run ./...

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved CLI behavior: clearer help and error exit codes, better precedence between flags/env/config, optional dotenv, delayed initialization until credentials validated, and more flexible runtime construction for varied environments.

* **Tests**
  * Added CLI tests covering help, flag/env/config precedence, missing-token failure before startup, text-file input parsing into multiple tracks, and correct application of output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->