### PR TITLE
test: add CLI smoke script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-cover lint fmt hooks clean help
+.PHONY: build run test test-cover smoke lint fmt hooks clean help
 
 # Binary name
 BINARY=mxlrcsvc-go
@@ -19,6 +19,10 @@ test:
 test-cover:
 	go test -count=1 -v -race -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+## smoke: Run CLI smoke tests
+smoke:
+	./scripts/smoke.sh
 
 ## lint: Run golangci-lint
 lint:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ mxlrcsvc-go "Dream Theater"
 
 > **_The `-d/--depth` argument limit the depth of subdirectory to scan. Use `-d 0` or `--depth 0` to only scan the specified directory._**
 
+## Development
+
+Run the lightweight CLI smoke test:
+
+```
+make smoke
+```
+
 ---
 
 ## How to get the Musixmatch Token

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mxlrcsvc-go "Dream Theater"
 
 Run the lightweight CLI smoke test:
 
-```
+```sh
 make smoke
 ```
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/mxlrcsvc-go-smoke.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BIN="$TMPDIR/mxlrcsvc-go"
+CONFIG_HOME="$TMPDIR/config"
+DATA_HOME="$TMPDIR/data"
+OUTDIR="$TMPDIR/out"
+
+mkdir -p "$CONFIG_HOME" "$DATA_HOME" "$OUTDIR"
+
+CGO_ENABLED=0 go build -o "$BIN" "$ROOT/cmd/mxlrcsvc-go"
+
+help_output="$("$BIN" --help)"
+if [[ "$help_output" != *"Usage: mxlrcsvc-go"* ]]; then
+  echo "smoke: --help output did not include usage" >&2
+  exit 1
+fi
+
+set +e
+missing_token_output="$(
+  cd "$TMPDIR" && env -i \
+      PATH="$PATH" \
+      HOME="$TMPDIR/home" \
+      XDG_CONFIG_HOME="$CONFIG_HOME" \
+      XDG_DATA_HOME="$DATA_HOME" \
+      "$BIN" --outdir "$OUTDIR" "Artist,Title" 2>&1
+)"
+missing_token_status=$?
+set -e
+
+if [[ $missing_token_status -eq 0 ]]; then
+  echo "smoke: missing-token command succeeded; want non-zero exit" >&2
+  exit 1
+fi
+if [[ "$missing_token_output" != *"no API token provided"* ]]; then
+  echo "smoke: missing-token output did not include expected error" >&2
+  echo "$missing_token_output" >&2
+  exit 1
+fi
+if [[ -e "$DATA_HOME/mxlrcsvc-go/mxlrcsvc.db" ]]; then
+  echo "smoke: missing-token command created a database" >&2
+  exit 1
+fi
+
+echo "smoke: ok"


### PR DESCRIPTION
## Summary
- add executable scripts/smoke.sh for network-free CLI validation
- expose the smoke script through make smoke
- document the smoke target in README

## Tests
- make smoke
- go test -count=1 ./...
- golangci-lint run ./...

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI smoke tests accessible via `make smoke` command to validate basic application functionality.

* **Documentation**
  * Updated README with instructions for running smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->