### PR TITLE
feat(m4): add durable work queue

### DIFF
--- a/.planning/quick/260426-m4-issues-18-and-44/260426-m4-PLAN.md
+++ b/.planning/quick/260426-m4-issues-18-and-44/260426-m4-PLAN.md
@@ -1,0 +1,74 @@
+---
+phase: quick
+plan: 260426-m4
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/queue/
+  - internal/db/migrations/
+  - internal/app/
+autonomous: true
+requirements:
+  - issue-18
+  - issue-44
+must_haves:
+  truths:
+    - "Work queue enqueue deduplicates by normalized artist/title"
+    - "Queue dequeue, complete, and fail operations are persisted in SQLite"
+    - "Fail uses geometric backoff and makes work retryable after a scheduled time"
+    - "App fetch-to-write flow is covered with a fake Musixmatch fetcher"
+    - "Tests run under go test ./..."
+---
+
+<objective>
+Implement M4 issues #18 and #44.
+
+Issue #18 adds a DB-backed work queue with atomic enqueue, dequeue, complete, fail, deduplication,
+and geometric backoff. Issue #44 adds fake Musixmatch integration coverage so fetch-to-write app
+behavior is tested without the network or a real token.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: DB-backed work queue</name>
+  <files>internal/queue/, internal/db/migrations/</files>
+  <done>
+    - Enqueue uses normalized artist/title deduplication
+    - Dequeue claims one ready pending item atomically
+    - Complete marks claimed work done
+    - Fail increments attempts and applies geometric retry delay
+    - Focused queue tests pass
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Fake fetcher app integration tests</name>
+  <files>internal/app/*_test.go</files>
+  <done>
+    - Successful synced lyrics are written through the real writer
+    - Fetch failure writes a retry file where practical
+    - No network/token dependency is introduced
+    - Focused app tests pass
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Verify and submit PR</name>
+  <files>all touched files</files>
+  <done>
+    - gofmt applied
+    - go test ./... passes
+    - Branch pushed
+    - PR opened with issue references
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+go test ./...
+```
+</verification>

--- a/.planning/quick/260426-m4-issues-18-and-44/260426-m4-SUMMARY.md
+++ b/.planning/quick/260426-m4-issues-18-and-44/260426-m4-SUMMARY.md
@@ -1,0 +1,19 @@
+# Summary: M4 issues #18 and #44
+
+## Completed
+
+- Added a SQLite-backed work queue with normalized artist/title dedupe, atomic enqueue/dequeue, completion, and geometric retry backoff.
+- Added migration coverage for work queue retry/dedupe columns and indexes.
+- Added app-level fake Musixmatch tests covering successful fetch-to-write and fetch-failure retry-file behavior.
+
+## Verification
+
+```bash
+go test ./...
+go test -count=1 -coverprofile=/tmp/stillwater-cover.out ./...
+go test -race -count=1 -covermode=atomic -coverprofile=/tmp/mxlrc-cover.out ./...
+golangci-lint run
+git diff --check
+```
+
+All checks passed.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/lyrics"
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+)
+
+type fakeFetcher struct {
+	song  models.Song
+	err   error
+	calls []models.Track
+}
+
+func (f *fakeFetcher) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	if err := ctx.Err(); err != nil {
+		return models.Song{}, err
+	}
+	f.calls = append(f.calls, track)
+	if f.err != nil {
+		return models.Song{}, f.err
+	}
+	return f.song, nil
+}
+
+func TestRunFetchesAndWritesSyncedLyrics(t *testing.T) {
+	t.Parallel()
+
+	outdir := t.TempDir()
+	track := models.Track{
+		ArtistName: "Test Artist",
+		TrackName:  "Test Song",
+	}
+	fetcher := &fakeFetcher{
+		song: models.Song{
+			Track: models.Track{
+				ArtistName:  "Test Artist",
+				TrackName:   "Test Song",
+				AlbumName:   "Test Album",
+				TrackLength: 123,
+			},
+			Subtitles: models.Synced{
+				Lines: []models.Lines{
+					{
+						Text: "first line",
+						Time: models.Time{Minutes: 0, Seconds: 1, Hundredths: 23},
+					},
+					{
+						Text: "second line",
+						Time: models.Time{Minutes: 0, Seconds: 2, Hundredths: 34},
+					},
+				},
+			},
+		},
+	}
+	inputs := queue.NewInputsQueue()
+	inputs.Push(models.Inputs{
+		Track:    track,
+		Outdir:   outdir,
+		Filename: "test-song.lrc",
+	})
+
+	a := NewApp(fetcher, lyrics.NewLRCWriter(), inputs, 0, "multi")
+	if err := a.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(fetcher.calls) != 1 {
+		t.Fatalf("FindLyrics() calls = %d, want 1", len(fetcher.calls))
+	}
+	if fetcher.calls[0] != track {
+		t.Fatalf("FindLyrics() track = %#v, want %#v", fetcher.calls[0], track)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outdir, "test-song.lrc"))
+	if err != nil {
+		t.Fatalf("reading LRC output: %v", err)
+	}
+	want := strings.Join([]string{
+		"[by:fashni]",
+		"[ar:Test Artist]",
+		"[ti:Test Song]",
+		"[al:Test Album]",
+		"[length:02:03]",
+		"[00:01.23]first line",
+		"[00:02.34]second line",
+		"",
+	}, "\n")
+	if string(got) != want {
+		t.Fatalf("LRC output = %q, want %q", got, want)
+	}
+}
+
+func TestRunWritesFailedFileOnFetchFailure(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	track := models.Track{
+		ArtistName: "Failure Artist",
+		TrackName:  "Failure Song",
+	}
+	inputs := queue.NewInputsQueue()
+	inputs.Push(models.Inputs{Track: track, Outdir: filepath.Join(tmp, "lyrics")})
+	fetcher := &fakeFetcher{err: errors.New("fake fetch failed")}
+
+	a := NewApp(fetcher, lyrics.NewLRCWriter(), inputs, 0, "multi")
+	if err := a.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(tmp, "*_failed.txt"))
+	if err != nil {
+		t.Fatalf("globbing failed file: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("failed file count = %d, want 1: %v", len(matches), matches)
+	}
+
+	got, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("reading failed file: %v", err)
+	}
+	if string(got) != "Failure Artist,Failure Song\n" {
+		t.Fatalf("failed file content = %q", got)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -11,11 +12,29 @@ import (
 	"path/filepath"
 
 	"github.com/pressly/goose/v3"
-	_ "modernc.org/sqlite" // pure-Go SQLite driver
+	"github.com/sydlexius/mxlrcsvc-go/internal/normalize"
+	"modernc.org/sqlite" // pure-Go SQLite driver
 )
 
 //go:embed migrations/*.sql
 var migrations embed.FS
+
+func init() {
+	sqlite.MustRegisterDeterministicScalarFunction(
+		"normalize_key",
+		1,
+		func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+			if len(args) != 1 || args[0] == nil {
+				return "", nil
+			}
+			s, ok := args[0].(string)
+			if !ok {
+				return "", fmt.Errorf("normalize_key: expected string, got %T", args[0])
+			}
+			return normalize.NormalizeKey(s), nil
+		},
+	)
+}
 
 // Open opens (or creates) the SQLite database at path, applies pragmas,
 // and runs any pending goose migrations. Returns a ready-to-use *sql.DB.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -230,15 +230,15 @@ func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 	})
 
 	columns := []string{"artist_key", "title_key", "filename", "attempts", "next_attempt_at", "last_error", "completed_at"}
-	for _, col := range columns {
+	for _, v := range columns {
 		var count int
 		row := sqlDB.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM pragma_table_info('work_queue') WHERE name = ?", col)
+			"SELECT COUNT(*) FROM pragma_table_info('work_queue') WHERE name = ?", v)
 		if err := row.Scan(&count); err != nil {
-			t.Fatalf("query work_queue column %q: %v", col, err)
+			t.Fatalf("query work_queue column %q: %v", v, err)
 		}
 		if count != 1 {
-			t.Fatalf("work_queue column %q count = %d; want 1", col, count)
+			t.Fatalf("work_queue column %q count = %d; want 1", v, count)
 		}
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/normalize"
 )
 
 // TestOpen_CreatesDatabaseAndAppliesMigrations verifies that Open succeeds,
@@ -260,5 +262,28 @@ func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 	}
 	if dequeueIndexCount != 1 {
 		t.Fatalf("work queue dequeue index count = %d; want 1", dequeueIndexCount)
+	}
+}
+
+func TestOpen_NormalizeKeySQLFunction(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "normalize-key.db")
+
+	sqlDB, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	var got string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT normalize_key(?)`, "  Beyoncé  ").Scan(&got); err != nil {
+		t.Fatalf("query normalize_key: %v", err)
+	}
+	if want := normalize.NormalizeKey("  Beyoncé  "); got != want {
+		t.Fatalf("normalize_key SQL result = %q; want %q", got, want)
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -214,3 +214,51 @@ func TestOpen_ScanResultsUniqueIndex(t *testing.T) {
 		t.Fatalf("scan result index columns = %v; want [library_id file_path]", cols)
 	}
 }
+
+func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "work-queue.db")
+
+	sqlDB, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	columns := []string{"artist_key", "title_key", "filename", "attempts", "next_attempt_at", "last_error", "completed_at"}
+	for _, col := range columns {
+		var count int
+		row := sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM pragma_table_info('work_queue') WHERE name = ?", col)
+		if err := row.Scan(&count); err != nil {
+			t.Fatalf("query work_queue column %q: %v", col, err)
+		}
+		if count != 1 {
+			t.Fatalf("work_queue column %q count = %d; want 1", col, count)
+		}
+	}
+
+	var unique int
+	row := sqlDB.QueryRowContext(ctx,
+		"SELECT [unique] FROM pragma_index_list('work_queue') WHERE name = 'idx_work_queue_artist_title_key'")
+	if err := row.Scan(&unique); err != nil {
+		t.Fatalf("query work queue dedupe index: %v", err)
+	}
+	if unique != 1 {
+		t.Fatalf("work queue dedupe index unique = %d; want 1", unique)
+	}
+
+	var dequeueIndexCount int
+	row = sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_work_queue_dequeue'")
+	if err := row.Scan(&dequeueIndexCount); err != nil {
+		t.Fatalf("query work queue dequeue index: %v", err)
+	}
+	if dequeueIndexCount != 1 {
+		t.Fatalf("work queue dequeue index count = %d; want 1", dequeueIndexCount)
+	}
+}

--- a/internal/db/migrations/004_work_queue_backoff.sql
+++ b/internal/db/migrations/004_work_queue_backoff.sql
@@ -20,10 +20,20 @@ SET artist_key = lower(trim(artist)),
 WHERE artist_key = '' OR title_key = '' OR next_attempt_at = '';
 
 DELETE FROM work_queue
-WHERE id NOT IN (
-    SELECT MIN(id)
-    FROM work_queue
-    GROUP BY artist_key, title_key
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT
+            id,
+            ROW_NUMBER() OVER (
+                PARTITION BY artist_key, title_key
+                ORDER BY
+                    CASE WHEN status IN ('pending', 'processing') THEN 0 ELSE 1 END,
+                    id ASC
+            ) AS rn
+        FROM work_queue
+    )
+    WHERE rn > 1
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_work_queue_artist_title_key

--- a/internal/db/migrations/004_work_queue_backoff.sql
+++ b/internal/db/migrations/004_work_queue_backoff.sql
@@ -11,8 +11,8 @@ ALTER TABLE work_queue ADD COLUMN last_error TEXT NOT NULL DEFAULT '';
 ALTER TABLE work_queue ADD COLUMN completed_at DATETIME;
 
 UPDATE work_queue
-SET artist_key = lower(trim(artist)),
-    title_key = lower(trim(title)),
+SET artist_key = normalize_key(artist),
+    title_key = normalize_key(title),
     next_attempt_at = CASE
         WHEN next_attempt_at = '' THEN strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
         ELSE next_attempt_at

--- a/internal/db/migrations/004_work_queue_backoff.sql
+++ b/internal/db/migrations/004_work_queue_backoff.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_work_queue_pending;
+
+ALTER TABLE work_queue ADD COLUMN artist_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE work_queue ADD COLUMN title_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE work_queue ADD COLUMN filename TEXT NOT NULL DEFAULT '';
+ALTER TABLE work_queue ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE work_queue ADD COLUMN next_attempt_at DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z';
+ALTER TABLE work_queue ADD COLUMN last_error TEXT NOT NULL DEFAULT '';
+ALTER TABLE work_queue ADD COLUMN completed_at DATETIME;
+
+UPDATE work_queue
+SET artist_key = lower(trim(artist)),
+    title_key = lower(trim(title)),
+    next_attempt_at = CASE
+        WHEN next_attempt_at = '' THEN strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        ELSE next_attempt_at
+    END
+WHERE artist_key = '' OR title_key = '' OR next_attempt_at = '';
+
+DELETE FROM work_queue
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM work_queue
+    GROUP BY artist_key, title_key
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_work_queue_artist_title_key
+    ON work_queue(artist_key, title_key);
+
+CREATE INDEX IF NOT EXISTS idx_work_queue_dequeue
+    ON work_queue(status, next_attempt_at, priority, created_at, id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_work_queue_dequeue;
+DROP INDEX IF EXISTS idx_work_queue_artist_title_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_work_queue_pending
+    ON work_queue(artist, title) WHERE status = 'pending';
+-- +goose StatementEnd

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/sydlexius/mxlrcsvc-go/internal/models"
@@ -115,10 +114,22 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
          )
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(artist_key, title_key) DO UPDATE SET
-             artist = excluded.artist,
-             title = excluded.title,
-             outdir = excluded.outdir,
-             filename = excluded.filename,
+             artist = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.artist
+                 ELSE excluded.artist
+             END,
+             title = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.title
+                 ELSE excluded.title
+             END,
+             outdir = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.outdir
+                 ELSE excluded.outdir
+             END,
+             filename = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.filename
+                 ELSE excluded.filename
+             END,
              priority = max(work_queue.priority, excluded.priority),
              status = CASE
                  WHEN work_queue.status IN ('done', 'processing') THEN work_queue.status
@@ -191,7 +202,8 @@ func (q *DBQueue) Complete(ctx context.Context, id int64) error {
          SET status = 'done',
              completed_at = ?,
              last_error = ''
-         WHERE id = ?`,
+         WHERE id = ?
+           AND status = 'processing'`,
 		now,
 		id,
 	)
@@ -210,7 +222,10 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 	defer func() { _ = tx.Rollback() }()
 
 	var attempts int
-	if err := tx.QueryRowContext(ctx, `SELECT attempts FROM work_queue WHERE id = ?`, id).Scan(&attempts); err != nil {
+	if err := tx.QueryRowContext(ctx,
+		`SELECT attempts FROM work_queue WHERE id = ? AND status = 'processing'`,
+		id,
+	).Scan(&attempts); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return WorkItem{}, sql.ErrNoRows
 		}
@@ -230,6 +245,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
              next_attempt_at = ?,
              last_error = ?
          WHERE id = ?
+           AND status = 'processing'
          RETURNING id, artist, title, outdir, filename, status, priority, attempts,
                    next_attempt_at, last_error, created_at, updated_at, completed_at`,
 		nextAttempts,
@@ -251,8 +267,16 @@ func (q *DBQueue) backoff(attempts int) time.Duration {
 	if attempts < 1 {
 		attempts = 1
 	}
-	mult := math.Pow(2, float64(attempts-1))
-	delay := time.Duration(float64(q.baseBackoff) * mult)
+	if q.baseBackoff <= 0 || q.maxBackoff <= 0 {
+		return 0
+	}
+	delay := q.baseBackoff
+	for i := 1; i < attempts; i++ {
+		if delay >= q.maxBackoff || delay > q.maxBackoff/2 {
+			return q.maxBackoff
+		}
+		delay *= 2
+	}
 	if delay > q.maxBackoff {
 		return q.maxBackoff
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,9 +1,32 @@
 package queue
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"math"
+	"time"
 
 	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/normalize"
+)
+
+const (
+	// StatusPending marks queued work ready to be processed.
+	StatusPending = "pending"
+	// StatusProcessing marks queued work currently being processed.
+	StatusProcessing = "processing"
+	// StatusDone marks queued work completed successfully.
+	StatusDone = "done"
+	// StatusFailed marks queued work that failed and may be retried after backoff.
+	StatusFailed = "failed"
+)
+
+const (
+	defaultBaseBackoff = time.Minute
+	defaultMaxBackoff  = time.Hour
+	timeFormat         = time.RFC3339
 )
 
 // InputsQueue is a FIFO queue for processing work items.
@@ -48,4 +71,261 @@ func (q *InputsQueue) Len() int {
 // Empty returns true if the queue has no items.
 func (q *InputsQueue) Empty() bool {
 	return len(q.Queue) == 0
+}
+
+// WorkItem represents a persisted queue row.
+type WorkItem struct {
+	ID            int64
+	Inputs        models.Inputs
+	Status        string
+	Priority      int
+	Attempts      int
+	NextAttemptAt time.Time
+	LastError     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	CompletedAt   *time.Time
+}
+
+// DBQueue is a SQLite-backed queue for durable lyrics work.
+type DBQueue struct {
+	db          *sql.DB
+	baseBackoff time.Duration
+	maxBackoff  time.Duration
+	now         func() time.Time
+}
+
+// NewDBQueue returns a durable queue backed by db.
+func NewDBQueue(db *sql.DB) *DBQueue {
+	return &DBQueue{
+		db:          db,
+		baseBackoff: defaultBaseBackoff,
+		maxBackoff:  defaultMaxBackoff,
+		now:         time.Now,
+	}
+}
+
+// Enqueue atomically inserts a new work item or refreshes an existing retryable
+// item with the same normalized artist/title key.
+func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority int) (WorkItem, error) {
+	now := formatTime(q.now())
+	row := q.db.QueryRowContext(ctx,
+		`INSERT INTO work_queue (
+             artist, title, artist_key, title_key, outdir, filename, status, priority, next_attempt_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(artist_key, title_key) DO UPDATE SET
+             artist = excluded.artist,
+             title = excluded.title,
+             outdir = excluded.outdir,
+             filename = excluded.filename,
+             priority = max(work_queue.priority, excluded.priority),
+             status = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.status
+                 ELSE 'pending'
+             END,
+             next_attempt_at = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.next_attempt_at
+                 ELSE excluded.next_attempt_at
+             END,
+             last_error = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.last_error
+                 ELSE ''
+             END,
+             completed_at = CASE
+                 WHEN work_queue.status = 'done' THEN work_queue.completed_at
+                 ELSE NULL
+             END
+         RETURNING id, artist, title, outdir, filename, status, priority, attempts,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+		inputs.Track.ArtistName,
+		inputs.Track.TrackName,
+		normalize.NormalizeKey(inputs.Track.ArtistName),
+		normalize.NormalizeKey(inputs.Track.TrackName),
+		inputs.Outdir,
+		inputs.Filename,
+		StatusPending,
+		priority,
+		now,
+	)
+	item, err := scanWorkItem(row)
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: enqueue: %w", err)
+	}
+	return item, nil
+}
+
+// Dequeue atomically claims the next ready item and marks it processing.
+func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
+	now := formatTime(q.now())
+	row := q.db.QueryRowContext(ctx,
+		`UPDATE work_queue
+         SET status = 'processing'
+         WHERE id = (
+             SELECT id
+             FROM work_queue
+             WHERE status IN ('pending', 'failed')
+               AND next_attempt_at <= ?
+             ORDER BY priority DESC, created_at ASC, id ASC
+             LIMIT 1
+         )
+         RETURNING id, artist, title, outdir, filename, status, priority, attempts,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+		now,
+	)
+	item, err := scanWorkItem(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkItem{}, sql.ErrNoRows
+	}
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: dequeue: %w", err)
+	}
+	return item, nil
+}
+
+// Complete marks a processing item done.
+func (q *DBQueue) Complete(ctx context.Context, id int64) error {
+	now := formatTime(q.now())
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET status = 'done',
+             completed_at = ?,
+             last_error = ''
+         WHERE id = ?`,
+		now,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: complete: %w", err)
+	}
+	return requireAffected(res, "queue: complete")
+}
+
+// Fail records a failed attempt and schedules the item after geometric backoff.
+func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, error) {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: begin fail tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var attempts int
+	if err := tx.QueryRowContext(ctx, `SELECT attempts FROM work_queue WHERE id = ?`, id).Scan(&attempts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return WorkItem{}, sql.ErrNoRows
+		}
+		return WorkItem{}, fmt.Errorf("queue: load attempts: %w", err)
+	}
+
+	nextAttempts := attempts + 1
+	nextAttemptAt := formatTime(q.now().Add(q.backoff(nextAttempts)))
+	lastError := ""
+	if cause != nil {
+		lastError = cause.Error()
+	}
+	row := tx.QueryRowContext(ctx,
+		`UPDATE work_queue
+         SET status = 'failed',
+             attempts = ?,
+             next_attempt_at = ?,
+             last_error = ?
+         WHERE id = ?
+         RETURNING id, artist, title, outdir, filename, status, priority, attempts,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+		nextAttempts,
+		nextAttemptAt,
+		lastError,
+		id,
+	)
+	item, err := scanWorkItem(row)
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: fail: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: commit fail tx: %w", err)
+	}
+	return item, nil
+}
+
+func (q *DBQueue) backoff(attempts int) time.Duration {
+	if attempts < 1 {
+		attempts = 1
+	}
+	mult := math.Pow(2, float64(attempts-1))
+	delay := time.Duration(float64(q.baseBackoff) * mult)
+	if delay > q.maxBackoff {
+		return q.maxBackoff
+	}
+	return delay
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanWorkItem(row rowScanner) (WorkItem, error) {
+	var item WorkItem
+	var nextAttemptAt, createdAt, updatedAt string
+	var completedAt sql.NullString
+	err := row.Scan(
+		&item.ID,
+		&item.Inputs.Track.ArtistName,
+		&item.Inputs.Track.TrackName,
+		&item.Inputs.Outdir,
+		&item.Inputs.Filename,
+		&item.Status,
+		&item.Priority,
+		&item.Attempts,
+		&nextAttemptAt,
+		&item.LastError,
+		&createdAt,
+		&updatedAt,
+		&completedAt,
+	)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	item.NextAttemptAt, err = parseTime(nextAttemptAt)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	item.CreatedAt, err = parseTime(createdAt)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	item.UpdatedAt, err = parseTime(updatedAt)
+	if err != nil {
+		return WorkItem{}, err
+	}
+	if completedAt.Valid {
+		t, err := parseTime(completedAt.String)
+		if err != nil {
+			return WorkItem{}, err
+		}
+		item.CompletedAt = &t
+	}
+	return item, nil
+}
+
+func parseTime(s string) (time.Time, error) {
+	t, err := time.Parse(timeFormat, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse time %q: %w", s, err)
+	}
+	return t, nil
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(timeFormat)
+}
+
+func requireAffected(res sql.Result, op string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s rows affected: %w", op, err)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -149,7 +149,9 @@ func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	q.now = func() time.Time { return now }
 
 	if _, err := q.Enqueue(ctx, models.Inputs{
-		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "claimed-out",
+		Filename: "claimed.lrc",
 	}, 1); err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
@@ -159,7 +161,9 @@ func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	}
 
 	dup, err := q.Enqueue(ctx, models.Inputs{
-		Track: models.Track{ArtistName: " artist ", TrackName: "title"},
+		Track:    models.Track{ArtistName: " artist ", TrackName: "title"},
+		Outdir:   "duplicate-out",
+		Filename: "duplicate.lrc",
 	}, 10)
 	if err != nil {
 		t.Fatalf("Enqueue duplicate: %v", err)
@@ -170,8 +174,36 @@ func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	if dup.Status != StatusProcessing {
 		t.Fatalf("duplicate status = %q; want %q", dup.Status, StatusProcessing)
 	}
+	if dup.Inputs.Outdir != "claimed-out" || dup.Inputs.Filename != "claimed.lrc" {
+		t.Fatalf("duplicate payload = %q/%q; want claimed-out/claimed.lrc", dup.Inputs.Outdir, dup.Inputs.Filename)
+	}
 	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("Dequeue after processing duplicate error = %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestDBQueue_CompleteRequiresProcessingStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Complete pending error = %v; want sql.ErrNoRows", err)
+	}
+
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete processing: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Complete done error = %v; want sql.ErrNoRows", err)
 	}
 }
 
@@ -181,9 +213,12 @@ func TestDBQueue_DequeueSkipsBackoffUntilReady(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	q.now = func() time.Time { return now }
 
-	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
-	if err != nil {
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1); err != nil {
 		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
 	}
 	if _, err := q.Fail(ctx, item.ID, errors.New("temporary failure")); err != nil {
 		t.Fatalf("Fail: %v", err)
@@ -210,9 +245,12 @@ func TestDBQueue_FailUsesGeometricBackoff(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	q.now = func() time.Time { return now }
 
-	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
-	if err != nil {
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1); err != nil {
 		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue first: %v", err)
 	}
 	failed, err := q.Fail(ctx, item.ID, errors.New("first"))
 	if err != nil {
@@ -223,6 +261,9 @@ func TestDBQueue_FailUsesGeometricBackoff(t *testing.T) {
 	}
 
 	q.now = func() time.Time { return now.Add(time.Second) }
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue second: %v", err)
+	}
 	failed, err = q.Fail(ctx, item.ID, errors.New("second"))
 	if err != nil {
 		t.Fatalf("Fail second: %v", err)
@@ -230,6 +271,31 @@ func TestDBQueue_FailUsesGeometricBackoff(t *testing.T) {
 	wantNext := now.Add(3 * time.Second)
 	if failed.Attempts != 2 || !failed.NextAttemptAt.Equal(wantNext) {
 		t.Fatalf("second failure attempts/next = %d/%s; want 2/%s", failed.Attempts, failed.NextAttemptAt, wantNext)
+	}
+}
+
+func TestDBQueue_FailRequiresProcessingStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Fail(ctx, item.ID, errors.New("not claimed")); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Fail pending error = %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestDBQueue_BackoffCapsLargeAttemptCounts(t *testing.T) {
+	q := NewDBQueue(nil)
+	q.baseBackoff = time.Minute
+	q.maxBackoff = time.Hour
+
+	if got := q.backoff(10_000); got != time.Hour {
+		t.Fatalf("backoff(10000) = %s; want %s", got, time.Hour)
 	}
 }
 
@@ -242,6 +308,9 @@ func TestDBQueue_CompleteMarksDone(t *testing.T) {
 	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
 	if err != nil {
 		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
 	}
 	if err := q.Complete(ctx, item.ID); err != nil {
 		t.Fatalf("Complete: %v", err)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,8 +1,14 @@
 package queue
 
 import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/sydlexius/mxlrcsvc-go/internal/db"
 	"github.com/sydlexius/mxlrcsvc-go/internal/models"
 )
 
@@ -61,5 +67,198 @@ func TestPop_NonEmptyQueue(t *testing.T) {
 	// Queue should be shortened by 1
 	if q.Len() != 0 {
 		t.Fatalf("queue length should be 0 after Pop(), got %d", q.Len())
+	}
+}
+
+func openQueueTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func TestDBQueue_EnqueueDedupesNormalizedArtistTitle(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	first, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "  Héllo  ", TrackName: " Wörld "},
+		Outdir:   "out-a",
+		Filename: "a.lrc",
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue first: %v", err)
+	}
+	second, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "hello", TrackName: "world"},
+		Outdir:   "out-b",
+		Filename: "b.lrc",
+	}, 5)
+	if err != nil {
+		t.Fatalf("Enqueue duplicate: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("duplicate enqueue ID = %d; want %d", second.ID, first.ID)
+	}
+	if second.Priority != 5 {
+		t.Fatalf("duplicate enqueue priority = %d; want 5", second.Priority)
+	}
+
+	var count int
+	if err := q.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM work_queue`).Scan(&count); err != nil {
+		t.Fatalf("count work_queue: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("work_queue rows = %d; want 1", count)
+	}
+}
+
+func TestDBQueue_DequeueClaimsHighestPriorityReadyItem(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Low", TrackName: "Ready"}}, 1); err != nil {
+		t.Fatalf("Enqueue low: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "High", TrackName: "Ready"}}, 10); err != nil {
+		t.Fatalf("Enqueue high: %v", err)
+	}
+
+	got, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if got.Inputs.Track.ArtistName != "High" {
+		t.Fatalf("dequeued artist = %q; want High", got.Inputs.Track.ArtistName)
+	}
+	if got.Status != StatusProcessing {
+		t.Fatalf("dequeued status = %q; want %q", got.Status, StatusProcessing)
+	}
+}
+
+func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	dup, err := q.Enqueue(ctx, models.Inputs{
+		Track: models.Track{ArtistName: " artist ", TrackName: "title"},
+	}, 10)
+	if err != nil {
+		t.Fatalf("Enqueue duplicate: %v", err)
+	}
+	if dup.ID != claimed.ID {
+		t.Fatalf("duplicate ID = %d; want %d", dup.ID, claimed.ID)
+	}
+	if dup.Status != StatusProcessing {
+		t.Fatalf("duplicate status = %q; want %q", dup.Status, StatusProcessing)
+	}
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue after processing duplicate error = %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestDBQueue_DequeueSkipsBackoffUntilReady(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Fail(ctx, item.ID, errors.New("temporary failure")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue during backoff error = %v; want sql.ErrNoRows", err)
+	}
+
+	q.now = func() time.Time { return now.Add(time.Minute) }
+	got, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after backoff: %v", err)
+	}
+	if got.ID != item.ID {
+		t.Fatalf("dequeued ID = %d; want %d", got.ID, item.ID)
+	}
+}
+
+func TestDBQueue_FailUsesGeometricBackoff(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.baseBackoff = time.Second
+	q.maxBackoff = time.Hour
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	failed, err := q.Fail(ctx, item.ID, errors.New("first"))
+	if err != nil {
+		t.Fatalf("Fail first: %v", err)
+	}
+	if failed.Attempts != 1 || !failed.NextAttemptAt.Equal(now.Add(time.Second)) {
+		t.Fatalf("first failure attempts/next = %d/%s; want 1/%s", failed.Attempts, failed.NextAttemptAt, now.Add(time.Second))
+	}
+
+	q.now = func() time.Time { return now.Add(time.Second) }
+	failed, err = q.Fail(ctx, item.ID, errors.New("second"))
+	if err != nil {
+		t.Fatalf("Fail second: %v", err)
+	}
+	wantNext := now.Add(3 * time.Second)
+	if failed.Attempts != 2 || !failed.NextAttemptAt.Equal(wantNext) {
+		t.Fatalf("second failure attempts/next = %d/%s; want 2/%s", failed.Attempts, failed.NextAttemptAt, wantNext)
+	}
+}
+
+func TestDBQueue_CompleteMarksDone(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var status string
+	var completedAt string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, completed_at FROM work_queue WHERE id = ?`,
+		item.ID,
+	).Scan(&status, &completedAt); err != nil {
+		t.Fatalf("query completed row: %v", err)
+	}
+	if status != StatusDone {
+		t.Fatalf("status = %q; want %q", status, StatusDone)
+	}
+	if completedAt != formatTime(now) {
+		t.Fatalf("completed_at = %q; want %q", completedAt, formatTime(now))
 	}
 }


### PR DESCRIPTION
## Summary
- add SQLite-backed work queue with normalized artist/title dedupe, atomic enqueue/dequeue, completion, and geometric retry backoff
- add work_queue migration coverage for dedupe and dequeue indexes
- add fake Musixmatch app integration tests for synced fetch-to-write and failed retry-file behavior

## Tests
- go test ./...
- go test -count=1 -coverprofile=/tmp/stillwater-cover.out ./...
- go test -race -count=1 -covermode=atomic -coverprofile=/tmp/mxlrc-cover.out ./...
- golangci-lint run
- git diff --check

Closes #18
Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable DB-backed work queue with atomic enqueue/dequeue/complete, deduplication by normalized artist/title, and geometric retry backoff.

* **Migrations**
  * Schema/index updates to support normalized keys, retry scheduling, and dequeue performance.

* **Tests**
  * App-level integration tests for fetch-to-write success and failure paths.
  * Extensive persistence and backoff tests validating enqueue/dequeue/complete/fail semantics.

* **Documentation**
  * Added planning and summary docs detailing implementation and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->