### PR TITLE
feat: add queue consumer worker

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -95,6 +95,7 @@ None yet.
 |---|-------------|------|--------|-----------|
 | 260411-l30 | issues #11 and #12 (Milestone 1) | 2026-04-11 | 2448d8f | [260411-l30-issues-11-and-12-milestone-1](./quick/260411-l30-issues-11-and-12-milestone-1/) |
 | 260411-p8r | Replace wantEq sentinel with *float64 pointer (issue #36) | 2026-04-12 | 8515549 | [260411-p8r-work-on-issue-36](./quick/260411-p8r-work-on-issue-36/) |
+| 260426-q19 | Queue consumer worker (issue #19) | 2026-04-26 | pending | [260426-q19-queue-consumer-worker](./quick/260426-q19-queue-consumer-worker/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260426-q19-queue-consumer-worker/260426-q19-PLAN.md
+++ b/.planning/quick/260426-q19-queue-consumer-worker/260426-q19-PLAN.md
@@ -1,0 +1,70 @@
+---
+phase: quick
+plan: 260426-q19
+type: execute
+wave: 1
+depends_on:
+  - 260426-m4
+files_modified:
+  - internal/worker/
+  - internal/models/
+  - internal/queue/
+autonomous: true
+requirements:
+  - issue-19
+must_haves:
+  truths:
+    - "A single worker dequeues one ready DB work item at a time"
+    - "Worker checks the lyrics cache before calling Musixmatch"
+    - "Fetched lyrics are stored in cache and written to every output path for the work item"
+    - "Successful work is completed; failed work is marked failed for queue backoff"
+    - "Focused worker tests and go test ./... pass"
+---
+
+<objective>
+Implement issue #19: M5.1 queue consumer worker.
+
+The worker consumes the existing SQLite-backed work queue, checks the cache before network fetches,
+computes a confidence signal for fetched results, writes lyrics to all output paths attached to the
+work item, and records queue success or retryable failure through Complete/Fail.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Model output paths</name>
+  <files>internal/models/, internal/queue/</files>
+  <done>
+    - Work items can represent one or more output paths
+    - Existing single outdir/filename behavior remains compatible
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Worker implementation</name>
+  <files>internal/worker/</files>
+  <done>
+    - Dequeue loop is single-threaded and context-aware
+    - Cache hit avoids fetcher call
+    - Cache miss fetches, computes confidence, stores cache, and writes all outputs
+    - Errors call queue Fail so backoff is preserved
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Verification</name>
+  <files>all touched files</files>
+  <done>
+    - Focused tests cover cache hit, fetch success, and failure backoff
+    - gofmt applied
+    - go test ./... passes
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+go test ./...
+```
+</verification>

--- a/.planning/quick/260426-q19-queue-consumer-worker/260426-q19-SUMMARY.md
+++ b/.planning/quick/260426-q19-queue-consumer-worker/260426-q19-SUMMARY.md
@@ -1,0 +1,18 @@
+# Summary: Issue #19 Queue Consumer Worker
+
+## Completed
+
+- Added `internal/worker` with a single-threaded queue consumer that dequeues ready DB work, checks cache first, fetches misses, computes a confidence score, writes every output path, and completes or fails the item.
+- Added `models.OutputPath` and plural `Inputs.OutputPaths` while preserving existing `Outdir` and `Filename` compatibility.
+- Added SQLite migration `005_work_queue_output_paths.sql` and queue JSON persistence for plural output paths.
+- Added focused tests for cache hits, fetch/cache/write success, queue failure marking, confidence scoring, and queue output path round-tripping.
+
+## Verification
+
+```bash
+go test ./...
+golangci-lint run
+git diff --check
+```
+
+All checks passed.

--- a/internal/db/migrations/005_work_queue_output_paths.sql
+++ b/internal/db/migrations/005_work_queue_output_paths.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE work_queue ADD COLUMN output_paths TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN output_paths;
+-- +goose StatementEnd

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -44,9 +44,16 @@ type Song struct {
 
 // Inputs represents a single work item in the processing queue.
 type Inputs struct {
-	Track    Track
-	Outdir   string
-	Filename string
+	Track       Track
+	Outdir      string
+	Filename    string
+	OutputPaths []OutputPath
+}
+
+// OutputPath represents one lyrics output destination.
+type OutputPath struct {
+	Outdir   string `json:"outdir,omitempty"`
+	Filename string `json:"filename,omitempty"`
 }
 
 // Library represents a configured music library root.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -108,11 +109,15 @@ func NewDBQueue(db *sql.DB) *DBQueue {
 // item with the same normalized artist/title key.
 func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority int) (WorkItem, error) {
 	now := formatTime(q.now())
+	outputPaths, err := marshalOutputPaths(inputs)
+	if err != nil {
+		return WorkItem{}, err
+	}
 	row := q.db.QueryRowContext(ctx,
 		`INSERT INTO work_queue (
-             artist, title, artist_key, title_key, outdir, filename, status, priority, next_attempt_at
+             artist, title, artist_key, title_key, outdir, filename, output_paths, status, priority, next_attempt_at
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(artist_key, title_key) DO UPDATE SET
              artist = CASE
                  WHEN work_queue.status IN ('done', 'processing') THEN work_queue.artist
@@ -129,6 +134,10 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
              filename = CASE
                  WHEN work_queue.status IN ('done', 'processing') THEN work_queue.filename
                  ELSE excluded.filename
+             END,
+             output_paths = CASE
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.output_paths
+                 ELSE excluded.output_paths
              END,
              priority = max(work_queue.priority, excluded.priority),
              status = CASE
@@ -148,13 +157,14 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE NULL
              END
          RETURNING id, artist, title, outdir, filename, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths`,
 		inputs.Track.ArtistName,
 		inputs.Track.TrackName,
 		normalize.NormalizeKey(inputs.Track.ArtistName),
 		normalize.NormalizeKey(inputs.Track.TrackName),
 		inputs.Outdir,
 		inputs.Filename,
+		outputPaths,
 		StatusPending,
 		priority,
 		now,
@@ -181,7 +191,7 @@ func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
              LIMIT 1
          )
          RETURNING id, artist, title, outdir, filename, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths`,
 		now,
 	)
 	item, err := scanWorkItem(row)
@@ -247,7 +257,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, outdir, filename, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at`,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths`,
 		nextAttempts,
 		nextAttemptAt,
 		lastError,
@@ -289,7 +299,7 @@ type rowScanner interface {
 
 func scanWorkItem(row rowScanner) (WorkItem, error) {
 	var item WorkItem
-	var nextAttemptAt, createdAt, updatedAt string
+	var nextAttemptAt, createdAt, updatedAt, outputPaths string
 	var completedAt sql.NullString
 	err := row.Scan(
 		&item.ID,
@@ -305,6 +315,7 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 		&createdAt,
 		&updatedAt,
 		&completedAt,
+		&outputPaths,
 	)
 	if err != nil {
 		return WorkItem{}, err
@@ -328,7 +339,43 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 		}
 		item.CompletedAt = &t
 	}
+	item.Inputs.OutputPaths, err = unmarshalOutputPaths(outputPaths, item.Inputs.Outdir, item.Inputs.Filename)
+	if err != nil {
+		return WorkItem{}, err
+	}
 	return item, nil
+}
+
+func marshalOutputPaths(inputs models.Inputs) (string, error) {
+	paths := inputs.OutputPaths
+	if len(paths) == 0 {
+		paths = []models.OutputPath{{
+			Outdir:   inputs.Outdir,
+			Filename: inputs.Filename,
+		}}
+	}
+	b, err := json.Marshal(paths)
+	if err != nil {
+		return "", fmt.Errorf("queue: marshal output paths: %w", err)
+	}
+	return string(b), nil
+}
+
+func unmarshalOutputPaths(s string, outdir string, filename string) ([]models.OutputPath, error) {
+	if s == "" {
+		return []models.OutputPath{{
+			Outdir:   outdir,
+			Filename: filename,
+		}}, nil
+	}
+	var paths []models.OutputPath
+	if err := json.Unmarshal([]byte(s), &paths); err != nil {
+		return nil, fmt.Errorf("queue: unmarshal output paths: %w", err)
+	}
+	if len(paths) == 0 {
+		paths = append(paths, models.OutputPath{Outdir: outdir, Filename: filename})
+	}
+	return paths, nil
 }
 
 func parseTime(s string) (time.Time, error) {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -182,6 +182,38 @@ func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	}
 }
 
+func TestDBQueue_EnqueuePersistsOutputPaths(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+		OutputPaths: []models.OutputPath{
+			{Outdir: "out-a", Filename: "a.lrc"},
+			{Outdir: "out-b", Filename: "b.lrc"},
+		},
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(item.Inputs.OutputPaths) != 2 {
+		t.Fatalf("enqueued output paths = %+v; want 2 paths", item.Inputs.OutputPaths)
+	}
+
+	got, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if len(got.Inputs.OutputPaths) != 2 {
+		t.Fatalf("dequeued output paths = %+v; want 2 paths", got.Inputs.OutputPaths)
+	}
+	if got.Inputs.OutputPaths[0].Outdir != "out-a" || got.Inputs.OutputPaths[1].Filename != "b.lrc" {
+		t.Fatalf("dequeued output paths = %+v; want persisted paths", got.Inputs.OutputPaths)
+	}
+}
+
 func TestDBQueue_CompleteRequiresProcessingStatus(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -91,10 +91,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	ctxNoCancel := context.WithoutCancel(ctx)
 	if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
 		cause := fmt.Errorf("worker: complete item %d: %w", item.ID, err)
-		if _, failErr := w.queue.Fail(ctxNoCancel, item.ID, cause); failErr != nil {
-			return fmt.Errorf("worker: complete item %d and mark failed: %w", item.ID, errors.Join(err, failErr))
+		if _, err := w.queue.Fail(ctxNoCancel, item.ID, cause); err != nil {
+			return fmt.Errorf("worker: complete item %d and mark failed: %w", item.ID, errors.Join(cause, err))
 		}
-		return fmt.Errorf("worker: complete item %d (marked failed): %w", item.ID, err)
+		return fmt.Errorf("worker: complete item %d (marked failed): %w", item.ID, cause)
 	}
 	return nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -51,10 +51,10 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 func (w *Worker) Run(ctx context.Context) error {
 	for {
 		if err := w.RunOnce(ctx); err != nil {
-			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, context.Canceled) {
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil
 			}
-			if errors.Is(err, context.DeadlineExceeded) {
+			if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 				return nil
 			}
 			return err
@@ -87,7 +87,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		}
 	}
 
-	if err := w.queue.Complete(ctx, item.ID); err != nil {
+	if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
 		return fmt.Errorf("worker: complete item %d: %w", item.ID, err)
 	}
 	return nil

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -37,6 +37,8 @@ type Worker struct {
 	writer  lyrics.Writer
 }
 
+var errQueueEmpty = errors.New("worker queue empty")
+
 // New creates a queue consumer worker.
 func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
 	return &Worker{
@@ -51,7 +53,7 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 func (w *Worker) Run(ctx context.Context) error {
 	for {
 		if err := w.RunOnce(ctx); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, errQueueEmpty) {
 				return nil
 			}
 			if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
@@ -69,6 +71,9 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	}
 	item, err := w.queue.Dequeue(ctx)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errQueueEmpty
+		}
 		return fmt.Errorf("worker: dequeue: %w", err)
 	}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -74,6 +74,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
 	if err != nil {
+		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
 		return w.fail(ctx, item.ID, err)
 	}
 	confidence := Confidence(item.Inputs.Track, song.Track)
@@ -81,6 +82,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	for _, p := range outputPaths(item.Inputs) {
 		if err := w.writer.WriteLRC(song, p.Filename, p.Outdir); err != nil {
+			slog.Warn("worker write failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "outdir", p.Outdir, "filename", p.Filename, "error", err)
 			return w.fail(ctx, item.ID, err)
 		}
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -69,7 +69,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	}
 	item, err := w.queue.Dequeue(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("worker: dequeue: %w", err)
 	}
 
 	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
@@ -82,13 +82,19 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	for _, p := range outputPaths(item.Inputs) {
 		if err := w.writer.WriteLRC(song, p.Filename, p.Outdir); err != nil {
+			err = fmt.Errorf("worker: write item %d output %s/%s: %w", item.ID, p.Outdir, p.Filename, err)
 			slog.Warn("worker write failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "outdir", p.Outdir, "filename", p.Filename, "error", err)
 			return w.fail(ctx, item.ID, err)
 		}
 	}
 
-	if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
-		return fmt.Errorf("worker: complete item %d: %w", item.ID, err)
+	ctxNoCancel := context.WithoutCancel(ctx)
+	if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
+		cause := fmt.Errorf("worker: complete item %d: %w", item.ID, err)
+		if _, failErr := w.queue.Fail(ctxNoCancel, item.ID, cause); failErr != nil {
+			return fmt.Errorf("worker: complete item %d and mark failed: %w", item.ID, errors.Join(err, failErr))
+		}
+		return fmt.Errorf("worker: complete item %d (marked failed): %w", item.ID, err)
 	}
 	return nil
 }
@@ -99,7 +105,7 @@ func (w *Worker) song(ctx context.Context, track models.Track) (models.Song, boo
 		return decodeSong(cached, track), true, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return models.Song{}, false, err
+		return models.Song{}, false, fmt.Errorf("worker: lookup exact cache: %w", err)
 	}
 
 	cached, err = w.cache.LookupFallback(ctx, track.ArtistName, track.TrackName)
@@ -107,19 +113,19 @@ func (w *Worker) song(ctx context.Context, track models.Track) (models.Song, boo
 		return decodeSong(cached, track), true, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return models.Song{}, false, err
+		return models.Song{}, false, fmt.Errorf("worker: lookup fallback cache: %w", err)
 	}
 
 	song, err := w.fetcher.FindLyrics(ctx, track)
 	if err != nil {
-		return models.Song{}, false, err
+		return models.Song{}, false, fmt.Errorf("worker: find lyrics: %w", err)
 	}
 	encoded, err := encodeSong(song)
 	if err != nil {
 		return models.Song{}, false, err
 	}
-	if err := w.cache.Store(ctx, song.Track.ArtistName, song.Track.TrackName, song.Track.AlbumName, encoded); err != nil {
-		return models.Song{}, false, err
+	if err := w.cache.Store(ctx, track.ArtistName, track.TrackName, track.AlbumName, encoded); err != nil {
+		return models.Song{}, false, fmt.Errorf("worker: store cache: %w", err)
 	}
 	return song, false, nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,166 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/lyrics"
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/musixmatch"
+	"github.com/sydlexius/mxlrcsvc-go/internal/normalize"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+)
+
+// Queue provides durable worker queue operations.
+type Queue interface {
+	Dequeue(ctx context.Context) (queue.WorkItem, error)
+	Complete(ctx context.Context, id int64) error
+	Fail(ctx context.Context, id int64, cause error) (queue.WorkItem, error)
+}
+
+// Cache provides lyrics cache operations.
+type Cache interface {
+	LookupExact(ctx context.Context, artist, title, album string) (string, error)
+	LookupFallback(ctx context.Context, artist, title string) (string, error)
+	Store(ctx context.Context, artist, title, album, lyrics string) error
+}
+
+// Worker consumes queued lyrics work one item at a time.
+type Worker struct {
+	queue   Queue
+	cache   Cache
+	fetcher musixmatch.Fetcher
+	writer  lyrics.Writer
+}
+
+// New creates a queue consumer worker.
+func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
+	return &Worker{
+		queue:   q,
+		cache:   c,
+		fetcher: fetcher,
+		writer:  writer,
+	}
+}
+
+// Run consumes ready work until the queue is empty or ctx is canceled.
+func (w *Worker) Run(ctx context.Context) error {
+	for {
+		if err := w.RunOnce(ctx); err != nil {
+			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// RunOnce claims and processes one ready queue item.
+func (w *Worker) RunOnce(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	item, err := w.queue.Dequeue(ctx)
+	if err != nil {
+		return err
+	}
+
+	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
+	if err != nil {
+		return w.fail(ctx, item.ID, err)
+	}
+	confidence := Confidence(item.Inputs.Track, song.Track)
+	slog.Info("worker lyrics match", "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "cache_hit", cacheHit)
+
+	for _, p := range outputPaths(item.Inputs) {
+		if err := w.writer.WriteLRC(song, p.Filename, p.Outdir); err != nil {
+			return w.fail(ctx, item.ID, err)
+		}
+	}
+
+	if err := w.queue.Complete(ctx, item.ID); err != nil {
+		return fmt.Errorf("worker: complete item %d: %w", item.ID, err)
+	}
+	return nil
+}
+
+func (w *Worker) song(ctx context.Context, track models.Track) (models.Song, bool, error) {
+	cached, err := w.cache.LookupExact(ctx, track.ArtistName, track.TrackName, track.AlbumName)
+	if err == nil {
+		return decodeSong(cached, track), true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return models.Song{}, false, err
+	}
+
+	cached, err = w.cache.LookupFallback(ctx, track.ArtistName, track.TrackName)
+	if err == nil {
+		return decodeSong(cached, track), true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return models.Song{}, false, err
+	}
+
+	song, err := w.fetcher.FindLyrics(ctx, track)
+	if err != nil {
+		return models.Song{}, false, err
+	}
+	encoded, err := encodeSong(song)
+	if err != nil {
+		return models.Song{}, false, err
+	}
+	if err := w.cache.Store(ctx, song.Track.ArtistName, song.Track.TrackName, song.Track.AlbumName, encoded); err != nil {
+		return models.Song{}, false, err
+	}
+	return song, false, nil
+}
+
+func (w *Worker) fail(ctx context.Context, id int64, cause error) error {
+	if _, err := w.queue.Fail(context.WithoutCancel(ctx), id, cause); err != nil {
+		return fmt.Errorf("worker: fail item %d after %v: %w", id, cause, err)
+	}
+	return nil
+}
+
+func outputPaths(inputs models.Inputs) []models.OutputPath {
+	if len(inputs.OutputPaths) > 0 {
+		return inputs.OutputPaths
+	}
+	return []models.OutputPath{{
+		Outdir:   inputs.Outdir,
+		Filename: inputs.Filename,
+	}}
+}
+
+func encodeSong(song models.Song) (string, error) {
+	b, err := json.Marshal(song)
+	if err != nil {
+		return "", fmt.Errorf("worker: encode song cache: %w", err)
+	}
+	return string(b), nil
+}
+
+func decodeSong(s string, fallback models.Track) models.Song {
+	var song models.Song
+	if err := json.Unmarshal([]byte(s), &song); err == nil && (song.Track.ArtistName != "" || song.Track.TrackName != "") {
+		return song
+	}
+	return models.Song{
+		Track:  fallback,
+		Lyrics: models.Lyrics{LyricsBody: s},
+	}
+}
+
+// Confidence returns a simple normalized metadata match score in the range 0..1.
+func Confidence(want models.Track, got models.Track) float64 {
+	artistScore := normalize.MatchConfidence(want.ArtistName, got.ArtistName)
+	titleScore := normalize.MatchConfidence(want.TrackName, got.TrackName)
+	return (artistScore + titleScore) / 2
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -282,6 +282,39 @@ func TestRunOnceCompleteFailureMarksQueueFailed(t *testing.T) {
 	}
 }
 
+func TestRunReturnsNilWhenQueueEmpty(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v; want nil", err)
+	}
+}
+
+func TestRunReturnsCompleteErrNoRows(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID: 8,
+			Inputs: models.Inputs{
+				Track:    track,
+				Outdir:   "out",
+				Filename: "artist-title.lrc",
+			},
+		}},
+		completeErr: sql.ErrNoRows,
+	}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+
+	err := w.Run(context.Background())
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Run error = %v; want sql.ErrNoRows", err)
+	}
+}
+
 func TestRunDrainsReadyItemsUntilQueueEmpty(t *testing.T) {
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	q := &fakeQueue{items: []queue.WorkItem{

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -228,6 +228,12 @@ func TestRunDrainsReadyItemsUntilQueueEmpty(t *testing.T) {
 	if len(writer.writes) != 2 {
 		t.Fatalf("writes = %d; want 2", len(writer.writes))
 	}
+	if writer.writes[0].Outdir != "out-a" || writer.writes[0].Filename != "a.lrc" {
+		t.Fatalf("writes[0] = %+v; want out-a/a.lrc", writer.writes[0])
+	}
+	if writer.writes[1].Outdir != "out-b" || writer.writes[1].Filename != "b.lrc" {
+		t.Fatalf("writes[1] = %+v; want out-b/b.lrc", writer.writes[1])
+	}
 }
 
 func TestConfidence(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,240 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+)
+
+type fakeQueue struct {
+	items      []queue.WorkItem
+	completed  []int64
+	failed     []int64
+	failCauses []error
+}
+
+func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
+	if len(q.items) == 0 {
+		return queue.WorkItem{}, sql.ErrNoRows
+	}
+	item := q.items[0]
+	q.items = q.items[1:]
+	return item, nil
+}
+
+func (q *fakeQueue) Complete(_ context.Context, id int64) error {
+	q.completed = append(q.completed, id)
+	return nil
+}
+
+func (q *fakeQueue) Fail(_ context.Context, id int64, cause error) (queue.WorkItem, error) {
+	q.failed = append(q.failed, id)
+	q.failCauses = append(q.failCauses, cause)
+	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
+}
+
+type fakeCache struct {
+	exact    string
+	fallback string
+	err      error
+	stores   []string
+}
+
+func (c *fakeCache) LookupExact(context.Context, string, string, string) (string, error) {
+	if c.err != nil {
+		return "", c.err
+	}
+	if c.exact == "" {
+		return "", sql.ErrNoRows
+	}
+	return c.exact, nil
+}
+
+func (c *fakeCache) LookupFallback(context.Context, string, string) (string, error) {
+	if c.err != nil {
+		return "", c.err
+	}
+	if c.fallback == "" {
+		return "", sql.ErrNoRows
+	}
+	return c.fallback, nil
+}
+
+func (c *fakeCache) Store(_ context.Context, _, _, _, lyrics string) error {
+	c.stores = append(c.stores, lyrics)
+	return nil
+}
+
+type fakeFetcher struct {
+	song  models.Song
+	err   error
+	calls int
+}
+
+func (f *fakeFetcher) FindLyrics(context.Context, models.Track) (models.Song, error) {
+	f.calls++
+	if f.err != nil {
+		return models.Song{}, f.err
+	}
+	return f.song, nil
+}
+
+type fakeWriter struct {
+	writes []models.OutputPath
+	err    error
+}
+
+func (w *fakeWriter) WriteLRC(_ models.Song, filename string, outdir string) error {
+	w.writes = append(w.writes, models.OutputPath{Outdir: outdir, Filename: filename})
+	return w.err
+}
+
+func TestRunOnceCacheHitAvoidsFetcherAndCompletes(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	song := models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "cached lyrics"},
+	}
+	cached, err := encodeSong(song)
+	if err != nil {
+		t.Fatalf("encodeSong: %v", err)
+	}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 1,
+		Inputs: models.Inputs{
+			Track:    track,
+			Outdir:   "out",
+			Filename: "artist-title.lrc",
+		},
+	}}}
+	cache := &fakeCache{exact: cached}
+	fetcher := &fakeFetcher{}
+	writer := &fakeWriter{}
+
+	w := New(q, cache, fetcher, writer)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if fetcher.calls != 0 {
+		t.Fatalf("fetcher calls = %d; want 0", fetcher.calls)
+	}
+	if len(writer.writes) != 1 || writer.writes[0].Outdir != "out" || writer.writes[0].Filename != "artist-title.lrc" {
+		t.Fatalf("writes = %+v; want one out/artist-title.lrc write", writer.writes)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 1 {
+		t.Fatalf("completed = %v; want [1]", q.completed)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none", q.failed)
+	}
+}
+
+func TestRunOnceFetchesCachesWritesAllOutputsAndCompletes(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 2,
+		Inputs: models.Inputs{
+			Track: track,
+			OutputPaths: []models.OutputPath{
+				{Outdir: "out-a", Filename: "a.lrc"},
+				{Outdir: "out-b", Filename: "b.lrc"},
+			},
+		},
+	}}}
+	cache := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+	writer := &fakeWriter{}
+
+	w := New(q, cache, fetcher, writer)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if fetcher.calls != 1 {
+		t.Fatalf("fetcher calls = %d; want 1", fetcher.calls)
+	}
+	if len(cache.stores) != 1 {
+		t.Fatalf("cache stores = %d; want 1", len(cache.stores))
+	}
+	if len(writer.writes) != 2 {
+		t.Fatalf("writes = %d; want 2", len(writer.writes))
+	}
+	if writer.writes[0].Outdir != "out-a" || writer.writes[1].Outdir != "out-b" {
+		t.Fatalf("writes = %+v; want both output paths", writer.writes)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 2 {
+		t.Fatalf("completed = %v; want [2]", q.completed)
+	}
+}
+
+func TestRunOnceFailureMarksQueueFailed(t *testing.T) {
+	wantErr := errors.New("fetch failed")
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:     3,
+		Inputs: models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: wantErr}, &fakeWriter{})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(q.failed) != 1 || q.failed[0] != 3 {
+		t.Fatalf("failed = %v; want [3]", q.failed)
+	}
+	if !errors.Is(q.failCauses[0], wantErr) {
+		t.Fatalf("fail cause = %v; want %v", q.failCauses[0], wantErr)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+}
+
+func TestRunDrainsReadyItemsUntilQueueEmpty(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{
+			ID:     4,
+			Inputs: models.Inputs{Track: track, Outdir: "out-a", Filename: "a.lrc"},
+		},
+		{
+			ID:     5,
+			Inputs: models.Inputs{Track: track, Outdir: "out-b", Filename: "b.lrc"},
+		},
+	}}
+	cache := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+	writer := &fakeWriter{}
+
+	w := New(q, cache, fetcher, writer)
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(q.completed) != 2 || q.completed[0] != 4 || q.completed[1] != 5 {
+		t.Fatalf("completed = %v; want [4 5]", q.completed)
+	}
+	if len(writer.writes) != 2 {
+		t.Fatalf("writes = %d; want 2", len(writer.writes))
+	}
+}
+
+func TestConfidence(t *testing.T) {
+	want := models.Track{ArtistName: "  Héllo ", TrackName: "World"}
+	got := models.Track{ArtistName: "hello", TrackName: " world "}
+
+	if score := Confidence(want, got); score != 1 {
+		t.Fatalf("Confidence() = %v; want 1", score)
+	}
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -11,10 +11,12 @@ import (
 )
 
 type fakeQueue struct {
-	items      []queue.WorkItem
-	completed  []int64
-	failed     []int64
-	failCauses []error
+	items       []queue.WorkItem
+	completed   []int64
+	failed      []int64
+	failCauses  []error
+	completeErr error
+	failErr     error
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -27,21 +29,34 @@ func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
 }
 
 func (q *fakeQueue) Complete(_ context.Context, id int64) error {
+	if q.completeErr != nil {
+		return q.completeErr
+	}
 	q.completed = append(q.completed, id)
 	return nil
 }
 
 func (q *fakeQueue) Fail(_ context.Context, id int64, cause error) (queue.WorkItem, error) {
+	if q.failErr != nil {
+		return queue.WorkItem{}, q.failErr
+	}
 	q.failed = append(q.failed, id)
 	q.failCauses = append(q.failCauses, cause)
 	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
+}
+
+type cacheStore struct {
+	artist string
+	title  string
+	album  string
+	lyrics string
 }
 
 type fakeCache struct {
 	exact    string
 	fallback string
 	err      error
-	stores   []string
+	stores   []cacheStore
 }
 
 func (c *fakeCache) LookupExact(context.Context, string, string, string) (string, error) {
@@ -64,8 +79,8 @@ func (c *fakeCache) LookupFallback(context.Context, string, string) (string, err
 	return c.fallback, nil
 }
 
-func (c *fakeCache) Store(_ context.Context, _, _, _, lyrics string) error {
-	c.stores = append(c.stores, lyrics)
+func (c *fakeCache) Store(_ context.Context, artist, title, album, lyrics string) error {
+	c.stores = append(c.stores, cacheStore{artist: artist, title: title, album: album, lyrics: lyrics})
 	return nil
 }
 
@@ -164,6 +179,9 @@ func TestRunOnceFetchesCachesWritesAllOutputsAndCompletes(t *testing.T) {
 	if len(cache.stores) != 1 {
 		t.Fatalf("cache stores = %d; want 1", len(cache.stores))
 	}
+	if cache.stores[0].artist != "Artist" || cache.stores[0].title != "Title" {
+		t.Fatalf("cache store key = %+v; want Artist/Title", cache.stores[0])
+	}
 	if len(writer.writes) != 2 {
 		t.Fatalf("writes = %d; want 2", len(writer.writes))
 	}
@@ -172,6 +190,37 @@ func TestRunOnceFetchesCachesWritesAllOutputsAndCompletes(t *testing.T) {
 	}
 	if len(q.completed) != 1 || q.completed[0] != 2 {
 		t.Fatalf("completed = %v; want [2]", q.completed)
+	}
+}
+
+func TestRunOnceStoresCacheWithRequestedTrackKeys(t *testing.T) {
+	track := models.Track{ArtistName: "Requested Artist", TrackName: "Requested Title", AlbumName: "Requested Album"}
+	fetched := models.Track{ArtistName: "Canonical Artist", TrackName: "Canonical Title", AlbumName: "Canonical Album"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 6,
+		Inputs: models.Inputs{
+			Track:    track,
+			Outdir:   "out",
+			Filename: "requested-title.lrc",
+		},
+	}}}
+	cache := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  fetched,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+
+	w := New(q, cache, fetcher, &fakeWriter{})
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(cache.stores) != 1 {
+		t.Fatalf("cache stores = %d; want 1", len(cache.stores))
+	}
+	store := cache.stores[0]
+	if store.artist != track.ArtistName || store.title != track.TrackName || store.album != track.AlbumName {
+		t.Fatalf("cache store key = %+v; want requested track %+v", store, track)
 	}
 }
 
@@ -192,6 +241,41 @@ func TestRunOnceFailureMarksQueueFailed(t *testing.T) {
 	}
 	if !errors.Is(q.failCauses[0], wantErr) {
 		t.Fatalf("fail cause = %v; want %v", q.failCauses[0], wantErr)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+}
+
+func TestRunOnceCompleteFailureMarksQueueFailed(t *testing.T) {
+	completeErr := errors.New("complete failed")
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID: 7,
+			Inputs: models.Inputs{
+				Track:    track,
+				Outdir:   "out",
+				Filename: "artist-title.lrc",
+			},
+		}},
+		completeErr: completeErr,
+	}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+
+	err := w.RunOnce(context.Background())
+	if !errors.Is(err, completeErr) {
+		t.Fatalf("RunOnce error = %v; want complete failure", err)
+	}
+	if len(q.failed) != 1 || q.failed[0] != 7 {
+		t.Fatalf("failed = %v; want [7]", q.failed)
+	}
+	if len(q.failCauses) != 1 || !errors.Is(q.failCauses[0], completeErr) {
+		t.Fatalf("fail causes = %v; want complete failure", q.failCauses)
 	}
 	if len(q.completed) != 0 {
 		t.Fatalf("completed = %v; want none", q.completed)


### PR DESCRIPTION
## Summary
- add a single-threaded worker that dequeues DB work, checks cache first, fetches misses, writes outputs, and completes or fails queue items
- persist plural output paths on work_queue while preserving outdir/filename compatibility
- add focused worker and queue tests plus GSD quick-task artifacts

## Tests
- go test -count=1 -coverprofile=mxlrc-cover.out ./...
- golangci-lint run
- git diff --check
- pre-commit hook suite during git commit

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue consumer worker that processes queued items, writes outputs to all destinations, and marks completion or failure.
  * Support for multiple output destinations per work item.
  * Cache-first retrieval with fallback fetch and computed confidence scoring.

* **Documentation**
  * Planning, summary, and verification guidance added for the new worker.

* **Chores**
  * Database migration to persist multiple output destinations.

* **Tests**
  * New tests covering queue persistence, worker flows (cache hit/miss/failure), and confidence scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->