### PR TITLE
feat: add scanner queue integration and API keys

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v1.6.1
 milestone_name: milestone
-status: verifying
-stopped_at: Completed 04-03-PLAN.md — Phase 4 build-verification complete
-last_updated: "2026-04-12T01:12:50Z"
-last_activity: 2026-04-12
+status: in_progress
+stopped_at: Completed quick tasks 260427-m55 and 260427-m6
+last_updated: "2026-04-27T19:15:17Z"
+last_activity: 2026-04-27
 progress:
   total_phases: 4
   completed_phases: 4
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-10)
 
 **Core value:** The tool fetches synced lyrics reliably and writes correct `.lrc` files. Everything else exists to support that.
-**Current focus:** All phases complete — final verification
+**Current focus:** Milestone issues after initial restructure
 
 ## Current Position
 
 Phase: 4 of 4 (Build Verification)
 Plan: 3 of 3 in current phase
-Status: All phases complete — ready for merge
-Last activity: 2026-04-12 - Completed quick task 260411-p8r: replace wantEq sentinel with *float64 (issue #36)
+Status: Quick milestone work in progress
+Last activity: 2026-04-27 - Completed quick tasks 260427-m55 (issue #20) and 260427-m6 (issue #21)
 
 Progress: [██████████] 100%
 
@@ -96,9 +96,11 @@ None yet.
 | 260411-l30 | issues #11 and #12 (Milestone 1) | 2026-04-11 | 2448d8f | [260411-l30-issues-11-and-12-milestone-1](./quick/260411-l30-issues-11-and-12-milestone-1/) |
 | 260411-p8r | Replace wantEq sentinel with *float64 pointer (issue #36) | 2026-04-12 | 8515549 | [260411-p8r-work-on-issue-36](./quick/260411-p8r-work-on-issue-36/) |
 | 260426-q19 | Queue consumer worker (issue #19) | 2026-04-26 | pending | [260426-q19-queue-consumer-worker](./quick/260426-q19-queue-consumer-worker/) |
+| 260427-m55 | Scanner-queue integration (issue #20) | 2026-04-27 | pending | [260427-m55-scanner-queue-integration](./quick/260427-m55-scanner-queue-integration/) |
+| 260427-m6 | API key service (issue #21) | 2026-04-27 | pending | [260427-m6-api-key-service](./quick/260427-m6-api-key-service/) |
 
 ## Session Continuity
 
-Last session: 2026-04-12T01:12:50Z
-Stopped at: Completed quick task 260411-p8r — wantEq *float64 pointer refactor
+Last session: 2026-04-27T19:15:17Z
+Stopped at: Completed quick tasks 260427-m55 and 260427-m6
 Resume file: None

--- a/.planning/quick/260427-m55-scanner-queue-integration/260427-m55-PLAN.md
+++ b/.planning/quick/260427-m55-scanner-queue-integration/260427-m55-PLAN.md
@@ -1,0 +1,71 @@
+---
+phase: quick
+plan: 260427-m55
+type: execute
+wave: 1
+depends_on:
+  - 260426-q19
+files_modified:
+  - internal/scan/
+  - internal/db/migrations/
+  - .planning/STATE.md
+autonomous: true
+requirements:
+  - issue-20
+must_haves:
+  truths:
+    - "Pending scan results can be read back from persistence with output destinations"
+    - "Cache hits are not enqueued for Musixmatch work"
+    - "Cache misses are enqueued into the durable work queue"
+    - "Scheduler OnScanComplete can be wired to run the enqueuer"
+    - "Focused scan integration tests and go test ./... pass"
+---
+
+<objective>
+Implement issue #20: M5.5.1 scanner-queue integration.
+
+The scan layer should bridge persisted library scan results to the durable work queue. After a
+library scan completes, the callback should be able to read pending results, skip entries already
+covered by the lyrics cache, enqueue misses for worker processing, and update scan result status so
+the same pending rows are not repeatedly enqueued.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Persist scan output destinations</name>
+  <files>internal/db/migrations/, internal/scan/repository.go</files>
+  <done>
+    - scan_results stores outdir and filename
+    - repository list methods return output destination fields
+    - pending results can be listed per library
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Enqueuer implementation</name>
+  <files>internal/scan/</files>
+  <done>
+    - Enqueuer checks cache before queueing work
+    - Cache misses enqueue models.Inputs with output paths
+    - Cache hits are marked done and misses are marked processing
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Verification</name>
+  <files>all touched files</files>
+  <done>
+    - Tests cover cache hit skip, miss enqueue, and scheduler callback wiring
+    - gofmt applied
+    - go test ./... passes
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+go test ./...
+```
+</verification>

--- a/.planning/quick/260427-m55-scanner-queue-integration/260427-m55-SUMMARY.md
+++ b/.planning/quick/260427-m55-scanner-queue-integration/260427-m55-SUMMARY.md
@@ -1,0 +1,19 @@
+# Summary: Issue #20 Scanner-Queue Integration
+
+## Completed
+
+- Added `scan_results.outdir` and `scan_results.filename` migration so persisted scan results retain worker output destinations.
+- Extended `internal/scan.Repo` with pending-result listing and status updates.
+- Added `internal/scan.Enqueuer` to read pending scan results, skip lyrics-cache hits, enqueue cache misses into the durable work queue, and adapt directly to `Scheduler.OnScanComplete`.
+- Added focused tests for output persistence, pending status transitions, cache-hit skipping, miss enqueueing, and callback wiring.
+
+## Verification
+
+```bash
+go test ./internal/scan ./internal/db
+go test ./...
+golangci-lint run
+git diff --check
+```
+
+All checks passed.

--- a/.planning/quick/260427-m6-api-key-service/260427-m6-PLAN.md
+++ b/.planning/quick/260427-m6-api-key-service/260427-m6-PLAN.md
@@ -1,0 +1,71 @@
+---
+phase: quick
+plan: 260427-m6
+type: execute
+wave: 1
+depends_on:
+  - 260427-m55
+files_modified:
+  - internal/auth/
+  - .planning/STATE.md
+autonomous: true
+requirements:
+  - issue-21
+must_haves:
+  truths:
+    - "Generated keys use the mxlrc_ prefix"
+    - "Raw key entropy is 32 bytes from crypto/rand, hex-encoded"
+    - "Only SHA-256 hashes are retained by the service after creation"
+    - "Scopes include webhook and admin, with admin implying all scopes"
+    - "CreateKey, ValidateKey, RevokeKey, and ListKeys are implemented"
+    - "Focused auth tests and go test ./... pass"
+---
+
+<objective>
+Implement issue #21: M6.1 API key service.
+
+The service should provide API key lifecycle primitives for later webhook/server work without
+introducing persistence decisions beyond a narrow storage interface. It must generate secure keys,
+hash before storage, validate active keys by scope, revoke keys, and list stored metadata without
+revealing raw key material.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Auth service API and models</name>
+  <files>internal/auth/</files>
+  <done>
+    - Public service exposes CreateKey, ValidateKey, RevokeKey, and ListKeys
+    - Key metadata includes ID, name, hash, scopes, creation time, and optional revocation time
+    - Scope parsing and admin implication are covered
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: In-memory store for current milestone</name>
+  <files>internal/auth/</files>
+  <done>
+    - Store interface keeps persistence replaceable for future DB/server work
+    - Memory store supports create/list/get/revoke operations
+    - Duplicate hashes are rejected
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Verification</name>
+  <files>all touched files</files>
+  <done>
+    - Focused tests cover creation, hashing, validation, scope behavior, revocation, and listing
+    - gofmt applied
+    - go test ./... passes
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+go test ./...
+```
+</verification>

--- a/.planning/quick/260427-m6-api-key-service/260427-m6-SUMMARY.md
+++ b/.planning/quick/260427-m6-api-key-service/260427-m6-SUMMARY.md
@@ -1,0 +1,20 @@
+# Summary: Issue #21 API Key Service
+
+## Completed
+
+- Added `internal/auth` with API key generation, SHA-256 hashing, validation, revocation, listing, and scope helpers.
+- Generated raw keys use the `mxlrc_` prefix with 32 bytes of `crypto/rand` entropy hex-encoded after the prefix.
+- Added scope handling for `webhook` and `admin`, with `admin` implying all scopes.
+- Added an in-memory `Store` implementation behind a persistence interface for later DB/server integration.
+- Added focused tests for generation, hashing, validation, admin implication, revocation, invalid scopes, and duplicate hashes.
+
+## Verification
+
+```bash
+go test ./internal/auth
+go test ./...
+golangci-lint run
+git diff --check
+```
+
+All checks passed.

--- a/internal/auth/memory.go
+++ b/internal/auth/memory.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// MemoryStore stores key metadata in memory for tests and single-process use.
+type MemoryStore struct {
+	mu   sync.RWMutex
+	keys map[string]Key
+}
+
+// NewMemoryStore returns an empty in-memory key store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{keys: map[string]Key{}}
+}
+
+// Create stores key metadata by hash.
+func (s *MemoryStore) Create(ctx context.Context, key Key) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if key.Hash == "" {
+		return fmt.Errorf("auth: key hash must not be empty")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[key.Hash]; ok {
+		return ErrDuplicateKey
+	}
+	s.keys[key.Hash] = cloneKey(key)
+	return nil
+}
+
+// FindByHash returns key metadata by hash.
+func (s *MemoryStore) FindByHash(ctx context.Context, hash string) (Key, error) {
+	if err := ctx.Err(); err != nil {
+		return Key{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key, ok := s.keys[hash]
+	if !ok {
+		return Key{}, ErrInvalidKey
+	}
+	return cloneKey(key), nil
+}
+
+// RevokeByHash records a revocation timestamp for hash.
+func (s *MemoryStore) RevokeByHash(ctx context.Context, hash string, revokedAt time.Time) (Key, error) {
+	if err := ctx.Err(); err != nil {
+		return Key{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key, ok := s.keys[hash]
+	if !ok {
+		return Key{}, ErrInvalidKey
+	}
+	at := revokedAt.UTC()
+	key.RevokedAt = &at
+	s.keys[hash] = cloneKey(key)
+	return cloneKey(key), nil
+}
+
+// List returns all key metadata in stable creation order.
+func (s *MemoryStore) List(ctx context.Context) ([]Key, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]Key, 0, len(s.keys))
+	for _, v := range s.keys {
+		keys = append(keys, cloneKey(v))
+	}
+	slices.SortFunc(keys, func(a Key, b Key) int {
+		switch {
+		case a.CreatedAt.Before(b.CreatedAt):
+			return -1
+		case a.CreatedAt.After(b.CreatedAt):
+			return 1
+		case a.ID < b.ID:
+			return -1
+		case a.ID > b.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return keys, nil
+}
+
+func cloneKey(key Key) Key {
+	key.Scopes = append([]Scope(nil), key.Scopes...)
+	if key.RevokedAt != nil {
+		at := *key.RevokedAt
+		key.RevokedAt = &at
+	}
+	return key
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,214 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	// KeyPrefix is prepended to every generated API key.
+	KeyPrefix = "mxlrc_"
+
+	keyBytes = 32
+)
+
+var (
+	// ErrDuplicateKey is returned when a generated key hash already exists.
+	ErrDuplicateKey = errors.New("auth: duplicate key")
+	// ErrInvalidKey is returned when a raw key is malformed or unknown.
+	ErrInvalidKey = errors.New("auth: invalid key")
+	// ErrRevokedKey is returned when a key was revoked before validation.
+	ErrRevokedKey = errors.New("auth: revoked key")
+	// ErrForbiddenScope is returned when a key lacks the required scope.
+	ErrForbiddenScope = errors.New("auth: forbidden scope")
+)
+
+// Scope identifies an API key permission.
+type Scope string
+
+const (
+	// ScopeWebhook permits webhook ingestion endpoints.
+	ScopeWebhook Scope = "webhook"
+	// ScopeAdmin permits every operation.
+	ScopeAdmin Scope = "admin"
+)
+
+// Key stores API key metadata. Raw key material is never stored here.
+type Key struct {
+	ID        string
+	Name      string
+	Hash      string
+	Scopes    []Scope
+	CreatedAt time.Time
+	RevokedAt *time.Time
+}
+
+// CreatedKey returns the one-time raw key with its stored metadata.
+type CreatedKey struct {
+	Raw string
+	Key Key
+}
+
+// Store persists API key metadata by SHA-256 hash.
+type Store interface {
+	Create(ctx context.Context, key Key) error
+	FindByHash(ctx context.Context, hash string) (Key, error)
+	RevokeByHash(ctx context.Context, hash string, revokedAt time.Time) (Key, error)
+	List(ctx context.Context) ([]Key, error)
+}
+
+// Service manages API key generation, validation, revocation, and listing.
+type Service struct {
+	store Store
+	rand  io.Reader
+	now   func() time.Time
+}
+
+// NewService returns an API key service backed by store.
+func NewService(store Store) *Service {
+	return &Service{
+		store: store,
+		rand:  rand.Reader,
+		now:   time.Now,
+	}
+}
+
+// CreateKey generates a new raw key and stores only its SHA-256 hash.
+func (s *Service) CreateKey(ctx context.Context, name string, scopes []Scope) (CreatedKey, error) {
+	if s.store == nil {
+		return CreatedKey{}, fmt.Errorf("auth: store dependency is nil")
+	}
+	if s.rand == nil {
+		return CreatedKey{}, fmt.Errorf("auth: rand dependency is nil")
+	}
+	if s.now == nil {
+		return CreatedKey{}, fmt.Errorf("auth: now dependency is nil")
+	}
+	norm, err := NormalizeScopes(scopes)
+	if err != nil {
+		return CreatedKey{}, err
+	}
+
+	raw, err := generateKey(s.rand)
+	if err != nil {
+		return CreatedKey{}, err
+	}
+	hash := HashKey(raw)
+	key := Key{
+		ID:        hash[:16],
+		Name:      strings.TrimSpace(name),
+		Hash:      hash,
+		Scopes:    norm,
+		CreatedAt: s.now().UTC(),
+	}
+	if err := s.store.Create(ctx, key); err != nil {
+		return CreatedKey{}, err
+	}
+	return CreatedKey{Raw: raw, Key: key}, nil
+}
+
+// ValidateKey returns stored key metadata if raw has the required scope.
+func (s *Service) ValidateKey(ctx context.Context, raw string, required Scope) (Key, error) {
+	if s.store == nil {
+		return Key{}, fmt.Errorf("auth: store dependency is nil")
+	}
+	if !strings.HasPrefix(raw, KeyPrefix) {
+		return Key{}, ErrInvalidKey
+	}
+	hash := HashKey(raw)
+	key, err := s.store.FindByHash(ctx, hash)
+	if err != nil {
+		return Key{}, err
+	}
+	if subtle.ConstantTimeCompare([]byte(key.Hash), []byte(hash)) != 1 {
+		return Key{}, ErrInvalidKey
+	}
+	if key.RevokedAt != nil {
+		return Key{}, ErrRevokedKey
+	}
+	if required != "" && !HasScope(key.Scopes, required) {
+		return Key{}, ErrForbiddenScope
+	}
+	return key, nil
+}
+
+// RevokeKey revokes raw and returns the updated metadata.
+func (s *Service) RevokeKey(ctx context.Context, raw string) (Key, error) {
+	if s.store == nil {
+		return Key{}, fmt.Errorf("auth: store dependency is nil")
+	}
+	if s.now == nil {
+		return Key{}, fmt.Errorf("auth: now dependency is nil")
+	}
+	if !strings.HasPrefix(raw, KeyPrefix) {
+		return Key{}, ErrInvalidKey
+	}
+	return s.store.RevokeByHash(ctx, HashKey(raw), s.now().UTC())
+}
+
+// ListKeys returns stored key metadata without raw key material.
+func (s *Service) ListKeys(ctx context.Context) ([]Key, error) {
+	if s.store == nil {
+		return nil, fmt.Errorf("auth: store dependency is nil")
+	}
+	return s.store.List(ctx)
+}
+
+// HashKey returns the lowercase hex SHA-256 hash for raw.
+func HashKey(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// NormalizeScopes validates, deduplicates, and sorts scopes.
+func NormalizeScopes(scopes []Scope) ([]Scope, error) {
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("auth: at least one scope is required")
+	}
+	seen := map[Scope]bool{}
+	var norm []Scope
+	for _, v := range scopes {
+		scope := Scope(strings.TrimSpace(string(v)))
+		switch scope {
+		case ScopeWebhook, ScopeAdmin:
+		default:
+			return nil, fmt.Errorf("auth: unsupported scope %q", v)
+		}
+		if !seen[scope] {
+			seen[scope] = true
+			norm = append(norm, scope)
+		}
+	}
+	slices.Sort(norm)
+	return norm, nil
+}
+
+// HasScope reports whether scopes grant required. Admin grants every scope.
+func HasScope(scopes []Scope, required Scope) bool {
+	if required == "" {
+		return true
+	}
+	for _, v := range scopes {
+		if v == ScopeAdmin || v == required {
+			return true
+		}
+	}
+	return false
+}
+
+func generateKey(r io.Reader) (string, error) {
+	b := make([]byte, keyBytes)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", fmt.Errorf("auth: generate key: %w", err)
+	}
+	return KeyPrefix + hex.EncodeToString(b), nil
+}

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestService_CreateKeyGeneratesPrefixedKeyAndStoresHash(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	svc := NewService(store)
+	svc.rand = bytes.NewReader(bytes.Repeat([]byte{0x42}, keyBytes))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+
+	created, err := svc.CreateKey(ctx, "webhook key", []Scope{ScopeWebhook})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	if !strings.HasPrefix(created.Raw, KeyPrefix) {
+		t.Fatalf("raw key = %q; want %s prefix", created.Raw, KeyPrefix)
+	}
+	if len(strings.TrimPrefix(created.Raw, KeyPrefix)) != 64 {
+		t.Fatalf("raw key hex length = %d; want 64", len(strings.TrimPrefix(created.Raw, KeyPrefix)))
+	}
+	if created.Key.Hash != HashKey(created.Raw) {
+		t.Fatalf("stored hash = %q; want hash of raw key", created.Key.Hash)
+	}
+	if strings.Contains(created.Key.Hash, created.Raw) {
+		t.Fatal("stored hash contains raw key material")
+	}
+	if !created.Key.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %s; want %s", created.Key.CreatedAt, now)
+	}
+
+	keys, err := svc.ListKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("ListKeys returned %d keys; want 1", len(keys))
+	}
+	if keys[0].Hash != created.Key.Hash {
+		t.Fatalf("listed hash = %q; want created hash", keys[0].Hash)
+	}
+}
+
+func TestService_ValidateKeyScopesAndAdminImplication(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	svc := NewService(store)
+	svc.rand = bytes.NewReader(bytes.Repeat([]byte{0x01}, keyBytes))
+
+	created, err := svc.CreateKey(ctx, "admin", []Scope{ScopeAdmin})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	key, err := svc.ValidateKey(ctx, created.Raw, ScopeWebhook)
+	if err != nil {
+		t.Fatalf("ValidateKey admin for webhook: %v", err)
+	}
+	if key.ID != created.Key.ID {
+		t.Fatalf("validated key ID = %q; want %q", key.ID, created.Key.ID)
+	}
+
+	svc.rand = bytes.NewReader(bytes.Repeat([]byte{0x02}, keyBytes))
+	webhook, err := svc.CreateKey(ctx, "webhook", []Scope{ScopeWebhook})
+	if err != nil {
+		t.Fatalf("CreateKey webhook: %v", err)
+	}
+	if _, err := svc.ValidateKey(ctx, webhook.Raw, ScopeAdmin); !errors.Is(err, ErrForbiddenScope) {
+		t.Fatalf("ValidateKey webhook for admin error = %v; want ErrForbiddenScope", err)
+	}
+}
+
+func TestService_RevokeKeyPreventsValidation(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	svc := NewService(store)
+	svc.rand = bytes.NewReader(bytes.Repeat([]byte{0x03}, keyBytes))
+	revokedAt := time.Date(2026, 4, 27, 13, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return revokedAt }
+
+	created, err := svc.CreateKey(ctx, "webhook", []Scope{ScopeWebhook})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	revoked, err := svc.RevokeKey(ctx, created.Raw)
+	if err != nil {
+		t.Fatalf("RevokeKey: %v", err)
+	}
+	if revoked.RevokedAt == nil || !revoked.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("RevokedAt = %v; want %s", revoked.RevokedAt, revokedAt)
+	}
+	if _, err := svc.ValidateKey(ctx, created.Raw, ScopeWebhook); !errors.Is(err, ErrRevokedKey) {
+		t.Fatalf("ValidateKey revoked error = %v; want ErrRevokedKey", err)
+	}
+}
+
+func TestService_InvalidKeysAndScopes(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	svc := NewService(store)
+
+	if _, err := svc.ValidateKey(ctx, "not-mxlrc", ScopeWebhook); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("ValidateKey malformed error = %v; want ErrInvalidKey", err)
+	}
+	if _, err := svc.CreateKey(ctx, "empty", nil); err == nil {
+		t.Fatal("CreateKey with no scopes returned nil error")
+	}
+	if _, err := svc.CreateKey(ctx, "bad", []Scope{"root"}); err == nil {
+		t.Fatal("CreateKey with unsupported scope returned nil error")
+	}
+}
+
+func TestNormalizeScopesDeduplicatesAndSorts(t *testing.T) {
+	got, err := NormalizeScopes([]Scope{ScopeWebhook, ScopeAdmin, ScopeWebhook})
+	if err != nil {
+		t.Fatalf("NormalizeScopes: %v", err)
+	}
+	want := []Scope{ScopeAdmin, ScopeWebhook}
+	if len(got) != len(want) {
+		t.Fatalf("scopes = %+v; want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scopes = %+v; want %+v", got, want)
+		}
+	}
+}
+
+func TestMemoryStoreRejectsDuplicateHashes(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	key := Key{ID: "id", Hash: "hash", Scopes: []Scope{ScopeWebhook}}
+	if err := store.Create(ctx, key); err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	if err := store.Create(ctx, key); !errors.Is(err, ErrDuplicateKey) {
+		t.Fatalf("Create duplicate error = %v; want ErrDuplicateKey", err)
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -217,6 +217,33 @@ func TestOpen_ScanResultsUniqueIndex(t *testing.T) {
 	}
 }
 
+func TestOpen_ScanResultsOutputColumns(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scan-outputs.db")
+
+	sqlDB, err := Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	for _, v := range []string{"outdir", "filename"} {
+		var count int
+		row := sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM pragma_table_info('scan_results') WHERE name = ?", v)
+		if err := row.Scan(&count); err != nil {
+			t.Fatalf("query scan_results column %q: %v", v, err)
+		}
+		if count != 1 {
+			t.Fatalf("scan_results column %q count = %d; want 1", v, count)
+		}
+	}
+}
+
 func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "work-queue.db")

--- a/internal/db/migrations/006_scan_results_outputs.sql
+++ b/internal/db/migrations/006_scan_results_outputs.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scan_results ADD COLUMN outdir TEXT NOT NULL DEFAULT '';
+ALTER TABLE scan_results ADD COLUMN filename TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE scan_results DROP COLUMN filename;
+ALTER TABLE scan_results DROP COLUMN outdir;
+-- +goose StatementEnd

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -57,8 +57,6 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) error {
 		return fmt.Errorf("scan: list pending for enqueue: %w", err)
 	}
 
-	var doneIDs []int64
-	var queuedIDs []int64
 	for _, res := range results {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -66,27 +64,23 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) error {
 		_, err := e.Cache.LookupFallback(ctx, res.Track.ArtistName, res.Track.TrackName)
 		switch {
 		case err == nil:
-			doneIDs = append(doneIDs, res.ID)
+			if err := e.Results.SetStatus(ctx, []int64{res.ID}, StatusDone); err != nil {
+				return fmt.Errorf("scan: mark cache hit done %d: %w", res.ID, err)
+			}
 			continue
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			return fmt.Errorf("scan: cache lookup %d: %w", res.ID, err)
 		}
 
+		if err := e.Results.SetStatus(ctx, []int64{res.ID}, StatusProcessing); err != nil {
+			return fmt.Errorf("scan: reserve result %d: %w", res.ID, err)
+		}
 		if _, err := e.Queue.Enqueue(ctx, scanInputs(res), e.Priority); err != nil {
+			if restoreErr := e.Results.SetStatus(ctx, []int64{res.ID}, StatusPending); restoreErr != nil {
+				return fmt.Errorf("scan: enqueue result %d: %w; restore pending: %w", res.ID, err, restoreErr)
+			}
 			return fmt.Errorf("scan: enqueue result %d: %w", res.ID, err)
-		}
-		queuedIDs = append(queuedIDs, res.ID)
-	}
-
-	if len(doneIDs) > 0 {
-		if err := e.Results.SetStatus(ctx, doneIDs, StatusDone); err != nil {
-			return fmt.Errorf("scan: mark cache hits done: %w", err)
-		}
-	}
-	if len(queuedIDs) > 0 {
-		if err := e.Results.SetStatus(ctx, queuedIDs, StatusProcessing); err != nil {
-			return fmt.Errorf("scan: mark queued results processing: %w", err)
 		}
 	}
 	return nil

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -76,7 +76,14 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) error {
 		if err := e.Results.SetStatus(ctx, []int64{res.ID}, StatusProcessing); err != nil {
 			return fmt.Errorf("scan: reserve result %d: %w", res.ID, err)
 		}
-		if _, err := e.Queue.Enqueue(ctx, scanInputs(res), e.Priority); err != nil {
+		inputs, err := scanInputs(res)
+		if err != nil {
+			if restoreErr := e.Results.SetStatus(ctx, []int64{res.ID}, StatusPending); restoreErr != nil {
+				return fmt.Errorf("scan: build inputs for result %d: %w; restore pending: %w", res.ID, err, restoreErr)
+			}
+			return fmt.Errorf("scan: build inputs for result %d: %w", res.ID, err)
+		}
+		if _, err := e.Queue.Enqueue(ctx, inputs, e.Priority); err != nil {
 			if restoreErr := e.Results.SetStatus(ctx, []int64{res.ID}, StatusPending); restoreErr != nil {
 				return fmt.Errorf("scan: enqueue result %d: %w; restore pending: %w", res.ID, err, restoreErr)
 			}
@@ -91,7 +98,7 @@ func (e *Enqueuer) OnScanComplete(ctx context.Context, lib models.Library, _ []m
 	return e.EnqueuePending(ctx, lib.ID)
 }
 
-func scanInputs(res models.ScanResult) models.Inputs {
+func scanInputs(res models.ScanResult) (models.Inputs, error) {
 	outdir := res.Outdir
 	if outdir == "" && res.FilePath != "" {
 		outdir = filepath.Dir(res.FilePath)
@@ -101,6 +108,9 @@ func scanInputs(res models.ScanResult) models.Inputs {
 		base := filepath.Base(res.FilePath)
 		filename = strings.TrimSuffix(base, filepath.Ext(base)) + ".lrc"
 	}
+	if outdir == "" && filename == "" && res.FilePath == "" {
+		return models.Inputs{}, fmt.Errorf("invalid scan result: missing file path and output destination")
+	}
 	return models.Inputs{
 		Track:    res.Track,
 		Outdir:   outdir,
@@ -109,5 +119,5 @@ func scanInputs(res models.ScanResult) models.Inputs {
 			Outdir:   outdir,
 			Filename: filename,
 		}},
-	}
+	}, nil
 }

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -1,0 +1,119 @@
+package scan
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+)
+
+// PendingResultStore reads and updates scan results eligible for queueing.
+type PendingResultStore interface {
+	ListPendingByLibrary(ctx context.Context, libraryID int64) ([]models.ScanResult, error)
+	SetStatus(ctx context.Context, ids []int64, status string) error
+}
+
+// LyricsCache reports whether lyrics already exist for a scanned track.
+type LyricsCache interface {
+	LookupFallback(ctx context.Context, artist, title string) (string, error)
+}
+
+// WorkQueue enqueues durable lyrics work.
+type WorkQueue interface {
+	Enqueue(ctx context.Context, inputs models.Inputs, priority int) (queue.WorkItem, error)
+}
+
+// Enqueuer bridges pending scan results to the durable work queue.
+type Enqueuer struct {
+	Results  PendingResultStore
+	Cache    LyricsCache
+	Queue    WorkQueue
+	Priority int
+}
+
+// EnqueuePending reads pending scan results for libraryID, skips cache hits,
+// and enqueues cache misses for worker processing.
+func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) error {
+	if e.Results == nil {
+		return fmt.Errorf("scan: enqueuer results dependency is nil")
+	}
+	if e.Cache == nil {
+		return fmt.Errorf("scan: enqueuer cache dependency is nil")
+	}
+	if e.Queue == nil {
+		return fmt.Errorf("scan: enqueuer queue dependency is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	results, err := e.Results.ListPendingByLibrary(ctx, libraryID)
+	if err != nil {
+		return fmt.Errorf("scan: list pending for enqueue: %w", err)
+	}
+
+	var doneIDs []int64
+	var queuedIDs []int64
+	for _, res := range results {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, err := e.Cache.LookupFallback(ctx, res.Track.ArtistName, res.Track.TrackName)
+		switch {
+		case err == nil:
+			doneIDs = append(doneIDs, res.ID)
+			continue
+		case errors.Is(err, sql.ErrNoRows):
+		default:
+			return fmt.Errorf("scan: cache lookup %d: %w", res.ID, err)
+		}
+
+		if _, err := e.Queue.Enqueue(ctx, scanInputs(res), e.Priority); err != nil {
+			return fmt.Errorf("scan: enqueue result %d: %w", res.ID, err)
+		}
+		queuedIDs = append(queuedIDs, res.ID)
+	}
+
+	if len(doneIDs) > 0 {
+		if err := e.Results.SetStatus(ctx, doneIDs, StatusDone); err != nil {
+			return fmt.Errorf("scan: mark cache hits done: %w", err)
+		}
+	}
+	if len(queuedIDs) > 0 {
+		if err := e.Results.SetStatus(ctx, queuedIDs, StatusProcessing); err != nil {
+			return fmt.Errorf("scan: mark queued results processing: %w", err)
+		}
+	}
+	return nil
+}
+
+// OnScanComplete adapts EnqueuePending to Scheduler.OnScanComplete.
+func (e *Enqueuer) OnScanComplete(ctx context.Context, lib models.Library, _ []models.ScanResult) error {
+	return e.EnqueuePending(ctx, lib.ID)
+}
+
+func scanInputs(res models.ScanResult) models.Inputs {
+	outdir := res.Outdir
+	if outdir == "" && res.FilePath != "" {
+		outdir = filepath.Dir(res.FilePath)
+	}
+	filename := res.Filename
+	if filename == "" && res.FilePath != "" {
+		base := filepath.Base(res.FilePath)
+		filename = strings.TrimSuffix(base, filepath.Ext(base)) + ".lrc"
+	}
+	return models.Inputs{
+		Track:    res.Track,
+		Outdir:   outdir,
+		Filename: filename,
+		OutputPaths: []models.OutputPath{{
+			Outdir:   outdir,
+			Filename: filename,
+		}},
+	}
+}

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -54,10 +54,14 @@ func (f fakeLyricsCache) LookupFallback(_ context.Context, artist string, title 
 
 type fakeWorkQueue struct {
 	inputs []models.Inputs
+	before func()
 	err    error
 }
 
 func (f *fakeWorkQueue) Enqueue(_ context.Context, inputs models.Inputs, _ int) (queue.WorkItem, error) {
+	if f.before != nil {
+		f.before()
+	}
 	if f.err != nil {
 		return queue.WorkItem{}, f.err
 	}
@@ -111,6 +115,53 @@ func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
 	}
 }
 
+func TestEnqueuer_ReservesMissBeforeEnqueue(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:    3,
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}}
+	cache := fakeLyricsCache{hits: map[string]bool{}}
+	var reservedBeforeEnqueue bool
+	work := &fakeWorkQueue{before: func() {
+		reservedBeforeEnqueue = len(store.status) == 1 &&
+			store.status[0].status == scan.StatusProcessing &&
+			len(store.status[0].ids) == 1 &&
+			store.status[0].ids[0] == 3
+	}}
+	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
+
+	if err := e.EnqueuePending(ctx, 7); err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if !reservedBeforeEnqueue {
+		t.Fatalf("status calls before enqueue = %+v; want processing reservation", store.status)
+	}
+}
+
+func TestEnqueuer_RestoresPendingWhenEnqueueFails(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:    4,
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}}
+	cache := fakeLyricsCache{hits: map[string]bool{}}
+	queueErr := errors.New("queue failed")
+	work := &fakeWorkQueue{err: queueErr}
+	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
+
+	err := e.EnqueuePending(ctx, 7)
+	if !errors.Is(err, queueErr) {
+		t.Fatalf("EnqueuePending error = %v; want wrapping %v", err, queueErr)
+	}
+	if len(store.status) != 2 {
+		t.Fatalf("status calls = %+v; want reserve and restore", store.status)
+	}
+	if store.status[0].status != scan.StatusProcessing || store.status[1].status != scan.StatusPending {
+		t.Fatalf("status calls = %+v; want processing then pending", store.status)
+	}
+}
+
 func TestEnqueuer_OnScanCompleteUsesLibraryID(t *testing.T) {
 	ctx := context.Background()
 	store := &fakePendingStore{}
@@ -136,7 +187,6 @@ func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
 		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
 	}}
 	cacheErr := errors.New("cache failed")
-	queueErr := errors.New("queue failed")
 
 	tests := []struct {
 		name  string
@@ -149,12 +199,6 @@ func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
 			cache: fakeLyricsCache{err: cacheErr},
 			queue: &fakeWorkQueue{},
 			want:  cacheErr,
-		},
-		{
-			name:  "queue",
-			cache: fakeLyricsCache{hits: map[string]bool{}},
-			queue: &fakeWorkQueue{err: queueErr},
-			want:  queueErr,
 		},
 	}
 

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -1,0 +1,171 @@
+package scan_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/mxlrcsvc-go/internal/models"
+	"github.com/sydlexius/mxlrcsvc-go/internal/queue"
+	"github.com/sydlexius/mxlrcsvc-go/internal/scan"
+)
+
+type fakePendingStore struct {
+	results   []models.ScanResult
+	status    []statusCall
+	libraryID int64
+	err       error
+}
+
+type statusCall struct {
+	ids    []int64
+	status string
+}
+
+func (f *fakePendingStore) ListPendingByLibrary(_ context.Context, libraryID int64) ([]models.ScanResult, error) {
+	f.libraryID = libraryID
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]models.ScanResult(nil), f.results...), nil
+}
+
+func (f *fakePendingStore) SetStatus(_ context.Context, ids []int64, status string) error {
+	cp := append([]int64(nil), ids...)
+	f.status = append(f.status, statusCall{ids: cp, status: status})
+	return nil
+}
+
+type fakeLyricsCache struct {
+	hits map[string]bool
+	err  error
+}
+
+func (f fakeLyricsCache) LookupFallback(_ context.Context, artist string, title string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.hits[artist+"\x00"+title] {
+		return "[00:00.00]cached", nil
+	}
+	return "", sql.ErrNoRows
+}
+
+type fakeWorkQueue struct {
+	inputs []models.Inputs
+	err    error
+}
+
+func (f *fakeWorkQueue) Enqueue(_ context.Context, inputs models.Inputs, _ int) (queue.WorkItem, error) {
+	if f.err != nil {
+		return queue.WorkItem{}, f.err
+	}
+	f.inputs = append(f.inputs, inputs)
+	return queue.WorkItem{ID: int64(len(f.inputs)), Inputs: inputs}, nil
+}
+
+func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{
+		{
+			ID: 1,
+			Track: models.Track{
+				ArtistName: "Cached",
+				TrackName:  "Song",
+			},
+			Outdir:   "/music",
+			Filename: "cached.lrc",
+		},
+		{
+			ID:       2,
+			FilePath: "/music/missing.mp3",
+			Track: models.Track{
+				ArtistName: "Missing",
+				TrackName:  "Song",
+			},
+		},
+	}}
+	cache := fakeLyricsCache{hits: map[string]bool{"Cached\x00Song": true}}
+	work := &fakeWorkQueue{}
+	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work, Priority: 5}
+
+	if err := e.EnqueuePending(ctx, 7); err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if len(work.inputs) != 1 {
+		t.Fatalf("enqueued inputs = %+v; want 1 miss", work.inputs)
+	}
+	got := work.inputs[0]
+	if got.Track.ArtistName != "Missing" || got.OutputPaths[0].Filename != "missing.lrc" {
+		t.Fatalf("enqueued input = %+v; want Missing/missing.lrc", got)
+	}
+	if len(store.status) != 2 {
+		t.Fatalf("status calls = %+v; want done and processing calls", store.status)
+	}
+	if store.status[0].status != scan.StatusDone || len(store.status[0].ids) != 1 || store.status[0].ids[0] != 1 {
+		t.Fatalf("first status call = %+v; want cache hit done", store.status[0])
+	}
+	if store.status[1].status != scan.StatusProcessing || len(store.status[1].ids) != 1 || store.status[1].ids[0] != 2 {
+		t.Fatalf("second status call = %+v; want miss processing", store.status[1])
+	}
+}
+
+func TestEnqueuer_OnScanCompleteUsesLibraryID(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{}
+	cache := fakeLyricsCache{hits: map[string]bool{}}
+	work := &fakeWorkQueue{}
+	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
+
+	if err := e.OnScanComplete(ctx, models.Library{ID: 9}, nil); err != nil {
+		t.Fatalf("OnScanComplete: %v", err)
+	}
+	if store.libraryID != 9 {
+		t.Fatalf("libraryID = %d; want 9", store.libraryID)
+	}
+	if len(store.status) != 0 {
+		t.Fatalf("status calls = %+v; want no status calls", store.status)
+	}
+}
+
+func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
+	ctx := context.Background()
+	results := []models.ScanResult{{
+		ID:    1,
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}
+	cacheErr := errors.New("cache failed")
+	queueErr := errors.New("queue failed")
+
+	tests := []struct {
+		name  string
+		cache fakeLyricsCache
+		queue *fakeWorkQueue
+		want  error
+	}{
+		{
+			name:  "cache",
+			cache: fakeLyricsCache{err: cacheErr},
+			queue: &fakeWorkQueue{},
+			want:  cacheErr,
+		},
+		{
+			name:  "queue",
+			cache: fakeLyricsCache{hits: map[string]bool{}},
+			queue: &fakeWorkQueue{err: queueErr},
+			want:  queueErr,
+		},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			store := &fakePendingStore{results: results}
+			e := scan.Enqueuer{Results: store, Cache: v.cache, Queue: v.queue}
+			err := e.EnqueuePending(ctx, 1)
+			if !errors.Is(err, v.want) {
+				t.Fatalf("EnqueuePending error = %v; want wrapping %v", err, v.want)
+			}
+		})
+	}
+}

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -118,8 +118,9 @@ func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
 func TestEnqueuer_ReservesMissBeforeEnqueue(t *testing.T) {
 	ctx := context.Background()
 	store := &fakePendingStore{results: []models.ScanResult{{
-		ID:    3,
-		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+		ID:       3,
+		FilePath: "/music/reserved.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
 	}}}
 	cache := fakeLyricsCache{hits: map[string]bool{}}
 	var reservedBeforeEnqueue bool
@@ -142,8 +143,9 @@ func TestEnqueuer_ReservesMissBeforeEnqueue(t *testing.T) {
 func TestEnqueuer_RestoresPendingWhenEnqueueFails(t *testing.T) {
 	ctx := context.Background()
 	store := &fakePendingStore{results: []models.ScanResult{{
-		ID:    4,
-		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+		ID:       4,
+		FilePath: "/music/failure.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
 	}}}
 	cache := fakeLyricsCache{hits: map[string]bool{}}
 	queueErr := errors.New("queue failed")
@@ -153,6 +155,31 @@ func TestEnqueuer_RestoresPendingWhenEnqueueFails(t *testing.T) {
 	err := e.EnqueuePending(ctx, 7)
 	if !errors.Is(err, queueErr) {
 		t.Fatalf("EnqueuePending error = %v; want wrapping %v", err, queueErr)
+	}
+	if len(store.status) != 2 {
+		t.Fatalf("status calls = %+v; want reserve and restore", store.status)
+	}
+	if store.status[0].status != scan.StatusProcessing || store.status[1].status != scan.StatusPending {
+		t.Fatalf("status calls = %+v; want processing then pending", store.status)
+	}
+}
+
+func TestEnqueuer_RestoresPendingWhenScanResultDestinationInvalid(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:    5,
+		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}}
+	cache := fakeLyricsCache{hits: map[string]bool{}}
+	work := &fakeWorkQueue{}
+	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
+
+	err := e.EnqueuePending(ctx, 7)
+	if err == nil {
+		t.Fatal("EnqueuePending returned nil error; want invalid destination error")
+	}
+	if len(work.inputs) != 0 {
+		t.Fatalf("enqueued inputs = %+v; want none", work.inputs)
 	}
 	if len(store.status) != 2 {
 		t.Fatalf("status calls = %+v; want reserve and restore", store.status)
@@ -183,10 +210,12 @@ func TestEnqueuer_OnScanCompleteUsesLibraryID(t *testing.T) {
 func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
 	ctx := context.Background()
 	results := []models.ScanResult{{
-		ID:    1,
-		Track: models.Track{ArtistName: "Artist", TrackName: "Title"},
+		ID:       1,
+		FilePath: "/music/error.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
 	}}
 	cacheErr := errors.New("cache failed")
+	queueErr := errors.New("queue failed")
 
 	tests := []struct {
 		name  string
@@ -199,6 +228,12 @@ func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
 			cache: fakeLyricsCache{err: cacheErr},
 			queue: &fakeWorkQueue{},
 			want:  cacheErr,
+		},
+		{
+			name:  "queue",
+			cache: fakeLyricsCache{hits: map[string]bool{}},
+			queue: &fakeWorkQueue{err: queueErr},
+			want:  queueErr,
 		},
 	}
 

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -38,9 +38,9 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 	defer func() { _ = tx.Rollback() }()
 
 	for _, res := range results {
-		status := res.Status
-		if status == "" {
-			status = StatusPending
+		insertStatus := res.Status
+		if insertStatus == "" {
+			insertStatus = StatusPending
 		}
 		_, err := tx.ExecContext(ctx,
 			`INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
@@ -50,14 +50,19 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
                  title = excluded.title,
                  outdir = excluded.outdir,
                  filename = excluded.filename,
-                 status = excluded.status`,
+                 status = CASE
+                     WHEN ? = '' THEN scan_results.status
+                     ELSE ?
+                 END`,
 			libraryID,
 			res.FilePath,
 			res.Track.ArtistName,
 			res.Track.TrackName,
 			res.Outdir,
 			res.Filename,
-			status,
+			insertStatus,
+			res.Status,
+			res.Status,
 		)
 		if err != nil {
 			return fmt.Errorf("scan: upsert %s: %w", res.FilePath, err)

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -92,24 +92,8 @@ func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []mo
 		}
 	}()
 
-	for rows.Next() {
-		var res models.ScanResult
-		if err := rows.Scan(
-			&res.ID,
-			&res.LibraryID,
-			&res.FilePath,
-			&res.Track.ArtistName,
-			&res.Track.TrackName,
-			&res.Outdir,
-			&res.Filename,
-			&res.Status,
-			&res.CreatedAt,
-		); err != nil {
-			return nil, fmt.Errorf("scan: list scan: %w", err)
-		}
-		results = append(results, res)
-	}
-	if err := rows.Err(); err != nil {
+	results, err = scanResultRows(rows)
+	if err != nil {
 		return nil, fmt.Errorf("scan: list rows: %w", err)
 	}
 	return results, nil
@@ -135,6 +119,15 @@ func (r *Repo) ListPendingByLibrary(ctx context.Context, libraryID int64) (resul
 		}
 	}()
 
+	results, err = scanResultRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan: list pending rows: %w", err)
+	}
+	return results, nil
+}
+
+func scanResultRows(rows *sql.Rows) ([]models.ScanResult, error) {
+	var results []models.ScanResult
 	for rows.Next() {
 		var res models.ScanResult
 		if err := rows.Scan(
@@ -148,12 +141,12 @@ func (r *Repo) ListPendingByLibrary(ctx context.Context, libraryID int64) (resul
 			&res.Status,
 			&res.CreatedAt,
 		); err != nil {
-			return nil, fmt.Errorf("scan: list pending scan: %w", err)
+			return nil, err
 		}
 		results = append(results, res)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("scan: list pending rows: %w", err)
+		return nil, err
 	}
 	return results, nil
 }

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -43,16 +43,20 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 			status = StatusPending
 		}
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO scan_results (library_id, file_path, artist, title, status)
-             VALUES (?, ?, ?, ?, ?)
+			`INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(library_id, file_path) DO UPDATE SET
                  artist = excluded.artist,
                  title = excluded.title,
+                 outdir = excluded.outdir,
+                 filename = excluded.filename,
                  status = excluded.status`,
 			libraryID,
 			res.FilePath,
 			res.Track.ArtistName,
 			res.Track.TrackName,
+			res.Outdir,
+			res.Filename,
 			status,
 		)
 		if err != nil {
@@ -68,7 +72,7 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 // ListByLibrary returns persisted scan results for a library in stable ID order.
 func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []models.ScanResult, retErr error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, library_id, file_path, artist, title, status, created_at
+		`SELECT id, library_id, file_path, artist, title, outdir, filename, status, created_at
          FROM scan_results
          WHERE library_id = ?
          ORDER BY id ASC`,
@@ -91,6 +95,8 @@ func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []mo
 			&res.FilePath,
 			&res.Track.ArtistName,
 			&res.Track.TrackName,
+			&res.Outdir,
+			&res.Filename,
 			&res.Status,
 			&res.CreatedAt,
 		); err != nil {
@@ -102,4 +108,87 @@ func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []mo
 		return nil, fmt.Errorf("scan: list rows: %w", err)
 	}
 	return results, nil
+}
+
+// ListPendingByLibrary returns pending scan results for a library in stable ID order.
+func (r *Repo) ListPendingByLibrary(ctx context.Context, libraryID int64) (results []models.ScanResult, retErr error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, library_id, file_path, artist, title, outdir, filename, status, created_at
+         FROM scan_results
+         WHERE library_id = ?
+           AND status = ?
+         ORDER BY id ASC`,
+		libraryID,
+		StatusPending,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan: list pending by library: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("scan: close pending rows: %w", err)
+		}
+	}()
+
+	for rows.Next() {
+		var res models.ScanResult
+		if err := rows.Scan(
+			&res.ID,
+			&res.LibraryID,
+			&res.FilePath,
+			&res.Track.ArtistName,
+			&res.Track.TrackName,
+			&res.Outdir,
+			&res.Filename,
+			&res.Status,
+			&res.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan: list pending scan: %w", err)
+		}
+		results = append(results, res)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan: list pending rows: %w", err)
+	}
+	return results, nil
+}
+
+// SetStatus updates scan result status for each id.
+func (r *Repo) SetStatus(ctx context.Context, ids []int64, status string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	switch status {
+	case StatusPending, StatusProcessing, StatusDone, StatusFailed:
+	default:
+		return fmt.Errorf("scan: unsupported status %q", status)
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("scan: begin set status tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, id := range ids {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE scan_results SET status = ? WHERE id = ?`,
+			status,
+			id,
+		)
+		if err != nil {
+			return fmt.Errorf("scan: set status %d: %w", id, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("scan: set status rows affected: %w", err)
+		}
+		if n == 0 {
+			return sql.ErrNoRows
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("scan: commit set status tx: %w", err)
+	}
+	return nil
 }

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -99,6 +99,49 @@ func TestRepo_UpsertDefaultsStatus(t *testing.T) {
 	}
 }
 
+func TestRepo_UpsertPreservesExistingStatusWhenStatusUnspecified(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	initial := []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Status:   scan.StatusDone,
+	}}
+	if err := scanRepo.Upsert(ctx, lib.ID, initial); err != nil {
+		t.Fatalf("Upsert initial: %v", err)
+	}
+	update := []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Updated Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+	}}
+	if err := scanRepo.Upsert(ctx, lib.ID, update); err != nil {
+		t.Fatalf("Upsert update: %v", err)
+	}
+
+	got, err := scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListByLibrary returned %d results; want 1", len(got))
+	}
+	if got[0].Status != scan.StatusDone {
+		t.Fatalf("Status = %q; want %q", got[0].Status, scan.StatusDone)
+	}
+	if got[0].Track.TrackName != "Updated Title" {
+		t.Fatalf("TrackName = %q; want Updated Title", got[0].Track.TrackName)
+	}
+}
+
 func TestRepo_ListByLibrary_IsolatedByLibrary(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -36,6 +36,8 @@ func TestRepo_UpsertAndListByLibrary(t *testing.T) {
 	results := []models.ScanResult{{
 		FilePath: "/music/a.mp3",
 		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
 		Status:   scan.StatusPending,
 	}}
 	if err := scanRepo.Upsert(ctx, lib.ID, results); err != nil {
@@ -59,6 +61,9 @@ func TestRepo_UpsertAndListByLibrary(t *testing.T) {
 	}
 	if got[0].Track.TrackName != "Updated Title" {
 		t.Errorf("TrackName = %q; want Updated Title", got[0].Track.TrackName)
+	}
+	if got[0].Outdir != "/music" || got[0].Filename != "a.lrc" {
+		t.Errorf("output = %q/%q; want /music/a.lrc", got[0].Outdir, got[0].Filename)
 	}
 	if got[0].Status != scan.StatusDone {
 		t.Errorf("Status = %q; want %q", got[0].Status, scan.StatusDone)
@@ -135,5 +140,56 @@ func TestRepo_ListByLibrary_IsolatedByLibrary(t *testing.T) {
 	}
 	if len(gotB) != 1 || gotB[0].Track.ArtistName != "Artist B" {
 		t.Fatalf("library B results = %+v; want Artist B only", gotB)
+	}
+}
+
+func TestRepo_ListPendingByLibraryAndSetStatus(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	results := []models.ScanResult{
+		{
+			FilePath: "/music/a.mp3",
+			Track:    models.Track{ArtistName: "Artist A", TrackName: "Title A"},
+			Outdir:   "/music",
+			Filename: "a.lrc",
+			Status:   scan.StatusPending,
+		},
+		{
+			FilePath: "/music/b.mp3",
+			Track:    models.Track{ArtistName: "Artist B", TrackName: "Title B"},
+			Status:   scan.StatusDone,
+		},
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, results); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	pending, err := scanRepo.ListPendingByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListPendingByLibrary: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending results = %+v; want 1 result", pending)
+	}
+	if pending[0].Filename != "a.lrc" {
+		t.Fatalf("pending filename = %q; want a.lrc", pending[0].Filename)
+	}
+
+	if err := scanRepo.SetStatus(ctx, []int64{pending[0].ID}, scan.StatusProcessing); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	pending, err = scanRepo.ListPendingByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListPendingByLibrary after SetStatus: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending results after SetStatus = %+v; want none", pending)
 	}
 }


### PR DESCRIPTION
## Summary
- wire pending library scan results to the durable work queue through a scan enqueuer callback
- persist scan output destinations and add pending/status repository methods
- add API key generation, SHA-256 hashing, validation, revocation, listing, scopes, and an in-memory store

Closes #20
Closes #21

## Test plan
- go test -count=1 -coverprofile=/tmp/mxlrc-cover.out ./...
- golangci-lint run
- git diff --cached --check
- pre-commit hooks during commit: go build, golangci-lint, govulncheck, typos, gitleaks, gofmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key service for creating, validating, revoking, and listing keys.
  * Scanner → durable work-queue integration to persist scan outputs and enqueue pending work.
  * Scan results now include stored output directory and filename.

* **Database**
  * Migration added to store scan result output paths.

* **Tests & Documentation**
  * Expanded tests for auth, scan enqueueing, repository behavior, and migration.
  * New planning and summary documents; planning state updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->