### PR TITLE
ci: add coverage and supply chain checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
-        run: go test -v -race -count=1 ./...
+        run: go test -v -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: false
 
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -23,6 +24,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v2.4.1'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,8 +7,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
@@ -27,6 +25,7 @@ jobs:
       - name: Run analysis
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,25 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+signs:
+  - artifacts: checksum
+    cmd: cosign
+    args:
+      - sign-blob
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes
+    signature: ${artifact}.sig
+    certificate: ${artifact}.pem
 
 changelog:
   sort: asc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mxlrcgo-svc
-[![build](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml)
+
+[![CI](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml/badge.svg)](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml)
+[![Release](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/release.yml/badge.svg)](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/release.yml)
+[![codecov](https://codecov.io/gh/sydlexius/mxlrcgo-svc/branch/main/graph/badge.svg)](https://codecov.io/gh/sydlexius/mxlrcgo-svc)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sydlexius/mxlrcgo-svc/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sydlexius/mxlrcgo-svc)
 
 Command line tool to fetch synced lyrics from [Musixmatch](https://www.musixmatch.com/) and save it as *.lrc file.
 
@@ -128,6 +132,12 @@ Run the lightweight CLI smoke test:
 
 ```sh
 make smoke
+```
+
+Generate a local coverage profile and HTML report:
+
+```sh
+make test-cover
 ```
 
 ---


### PR DESCRIPTION
## Summary
- generate Go coverage in CI and upload it to Codecov without blocking local development
- add OpenSSF Scorecard analysis with SARIF upload
- install cosign for releases and sign GoReleaser checksum artifacts
- add README badges and local coverage instructions

Closes #38
Closes #46

## Test plan
- go test -count=1 -coverprofile=/tmp/mxlrcgo-svc-cover.out ./...
- go test -v -race -count=1 -coverprofile=coverage.out ./...
- golangci-lint run ./...
- goreleaser check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/scorecard.yml .goreleaser.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic generation and reporting of test coverage to external tracking
  * Release artifacts are cryptographically signed for stronger verification
  * Automated weekly security scorecard scans with manual trigger support

* **Documentation**
  * Project badges updated to show CI, release, coverage, and security scorecard status
  * Added local coverage report instructions to development docs

* **Chores**
  * CI/CD workflow permissions and release pipeline configuration improvements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->