### PR TITLE
chore: finish remaining repo issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 
 - **Binary name**: `mxlrcgo-svc` (matches new module name)
 - **No CGO**: Must remain CGO_ENABLED=0 for cross-compilation
-- **Go 1.25+**: Minimum Go version per go.mod
+- **Go 1.26.2+**: Minimum Go version per go.mod
 - **Behavior preservation**: All existing CLI flags and behaviors must work identically after restructuring
 - **Token precedence**: CLI flag > environment variable (`MUSIXMATCH_TOKEN`) > `.env` file
 <!-- GSD:project-end -->
@@ -20,7 +20,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 ## Technology Stack
 
 ## Languages
-- Go 1.25 (minimum, per `go.mod`) - All application code
+- Go 1.26.2 (minimum, per `go.mod`) - All application code
 - Bash - Pre-commit hooks (`.githooks/pre-commit`), Makefile targets
 - YAML - CI/CD workflows (`.github/workflows/`), configuration files
 ## Runtime
@@ -61,7 +61,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - `.pre-commit-config.yaml` - Pre-commit framework hooks: trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files (500KB), check-merge-conflict, typos, gitleaks, golangci-lint, gofmt, conventional-pre-commit
 - `.githooks/pre-commit` - Manual pre-commit hook: typos, gofmt, go build, golangci-lint, govulncheck
 ## Platform Requirements
-- Go 1.25+
+- Go 1.26.2+
 - golangci-lint v2.11+ (for linting)
 - typos-cli (for spell checking)
 - govulncheck (for vulnerability scanning)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS build
+FROM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS build
 
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Command line tool to fetch synced lyrics from [Musixmatch](https://www.musixmatc
 **TBA**
 
 ### Build from source
-Required Go 1.25+
+Required Go 1.26.2+
 ```sh
 go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest
 ```
@@ -77,14 +77,15 @@ disabled = []
 [verification]
 enabled = false
 whisper_url = ""
+ffmpeg_path = "ffmpeg"
 sample_duration_seconds = 30
 min_confidence = 0.85
 min_similarity = 0.35
 ```
 
-Environment variables override the TOML file: `MXLRC_PROVIDER_PRIMARY`, `MXLRC_PROVIDERS_DISABLED`, `MXLRC_VERIFICATION_ENABLED`, `MXLRC_VERIFICATION_WHISPER_URL`, `MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS`, `MXLRC_VERIFICATION_MIN_CONFIDENCE`, and `MXLRC_VERIFICATION_MIN_SIMILARITY`. `MXLRC_WHISPER_URL` and `MXLRC_VERIFICATION_SAMPLE_DURATION` remain accepted as legacy aliases.
+Environment variables override the TOML file: `MXLRC_PROVIDER_PRIMARY`, `MXLRC_PROVIDERS_DISABLED`, `MXLRC_VERIFICATION_ENABLED`, `MXLRC_VERIFICATION_WHISPER_URL`, `MXLRC_VERIFICATION_FFMPEG_PATH`, `MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS`, `MXLRC_VERIFICATION_MIN_CONFIDENCE`, and `MXLRC_VERIFICATION_MIN_SIMILARITY`. `MXLRC_WHISPER_URL` and `MXLRC_VERIFICATION_SAMPLE_DURATION` remain accepted as legacy aliases.
 
-When verification is enabled, the worker calls a Whisper-compatible `/v1/audio/transcriptions` sidecar for scanned audio whose Musixmatch metadata confidence is below `min_confidence`. The transcript must overlap the candidate lyrics by at least `min_similarity`. `sample_duration_seconds` is reserved for the ffmpeg sampling follow-up and is not sent to the Whisper-compatible API.
+When verification is enabled, `ffmpeg` must be installed or `ffmpeg_path` must point to an executable ffmpeg binary. The worker extracts a bounded mono 16 kHz WAV sample using `sample_duration_seconds`, then sends that sample to a Whisper-compatible `/v1/audio/transcriptions` sidecar for scanned audio whose Musixmatch metadata confidence is below `min_confidence`. The transcript must overlap the candidate lyrics by at least `min_similarity`.
 
 ### Library and key management
 ```sh

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@
 # MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY,
 # MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED,
 # MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL,
+# MXLRC_VERIFICATION_FFMPEG_PATH,
 # MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_MIN_CONFIDENCE,
 # MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_DOCKER
 
@@ -44,6 +45,7 @@ disabled = []
 # Optional STT verification for low-confidence scanned audio.
 enabled = false
 whisper_url = ""
+ffmpeg_path = "ffmpeg"
 sample_duration_seconds = 30
 min_confidence = 0.85
 min_similarity = 0.35

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sydlexius/mxlrcgo-svc
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -482,6 +482,7 @@ func newVerifier(cfg config.Config) (verification.Verifier, error) {
 		cfg.Verification.WhisperURL,
 		cfg.Verification.SampleDurationSeconds,
 		cfg.Verification.MinSimilarity,
+		cfg.Verification.FFmpegPath,
 	)
 }
 
@@ -803,6 +804,7 @@ func configKeys() []string {
 		"providers.disabled",
 		"verification.enabled",
 		"verification.whisper_url",
+		"verification.ffmpeg_path",
 		"verification.sample_duration_seconds",
 		"verification.min_confidence",
 		"verification.min_similarity",
@@ -831,6 +833,8 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return strconv.FormatBool(cfg.Verification.Enabled), true
 	case "verification.whisper_url":
 		return cfg.Verification.WhisperURL, true
+	case "verification.ffmpeg_path":
+		return cfg.Verification.FFmpegPath, true
 	case "verification.sample_duration_seconds":
 		return strconv.Itoa(cfg.Verification.SampleDurationSeconds), true
 	case "verification.min_confidence":
@@ -872,6 +876,11 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 		cfg.Verification.Enabled = v
 	case "verification.whisper_url":
 		cfg.Verification.WhisperURL = value
+	case "verification.ffmpeg_path":
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("verification.ffmpeg_path must not be empty")
+		}
+		cfg.Verification.FFmpegPath = value
 	case "verification.sample_duration_seconds":
 		n, err := strconv.Atoi(value)
 		if err != nil || n <= 0 {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -48,6 +48,21 @@ func TestNewVerifierRequiresURLWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestNewVerifierDisabledDoesNotRequireFFmpeg(t *testing.T) {
+	got, err := newVerifier(config.Config{
+		Verification: config.VerificationConfig{
+			Enabled:    false,
+			FFmpegPath: "/path/that/does/not/exist",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newVerifier: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("newVerifier = %#v; want nil", got)
+	}
+}
+
 func TestConfigureWorkerVerificationAcceptsNilVerifier(t *testing.T) {
 	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
 	configureWorkerVerification(w, config.Config{}, nil)
@@ -58,6 +73,7 @@ func TestVerificationConfigKeys(t *testing.T) {
 		Verification: config.VerificationConfig{
 			Enabled:               true,
 			WhisperURL:            "http://whisper:9000",
+			FFmpegPath:            "/usr/bin/ffmpeg",
 			SampleDurationSeconds: 45,
 			MinConfidence:         0.7,
 			MinSimilarity:         0.5,
@@ -66,6 +82,7 @@ func TestVerificationConfigKeys(t *testing.T) {
 	tests := map[string]string{
 		"verification.enabled":                 "true",
 		"verification.whisper_url":             "http://whisper:9000",
+		"verification.ffmpeg_path":             "/usr/bin/ffmpeg",
 		"verification.sample_duration_seconds": "45",
 		"verification.min_confidence":          "0.7",
 		"verification.min_similarity":          "0.5",
@@ -83,6 +100,18 @@ func TestVerificationConfigKeys(t *testing.T) {
 	if err := setConfigValue(&cfg, "verification.min_similarity", "0"); err == nil {
 		t.Fatal("setConfigValue accepted invalid verification.min_similarity")
 	}
+	if err := setConfigValue(&cfg, "verification.ffmpeg_path", " "); err == nil {
+		t.Fatal("setConfigValue accepted blank verification.ffmpeg_path")
+	}
+}
+
+func TestConfigKeysIncludesVerificationFFmpegPath(t *testing.T) {
+	for _, key := range configKeys() {
+		if key == "verification.ffmpeg_path" {
+			return
+		}
+	}
+	t.Fatal("configKeys missing verification.ffmpeg_path")
 }
 
 var _ lyrics.Writer = fakeWriter{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type ProvidersConfig struct {
 type VerificationConfig struct {
 	Enabled               bool    `toml:"enabled"`
 	WhisperURL            string  `toml:"whisper_url"`
+	FFmpegPath            string  `toml:"ffmpeg_path"`
 	SampleDurationSeconds int     `toml:"sample_duration_seconds"`
 	MinConfidence         float64 `toml:"min_confidence"`
 	MinSimilarity         float64 `toml:"min_similarity"`
@@ -66,7 +67,7 @@ func defaults() Config {
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
 		Server:       ServerConfig{Addr: "127.0.0.1:3876"},
 		Providers:    ProvidersConfig{Primary: "musixmatch"},
-		Verification: VerificationConfig{SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
+		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
 	}
 }
 
@@ -103,6 +104,9 @@ func Load(path string) (Config, error) {
 			if cfg.Verification.SampleDurationSeconds <= 0 {
 				cfg.Verification.SampleDurationSeconds = d.Verification.SampleDurationSeconds
 			}
+			if cfg.Verification.FFmpegPath == "" {
+				cfg.Verification.FFmpegPath = d.Verification.FFmpegPath
+			}
 			if cfg.Verification.MinConfidence <= 0 || cfg.Verification.MinConfidence > 1 {
 				cfg.Verification.MinConfidence = d.Verification.MinConfidence
 			}
@@ -123,7 +127,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -182,6 +186,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v != "" {
 		cfg.Verification.WhisperURL = v
+	}
+	if v := os.Getenv("MXLRC_VERIFICATION_FFMPEG_PATH"); v != "" {
+		cfg.Verification.FFmpegPath = v
 	}
 	sampleDurationVar := "MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS"
 	v = os.Getenv(sampleDurationVar)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ func isolateEnv(t *testing.T) {
 		"MXLRC_OUTPUT_DIR", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
 		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
 		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
+		"MXLRC_VERIFICATION_FFMPEG_PATH",
 		"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION",
 		"MXLRC_VERIFICATION_MIN_CONFIDENCE", "MXLRC_VERIFICATION_MIN_SIMILARITY",
 		"MXLRC_DOCKER",
@@ -55,6 +56,9 @@ func TestLoad_MissingConfigFileIsNotFatal(t *testing.T) {
 	}
 	if cfg.Verification.MinConfidence != 0.85 {
 		t.Errorf("default verification min confidence = %v; want 0.85", cfg.Verification.MinConfidence)
+	}
+	if cfg.Verification.FFmpegPath != "ffmpeg" {
+		t.Errorf("default verification ffmpeg path = %q; want ffmpeg", cfg.Verification.FFmpegPath)
 	}
 	if cfg.Verification.MinSimilarity != 0.35 {
 		t.Errorf("default verification min similarity = %v; want 0.35", cfg.Verification.MinSimilarity)
@@ -307,6 +311,7 @@ func TestLoad_ProvidersAndVerificationFromFileAndEnv(t *testing.T) {
 		"[verification]\n" +
 		"enabled = true\n" +
 		"whisper_url = \"http://whisper:9000\"\n" +
+		"ffmpeg_path = \"/usr/bin/ffmpeg\"\n" +
 		"sample_duration_seconds = 45\n" +
 		"min_confidence = 0.8\n" +
 		"min_similarity = 0.4\n"
@@ -318,6 +323,7 @@ func TestLoad_ProvidersAndVerificationFromFileAndEnv(t *testing.T) {
 	t.Setenv("MXLRC_VERIFICATION_ENABLED", "false")
 	t.Setenv("MXLRC_VERIFICATION_WHISPER_URL", "http://env-whisper:9000")
 	t.Setenv("MXLRC_WHISPER_URL", "http://legacy-whisper:9000")
+	t.Setenv("MXLRC_VERIFICATION_FFMPEG_PATH", "/opt/ffmpeg")
 	t.Setenv("MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "60")
 	t.Setenv("MXLRC_VERIFICATION_SAMPLE_DURATION", "45")
 	t.Setenv("MXLRC_VERIFICATION_MIN_CONFIDENCE", "0.7")
@@ -341,6 +347,9 @@ func TestLoad_ProvidersAndVerificationFromFileAndEnv(t *testing.T) {
 	}
 	if cfg.Verification.SampleDurationSeconds != 60 {
 		t.Fatalf("verification.sample_duration_seconds = %d; want 60", cfg.Verification.SampleDurationSeconds)
+	}
+	if cfg.Verification.FFmpegPath != "/opt/ffmpeg" {
+		t.Fatalf("verification.ffmpeg_path = %q; want env value", cfg.Verification.FFmpegPath)
 	}
 	if cfg.Verification.MinConfidence != 0.7 {
 		t.Fatalf("verification.min_confidence = %v; want 0.7", cfg.Verification.MinConfidence)

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -10,7 +10,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -36,11 +38,12 @@ type HTTPVerifier struct {
 	baseURL               string
 	sampleDurationSeconds int
 	minSimilarity         float64
+	ffmpegPath            string
 	client                *http.Client
 }
 
 // NewHTTPVerifier creates a verifier for an OpenAI-compatible transcription API.
-func NewHTTPVerifier(baseURL string, sampleDurationSeconds int, minSimilarity float64) (*HTTPVerifier, error) {
+func NewHTTPVerifier(baseURL string, sampleDurationSeconds int, minSimilarity float64, ffmpegPath string) (*HTTPVerifier, error) {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return nil, fmt.Errorf("verification: whisper_url must not be empty")
@@ -54,10 +57,19 @@ func NewHTTPVerifier(baseURL string, sampleDurationSeconds int, minSimilarity fl
 	if minSimilarity <= 0 || minSimilarity > 1 {
 		minSimilarity = 0.35
 	}
+	ffmpegPath = strings.TrimSpace(ffmpegPath)
+	if ffmpegPath == "" {
+		ffmpegPath = "ffmpeg"
+	}
+	resolvedFFmpegPath, err := exec.LookPath(ffmpegPath)
+	if err != nil {
+		return nil, fmt.Errorf("verification: ffmpeg unavailable at %q: %w", ffmpegPath, err)
+	}
 	return &HTTPVerifier{
 		baseURL:               strings.TrimRight(baseURL, "/"),
-		sampleDurationSeconds: sampleDurationSeconds, // reserved for ffmpeg sampling before upload
+		sampleDurationSeconds: sampleDurationSeconds,
 		minSimilarity:         minSimilarity,
+		ffmpegPath:            resolvedFFmpegPath,
 		client:                &http.Client{Timeout: 2 * time.Minute},
 	}, nil
 }
@@ -71,7 +83,14 @@ func (v *HTTPVerifier) Verify(ctx context.Context, audioPath string, song models
 	if lyrics == "" {
 		return Result{}, fmt.Errorf("verification: lyrics text is empty")
 	}
-	transcript, err := v.transcribe(ctx, audioPath)
+	samplePath, err := v.sample(ctx, audioPath)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		_ = os.Remove(samplePath)
+	}()
+	transcript, err := v.transcribe(ctx, samplePath)
 	if err != nil {
 		return Result{}, err
 	}
@@ -81,6 +100,48 @@ func (v *HTTPVerifier) Verify(ctx context.Context, audioPath string, song models
 		Similarity: similarity,
 		Transcript: transcript,
 	}, nil
+}
+
+func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, retErr error) {
+	f, err := os.CreateTemp("", "mxlrcgo-svc-verify-*.wav")
+	if err != nil {
+		return "", fmt.Errorf("verification: create sample file: %w", err)
+	}
+	samplePath := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(samplePath)
+		return "", fmt.Errorf("verification: close sample file: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(samplePath)
+		}
+	}()
+
+	cmd := exec.CommandContext(ctx, v.ffmpegPath, ffmpegSampleArgs(audioPath, samplePath, v.sampleDurationSeconds)...) //nolint:gosec // ffmpeg path is configured and validated; audio path is a scanned user file
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", fmt.Errorf("verification: sample audio: %w", ctxErr)
+		}
+		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return samplePath, nil
+}
+
+func ffmpegSampleArgs(audioPath, samplePath string, durationSeconds int) []string {
+	return []string{
+		"-nostdin",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-y",
+		"-i", audioPath,
+		"-t", strconv.Itoa(durationSeconds),
+		"-vn",
+		"-ac", "1",
+		"-ar", "16000",
+		samplePath,
+	}
 }
 
 func (v *HTTPVerifier) transcribe(ctx context.Context, audioPath string) (text string, err error) {

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -51,9 +51,7 @@ func NewHTTPVerifier(baseURL string, sampleDurationSeconds int, minSimilarity fl
 	if _, err := url.ParseRequestURI(baseURL); err != nil {
 		return nil, fmt.Errorf("verification: invalid whisper_url: %w", err)
 	}
-	if sampleDurationSeconds <= 0 {
-		sampleDurationSeconds = 30
-	}
+	sampleDurationSeconds = clampSampleDuration(sampleDurationSeconds)
 	if minSimilarity <= 0 || minSimilarity > 1 {
 		minSimilarity = 0.35
 	}
@@ -127,6 +125,16 @@ func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, 
 		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 	return samplePath, nil
+}
+
+func clampSampleDuration(durationSeconds int) int {
+	if durationSeconds < 30 {
+		return 30
+	}
+	if durationSeconds > 60 {
+		return 60
+	}
+	return durationSeconds
 }
 
 func ffmpegSampleArgs(audioPath, samplePath string, durationSeconds int) []string {

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -42,6 +42,11 @@ type HTTPVerifier struct {
 	client                *http.Client
 }
 
+const (
+	minSampleDurationSeconds = 30 // minimum sampling window required by verification policy
+	maxSampleDurationSeconds = 60 // maximum sampling window keeps transcription payloads bounded
+)
+
 // NewHTTPVerifier creates a verifier for an OpenAI-compatible transcription API.
 func NewHTTPVerifier(baseURL string, sampleDurationSeconds int, minSimilarity float64, ffmpegPath string) (*HTTPVerifier, error) {
 	baseURL = strings.TrimSpace(baseURL)
@@ -128,11 +133,11 @@ func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, 
 }
 
 func clampSampleDuration(durationSeconds int) int {
-	if durationSeconds < 30 {
-		return 30
+	if durationSeconds < minSampleDurationSeconds {
+		return minSampleDurationSeconds
 	}
-	if durationSeconds > 60 {
-		return 60
+	if durationSeconds > maxSampleDurationSeconds {
+		return maxSampleDurationSeconds
 	}
 	return durationSeconds
 }

--- a/internal/verification/verification_test.go
+++ b/internal/verification/verification_test.go
@@ -3,10 +3,13 @@ package verification
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
@@ -57,6 +60,7 @@ func TestHTTPVerifierVerifyPostsAudioAndComparesTranscript(t *testing.T) {
 	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
 		t.Fatalf("write audio: %v", err)
 	}
+	ffmpegPath := fakeFFmpeg(t, `printf 'sampled audio' > "$last"`)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/audio/transcriptions" {
@@ -72,12 +76,19 @@ func TestHTTPVerifierVerifyPostsAudioAndComparesTranscript(t *testing.T) {
 		if err != nil {
 			t.Fatalf("FormFile: %v", err)
 		}
+		b, err := io.ReadAll(f)
 		_ = f.Close()
+		if err != nil {
+			t.Fatalf("read form file: %v", err)
+		}
+		if string(b) != "sampled audio" {
+			t.Fatalf("uploaded audio = %q; want sampled audio", string(b))
+		}
 		_ = json.NewEncoder(w).Encode(map[string]string{"text": "hello world"})
 	}))
 	defer srv.Close()
 
-	v, err := NewHTTPVerifier(srv.URL, 45, 0.5)
+	v, err := NewHTTPVerifier(srv.URL, 45, 0.5, ffmpegPath)
 	if err != nil {
 		t.Fatalf("NewHTTPVerifier: %v", err)
 	}
@@ -95,6 +106,90 @@ func TestHTTPVerifierVerifyPostsAudioAndComparesTranscript(t *testing.T) {
 	}
 }
 
+func TestHTTPVerifierBuildsFFmpegSampleCommand(t *testing.T) {
+	got := ffmpegSampleArgs("song.flac", "sample.wav", 45)
+	want := []string{
+		"-nostdin",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-y",
+		"-i", "song.flac",
+		"-t", "45",
+		"-vn",
+		"-ac", "1",
+		"-ar", "16000",
+		"sample.wav",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ffmpegSampleArgs = %#v; want %#v", got, want)
+	}
+}
+
+func TestNewHTTPVerifierErrorsWhenFFmpegMissing(t *testing.T) {
+	_, err := NewHTTPVerifier("http://whisper:9000", 30, 0.5, filepath.Join(t.TempDir(), "missing-ffmpeg"))
+	if err == nil {
+		t.Fatal("NewHTTPVerifier returned nil error; want missing ffmpeg error")
+	}
+}
+
+func TestHTTPVerifierCleansSampleAfterFFmpegFailure(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t, `printf 'partial sample' > "$last"; exit 2`)
+	v, err := NewHTTPVerifier("http://whisper:9000", 30, 0.5, ffmpegPath)
+	if err != nil {
+		t.Fatalf("NewHTTPVerifier: %v", err)
+	}
+
+	_, err = v.Verify(context.Background(), audioPath, models.Song{
+		Lyrics: models.Lyrics{LyricsBody: "hello world lyrics"},
+	})
+	if err == nil {
+		t.Fatal("Verify returned nil error; want ffmpeg failure")
+	}
+	matches, err := filepath.Glob(filepath.Join(tmp, "mxlrcgo-svc-verify-*.wav"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("sample files after failure = %#v; want cleanup", matches)
+	}
+}
+
+func TestHTTPVerifierCleansSampleAfterContextCancellation(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t, `printf 'sampled audio' > "$last"`)
+	v, err := NewHTTPVerifier("http://whisper:9000", 30, 0.5, ffmpegPath)
+	if err != nil {
+		t.Fatalf("NewHTTPVerifier: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = v.Verify(ctx, audioPath, models.Song{
+		Lyrics: models.Lyrics{LyricsBody: "hello world lyrics"},
+	})
+	if err == nil {
+		t.Fatal("Verify returned nil error; want context cancellation")
+	}
+	matches, err := filepath.Glob(filepath.Join(tmp, "mxlrcgo-svc-verify-*.wav"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("sample files after cancellation = %#v; want cleanup", matches)
+	}
+}
+
 func TestHTTPVerifierTranscriptionURL(t *testing.T) {
 	tests := map[string]string{
 		"http://whisper:9000":                         "http://whisper:9000/v1/audio/transcriptions",
@@ -103,8 +198,9 @@ func TestHTTPVerifierTranscriptionURL(t *testing.T) {
 		"http://whisper:9000/v1/":                     "http://whisper:9000/v1/audio/transcriptions",
 		"http://whisper:9000/v1/audio/transcriptions": "http://whisper:9000/v1/audio/transcriptions",
 	}
+	ffmpegPath := fakeFFmpeg(t, `printf 'sampled audio' > "$last"`)
 	for rawURL, want := range tests {
-		v, err := NewHTTPVerifier(rawURL, 30, 0.5)
+		v, err := NewHTTPVerifier(rawURL, 30, 0.5, ffmpegPath)
 		if err != nil {
 			t.Fatalf("NewHTTPVerifier(%q): %v", rawURL, err)
 		}
@@ -112,4 +208,14 @@ func TestHTTPVerifierTranscriptionURL(t *testing.T) {
 			t.Fatalf("transcriptionURL(%q) = %q; want %q", rawURL, got, want)
 		}
 	}
+}
+
+func fakeFFmpeg(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\nlast=''\nfor arg do\n  last=\"$arg\"\ndone\n" + strings.TrimSpace(body) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return path
 }

--- a/internal/verification/verification_test.go
+++ b/internal/verification/verification_test.go
@@ -125,6 +125,31 @@ func TestHTTPVerifierBuildsFFmpegSampleCommand(t *testing.T) {
 	}
 }
 
+func TestNewHTTPVerifierClampsSampleDuration(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t, `printf 'sampled audio' > "$last"`)
+	tests := []struct {
+		name     string
+		duration int
+		want     int
+	}{
+		{name: "zero defaults to minimum", duration: 0, want: 30},
+		{name: "below minimum", duration: 10, want: 30},
+		{name: "within bounds", duration: 45, want: 45},
+		{name: "above maximum", duration: 300, want: 60},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := NewHTTPVerifier("http://whisper:9000", tc.duration, 0.5, ffmpegPath)
+			if err != nil {
+				t.Fatalf("NewHTTPVerifier: %v", err)
+			}
+			if v.sampleDurationSeconds != tc.want {
+				t.Fatalf("sampleDurationSeconds = %d; want %d", v.sampleDurationSeconds, tc.want)
+			}
+		})
+	}
+}
+
 func TestNewHTTPVerifierErrorsWhenFFmpegMissing(t *testing.T) {
 	_, err := NewHTTPVerifier("http://whisper:9000", 30, 0.5, filepath.Join(t.TempDir(), "missing-ffmpeg"))
 	if err == nil {


### PR DESCRIPTION
## Summary
- extract bounded ffmpeg WAV samples before Whisper-compatible verification uploads
- add explicit `verification.ffmpeg_path` config/env/CLI config support and docs
- update Go toolchain and Docker build image pins to Go 1.26.2

## Test plan
- `go test -count=1 -coverprofile=/tmp/mxlrcgo-cover.out ./...`
- `go test -race -count=1 ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /tmp/mxlrcgo-svc ./cmd/mxlrcgo-svc`
- `goreleaser check`
- `docker build -t mxlrcgo-svc:test .`

Closes #56
Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ffmpeg_path setting (default "ffmpeg") and corresponding env override.
  * Verification now samples audio with ffmpeg (bounded mono 16 kHz WAV) and sends the sample for transcription; verification requires a working ffmpeg when enabled.

* **Documentation**
  * Bumped documented minimum Go version to 1.26.2 and documented ffmpeg_path and its env override; updated verification behavior notes.

* **Tests**
  * Added tests for ffmpeg sampling, argument handling, duration clamping, constructor failures, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->