### PR TITLE
ci: improve OpenSSF scorecard coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,15 @@ on:
     - cron: "17 4 * * 1"
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
+permissions: read-all
 
 jobs:
   analyze:
     name: Analyze Go
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -10,14 +10,15 @@ on:
     types:
       - completed
 
-permissions:
-  contents: write
-  pull-requests: write
-  checks: read
+permissions: read-all
 
 jobs:
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions:
-  contents: write
-  id-token: write
+permissions: read-all
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -25,7 +27,6 @@ jobs:
       - name: Run analysis
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the current `main` branch and the latest released version.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub Security Advisories:
+
+https://github.com/sydlexius/mxlrcgo-svc/security/advisories/new
+
+Do not open a public issue for security-sensitive reports. Include a clear description, reproduction steps or proof of concept when available, affected versions, and any known mitigations.
+
+Reports are triaged as time permits. Confirmed vulnerabilities will be fixed in `main` and released with an advisory when appropriate.

--- a/internal/lyrics/fuzz_test.go
+++ b/internal/lyrics/fuzz_test.go
@@ -1,0 +1,28 @@
+package lyrics
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzSlugify(f *testing.F) {
+	f.Add("")
+	f.Add("Artist - Track")
+	f.Add(`\/:*?"<>|`)
+	f.Add("  Cafe\u0301 ---- \u4e16\u754c  ")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		got := Slugify(s)
+		if !utf8.ValidString(got) {
+			t.Fatalf("Slugify returned invalid UTF-8: %q", got)
+		}
+		if strings.ContainsAny(got, `\/:*?"<>|`) {
+			t.Fatalf("Slugify returned forbidden filename characters: %q", got)
+		}
+		if strings.HasPrefix(got, "-") || strings.HasPrefix(got, "_") ||
+			strings.HasSuffix(got, "-") || strings.HasSuffix(got, "_") {
+			t.Fatalf("Slugify returned untrimmed edge separator: %q", got)
+		}
+	})
+}

--- a/internal/normalize/fuzz_test.go
+++ b/internal/normalize/fuzz_test.go
@@ -1,0 +1,42 @@
+package normalize_test
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
+)
+
+func FuzzNormalizeKey(f *testing.F) {
+	f.Add("")
+	f.Add("  H\u00e9llo W\u00f6rld  ")
+	f.Add("hell\x80o")
+	f.Add("\uff48\uff45\uff4c\uff4c\uff4f")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		got := normalize.NormalizeKey(s)
+		if !utf8.ValidString(got) {
+			t.Fatalf("NormalizeKey returned invalid UTF-8: %q", got)
+		}
+		if got != normalize.NormalizeKey(got) {
+			t.Fatalf("NormalizeKey is not idempotent: %q", got)
+		}
+	})
+}
+
+func FuzzMatchConfidence(f *testing.F) {
+	f.Add("", "")
+	f.Add("hello", "hello")
+	f.Add("H\u00e9llo", "hello")
+	f.Add("abc", "xyz")
+
+	f.Fuzz(func(t *testing.T, a string, b string) {
+		got := normalize.MatchConfidence(a, b)
+		if got < 0 || got > 1 {
+			t.Fatalf("MatchConfidence(%q, %q) = %f, want [0,1]", a, b, got)
+		}
+		if got != normalize.MatchConfidence(b, a) {
+			t.Fatalf("MatchConfidence is not symmetric for %q and %q", a, b)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add a security policy for private vulnerability reporting
- add Go fuzz targets for filename sanitization and normalization behavior
- pin the remaining third-party workflow action and tune workflow permissions for Scorecard reporting
- make the Scorecard workflow self-contained for manual refreshes

## Verification
- go test -count=1 ./...
- golangci-lint run ./...
- pre-commit hooks via git commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy documentation outlining supported versions, security update process, and private vulnerability reporting guidance.

* **Tests**
  * Added fuzz tests to improve robustness and reliability of string processing functions.

* **Chores**
  * Updated CI/CD workflow configurations with refined permission scoping and dependency pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->