### PR TITLE
ci: use codecov oidc uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -71,9 +74,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          use_oidc: true
 
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
-<!-- GSD:project-start source:PROJECT.md -->
 ## Project
 
 **mxlrcgo-svc (sydlexius/mxlrcgo-svc)**
@@ -14,9 +13,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - **Go 1.26.2+**: Minimum Go version per go.mod
 - **Behavior preservation**: All existing CLI flags and behaviors must work identically after restructuring
 - **Token precedence**: CLI flag > environment variable (`MUSIXMATCH_TOKEN`) > `.env` file
-<!-- GSD:project-end -->
 
-<!-- GSD:stack-start source:codebase/STACK.md -->
 ## Technology Stack
 
 ## Languages
@@ -78,9 +75,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - `dependabot-merge.yml` - Auto-merges approved Dependabot PRs after CI passes (squash merge, delete branch).
 - Weekly updates (Monday) for `gomod` and `github-actions` ecosystems
 - Conventional commit prefixes (`chore(deps)` for Go, `ci` for Actions)
-<!-- GSD:stack-end -->
 
-<!-- GSD:conventions-start source:CONVENTIONS.md -->
 ## Conventions
 
 ## Naming Patterns
@@ -151,9 +146,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - Runs as both pre-commit hook check and pre-commit framework hook
 ## Secret Scanning
 - Scans for accidentally committed secrets/credentials
-<!-- GSD:conventions-end -->
 
-<!-- GSD:architecture-start source:ARCHITECTURE.md -->
 ## Architecture
 
 ## Pattern Overview
@@ -228,32 +221,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - Response body size is capped at 2 MiB to prevent memory exhaustion
 - `defer` pattern used for closing `http.Response.Body` and output files
 ## Cross-Cutting Concerns
-<!-- GSD:architecture-end -->
 
-<!-- GSD:skills-start source:skills/ -->
 ## Project Skills
 
 No project skills found. Add skills to any of: `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, or `.github/skills/` with a `SKILL.md` index file.
-<!-- GSD:skills-end -->
-
-<!-- GSD:workflow-start source:GSD defaults -->
-## GSD Workflow Enforcement
-
-Before using Edit, Write, or other file-changing tools, start work through a GSD command so planning artifacts and execution context stay in sync.
-
-Use these entry points:
-- `/gsd-quick` for small fixes, doc updates, and ad-hoc tasks
-- `/gsd-debug` for investigation and bug fixing
-- `/gsd-execute-phase` for planned phase work
-
-Do not make direct repo edits outside a GSD workflow unless the user explicitly asks to bypass it.
-<!-- GSD:workflow-end -->
-
-
-
-<!-- GSD:profile-start -->
-## Developer Profile
-
-> Profile not yet configured. Run `/gsd-profile-user` to generate your developer profile.
-> This section is managed by `generate-claude-profile` -- do not edit manually.
-<!-- GSD:profile-end -->


### PR DESCRIPTION
## Summary
- switch Codecov uploads to OIDC and fail CI if coverage upload fails
- remove obsolete GSD workflow/profile references from AGENTS.md

## Test plan
- go test -count=1 -coverprofile=/tmp/mxlrcgo-cover.out ./...
- git diff --check

## Repo settings handled outside this PR
- enabled private vulnerability reporting
- enabled main branch protection with required PR review, required status checks, linear history, no force pushes/deletions, and required conversation resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD security by implementing OIDC-based authentication for coverage uploads.
  * Improved workflow reliability with stricter validation that fails the pipeline on coverage upload errors.
  * Streamlined project documentation by removing archived workflow management sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->