### PR TITLE
fix: apply geometric backoff to scan failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,15 +13,24 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
 
+const (
+	defaultBaseBackoff = time.Minute
+	defaultMaxBackoff  = time.Hour
+)
+
 // App owns all processing state and orchestrates the lyrics fetch loop.
 type App struct {
-	inputs   *queue.InputsQueue
-	failed   *queue.InputsQueue
-	fetcher  musixmatch.Fetcher
-	writer   lyrics.Writer
-	mode     string
-	total    int
-	cooldown int
+	inputs       *queue.InputsQueue
+	failed       *queue.InputsQueue
+	fetcher      musixmatch.Fetcher
+	writer       lyrics.Writer
+	mode         string
+	total        int
+	cooldown     int
+	baseBackoff  time.Duration
+	maxBackoff   time.Duration
+	sleep        func(context.Context, time.Duration) bool
+	failureCount int
 }
 
 // NewApp creates an App with the given dependencies.
@@ -29,13 +38,16 @@ type App struct {
 // A new failed queue is created internally.
 func NewApp(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) *App {
 	return &App{
-		inputs:   inputs,
-		failed:   queue.NewInputsQueue(),
-		fetcher:  fetcher,
-		writer:   writer,
-		mode:     mode,
-		total:    inputs.Len(),
-		cooldown: cooldown,
+		inputs:      inputs,
+		failed:      queue.NewInputsQueue(),
+		fetcher:     fetcher,
+		writer:      writer,
+		mode:        mode,
+		total:       inputs.Len(),
+		cooldown:    cooldown,
+		baseBackoff: defaultBaseBackoff,
+		maxBackoff:  defaultMaxBackoff,
+		sleep:       sleep,
 	}
 }
 
@@ -55,6 +67,7 @@ func (a *App) Run(ctx context.Context) error {
 		slog.Info("searching song", "artist", cur.Track.ArtistName, "track", cur.Track.TrackName)
 		song, err := a.fetcher.FindLyrics(ctx, cur.Track)
 		if err == nil {
+			a.failureCount = 0
 			cur, err = a.inputs.Pop()
 			if err != nil {
 				slog.Error("unexpected empty queue on pop", "error", err)
@@ -66,6 +79,7 @@ func (a *App) Run(ctx context.Context) error {
 				a.failed.Push(cur)
 			}
 		} else {
+			a.failureCount++
 			slog.Error("lyrics fetch failed", "error", err)
 			item, popErr := a.inputs.Pop()
 			if popErr != nil {
@@ -74,7 +88,11 @@ func (a *App) Run(ctx context.Context) error {
 			}
 			a.failed.Push(item)
 		}
-		a.timer(ctx)
+		if err != nil {
+			a.backoffTimer(ctx, a.failureCount)
+		} else {
+			a.timer(ctx)
+		}
 	}
 
 	return a.handleFailed()
@@ -86,21 +104,60 @@ func (a *App) timer(ctx context.Context) {
 		return
 	}
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
 	for i := a.cooldown; i >= 0; i-- {
 		fmt.Printf("    Please wait... %ds    \r", i)
 		if i == 0 {
 			break
 		}
-		select {
-		case <-ctx.Done():
+		if !a.sleep(ctx, time.Second) {
 			return
-		case <-ticker.C:
 		}
 	}
 	fmt.Printf("\n\n")
+}
+
+func (a *App) backoffTimer(ctx context.Context, attempts int) {
+	if a.inputs.Empty() {
+		return
+	}
+
+	delay := a.backoff(attempts)
+	if delay <= 0 {
+		return
+	}
+	slog.Warn("backing off after lyrics fetch failure", "attempts", attempts, "delay", delay)
+	_ = a.sleep(ctx, delay)
+}
+
+func (a *App) backoff(attempts int) time.Duration {
+	if attempts < 1 {
+		attempts = 1
+	}
+	if a.baseBackoff <= 0 || a.maxBackoff <= 0 {
+		return 0
+	}
+	delay := a.baseBackoff
+	for i := 1; i < attempts; i++ {
+		if delay >= a.maxBackoff || delay > a.maxBackoff/2 {
+			return a.maxBackoff
+		}
+		delay *= 2
+	}
+	if delay > a.maxBackoff {
+		return a.maxBackoff
+	}
+	return delay
+}
+
+func sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // handleFailed processes remaining and failed items after the loop exits.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
@@ -129,5 +130,36 @@ func TestRunWritesFailedFileOnFetchFailure(t *testing.T) {
 	}
 	if string(got) != "Failure Artist,Failure Song\n" {
 		t.Fatalf("failed file content = %q", got)
+	}
+}
+
+func TestRunBacksOffGeometricallyAfterFetchFailures(t *testing.T) {
+	inputs := queue.NewInputsQueue()
+	inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}})
+	inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Two"}})
+	inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Three"}})
+	fetcher := &fakeFetcher{err: errors.New("rate limited")}
+
+	a := NewApp(fetcher, lyrics.NewLRCWriter(), inputs, 0, "dir")
+	a.baseBackoff = time.Second
+	a.maxBackoff = time.Hour
+	var sleeps []time.Duration
+	a.sleep = func(_ context.Context, d time.Duration) bool {
+		sleeps = append(sleeps, d)
+		return true
+	}
+
+	if err := a.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []time.Duration{time.Second, 2 * time.Second}
+	if len(sleeps) != len(want) {
+		t.Fatalf("sleep count = %d, want %d: %v", len(sleeps), len(want), sleeps)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Fatalf("sleep[%d] = %s, want %s", i, sleeps[i], want[i])
+		}
 	}
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -145,15 +145,15 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
              END,
              priority = max(work_queue.priority, excluded.priority),
              status = CASE
-                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.status
+                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.status
                  ELSE 'pending'
              END,
              next_attempt_at = CASE
-                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.next_attempt_at
+                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.next_attempt_at
                  ELSE excluded.next_attempt_at
              END,
              last_error = CASE
-                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.last_error
+                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.last_error
                  ELSE ''
              END,
              completed_at = CASE

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -182,6 +182,56 @@ func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	}
 }
 
+func TestDBQueue_EnqueueDuplicatePreservesFailedBackoff(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "failed-out",
+		Filename: "failed.lrc",
+	}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	failed, err := q.Fail(ctx, claimed.ID, errors.New("rate limited"))
+	if err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+
+	dup, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: " artist ", TrackName: "title"},
+		Outdir:   "duplicate-out",
+		Filename: "duplicate.lrc",
+	}, 10)
+	if err != nil {
+		t.Fatalf("Enqueue duplicate: %v", err)
+	}
+	if dup.ID != failed.ID {
+		t.Fatalf("duplicate ID = %d; want %d", dup.ID, failed.ID)
+	}
+	if dup.Status != StatusFailed {
+		t.Fatalf("duplicate status = %q; want %q", dup.Status, StatusFailed)
+	}
+	if dup.Attempts != failed.Attempts {
+		t.Fatalf("duplicate attempts = %d; want %d", dup.Attempts, failed.Attempts)
+	}
+	if !dup.NextAttemptAt.Equal(failed.NextAttemptAt) {
+		t.Fatalf("duplicate next attempt = %s; want %s", dup.NextAttemptAt, failed.NextAttemptAt)
+	}
+	if dup.LastError != failed.LastError {
+		t.Fatalf("duplicate last error = %q; want %q", dup.LastError, failed.LastError)
+	}
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue during preserved backoff error = %v; want sql.ErrNoRows", err)
+	}
+}
+
 func TestDBQueue_EnqueuePersistsOutputPaths(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))


### PR DESCRIPTION
## Summary
- apply geometric backoff in the one-shot scan/fetch loop after lyrics fetch failures
- reset the scan failure backoff after a successful fetch
- preserve failed DB queue status and retry schedule when duplicate work is enqueued
- add regression coverage for both scan-mode backoff and duplicate enqueue behavior

## Validation
- go test -count=1 ./internal/app ./internal/queue
- golangci-lint run ./internal/app ./internal/queue
- go test -count=1 ./...
- golangci-lint run