### PR TITLE
feat: add bash support to container

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,12 +78,6 @@ docker_manifests:
       - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-amd64"
       - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-arm64"
 
-  - name_template: "ghcr.io/sydlexius/mxlrcgo-svc:dev"
-    skip_push: '{{ not .Prerelease }}'
-    image_templates:
-      - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-amd64"
-      - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-arm64"
-
 signs:
   - artifacts: checksum
     cmd: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,6 +78,12 @@ docker_manifests:
       - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-amd64"
       - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-arm64"
 
+  - name_template: "ghcr.io/sydlexius/mxlrcgo-svc:dev"
+    skip_push: '{{ not .Prerelease }}'
+    image_templates:
+      - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-amd64"
+      - "ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}-arm64"
+
 signs:
   - artifacts: checksum
     cmd: cosign
@@ -131,7 +137,7 @@ release:
     owner: sydlexius
     name: mxlrcgo-svc
   prerelease: auto
-  make_latest: auto
+  make_latest: "{{ not .Prerelease }}"
   header: |
     ## mxlrcgo-svc {{ .Tag }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache ca-certificates su-exec tzdata && \
+RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
-    { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/sh -D mxlrcgo; } && \
+    { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \
     mkdir -p /config /music && \
     chown mxlrcgo:mxlrcgo /config /music
 

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -4,9 +4,9 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache ca-certificates su-exec tzdata && \
+RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
-    { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/sh -D mxlrcgo; } && \
+    { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \
     mkdir -p /config /music && \
     chown mxlrcgo:mxlrcgo /config /music
 

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$(id -u)" = "0" ]; then
 
     if [ "${CURRENT_UID}" != "${PUID}" ] || [ "${CURRENT_GID}" != "${PGID}" ]; then
         deluser mxlrcgo 2>/dev/null || true
-        adduser -u "${PUID}" -G "${PGID_GROUP:-mxlrcgo}" -s /bin/sh -D mxlrcgo
+        adduser -u "${PUID}" -G "${PGID_GROUP:-mxlrcgo}" -s /bin/bash -D mxlrcgo
     fi
 
     chown -R mxlrcgo:"${PGID_GROUP:-mxlrcgo}" /config /music 2>/dev/null || true

--- a/cmd/mxlrcgo-svc/main_test.go
+++ b/cmd/mxlrcgo-svc/main_test.go
@@ -151,6 +151,69 @@ func TestRunWithOptions_HelpDoesNotStartApplication(t *testing.T) {
 	}
 }
 
+func TestRunWithOptions_SubcommandHelpShowsSelectedCommand(t *testing.T) {
+	isolateCLIEnv(t)
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "serve",
+			args: []string{"serve", "--help"},
+			want: []string{"Usage: mxlrcgo-svc serve", "--scan-interval", "--work-interval"},
+		},
+		{
+			name: "scan",
+			args: []string{"scan", "--help"},
+			want: []string{"Usage: mxlrcgo-svc scan", "--upgrade", "--bfs"},
+		},
+		{
+			name: "library",
+			args: []string{"library", "--help"},
+			want: []string{"Usage: mxlrcgo-svc library", "add", "list"},
+		},
+		{
+			name: "library add",
+			args: []string{"library", "add", "--help"},
+			want: []string{"Usage: mxlrcgo-svc library add", "--name", "--config"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			rec := &runRecord{}
+			code := runWithOptions(runOptions{
+				args:       tc.args,
+				out:        &out,
+				loadDotenv: func() error { return nil },
+				newFetcher: func(token string) musixmatch.Fetcher {
+					rec.token = token
+					return &fakeFetcher{rec: rec}
+				},
+				newWriter: func() lyrics.Writer { return fakeWriter{} },
+				newApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
+					rec.appCreated = true
+					return fakeRunner{rec: rec}
+				},
+			})
+			if code != 0 {
+				t.Fatalf("run exit code = %d; want 0", code)
+			}
+			if rec.appCreated {
+				t.Fatal("app was created; want help to stop before startup")
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("help output = %q; want %q", out.String(), want)
+				}
+			}
+		})
+	}
+}
+
 func TestRunWithOptions_CLIPrecedenceAndPairInput(t *testing.T) {
 	isolateCLIEnv(t)
 	dir := t.TempDir()

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -223,13 +223,13 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 	}
 	if err := parser.Parse(rawArgs); err != nil {
 		if err == arg.ErrHelp {
-			if err := parser.WriteHelpForSubcommand(out); err != nil {
+			if err := parser.WriteHelpForSubcommand(out, parser.SubcommandNames()...); err != nil {
 				_, _ = fmt.Fprintln(out, err)
 				return 2
 			}
 			return 0
 		}
-		if usageErr := parser.WriteUsageForSubcommand(out); usageErr != nil {
+		if usageErr := parser.WriteUsageForSubcommand(out, parser.SubcommandNames()...); usageErr != nil {
 			_, _ = fmt.Fprintln(out, usageErr)
 			return 2
 		}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
@@ -66,6 +68,64 @@ func TestNewVerifierDisabledDoesNotRequireFFmpeg(t *testing.T) {
 func TestConfigureWorkerVerificationAcceptsNilVerifier(t *testing.T) {
 	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
 	configureWorkerVerification(w, config.Config{}, nil)
+}
+
+func TestRunSubcommandHelpShowsSelectedCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "serve",
+			args: []string{"serve", "--help"},
+			want: []string{"Usage: mxlrcgo-svc serve", "--scan-interval", "--work-interval"},
+		},
+		{
+			name: "scan",
+			args: []string{"scan", "--help"},
+			want: []string{"Usage: mxlrcgo-svc scan", "--upgrade", "--bfs"},
+		},
+		{
+			name: "library",
+			args: []string{"library", "--help"},
+			want: []string{"Usage: mxlrcgo-svc library", "add", "list"},
+		},
+		{
+			name: "library add",
+			args: []string{"library", "add", "--help"},
+			want: []string{"Usage: mxlrcgo-svc library add", "--name", "--config"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			code := Run(context.Background(), tc.args, &out, Deps{})
+			if code != 0 {
+				t.Fatalf("Run exit code = %d; want 0", code)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("help output = %q; want %q", out.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunSubcommandParseErrorShowsSelectedUsage(t *testing.T) {
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"serve", "--not-a-real-flag"}, &out, Deps{})
+	if code != 2 {
+		t.Fatalf("Run exit code = %d; want 2", code)
+	}
+	if !strings.Contains(out.String(), "Usage: mxlrcgo-svc serve") {
+		t.Fatalf("usage output = %q; want serve usage", out.String())
+	}
+	if strings.Contains(out.String(), "Usage: mxlrcgo-svc <command>") {
+		t.Fatalf("usage output = %q; want selected subcommand usage, not top-level usage", out.String())
+	}
 }
 
 func TestVerificationConfigKeys(t *testing.T) {

--- a/unraid/mxlrcgo-svc.xml
+++ b/unraid/mxlrcgo-svc.xml
@@ -9,7 +9,7 @@
     <TagDescription>Latest stable release</TagDescription>
   </Branch>
   <Network>bridge</Network>
-  <Shell>sh</Shell>
+  <Shell>bash</Shell>
   <Privileged>false</Privileged>
   <Support>https://github.com/sydlexius/mxlrcgo-svc/issues</Support>
   <Project>https://github.com/sydlexius/mxlrcgo-svc</Project>


### PR DESCRIPTION
## Summary
- install Bash in the runtime and GoReleaser Docker images
- set the mxlrcgo container user's login shell to /bin/bash and update the Unraid template shell
- fix subcommand help rendering so selected subcommands show their own flags and nested commands
- ensure future prereleases are not marked as latest by GoReleaser

## Validation
- go test -count=1 ./cmd/mxlrcgo-svc ./internal/commands
- golangci-lint run ./cmd/mxlrcgo-svc ./internal/commands
- go test -count=1 ./...
- golangci-lint run
- goreleaser check
- XML parse for unraid/mxlrcgo-svc.xml
- docker build -t mxlrcgo-svc:bash-test .
- docker run --rm --entrypoint /bin/bash mxlrcgo-svc:bash-test -lc 'command -v bash && getent passwd mxlrcgo'
- docker run --rm mxlrcgo-svc:bash-test mxlrcgo-svc serve --help

## Test image
- ghcr.io/sydlexius/mxlrcgo-svc:1.0.2-dev.1
- ghcr.io/sydlexius/mxlrcgo-svc:beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid subcommand options now display the specific subcommand's usage information instead of generic application usage.

* **Improvements**
  * Updated default shell to bash in Docker and container environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->