### PR TITLE
feat: prioritize webhooks and update libraries

### DIFF
--- a/cmd/mxlrcgo-svc/main_test.go
+++ b/cmd/mxlrcgo-svc/main_test.go
@@ -477,12 +477,17 @@ func TestRunWithOptions_LibraryUpdateMissingLibraryFails(t *testing.T) {
 	dir := t.TempDir()
 	cfg := writeConfig(t, "config-token", 1, filepath.Join(dir, "out"), filepath.Join(dir, "state", "test.db"))
 
+	var out bytes.Buffer
 	code := runWithOptions(runOptions{
 		args:       []string{"library", "update", "99", "--name", "Missing", "--config", cfg},
+		out:        &out,
 		loadDotenv: func() error { return nil },
 	})
 	if code == 0 {
 		t.Fatal("library update missing exit code = 0; want failure")
+	}
+	if !strings.Contains(out.String(), "library 99 not found") {
+		t.Fatalf("library update missing output = %q; want not-found message", out.String())
 	}
 }
 

--- a/cmd/mxlrcgo-svc/main_test.go
+++ b/cmd/mxlrcgo-svc/main_test.go
@@ -432,6 +432,36 @@ func TestRunWithOptions_LibrarySubcommands(t *testing.T) {
 		t.Fatalf("library list output = %q; want Music", out.String())
 	}
 
+	renamedPath := filepath.Join(dir, "renamed")
+	if err := os.Mkdir(renamedPath, 0o750); err != nil {
+		t.Fatalf("mkdir renamed library: %v", err)
+	}
+	out.Reset()
+	code = runWithOptions(runOptions{
+		args:       []string{"library", "update", "1", "--path", renamedPath, "--name", "Renamed", "--config", cfg},
+		out:        &out,
+		loadDotenv: func() error { return nil },
+	})
+	if code != 0 {
+		t.Fatalf("library update exit code = %d; want 0", code)
+	}
+	if !strings.Contains(out.String(), "Renamed") || !strings.Contains(out.String(), renamedPath) {
+		t.Fatalf("library update output = %q; want updated name and path", out.String())
+	}
+
+	out.Reset()
+	code = runWithOptions(runOptions{
+		args:       []string{"library", "update", "1", "--name", "Display", "--config", cfg},
+		out:        &out,
+		loadDotenv: func() error { return nil },
+	})
+	if code != 0 {
+		t.Fatalf("library update name exit code = %d; want 0", code)
+	}
+	if !strings.Contains(out.String(), "Display") || !strings.Contains(out.String(), renamedPath) {
+		t.Fatalf("library update name output = %q; want new name and existing path", out.String())
+	}
+
 	out.Reset()
 	code = runWithOptions(runOptions{args: []string{"library", "remove", "1", "--config", cfg}, out: &out, loadDotenv: func() error { return nil }})
 	if code != 0 {
@@ -439,6 +469,20 @@ func TestRunWithOptions_LibrarySubcommands(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "removed library 1") {
 		t.Fatalf("library remove output = %q; want removed message", out.String())
+	}
+}
+
+func TestRunWithOptions_LibraryUpdateMissingLibraryFails(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+	cfg := writeConfig(t, "config-token", 1, filepath.Join(dir, "out"), filepath.Join(dir, "state", "test.db"))
+
+	code := runWithOptions(runOptions{
+		args:       []string{"library", "update", "99", "--name", "Missing", "--config", cfg},
+		loadDotenv: func() error { return nil },
+	})
+	if code == 0 {
+		t.Fatal("library update missing exit code = 0; want failure")
 	}
 }
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -104,6 +104,7 @@ type LibraryCmd struct {
 	Add    *LibraryAddCmd    `arg:"subcommand:add" help:"add a library root"`
 	List   *LibraryListCmd   `arg:"subcommand:list" help:"list library roots"`
 	Remove *LibraryRemoveCmd `arg:"subcommand:remove" help:"remove a library root"`
+	Update *LibraryUpdateCmd `arg:"subcommand:update" help:"update a library root"`
 }
 
 // LibraryAddCmd adds a library root.
@@ -121,6 +122,14 @@ type LibraryListCmd struct {
 // LibraryRemoveCmd removes a library root.
 type LibraryRemoveCmd struct {
 	ID         int64  `arg:"positional,required" help:"library id"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// LibraryUpdateCmd updates a library root.
+type LibraryUpdateCmd struct {
+	ID         int64  `arg:"positional,required" help:"library id"`
+	Path       string `arg:"--path" help:"new library root path" default:""`
+	Name       string `arg:"--name" help:"new display name" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
@@ -539,9 +548,10 @@ func runScan(ctx context.Context, args ScanCmd) int {
 func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions) scan.Scheduler {
 	results := scan.New(sqlDB)
 	enq := scan.Enqueuer{
-		Results: results,
-		Cache:   cache.New(sqlDB),
-		Queue:   queue.NewDBQueue(sqlDB),
+		Results:  results,
+		Cache:    cache.New(sqlDB),
+		Queue:    queue.NewDBQueue(sqlDB),
+		Priority: queue.PriorityScan,
 	}
 	return scan.Scheduler{
 		Libraries: library.New(sqlDB),
@@ -596,6 +606,30 @@ func runLibrary(ctx context.Context, out io.Writer, args LibraryCmd) int {
 			return 1
 		}
 		_, _ = fmt.Fprintf(out, "removed library %d\n", args.Remove.ID)
+	case args.Update != nil:
+		if args.Update.Path == "" && args.Update.Name == "" {
+			_, _ = fmt.Fprintln(out, "library update requires --path, --name, or both")
+			return 2
+		}
+		lib, err := repo.Get(ctx, args.Update.ID)
+		if err != nil {
+			slog.Error("failed to find library", "error", err)
+			return 1
+		}
+		path := lib.Path
+		if args.Update.Path != "" {
+			path = args.Update.Path
+		}
+		name := lib.Name
+		if args.Update.Name != "" {
+			name = args.Update.Name
+		}
+		lib, err = repo.Update(ctx, args.Update.ID, path, name)
+		if err != nil {
+			slog.Error("failed to update library", "error", err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(out, "%d\t%s\t%s\n", lib.ID, lib.Name, lib.Path)
 	default:
 		_, _ = fmt.Fprintln(out, "missing library subcommand")
 		return 2
@@ -611,6 +645,8 @@ func libraryConfigPath(args LibraryCmd) string {
 		return args.List.ConfigPath
 	case args.Remove != nil:
 		return args.Remove.ConfigPath
+	case args.Update != nil:
+		return args.Update.ConfigPath
 	default:
 		return ""
 	}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -87,7 +87,7 @@ type ServeCmd struct {
 	Upgrade      bool    `arg:"--upgrade" help:"scheduler re-fetches .txt lyrics to promote them"`
 	BFS          bool    `arg:"--bfs" help:"scheduler uses breadth-first traversal"`
 	ScanInterval int     `arg:"--scan-interval" help:"scheduler interval in seconds (default: 900; 0 disables repeat)" default:"900"`
-	WorkInterval int     `arg:"--work-interval" help:"worker poll interval in seconds" default:"5"`
+	WorkInterval int     `arg:"--work-interval" help:"worker poll interval in seconds (minimum 15)" default:"15"`
 }
 
 // ScanCmd scans libraries once and enqueues cache misses.
@@ -458,9 +458,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 }
 
 func runWorkerLoop(ctx context.Context, w *worker.Worker, interval time.Duration) {
-	if interval <= 0 {
-		interval = 5 * time.Second
-	}
+	interval = normalizeWorkerInterval(interval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -473,6 +471,13 @@ func runWorkerLoop(ctx context.Context, w *worker.Worker, interval time.Duration
 		case <-ticker.C:
 		}
 	}
+}
+
+func normalizeWorkerInterval(interval time.Duration) time.Duration {
+	if interval < 15*time.Second {
+		return 15 * time.Second
+	}
+	return interval
 }
 
 func selectedProvider(cfg config.Config, token string, newFetcher func(string) musixmatch.Fetcher) (providers.LyricsProvider, error) {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -618,6 +618,11 @@ func runLibrary(ctx context.Context, out io.Writer, args LibraryCmd) int {
 		}
 		lib, err := repo.Get(ctx, args.Update.ID)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				slog.Error("failed to find library", "library_id", args.Update.ID, "error", err)
+				_, _ = fmt.Fprintf(out, "library %d not found\n", args.Update.ID)
+				return 1
+			}
 			slog.Error("failed to find library", "error", err)
 			return 1
 		}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -87,7 +87,7 @@ type ServeCmd struct {
 	Upgrade      bool    `arg:"--upgrade" help:"scheduler re-fetches .txt lyrics to promote them"`
 	BFS          bool    `arg:"--bfs" help:"scheduler uses breadth-first traversal"`
 	ScanInterval int     `arg:"--scan-interval" help:"scheduler interval in seconds (default: 900; 0 disables repeat)" default:"900"`
-	WorkInterval int     `arg:"--work-interval" help:"worker poll interval in seconds (minimum 15)" default:"15"`
+	WorkInterval *int    `arg:"--work-interval" help:"worker cooldown interval in seconds (default: api.cooldown; minimum 15)"`
 }
 
 // ScanCmd scans libraries once and enqueues cache misses.
@@ -416,7 +416,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		runWorkerLoop(runCtx, w, time.Duration(args.WorkInterval)*time.Second)
+		runWorkerLoop(runCtx, w, serveWorkerInterval(cfg, args))
 	}()
 	go func() {
 		defer wg.Done()
@@ -462,7 +462,7 @@ func runWorkerLoop(ctx context.Context, w *worker.Worker, interval time.Duration
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
-		if err := w.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := w.RunPaced(ctx, interval); err != nil && !errors.Is(err, context.Canceled) {
 			slog.Warn("worker run failed", "error", err)
 		}
 		select {
@@ -471,6 +471,14 @@ func runWorkerLoop(ctx context.Context, w *worker.Worker, interval time.Duration
 		case <-ticker.C:
 		}
 	}
+}
+
+func serveWorkerInterval(cfg config.Config, args ServeCmd) time.Duration {
+	interval := cfg.API.Cooldown
+	if args.WorkInterval != nil {
+		interval = *args.WorkInterval
+	}
+	return time.Duration(interval) * time.Second
 }
 
 func normalizeWorkerInterval(interval time.Duration) time.Duration {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -98,6 +98,21 @@ func TestNormalizeWorkerInterval(t *testing.T) {
 	}
 }
 
+func TestServeWorkerIntervalUsesConfigUnlessFlagProvided(t *testing.T) {
+	cfg := config.Config{
+		API: config.APIConfig{Cooldown: 45},
+	}
+
+	if got := serveWorkerInterval(cfg, ServeCmd{}); got != 45*time.Second {
+		t.Fatalf("serveWorkerInterval without flag = %s; want 45s", got)
+	}
+
+	flag := 30
+	if got := serveWorkerInterval(cfg, ServeCmd{WorkInterval: &flag}); got != 30*time.Second {
+		t.Fatalf("serveWorkerInterval with flag = %s; want 30s", got)
+	}
+}
+
 func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -172,8 +172,9 @@ func TestRunLibraryUpdate(t *testing.T) {
 		t.Fatalf("library update exit code = %d; want 0", code)
 	}
 	gotOut := strings.TrimSpace(out.String())
-	if !strings.HasPrefix(gotOut, "1\t") || !strings.Contains(gotOut, "\tRenamed\t"+renamedPath) {
-		t.Fatalf("library update output = %q; want updated name and path", out.String())
+	wantOut := "1\tRenamed\t" + renamedPath
+	if gotOut != wantOut {
+		t.Fatalf("library update output = %q; want %q", gotOut, wantOut)
 	}
 
 	out.Reset()
@@ -186,8 +187,9 @@ func TestRunLibraryUpdate(t *testing.T) {
 		t.Fatalf("library update name exit code = %d; want 0", code)
 	}
 	gotOut = strings.TrimSpace(out.String())
-	if !strings.HasPrefix(gotOut, "1\t") || !strings.Contains(gotOut, "\tDisplay\t"+renamedPath) {
-		t.Fatalf("library update name output = %q; want new name and existing path", out.String())
+	wantOut = "1\tDisplay\t" + renamedPath
+	if gotOut != wantOut {
+		t.Fatalf("library update name output = %q; want %q", gotOut, wantOut)
 	}
 }
 

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,13 +1,19 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 	"github.com/sydlexius/mxlrcgo-svc/internal/worker"
 )
 
@@ -68,6 +74,127 @@ func TestConfigureWorkerVerificationAcceptsNilVerifier(t *testing.T) {
 	configureWorkerVerification(w, config.Config{}, nil)
 }
 
+func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7})
+	if got.OnScanComplete == nil {
+		t.Fatal("scheduler OnScanComplete = nil; want enqueue callback")
+	}
+	if err := got.OnScanComplete(context.Background(), models.Library{ID: 123}, nil); err != nil {
+		t.Fatalf("OnScanComplete: %v", err)
+	}
+}
+
+func TestRunLibraryUpdate(t *testing.T) {
+	isolateCommandsEnv(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := writeCommandsConfig(t, filepath.Join(dir, "state", "test.db"))
+	libPath := filepath.Join(dir, "music")
+	if err := os.Mkdir(libPath, 0o750); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runLibrary(ctx, &out, LibraryCmd{Add: &LibraryAddCmd{
+		Path:       libPath,
+		Name:       "Music",
+		ConfigPath: cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library add exit code = %d; want 0", code)
+	}
+
+	renamedPath := filepath.Join(dir, "renamed")
+	if err := os.Mkdir(renamedPath, 0o750); err != nil {
+		t.Fatalf("mkdir renamed library: %v", err)
+	}
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         1,
+		Path:       renamedPath,
+		Name:       "Renamed",
+		ConfigPath: cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library update exit code = %d; want 0", code)
+	}
+	if !strings.Contains(out.String(), "Renamed") || !strings.Contains(out.String(), renamedPath) {
+		t.Fatalf("library update output = %q; want updated name and path", out.String())
+	}
+
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         1,
+		Name:       "Display",
+		ConfigPath: cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library update name exit code = %d; want 0", code)
+	}
+	if !strings.Contains(out.String(), "Display") || !strings.Contains(out.String(), renamedPath) {
+		t.Fatalf("library update name output = %q; want new name and existing path", out.String())
+	}
+}
+
+func TestRunLibraryUpdateFailures(t *testing.T) {
+	isolateCommandsEnv(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := writeCommandsConfig(t, filepath.Join(dir, "state", "test.db"))
+
+	var out bytes.Buffer
+	code := runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         1,
+		ConfigPath: cfg,
+	}})
+	if code != 2 {
+		t.Fatalf("library update without changes exit code = %d; want 2", code)
+	}
+	if !strings.Contains(out.String(), "requires --path") {
+		t.Fatalf("library update without changes output = %q; want validation message", out.String())
+	}
+
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         99,
+		Name:       "Missing",
+		ConfigPath: cfg,
+	}})
+	if code != 1 {
+		t.Fatalf("library update missing exit code = %d; want 1", code)
+	}
+
+	libPath := filepath.Join(dir, "music")
+	if err := os.Mkdir(libPath, 0o750); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Add: &LibraryAddCmd{
+		Path:       libPath,
+		Name:       "Music",
+		ConfigPath: cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library add exit code = %d; want 0", code)
+	}
+
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         1,
+		Name:       " ",
+		ConfigPath: cfg,
+	}})
+	if code != 1 {
+		t.Fatalf("library update invalid exit code = %d; want 1", code)
+	}
+}
+
 func TestVerificationConfigKeys(t *testing.T) {
 	cfg := config.Config{
 		Verification: config.VerificationConfig{
@@ -112,6 +239,33 @@ func TestConfigKeysIncludesVerificationFFmpegPath(t *testing.T) {
 		}
 	}
 	t.Fatal("configKeys missing verification.ffmpeg_path")
+}
+
+func isolateCommandsEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN",
+		"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN",
+		"MXLRC_OUTPUT_DIR", "MXLRC_DB_PATH", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
+		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
+		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
+		"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION",
+		"MXLRC_VERIFICATION_MIN_CONFIDENCE", "MXLRC_VERIFICATION_MIN_SIMILARITY",
+	} {
+		t.Setenv(v, "")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+}
+
+func writeCommandsConfig(t *testing.T, dbPath string) string {
+	t.Helper()
+	cfg := filepath.Join(t.TempDir(), "config.toml")
+	content := "[db]\npath = \"" + filepath.ToSlash(dbPath) + "\"\n"
+	if err := os.WriteFile(cfg, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfg
 }
 
 var _ lyrics.Writer = fakeWriter{}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
@@ -72,6 +73,26 @@ func TestNewVerifierDisabledDoesNotRequireFFmpeg(t *testing.T) {
 func TestConfigureWorkerVerificationAcceptsNilVerifier(t *testing.T) {
 	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
 	configureWorkerVerification(w, config.Config{}, nil)
+}
+
+func TestNormalizeWorkerInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{name: "zero", interval: 0, want: 15 * time.Second},
+		{name: "below minimum", interval: 5 * time.Second, want: 15 * time.Second},
+		{name: "minimum", interval: 15 * time.Second, want: 15 * time.Second},
+		{name: "above minimum", interval: 30 * time.Second, want: 30 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeWorkerInterval(tc.interval); got != tc.want {
+				t.Fatalf("normalizeWorkerInterval(%s) = %s; want %s", tc.interval, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestSchedulerBuildsScanEnqueuer(t *testing.T) {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/library"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 	"github.com/sydlexius/mxlrcgo-svc/internal/worker"
 )
@@ -102,12 +105,35 @@ func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(context.Background(), "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(context.Background(), lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+		Status:   scan.StatusPending,
+	}}); err != nil {
+		t.Fatalf("Upsert scan result: %v", err)
+	}
+
 	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7})
 	if got.OnScanComplete == nil {
 		t.Fatal("scheduler OnScanComplete = nil; want enqueue callback")
 	}
-	if err := got.OnScanComplete(context.Background(), models.Library{ID: 123}, nil); err != nil {
+	if err := got.OnScanComplete(context.Background(), models.Library{ID: lib.ID}, nil); err != nil {
 		t.Fatalf("OnScanComplete: %v", err)
+	}
+	item, err := queue.NewDBQueue(sqlDB).Dequeue(context.Background())
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if item.Priority != queue.PriorityScan {
+		t.Fatalf("Dequeue priority = %d; want scan priority %d", item.Priority, queue.PriorityScan)
 	}
 }
 
@@ -145,7 +171,8 @@ func TestRunLibraryUpdate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("library update exit code = %d; want 0", code)
 	}
-	if !strings.Contains(out.String(), "Renamed") || !strings.Contains(out.String(), renamedPath) {
+	gotOut := strings.TrimSpace(out.String())
+	if !strings.HasPrefix(gotOut, "1\t") || !strings.Contains(gotOut, "\tRenamed\t"+renamedPath) {
 		t.Fatalf("library update output = %q; want updated name and path", out.String())
 	}
 
@@ -158,7 +185,8 @@ func TestRunLibraryUpdate(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("library update name exit code = %d; want 0", code)
 	}
-	if !strings.Contains(out.String(), "Display") || !strings.Contains(out.String(), renamedPath) {
+	gotOut = strings.TrimSpace(out.String())
+	if !strings.HasPrefix(gotOut, "1\t") || !strings.Contains(gotOut, "\tDisplay\t"+renamedPath) {
 		t.Fatalf("library update name output = %q; want new name and existing path", out.String())
 	}
 }

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -220,6 +220,9 @@ func TestRunLibraryUpdateFailures(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("library update missing exit code = %d; want 1", code)
 	}
+	if !strings.Contains(out.String(), "library 99 not found") {
+		t.Fatalf("library update missing output = %q; want not-found message", out.String())
+	}
 
 	libPath := filepath.Join(dir, "music")
 	if err := os.Mkdir(libPath, 0o750); err != nil {

--- a/internal/queue/priority.go
+++ b/internal/queue/priority.go
@@ -1,0 +1,8 @@
+package queue
+
+const (
+	// PriorityScan is the baseline priority used for library scan-enqueued work.
+	PriorityScan = 0
+	// PriorityWebhook is used for webhook-enqueued work that should jump ahead of scan backlog.
+	PriorityWebhook = 10
+)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -142,6 +142,79 @@ func TestDBQueue_DequeueClaimsHighestPriorityReadyItem(t *testing.T) {
 	}
 }
 
+func TestDBQueue_DequeueKeepsFIFOWithinSamePriority(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	inputs := []models.Inputs{
+		{Track: models.Track{ArtistName: "Artist", TrackName: "One"}},
+		{Track: models.Track{ArtistName: "Artist", TrackName: "Two"}},
+		{Track: models.Track{ArtistName: "Artist", TrackName: "Three"}},
+	}
+	for _, v := range inputs {
+		if _, err := q.Enqueue(ctx, v, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %q: %v", v.Track.TrackName, err)
+		}
+	}
+
+	first, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue first: %v", err)
+	}
+	second, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue second: %v", err)
+	}
+	third, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue third: %v", err)
+	}
+
+	if first.Inputs.Track.TrackName != "One" || second.Inputs.Track.TrackName != "Two" || third.Inputs.Track.TrackName != "Three" {
+		t.Fatalf("dequeue order = %q, %q, %q; want One, Two, Three",
+			first.Inputs.Track.TrackName, second.Inputs.Track.TrackName, third.Inputs.Track.TrackName)
+	}
+}
+
+func TestDBQueue_DequeuePrioritizesWebhookAheadOfScanBacklog(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Scan", TrackName: "One"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue scan one: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Scan", TrackName: "Two"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue scan two: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Webhook", TrackName: "Now"}}, PriorityWebhook); err != nil {
+		t.Fatalf("Enqueue webhook: %v", err)
+	}
+
+	first, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue first: %v", err)
+	}
+	second, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue second: %v", err)
+	}
+	third, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue third: %v", err)
+	}
+
+	if first.Inputs.Track.ArtistName != "Webhook" {
+		t.Fatalf("first dequeue artist = %q; want Webhook", first.Inputs.Track.ArtistName)
+	}
+	if second.Inputs.Track.TrackName != "One" || third.Inputs.Track.TrackName != "Two" {
+		t.Fatalf("scan dequeue order = %q, %q; want One, Two", second.Inputs.Track.TrackName, third.Inputs.Track.TrackName)
+	}
+}
+
 func TestDBQueue_EnqueueDuplicateDoesNotRequeueProcessingItem(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -53,12 +53,13 @@ func (f fakeLyricsCache) LookupFallback(_ context.Context, artist string, title 
 }
 
 type fakeWorkQueue struct {
-	inputs []models.Inputs
-	before func()
-	err    error
+	inputs     []models.Inputs
+	priorities []int
+	before     func()
+	err        error
 }
 
-func (f *fakeWorkQueue) Enqueue(_ context.Context, inputs models.Inputs, _ int) (queue.WorkItem, error) {
+func (f *fakeWorkQueue) Enqueue(_ context.Context, inputs models.Inputs, priority int) (queue.WorkItem, error) {
 	if f.before != nil {
 		f.before()
 	}
@@ -66,7 +67,8 @@ func (f *fakeWorkQueue) Enqueue(_ context.Context, inputs models.Inputs, _ int) 
 		return queue.WorkItem{}, f.err
 	}
 	f.inputs = append(f.inputs, inputs)
-	return queue.WorkItem{ID: int64(len(f.inputs)), Inputs: inputs}, nil
+	f.priorities = append(f.priorities, priority)
+	return queue.WorkItem{ID: int64(len(f.inputs)), Inputs: inputs, Priority: priority}, nil
 }
 
 func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
@@ -106,6 +108,9 @@ func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
 	}
 	if got.SourcePath != "/music/missing.mp3" {
 		t.Fatalf("source path = %q; want scan result file path", got.SourcePath)
+	}
+	if len(work.priorities) != 1 || work.priorities[0] != 5 {
+		t.Fatalf("enqueued priorities = %+v; want [5]", work.priorities)
 	}
 	if len(store.status) != 2 {
 		t.Fatalf("status calls = %+v; want done and processing calls", store.status)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,10 +40,11 @@ type Handler struct {
 // NewHandler creates an HTTP API handler.
 func NewHandler(a Authenticator, q WorkQueue, outdir string) *Handler {
 	h := &Handler{
-		auth:   a,
-		queue:  q,
-		outdir: outdir,
-		mux:    http.NewServeMux(),
+		auth:     a,
+		queue:    q,
+		outdir:   outdir,
+		priority: queue.PriorityWebhook,
+		mux:      http.NewServeMux(),
 	}
 	h.mux.HandleFunc("POST /api/v1/webhooks/lidarr", h.handleLidarr)
 	return h

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,9 +29,10 @@ func (f *fakeAuth) ValidateKey(_ context.Context, raw string, required auth.Scop
 }
 
 type fakeQueue struct {
-	items    []models.Inputs
-	cleanups []models.Inputs
-	err      error
+	items      []models.Inputs
+	priorities []int
+	cleanups   []models.Inputs
+	err        error
 }
 
 func (f *fakeQueue) Enqueue(_ context.Context, inputs models.Inputs, priority int) (queue.WorkItem, error) {
@@ -39,6 +40,7 @@ func (f *fakeQueue) Enqueue(_ context.Context, inputs models.Inputs, priority in
 		return queue.WorkItem{}, f.err
 	}
 	f.items = append(f.items, inputs)
+	f.priorities = append(f.priorities, priority)
 	return queue.WorkItem{ID: int64(len(f.items)), Inputs: inputs, Priority: priority}, nil
 }
 
@@ -80,6 +82,11 @@ func TestLidarrWebhookDownloadEnqueuesBeforeOK(t *testing.T) {
 	}
 	if q.items[0].Outdir != "lyrics" || len(q.items[0].OutputPaths) != 1 || q.items[0].OutputPaths[0].Outdir != "lyrics" {
 		t.Fatalf("output destination = %+v; want lyrics outdir", q.items[0])
+	}
+	for i, v := range q.priorities {
+		if v != queue.PriorityWebhook {
+			t.Fatalf("queued priority[%d] = %d; want %d", i, v, queue.PriorityWebhook)
+		}
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -61,18 +61,22 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 	}
 }
 
-// Run processes one ready work item, or returns nil when no work is ready.
+// Run processes ready work items until the queue is empty or the context ends.
 func (w *Worker) Run(ctx context.Context) error {
-	if err := w.RunOnce(ctx); err != nil {
-		if errors.Is(err, errQueueEmpty) {
+	for {
+		if err := w.RunOnce(ctx); err != nil {
+			if errors.Is(err, errQueueEmpty) {
+				return nil
+			}
+			if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				return nil
+			}
+			return err
+		}
+		if ctx.Err() != nil {
 			return nil
 		}
-		if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-			return nil
-		}
-		return err
 	}
-	return nil
 }
 
 // RunOnce claims and processes one ready queue item.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
@@ -63,6 +64,27 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 
 // Run processes ready work items until the queue is empty or the context ends.
 func (w *Worker) Run(ctx context.Context) error {
+	return w.run(ctx, nil)
+}
+
+// RunPaced processes ready work items, waiting interval after each processed item.
+func (w *Worker) RunPaced(ctx context.Context, interval time.Duration) error {
+	return w.run(ctx, func(ctx context.Context) error {
+		if interval <= 0 {
+			return nil
+		}
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	})
+}
+
+func (w *Worker) run(ctx context.Context, pause func(context.Context) error) error {
 	for {
 		if err := w.RunOnce(ctx); err != nil {
 			if errors.Is(err, errQueueEmpty) {
@@ -75,6 +97,14 @@ func (w *Worker) Run(ctx context.Context) error {
 		}
 		if ctx.Err() != nil {
 			return nil
+		}
+		if pause != nil {
+			if err := pause(ctx); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil
+				}
+				return err
+			}
 		}
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -61,19 +61,18 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 	}
 }
 
-// Run consumes ready work until the queue is empty or ctx is canceled.
+// Run processes one ready work item, or returns nil when no work is ready.
 func (w *Worker) Run(ctx context.Context) error {
-	for {
-		if err := w.RunOnce(ctx); err != nil {
-			if errors.Is(err, errQueueEmpty) {
-				return nil
-			}
-			if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-				return nil
-			}
-			return err
+	if err := w.RunOnce(ctx); err != nil {
+		if errors.Is(err, errQueueEmpty) {
+			return nil
 		}
+		if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			return nil
+		}
+		return err
 	}
+	return nil
 }
 
 // RunOnce claims and processes one ready queue item.

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -489,6 +489,40 @@ func TestRunProcessesReadyItemsUntilQueueEmpty(t *testing.T) {
 	}
 }
 
+func TestRunPacedPausesAfterEachProcessedItem(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{
+			ID:     4,
+			Inputs: models.Inputs{Track: track, Outdir: "out-a", Filename: "a.lrc"},
+		},
+		{
+			ID:     5,
+			Inputs: models.Inputs{Track: track, Outdir: "out-b", Filename: "b.lrc"},
+		},
+	}}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	var completedAtPause []int
+
+	err := w.run(context.Background(), func(context.Context) error {
+		completedAtPause = append(completedAtPause, len(q.completed))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(q.completed) != 2 {
+		t.Fatalf("completed = %v; want two completed items", q.completed)
+	}
+	if len(completedAtPause) < 2 || completedAtPause[0] != 1 || completedAtPause[1] != 2 {
+		t.Fatalf("completed at pause = %v; want pauses after each processed item", completedAtPause)
+	}
+}
+
 func TestConfidence(t *testing.T) {
 	want := models.Track{ArtistName: "  Héllo ", TrackName: "World"}
 	got := models.Track{ArtistName: "hello", TrackName: " world "}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -448,7 +448,7 @@ func TestRunReturnsCompleteErrNoRows(t *testing.T) {
 	}
 }
 
-func TestRunDrainsReadyItemsUntilQueueEmpty(t *testing.T) {
+func TestRunProcessesOneReadyItem(t *testing.T) {
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	q := &fakeQueue{items: []queue.WorkItem{
 		{
@@ -472,17 +472,17 @@ func TestRunDrainsReadyItemsUntilQueueEmpty(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if len(q.completed) != 2 || q.completed[0] != 4 || q.completed[1] != 5 {
-		t.Fatalf("completed = %v; want [4 5]", q.completed)
+	if len(q.completed) != 1 || q.completed[0] != 4 {
+		t.Fatalf("completed = %v; want [4]", q.completed)
 	}
-	if len(writer.writes) != 2 {
-		t.Fatalf("writes = %d; want 2", len(writer.writes))
+	if len(writer.writes) != 1 {
+		t.Fatalf("writes = %d; want 1", len(writer.writes))
 	}
 	if writer.writes[0].Outdir != "out-a" || writer.writes[0].Filename != "a.lrc" {
 		t.Fatalf("writes[0] = %+v; want out-a/a.lrc", writer.writes[0])
 	}
-	if writer.writes[1].Outdir != "out-b" || writer.writes[1].Filename != "b.lrc" {
-		t.Fatalf("writes[1] = %+v; want out-b/b.lrc", writer.writes[1])
+	if len(q.items) != 1 || q.items[0].ID != 5 {
+		t.Fatalf("remaining items = %+v; want item 5 still queued", q.items)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -448,7 +448,7 @@ func TestRunReturnsCompleteErrNoRows(t *testing.T) {
 	}
 }
 
-func TestRunProcessesOneReadyItem(t *testing.T) {
+func TestRunProcessesReadyItemsUntilQueueEmpty(t *testing.T) {
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	q := &fakeQueue{items: []queue.WorkItem{
 		{
@@ -472,17 +472,20 @@ func TestRunProcessesOneReadyItem(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if len(q.completed) != 1 || q.completed[0] != 4 {
-		t.Fatalf("completed = %v; want [4]", q.completed)
+	if len(q.completed) != 2 || q.completed[0] != 4 || q.completed[1] != 5 {
+		t.Fatalf("completed = %v; want [4 5]", q.completed)
 	}
-	if len(writer.writes) != 1 {
-		t.Fatalf("writes = %d; want 1", len(writer.writes))
+	if len(writer.writes) != 2 {
+		t.Fatalf("writes = %d; want 2", len(writer.writes))
 	}
 	if writer.writes[0].Outdir != "out-a" || writer.writes[0].Filename != "a.lrc" {
 		t.Fatalf("writes[0] = %+v; want out-a/a.lrc", writer.writes[0])
 	}
-	if len(q.items) != 1 || q.items[0].ID != 5 {
-		t.Fatalf("remaining items = %+v; want item 5 still queued", q.items)
+	if writer.writes[1].Outdir != "out-b" || writer.writes[1].Filename != "b.lrc" {
+		t.Fatalf("writes[1] = %+v; want out-b/b.lrc", writer.writes[1])
+	}
+	if len(q.items) != 0 {
+		t.Fatalf("remaining items = %+v; want none", q.items)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit scan and webhook queue priority constants, and enqueue Lidarr webhook work above scan backlog
- add library update CLI support for changing path, name, or both while preserving library IDs
- cover queue priority ordering, webhook priority, scan priority propagation, successful library updates, and missing-library failure

## Tests
- go test ./...
- golangci-lint run
- pre-commit hooks: go build, golangci-lint, govulncheck, typos, gitleaks, gofmt

Closes #70
Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a library update command to modify a library's path and display name with validation and clear tab-delimited output.

* **Behavior Changes**
  * Webhook-triggered work is prioritized ahead of scan backlog.
  * Worker supports paced runs (waits between processed items) and serve/work-interval enforces a 15s minimum.

* **Tests**
  * Expanded tests for library updates (success and failure paths), queue priority ordering, enqueue priorities, and worker pacing/run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->