### PR TITLE
fix: apply geometric backoff to worker on consecutive failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,14 +8,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
-)
-
-const (
-	defaultBaseBackoff = time.Minute
-	defaultMaxBackoff  = time.Hour
 )
 
 // App owns all processing state and orchestrates the lyrics fetch loop.
@@ -45,8 +41,8 @@ func NewApp(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.Inpu
 		mode:        mode,
 		total:       inputs.Len(),
 		cooldown:    cooldown,
-		baseBackoff: defaultBaseBackoff,
-		maxBackoff:  defaultMaxBackoff,
+		baseBackoff: backoff.DefaultBase,
+		maxBackoff:  backoff.DefaultMax,
 		sleep:       sleep,
 	}
 }
@@ -121,32 +117,12 @@ func (a *App) backoffTimer(ctx context.Context, attempts int) {
 		return
 	}
 
-	delay := a.backoff(attempts)
+	delay := backoff.Geometric(attempts, a.baseBackoff, a.maxBackoff)
 	if delay <= 0 {
 		return
 	}
 	slog.Warn("backing off after lyrics fetch failure", "attempts", attempts, "delay", delay)
 	_ = a.sleep(ctx, delay)
-}
-
-func (a *App) backoff(attempts int) time.Duration {
-	if attempts < 1 {
-		attempts = 1
-	}
-	if a.baseBackoff <= 0 || a.maxBackoff <= 0 {
-		return 0
-	}
-	delay := a.baseBackoff
-	for i := 1; i < attempts; i++ {
-		if delay >= a.maxBackoff || delay > a.maxBackoff/2 {
-			return a.maxBackoff
-		}
-		delay *= 2
-	}
-	if delay > a.maxBackoff {
-		return a.maxBackoff
-	}
-	return delay
 }
 
 func sleep(ctx context.Context, d time.Duration) bool {

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,37 @@
+// Package backoff provides shared retry-delay formulas used by the worker,
+// the durable queue, and the legacy fetch loop. Keeping the formula in one
+// place ensures all three surfaces present the same cadence to operators
+// (1m, 2m, 4m, ..., capped at 1h with the defaults).
+package backoff
+
+import "time"
+
+// Default base and cap durations for geometric backoff. Callers may override
+// these via Geometric's parameters when they need a different cadence.
+const (
+	DefaultBase = time.Minute
+	DefaultMax  = time.Hour
+)
+
+// Geometric returns the wait duration for the given 1-indexed attempt count,
+// doubling from base each step and capping at max. Returns 0 if base or max
+// is non-positive. Attempts < 1 are treated as 1.
+func Geometric(attempts int, base, max time.Duration) time.Duration {
+	if base <= 0 || max <= 0 {
+		return 0
+	}
+	if attempts < 1 {
+		attempts = 1
+	}
+	delay := base
+	for i := 1; i < attempts; i++ {
+		if delay >= max || delay > max/2 {
+			return max
+		}
+		delay *= 2
+	}
+	if delay > max {
+		return max
+	}
+	return delay
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,58 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGeometricRampsAndCaps(t *testing.T) {
+	base := time.Second
+	max := 4 * time.Second
+
+	tests := []struct {
+		attempts int
+		want     time.Duration
+	}{
+		{attempts: 0, want: time.Second},
+		{attempts: 1, want: time.Second},
+		{attempts: 2, want: 2 * time.Second},
+		{attempts: 3, want: 4 * time.Second},
+		{attempts: 4, want: 4 * time.Second},
+		{attempts: 100, want: 4 * time.Second},
+	}
+	for _, tc := range tests {
+		if got := Geometric(tc.attempts, base, max); got != tc.want {
+			t.Fatalf("Geometric(%d, %s, %s) = %s; want %s", tc.attempts, base, max, got, tc.want)
+		}
+	}
+}
+
+func TestGeometricZeroBaseOrMaxReturnsZero(t *testing.T) {
+	if got := Geometric(3, 0, time.Hour); got != 0 {
+		t.Fatalf("Geometric with zero base = %s; want 0", got)
+	}
+	if got := Geometric(3, time.Minute, 0); got != 0 {
+		t.Fatalf("Geometric with zero max = %s; want 0", got)
+	}
+	if got := Geometric(3, -time.Minute, time.Hour); got != 0 {
+		t.Fatalf("Geometric with negative base = %s; want 0", got)
+	}
+}
+
+func TestGeometricDefaultsCadence(t *testing.T) {
+	want := []time.Duration{
+		1 * time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		16 * time.Minute,
+		32 * time.Minute,
+		time.Hour,
+		time.Hour,
+	}
+	for i, w := range want {
+		if got := Geometric(i+1, DefaultBase, DefaultMax); got != w {
+			t.Fatalf("Geometric(%d, defaults) = %s; want %s", i+1, got, w)
+		}
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
 )
@@ -23,11 +24,7 @@ const (
 	StatusFailed = "failed"
 )
 
-const (
-	defaultBaseBackoff = time.Minute
-	defaultMaxBackoff  = time.Hour
-	timeFormat         = time.RFC3339
-)
+const timeFormat = time.RFC3339
 
 // InputsQueue is a FIFO queue for processing work items.
 type InputsQueue struct {
@@ -99,8 +96,8 @@ type DBQueue struct {
 func NewDBQueue(db *sql.DB) *DBQueue {
 	return &DBQueue{
 		db:          db,
-		baseBackoff: defaultBaseBackoff,
-		maxBackoff:  defaultMaxBackoff,
+		baseBackoff: backoff.DefaultBase,
+		maxBackoff:  backoff.DefaultMax,
 		now:         time.Now,
 	}
 }
@@ -270,7 +267,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 	}
 
 	nextAttempts := attempts + 1
-	nextAttemptAt := formatTime(q.now().Add(q.backoff(nextAttempts)))
+	nextAttemptAt := formatTime(q.now().Add(backoff.Geometric(nextAttempts, q.baseBackoff, q.maxBackoff)))
 	lastError := ""
 	if cause != nil {
 		lastError = cause.Error()
@@ -298,26 +295,6 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 		return WorkItem{}, fmt.Errorf("queue: commit fail tx: %w", err)
 	}
 	return item, nil
-}
-
-func (q *DBQueue) backoff(attempts int) time.Duration {
-	if attempts < 1 {
-		attempts = 1
-	}
-	if q.baseBackoff <= 0 || q.maxBackoff <= 0 {
-		return 0
-	}
-	delay := q.baseBackoff
-	for i := 1; i < attempts; i++ {
-		if delay >= q.maxBackoff || delay > q.maxBackoff/2 {
-			return q.maxBackoff
-		}
-		delay *= 2
-	}
-	if delay > q.maxBackoff {
-		return q.maxBackoff
-	}
-	return delay
 }
 
 type rowScanner interface {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -548,16 +548,6 @@ func TestDBQueue_FailRequiresProcessingStatus(t *testing.T) {
 	}
 }
 
-func TestDBQueue_BackoffCapsLargeAttemptCounts(t *testing.T) {
-	q := NewDBQueue(nil)
-	q.baseBackoff = time.Minute
-	q.maxBackoff = time.Hour
-
-	if got := q.backoff(10_000); got != time.Hour {
-		t.Fatalf("backoff(10000) = %s; want %s", got, time.Hour)
-	}
-}
-
 func TestDBQueue_CompleteMarksDone(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
@@ -47,11 +48,6 @@ type Worker struct {
 
 var errQueueEmpty = errors.New("worker queue empty")
 
-const (
-	defaultBaseBackoff = time.Minute
-	defaultMaxBackoff  = time.Hour
-)
-
 // New creates a queue consumer worker.
 func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
 	return &Worker{
@@ -60,8 +56,8 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		fetcher:               fetcher,
 		writer:                writer,
 		verifyBelowConfidence: 0.85,
-		baseBackoff:           defaultBaseBackoff,
-		maxBackoff:            defaultMaxBackoff,
+		baseBackoff:           backoff.DefaultBase,
+		maxBackoff:            backoff.DefaultMax,
 		sleep:                 sleepCtx,
 	}
 }
@@ -76,26 +72,6 @@ func sleepCtx(ctx context.Context, d time.Duration) {
 	case <-ctx.Done():
 	case <-timer.C:
 	}
-}
-
-func (w *Worker) backoff(attempts int) time.Duration {
-	if attempts < 1 {
-		attempts = 1
-	}
-	if w.baseBackoff <= 0 || w.maxBackoff <= 0 {
-		return 0
-	}
-	delay := w.baseBackoff
-	for i := 1; i < attempts; i++ {
-		if delay >= w.maxBackoff || delay > w.maxBackoff/2 {
-			return w.maxBackoff
-		}
-		delay *= 2
-	}
-	if delay > w.maxBackoff {
-		return w.maxBackoff
-	}
-	return delay
 }
 
 // EnableVerification configures optional STT verification for low-confidence matches.
@@ -130,6 +106,14 @@ func (w *Worker) RunPaced(ctx context.Context, interval time.Duration) error {
 
 func (w *Worker) run(ctx context.Context, pause func(context.Context) error) error {
 	for {
+		if w.consecutiveFailures > 0 {
+			delay := backoff.Geometric(w.consecutiveFailures, w.baseBackoff, w.maxBackoff)
+			slog.Warn("worker backing off after consecutive failures", "attempts", w.consecutiveFailures, "delay", delay)
+			w.sleep(ctx, delay)
+			if ctx.Err() != nil {
+				return nil
+			}
+		}
 		if err := w.RunOnce(ctx); err != nil {
 			if errors.Is(err, errQueueEmpty) {
 				return nil
@@ -143,12 +127,6 @@ func (w *Worker) run(ctx context.Context, pause func(context.Context) error) err
 			return nil
 		}
 		if w.consecutiveFailures > 0 {
-			delay := w.backoff(w.consecutiveFailures)
-			slog.Warn("worker backing off after fetch failures", "attempts", w.consecutiveFailures, "delay", delay)
-			w.sleep(ctx, delay)
-			if ctx.Err() != nil {
-				return nil
-			}
 			continue
 		}
 		if pause != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -39,9 +39,18 @@ type Worker struct {
 	writer                lyrics.Writer
 	verifier              verification.Verifier
 	verifyBelowConfidence float64
+	consecutiveFailures   int
+	baseBackoff           time.Duration
+	maxBackoff            time.Duration
+	sleep                 func(context.Context, time.Duration)
 }
 
 var errQueueEmpty = errors.New("worker queue empty")
+
+const (
+	defaultBaseBackoff = time.Minute
+	defaultMaxBackoff  = time.Hour
+)
 
 // New creates a queue consumer worker.
 func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
@@ -51,7 +60,42 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		fetcher:               fetcher,
 		writer:                writer,
 		verifyBelowConfidence: 0.85,
+		baseBackoff:           defaultBaseBackoff,
+		maxBackoff:            defaultMaxBackoff,
+		sleep:                 sleepCtx,
 	}
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+func (w *Worker) backoff(attempts int) time.Duration {
+	if attempts < 1 {
+		attempts = 1
+	}
+	if w.baseBackoff <= 0 || w.maxBackoff <= 0 {
+		return 0
+	}
+	delay := w.baseBackoff
+	for i := 1; i < attempts; i++ {
+		if delay >= w.maxBackoff || delay > w.maxBackoff/2 {
+			return w.maxBackoff
+		}
+		delay *= 2
+	}
+	if delay > w.maxBackoff {
+		return w.maxBackoff
+	}
+	return delay
 }
 
 // EnableVerification configures optional STT verification for low-confidence matches.
@@ -97,6 +141,15 @@ func (w *Worker) run(ctx context.Context, pause func(context.Context) error) err
 		}
 		if ctx.Err() != nil {
 			return nil
+		}
+		if w.consecutiveFailures > 0 {
+			delay := w.backoff(w.consecutiveFailures)
+			slog.Warn("worker backing off after fetch failures", "attempts", w.consecutiveFailures, "delay", delay)
+			w.sleep(ctx, delay)
+			if ctx.Err() != nil {
+				return nil
+			}
+			continue
 		}
 		if pause != nil {
 			if err := pause(ctx); err != nil {
@@ -151,11 +204,13 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	ctxNoCancel := context.WithoutCancel(ctx)
 	if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
 		cause := fmt.Errorf("worker: complete item %d: %w", item.ID, err)
+		w.consecutiveFailures++
 		if _, err := w.queue.Fail(ctxNoCancel, item.ID, cause); err != nil {
 			return fmt.Errorf("worker: complete item %d and mark failed: %w", item.ID, errors.Join(cause, err))
 		}
 		return fmt.Errorf("worker: complete item %d (marked failed): %w", item.ID, cause)
 	}
+	w.consecutiveFailures = 0
 	return nil
 }
 
@@ -210,6 +265,7 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 }
 
 func (w *Worker) fail(ctx context.Context, id int64, cause error) error {
+	w.consecutiveFailures++
 	if _, err := w.queue.Fail(context.WithoutCancel(ctx), id, cause); err != nil {
 		return fmt.Errorf("worker: fail item %d after %v: %w", id, cause, err)
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
@@ -521,6 +522,109 @@ func TestRunPacedPausesAfterEachProcessedItem(t *testing.T) {
 	if len(completedAtPause) < 2 || completedAtPause[0] != 1 || completedAtPause[1] != 2 {
 		t.Fatalf("completed at pause = %v; want pauses after each processed item", completedAtPause)
 	}
+}
+
+func TestRunBacksOffGeometricallyAfterConsecutiveFailures(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 100, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		{ID: 101, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "b.lrc"}},
+		{ID: 102, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "c.lrc"}},
+	}}
+	fetcher := &fakeFetcher{err: errors.New("rate limited")}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.baseBackoff = time.Second
+	w.maxBackoff = time.Hour
+	var sleeps []time.Duration
+	w.sleep = func(_ context.Context, d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+
+	if err := w.run(context.Background(), nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(q.failed) != 3 {
+		t.Fatalf("failed = %v; want all 3 items marked failed", q.failed)
+	}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+	if len(sleeps) != len(want) {
+		t.Fatalf("sleep count = %d, want %d: %v", len(sleeps), len(want), sleeps)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Fatalf("sleep[%d] = %s, want %s", i, sleeps[i], want[i])
+		}
+	}
+}
+
+func TestRunResetsBackoffAfterSuccess(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	cached, err := encodeSong(models.Song{Track: track, Lyrics: models.Lyrics{LyricsBody: "cached"}})
+	if err != nil {
+		t.Fatalf("encodeSong: %v", err)
+	}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 200, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		{ID: 201, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "b.lrc"}},
+		{ID: 202, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "c.lrc"}},
+	}}
+	cache := &fakeCacheToggle{hits: []bool{false, true, false}, payload: cached}
+	fetcher := &fakeFetcher{err: errors.New("rate limited")}
+	w := New(q, cache, fetcher, &fakeWriter{})
+	w.baseBackoff = time.Second
+	w.maxBackoff = time.Hour
+	var sleeps []time.Duration
+	var pauses int
+	w.sleep = func(_ context.Context, d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+
+	if err := w.run(context.Background(), func(context.Context) error {
+		pauses++
+		return nil
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if pauses != 1 {
+		t.Fatalf("pauses = %d; want 1 (after the cache-hit success)", pauses)
+	}
+	want := []time.Duration{time.Second, time.Second}
+	if len(sleeps) != len(want) {
+		t.Fatalf("sleep count = %d, want %d: %v", len(sleeps), len(want), sleeps)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Fatalf("sleep[%d] = %s, want %s (counter must reset on cache-hit success)", i, sleeps[i], want[i])
+		}
+	}
+}
+
+type fakeCacheToggle struct {
+	hits    []bool
+	payload string
+	idx     int
+}
+
+func (c *fakeCacheToggle) LookupExact(context.Context, string, string, string) (string, error) {
+	hit := false
+	if c.idx < len(c.hits) {
+		hit = c.hits[c.idx]
+	}
+	c.idx++
+	if hit {
+		return c.payload, nil
+	}
+	return "", sql.ErrNoRows
+}
+
+func (c *fakeCacheToggle) LookupFallback(context.Context, string, string) (string, error) {
+	return "", sql.ErrNoRows
+}
+
+func (c *fakeCacheToggle) Store(context.Context, string, string, string, string) error {
+	return nil
 }
 
 func TestConfidence(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -601,6 +601,62 @@ func TestRunResetsBackoffAfterSuccess(t *testing.T) {
 	}
 }
 
+func TestRunBackoffFiresBeforeRunOnceAfterErrorReturn(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{
+		items: []queue.WorkItem{
+			{ID: 300, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		},
+	}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: errors.New("rate limited")}, &fakeWriter{})
+	w.baseBackoff = time.Second
+	w.maxBackoff = time.Hour
+	w.consecutiveFailures = 3
+
+	var sleeps []time.Duration
+	w.sleep = func(_ context.Context, d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+
+	if err := w.run(context.Background(), nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(sleeps) == 0 || sleeps[0] != 4*time.Second {
+		t.Fatalf("first sleep = %v; want 4s before any dequeue (carry-over backoff)", sleeps)
+	}
+}
+
+func TestRunCounterIncrementsOnWriteFailure(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 400, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		{ID: 401, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "b.lrc"}},
+	}}
+	fetcher := &fakeFetcher{song: models.Song{Track: track, Lyrics: models.Lyrics{LyricsBody: "ok"}}}
+	writer := &fakeWriter{err: errors.New("disk full")}
+	w := New(q, &fakeCache{}, fetcher, writer)
+	w.baseBackoff = time.Second
+	w.maxBackoff = time.Hour
+
+	var sleeps []time.Duration
+	w.sleep = func(_ context.Context, d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+
+	if err := w.run(context.Background(), nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := []time.Duration{time.Second, 2 * time.Second}
+	if len(sleeps) != len(want) {
+		t.Fatalf("sleeps = %v; want %v (write failures must also trip backoff)", sleeps, want)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Fatalf("sleeps[%d] = %s; want %s", i, sleeps[i], want[i])
+		}
+	}
+}
+
 type fakeCacheToggle struct {
 	hits    []bool
 	payload string


### PR DESCRIPTION
Closes #80.

## Summary

- Track consecutive-failure count inside \`*worker.Worker\`. Increment on every \`fail()\` path; reset on the success path (cache hit or fresh fetch + write + complete).
- When the counter is non-zero, the run loop sleeps \`backoff(count)\` (1m → 2m → 4m → ... capped at 1h) instead of the normal \`WorkInterval\` pace.
- First success resets the counter and normal pacing resumes.

## Why

PR #66 added per-item backoff via \`DBQueue.Fail\` updating \`next_attempt_at\`, which delays retries of the **same** item. But when the worker has many pending items and the upstream API is failing globally (rate limit, outage, bad token), it just moves to the next ready item every \`WorkInterval\` (≥15s), hammering the API indefinitely. Reported by user running \`mxlrcgo-svc serve\` in docker against a multi-thousand-track library: "it fires as quickly as possible." The new global backoff at the worker layer mirrors the same geometric formula already in \`internal/queue/queue.go\` and \`internal/app/app.go\`.

## Test plan

- [x] \`TestRunBacksOffGeometricallyAfterConsecutiveFailures\` — three failing items produce sleeps \`[1s, 2s, 4s]\` (with test-only \`baseBackoff: 1s\`).
- [x] \`TestRunResetsBackoffAfterSuccess\` — fail/success/fail sequence: counter resets after the cache-hit success, so the third failure sleeps 1s (not 4s) and the success uses the normal \`pause()\` callback.
- [x] All existing worker tests still pass; full \`go test ./...\` green.
- [x] \`golangci-lint run ./internal/worker/\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Worker now applies exponential backoff delays between retry attempts after consecutive failures, reducing system load and improving stability. Backoff counter automatically resets upon successful operations.

* **Tests**
  * Added test coverage for exponential backoff behavior and backoff reset after successful operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->