### PR TITLE
fix: distinguish Musixmatch 401/429 and add circuit breaker on rate-limit signals

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 0%

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,7 +1,8 @@
 # mxlrcgo-svc configuration file
 # Copy to ~/.config/mxlrcgo-svc/config.toml and edit as needed.
 # Environment variable overrides (in precedence order): MUSIXMATCH_TOKEN,
-# MXLRC_API_TOKEN, MXLRC_API_COOLDOWN (or MXLRC_COOLDOWN), MXLRC_OUTPUT_DIR,
+# MXLRC_API_TOKEN, MXLRC_API_COOLDOWN (or MXLRC_COOLDOWN),
+# MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_OUTPUT_DIR,
 # MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY,
 # MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED,
 # MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL,
@@ -16,6 +17,12 @@
 
 # Cooldown between API requests in seconds.
 cooldown = 15
+
+# Worker circuit-breaker window in seconds. When the upstream API returns a
+# rate-limit (HTTP 429) or unauthorized (HTTP 401) signal, the worker stops
+# dequeuing for this many seconds before resuming. Default 1800 (30 min);
+# minimum 300 (5 min) -- smaller values are clamped at load time.
+circuit_open_duration = 1800
 
 [output]
 # Default output directory for .lrc files.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -409,6 +409,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	}
 	workQ := queue.NewDBQueue(sqlDB)
 	w := worker.New(workQ, cache.New(sqlDB), fetcher, newWriter())
+	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	configureWorkerVerification(w, cfg, verifier)
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -850,6 +851,7 @@ func configKeys() []string {
 	return []string{
 		"api.token",
 		"api.cooldown",
+		"api.circuit_open_duration",
 		"output.dir",
 		"db.path",
 		"server.addr",
@@ -871,6 +873,8 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return cfg.API.Token, true
 	case "api.cooldown":
 		return strconv.Itoa(cfg.API.Cooldown), true
+	case "api.circuit_open_duration":
+		return strconv.Itoa(cfg.API.CircuitOpenDuration), true
 	case "output.dir":
 		return cfg.Output.Dir, true
 	case "db.path":
@@ -910,6 +914,12 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 			return fmt.Errorf("api.cooldown must be a non-negative integer")
 		}
 		cfg.API.Cooldown = n
+	case "api.circuit_open_duration":
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("api.circuit_open_duration must be a positive integer (seconds)")
+		}
+		cfg.API.CircuitOpenDuration = n
 	case "output.dir":
 		cfg.Output.Dir = value
 	case "db.path":

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -366,6 +367,34 @@ func TestConfigKeysIncludesVerificationFFmpegPath(t *testing.T) {
 		}
 	}
 	t.Fatal("configKeys missing verification.ffmpeg_path")
+}
+
+func TestCircuitOpenDurationConfigKey(t *testing.T) {
+	cfg := config.Config{API: config.APIConfig{CircuitOpenDuration: 1800}}
+
+	got, ok := configValue(cfg, "api.circuit_open_duration")
+	if !ok {
+		t.Fatal("configValue(api.circuit_open_duration) ok = false; want true")
+	}
+	if got != "1800" {
+		t.Fatalf("configValue(api.circuit_open_duration) = %q; want %q", got, "1800")
+	}
+
+	if err := setConfigValue(&cfg, "api.circuit_open_duration", "600"); err != nil {
+		t.Fatalf("setConfigValue valid: %v", err)
+	}
+	if cfg.API.CircuitOpenDuration != 600 {
+		t.Fatalf("CircuitOpenDuration = %d; want 600", cfg.API.CircuitOpenDuration)
+	}
+	for _, bad := range []string{"", "abc", "0", "-30"} {
+		if err := setConfigValue(&cfg, "api.circuit_open_duration", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid api.circuit_open_duration %q", bad)
+		}
+	}
+
+	if !slices.Contains(configKeys(), "api.circuit_open_duration") {
+		t.Fatal("configKeys missing api.circuit_open_duration")
+	}
 }
 
 func isolateCommandsEnv(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,19 @@ type Config struct {
 type APIConfig struct {
 	Token    string `toml:"token"`
 	Cooldown int    `toml:"cooldown"`
+	// CircuitOpenDuration is the duration in seconds the worker pauses
+	// dequeuing after the upstream API returns a rate-limit or unauthorized
+	// signal. Default 1800 (30 min). Values below circuitOpenMinSeconds are
+	// clamped at load time.
+	CircuitOpenDuration int `toml:"circuit_open_duration"`
 }
+
+// circuitOpenDefaultSeconds is the default circuit-open window (30 min).
+const circuitOpenDefaultSeconds = 30 * 60
+
+// circuitOpenMinSeconds is the minimum permissible circuit-open window.
+// Values below this are clamped to this floor with a warning.
+const circuitOpenMinSeconds = 5 * 60
 
 // OutputConfig holds output-related configuration.
 type OutputConfig struct {
@@ -62,7 +74,7 @@ type VerificationConfig struct {
 // defaults sets built-in fallback values.
 func defaults() Config {
 	return Config{
-		API:          APIConfig{Cooldown: 15},
+		API:          APIConfig{Cooldown: 15, CircuitOpenDuration: circuitOpenDefaultSeconds},
 		Output:       OutputConfig{Dir: "lyrics"},
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
 		Server:       ServerConfig{Addr: "127.0.0.1:3876"},
@@ -113,11 +125,19 @@ func Load(path string) (Config, error) {
 			if cfg.Verification.MinSimilarity <= 0 || cfg.Verification.MinSimilarity > 1 {
 				cfg.Verification.MinSimilarity = d.Verification.MinSimilarity
 			}
+			// CircuitOpenDuration: 0 means "not set in file"; restore the
+			// default so users copying config.example.toml don't disable
+			// the breaker. Any non-zero value is honored and may be
+			// clamped to the minimum below.
+			if cfg.API.CircuitOpenDuration == 0 {
+				cfg.API.CircuitOpenDuration = d.API.CircuitOpenDuration
+			}
 		} else if !os.IsNotExist(err) {
 			return cfg, fmt.Errorf("config: stat %s: %w", path, err)
 		}
 	}
 	applyEnvOverrides(&cfg)
+	clampCircuitOpenDuration(&cfg)
 	if cfg.DB.Path == "" {
 		return cfg, fmt.Errorf("config: cannot determine DB path: set MXLRC_DB_PATH or XDG_DATA_HOME")
 	}
@@ -149,6 +169,15 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", cooldownVar, "value", v, "current", cfg.API.Cooldown) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.Cooldown = n
+		}
+	}
+
+	if v := os.Getenv("MXLRC_API_CIRCUIT_OPEN_DURATION"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_API_CIRCUIT_OPEN_DURATION", "value", v, "current", cfg.API.CircuitOpenDuration) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.API.CircuitOpenDuration = n
 		}
 	}
 
@@ -219,6 +248,20 @@ func applyEnvOverrides(cfg *Config) {
 		} else {
 			cfg.Verification.MinSimilarity = n
 		}
+	}
+}
+
+// clampCircuitOpenDuration enforces the minimum window for the worker
+// circuit breaker. Values below circuitOpenMinSeconds are raised to that
+// floor and a warning is logged so misconfiguration is visible.
+func clampCircuitOpenDuration(cfg *Config) {
+	if cfg.API.CircuitOpenDuration <= 0 {
+		cfg.API.CircuitOpenDuration = circuitOpenDefaultSeconds
+		return
+	}
+	if cfg.API.CircuitOpenDuration < circuitOpenMinSeconds {
+		slog.Warn("circuit_open_duration below minimum; clamping", "configured", cfg.API.CircuitOpenDuration, "minimum", circuitOpenMinSeconds)
+		cfg.API.CircuitOpenDuration = circuitOpenMinSeconds
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ func isolateEnv(t *testing.T) {
 	for _, k := range []string{
 		"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN",
 		"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN",
+		"MXLRC_API_CIRCUIT_OPEN_DURATION",
 		"MXLRC_OUTPUT_DIR", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
 		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
 		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
@@ -400,6 +401,49 @@ func TestLoad_BlankProviderAndInvalidVerificationSampleReDefault(t *testing.T) {
 	}
 	if cfg.Verification.MinSimilarity != 0.35 {
 		t.Fatalf("verification.min_similarity = %v; want 0.35", cfg.Verification.MinSimilarity)
+	}
+}
+
+// TestLoad_CircuitOpenDurationDefault verifies the default 30 min window.
+func TestLoad_CircuitOpenDurationDefault(t *testing.T) {
+	isolateEnv(t)
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.CircuitOpenDuration != 30*60 {
+		t.Fatalf("CircuitOpenDuration = %d; want 1800", cfg.API.CircuitOpenDuration)
+	}
+}
+
+// TestLoad_CircuitOpenDurationEnvOverride verifies the env var overrides
+// the default.
+func TestLoad_CircuitOpenDurationEnvOverride(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_API_CIRCUIT_OPEN_DURATION", "1200")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.CircuitOpenDuration != 1200 {
+		t.Fatalf("CircuitOpenDuration = %d; want 1200", cfg.API.CircuitOpenDuration)
+	}
+}
+
+// TestLoad_CircuitOpenDurationClampsBelowMinimum verifies values below the
+// 5 min minimum are clamped up.
+func TestLoad_CircuitOpenDurationClampsBelowMinimum(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_API_CIRCUIT_OPEN_DURATION", "60")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.CircuitOpenDuration != 5*60 {
+		t.Fatalf("CircuitOpenDuration = %d; want 300 (clamped)", cfg.API.CircuitOpenDuration)
 	}
 }
 

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -121,7 +121,7 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	}
 
 	if v.GetInt("message", "header", "status_code") == 401 && string(v.GetStringBytes("message", "header", "hint")) == "renew" {
-		return song, errors.New("invalid token")
+		return song, fmt.Errorf("%w: token renewal required", ErrUnauthorized)
 	}
 
 	mtg := v.Get("message", "body", "macro_calls", "matcher.track.get", "message")

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -18,6 +18,21 @@ import (
 
 const apiURL = "https://apic-desktop.musixmatch.com/ws/1.1/macro.subtitles.get"
 
+// Sentinel errors returned by the Musixmatch client. Callers should use
+// errors.Is to test for these classes rather than string-matching the message.
+var (
+	// ErrUnauthorized indicates HTTP 401 from the Musixmatch API. The token
+	// may be invalid, expired, or (per observed behavior) the egress IP may
+	// be throttled. Treat as a circuit-breaker signal.
+	ErrUnauthorized = errors.New("musixmatch: unauthorized")
+	// ErrRateLimited indicates HTTP 429 from the Musixmatch API. Treat as a
+	// circuit-breaker signal.
+	ErrRateLimited = errors.New("musixmatch: rate limited")
+	// ErrNotFound indicates HTTP 404 or an inner status_code 404 from the
+	// Musixmatch API meaning no matching track or lyrics were found.
+	ErrNotFound = errors.New("musixmatch: no results found")
+)
+
 // Client communicates with the Musixmatch desktop API.
 type Client struct {
 	Token      string
@@ -79,9 +94,11 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	if res.StatusCode != http.StatusOK {
 		switch res.StatusCode {
 		case http.StatusUnauthorized:
-			return song, errors.New("too many requests: increase the cooldown time and try again in a few minutes")
+			return song, fmt.Errorf("%w: token may be invalid or expired", ErrUnauthorized)
+		case http.StatusTooManyRequests:
+			return song, fmt.Errorf("%w: increase the cooldown time and try again in a few minutes", ErrRateLimited)
 		case http.StatusNotFound:
-			return song, errors.New("no results found")
+			return song, ErrNotFound
 		default:
 			errBody, _ := io.ReadAll(io.LimitReader(res.Body, 8<<10))
 			return song, fmt.Errorf("musixmatch API error: status %d, body: %s", res.StatusCode, strings.TrimSpace(string(errBody)))
@@ -121,9 +138,9 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 			return song, err
 		}
 	case 401:
-		return song, errors.New("too many requests: increase the cooldown time and try again in a few minutes")
+		return song, fmt.Errorf("%w: token may be invalid or expired", ErrUnauthorized)
 	case 404:
-		return song, errors.New("no results found")
+		return song, ErrNotFound
 	default:
 		return song, errors.New("unknown error")
 	}

--- a/internal/musixmatch/client_test.go
+++ b/internal/musixmatch/client_test.go
@@ -202,7 +202,7 @@ func TestFindLyricsErrors(t *testing.T) {
 					}
 				}
 			}`),
-			wantErr: "invalid token",
+			wantErr: "token renewal required",
 		},
 		"restricted lyrics": {
 			client: newTestClient(http.StatusOK, `{
@@ -292,6 +292,18 @@ func TestFindLyricsReturnsSentinelErrors(t *testing.T) {
 				t.Fatalf("error = %v; want errors.Is(_, %v)", err, tt.sentinel)
 			}
 		})
+	}
+}
+
+func TestFindLyricsInBodyInvalidTokenReturnsErrUnauthorized(t *testing.T) {
+	body := `{"message": {"header": {"status_code": 401, "hint": "renew"}}}`
+	client := newTestClient(http.StatusOK, body)
+	_, err := client.FindLyrics(context.Background(), models.Track{TrackName: "title", ArtistName: "artist"})
+	if err == nil {
+		t.Fatal("FindLyrics returned nil error for in-body 401/renew")
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("error = %v; want errors.Is(_, ErrUnauthorized) so circuit breaker keys off it", err)
 	}
 }
 

--- a/internal/musixmatch/client_test.go
+++ b/internal/musixmatch/client_test.go
@@ -183,7 +183,11 @@ func TestFindLyricsErrors(t *testing.T) {
 	}{
 		"http unauthorized": {
 			client:  newTestClient(http.StatusUnauthorized, ""),
-			wantErr: "too many requests",
+			wantErr: "unauthorized",
+		},
+		"http too many requests": {
+			client:  newTestClient(http.StatusTooManyRequests, ""),
+			wantErr: "rate limited",
 		},
 		"http not found": {
 			client:  newTestClient(http.StatusNotFound, ""),
@@ -263,6 +267,29 @@ func TestFindLyricsErrors(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %q; want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFindLyricsReturnsSentinelErrors(t *testing.T) {
+	tests := map[string]struct {
+		status   int
+		sentinel error
+	}{
+		"401 unauthorized":      {http.StatusUnauthorized, ErrUnauthorized},
+		"429 too many requests": {http.StatusTooManyRequests, ErrRateLimited},
+		"404 not found":         {http.StatusNotFound, ErrNotFound},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := newTestClient(tt.status, "")
+			_, err := client.FindLyrics(context.Background(), models.Track{TrackName: "title", ArtistName: "artist"})
+			if err == nil {
+				t.Fatal("FindLyrics returned nil error")
+			}
+			if !errors.Is(err, tt.sentinel) {
+				t.Fatalf("error = %v; want errors.Is(_, %v)", err, tt.sentinel)
 			}
 		})
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -275,6 +275,26 @@ func (q *DBQueue) Complete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// Release returns a processing item to the pending pool without recording a
+// failure. Used when the worker dequeued the item but cannot process it for a
+// reason that should not count against the row's retry budget (e.g. the
+// global rate-limit circuit breaker tripped). Attempts and next_attempt_at
+// are left untouched so the row is immediately eligible for the next dequeue.
+func (q *DBQueue) Release(ctx context.Context, id int64) error {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET status = 'pending',
+             last_error = ''
+         WHERE id = ?
+           AND status = 'processing'`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: release: %w", err)
+	}
+	return requireAffected(res, "queue: release")
+}
+
 // Cleanup removes retryable queued work for the same normalized artist/title.
 // Processing and completed rows are preserved to avoid racing active workers or
 // losing history for work that has already finished.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -750,6 +750,71 @@ func TestDBQueue_FailRequiresProcessingStatus(t *testing.T) {
 	}
 }
 
+func TestDBQueue_ReleaseReturnsItemToPendingWithoutFailure(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	dequeued, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if dequeued.ID != item.ID {
+		t.Fatalf("Dequeue id = %d; want %d", dequeued.ID, item.ID)
+	}
+
+	if err := q.Release(ctx, item.ID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	var status string
+	var attempts int
+	var nextAttempt string
+	var lastError string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, attempts, next_attempt_at, last_error FROM work_queue WHERE id = ?`,
+		item.ID,
+	).Scan(&status, &attempts, &nextAttempt, &lastError); err != nil {
+		t.Fatalf("query released row: %v", err)
+	}
+	if status != StatusPending {
+		t.Fatalf("status = %q; want %q (release must restore pending)", status, StatusPending)
+	}
+	if attempts != 0 {
+		t.Fatalf("attempts = %d; want 0 (release must not count as a failure)", attempts)
+	}
+	if lastError != "" {
+		t.Fatalf("last_error = %q; want empty after release", lastError)
+	}
+	requeued, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after release: %v", err)
+	}
+	if requeued.ID != item.ID {
+		t.Fatalf("re-dequeued id = %d; want %d (released item must be eligible again)", requeued.ID, item.ID)
+	}
+}
+
+func TestDBQueue_ReleaseRequiresProcessingStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := q.Release(ctx, item.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Release on pending row = %v; want sql.ErrNoRows", err)
+	}
+}
+
 func TestDBQueue_CompleteMarksDone(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -32,9 +32,19 @@ type Cache interface {
 	Store(ctx context.Context, artist, title, album, lyrics string) error
 }
 
+// defaultCircuitOpenDuration is the fallback window applied when no value
+// is configured via SetCircuitOpenDuration. Mirrors the config default so
+// non-server callers (tests, ad-hoc CLI runs) get sensible behavior.
+const defaultCircuitOpenDuration = 30 * time.Minute
+
 // Worker consumes queued lyrics work one item at a time. The scan_results
 // writeback for successful completions is handled atomically inside
 // queue.DBQueue.Complete, so the worker has no separate ledger dependency.
+//
+// Worker is intentionally single-goroutine: per-provider concurrency is the
+// architectural model (see CLAUDE.md). RunOnce must not be invoked
+// concurrently against the same Worker; the circuit-breaker state is
+// therefore stored without a mutex.
 type Worker struct {
 	queue                 Queue
 	cache                 Cache
@@ -46,6 +56,9 @@ type Worker struct {
 	baseBackoff           time.Duration
 	maxBackoff            time.Duration
 	sleep                 func(context.Context, time.Duration)
+	now                   func() time.Time
+	circuitOpenDuration   time.Duration
+	circuitOpenUntil      time.Time
 }
 
 var errQueueEmpty = errors.New("worker queue empty")
@@ -61,6 +74,18 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		baseBackoff:           backoff.DefaultBase,
 		maxBackoff:            backoff.DefaultMax,
 		sleep:                 sleepCtx,
+		now:                   time.Now,
+		circuitOpenDuration:   defaultCircuitOpenDuration,
+	}
+}
+
+// SetCircuitOpenDuration overrides the window the worker stays quiet after
+// observing a rate-limit or unauthorized signal from the fetcher. Values
+// less than or equal to zero are ignored; clamping against any minimum
+// is the responsibility of the caller (typically the config layer).
+func (w *Worker) SetCircuitOpenDuration(d time.Duration) {
+	if d > 0 {
+		w.circuitOpenDuration = d
 	}
 }
 
@@ -147,6 +172,17 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// Circuit breaker gate: while open, do not dequeue and do not mark any
+	// rows failed. Returning errQueueEmpty unwinds the run loop cleanly so
+	// the outer ticker idles for the configured window.
+	if !w.circuitOpenUntil.IsZero() {
+		if w.now().Before(w.circuitOpenUntil) {
+			return errQueueEmpty
+		}
+		// Circuit just closed; log once on the first dequeue attempt.
+		w.circuitOpenUntil = time.Time{}
+		slog.Info("worker circuit closed")
+	}
 	item, err := w.queue.Dequeue(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -157,6 +193,9 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
 	if err != nil {
+		if w.tripCircuitIfRateLimited(item, err) {
+			return errQueueEmpty
+		}
 		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
 		return w.fail(ctx, item, err)
 	}
@@ -242,6 +281,22 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 		return fmt.Errorf("worker: store cache: %w", err)
 	}
 	return nil
+}
+
+// tripCircuitIfRateLimited inspects the fetcher error for the upstream
+// rate-limit / unauthorized sentinels and, if matched, opens the circuit
+// breaker. Returns true when the circuit was opened so the caller can
+// short-circuit out of RunOnce without marking the row failed and without
+// tripping the per-item geometric backoff. The dequeued item is intentionally
+// left alone: the next dequeue after the circuit closes will pick it up
+// (or the queue's own attempts/next_attempt_at logic will handle it).
+func (w *Worker) tripCircuitIfRateLimited(item queue.WorkItem, err error) bool {
+	if !errors.Is(err, musixmatch.ErrRateLimited) && !errors.Is(err, musixmatch.ErrUnauthorized) {
+		return false
+	}
+	w.circuitOpenUntil = w.now().Add(w.circuitOpenDuration)
+	slog.Warn("worker circuit opened", "until", w.circuitOpenUntil, "id", item.ID, "cause", err)
+	return true
 }
 
 func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -194,7 +194,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
 	if err != nil {
-		if w.tripCircuitIfRateLimited(ctx, item, err) {
+		if tripped, releaseErr := w.tripCircuitIfRateLimited(ctx, item, err); tripped {
+			if releaseErr != nil {
+				return releaseErr
+			}
 			return errQueueEmpty
 		}
 		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
@@ -286,21 +289,22 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 
 // tripCircuitIfRateLimited inspects the fetcher error for the upstream
 // rate-limit / unauthorized sentinels and, if matched, opens the circuit
-// breaker and releases the dequeued item back to the pending pool. Returns
-// true when the circuit was opened so the caller can short-circuit out of
-// RunOnce without marking the row failed and without tripping the per-item
-// geometric backoff. Release uses a context decoupled from cancellation so
-// the row never stays stuck in 'processing' when ctx is being torn down.
-func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkItem, err error) bool {
+// breaker and releases the dequeued item back to the pending pool. The
+// first return value reports whether the error was a rate-limit signal
+// (and therefore the caller must NOT call w.fail on the item). The second
+// return value is non-nil when Release failed, in which case the item is
+// orphaned in 'processing' and RunOnce must surface the failure to the
+// outer loop rather than swallow it as errQueueEmpty.
+func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkItem, err error) (bool, error) {
 	if !errors.Is(err, musixmatch.ErrRateLimited) && !errors.Is(err, musixmatch.ErrUnauthorized) {
-		return false
+		return false, nil
 	}
 	w.circuitOpenUntil = w.now().Add(w.circuitOpenDuration)
 	slog.Warn("worker circuit opened", "until", w.circuitOpenUntil, "id", item.ID, "cause", err)
 	if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
-		slog.Warn("worker release after circuit open failed", "id", item.ID, "error", releaseErr)
+		return true, fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)
 	}
-	return true
+	return true, nil
 }
 
 func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -23,6 +23,7 @@ type Queue interface {
 	Dequeue(ctx context.Context) (queue.WorkItem, error)
 	Complete(ctx context.Context, id int64) error
 	Fail(ctx context.Context, id int64, cause error) (queue.WorkItem, error)
+	Release(ctx context.Context, id int64) error
 }
 
 // Cache provides lyrics cache operations.
@@ -193,7 +194,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	song, cacheHit, err := w.song(ctx, item.Inputs.Track)
 	if err != nil {
-		if w.tripCircuitIfRateLimited(item, err) {
+		if w.tripCircuitIfRateLimited(ctx, item, err) {
 			return errQueueEmpty
 		}
 		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
@@ -285,17 +286,20 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 
 // tripCircuitIfRateLimited inspects the fetcher error for the upstream
 // rate-limit / unauthorized sentinels and, if matched, opens the circuit
-// breaker. Returns true when the circuit was opened so the caller can
-// short-circuit out of RunOnce without marking the row failed and without
-// tripping the per-item geometric backoff. The dequeued item is intentionally
-// left alone: the next dequeue after the circuit closes will pick it up
-// (or the queue's own attempts/next_attempt_at logic will handle it).
-func (w *Worker) tripCircuitIfRateLimited(item queue.WorkItem, err error) bool {
+// breaker and releases the dequeued item back to the pending pool. Returns
+// true when the circuit was opened so the caller can short-circuit out of
+// RunOnce without marking the row failed and without tripping the per-item
+// geometric backoff. Release uses a context decoupled from cancellation so
+// the row never stays stuck in 'processing' when ctx is being torn down.
+func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkItem, err error) bool {
 	if !errors.Is(err, musixmatch.ErrRateLimited) && !errors.Is(err, musixmatch.ErrUnauthorized) {
 		return false
 	}
 	w.circuitOpenUntil = w.now().Add(w.circuitOpenDuration)
 	slog.Warn("worker circuit opened", "until", w.circuitOpenUntil, "id", item.ID, "cause", err)
+	if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
+		slog.Warn("worker release after circuit open failed", "id", item.ID, "error", releaseErr)
+	}
 	return true
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -14,13 +14,21 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 )
 
+// fakeQueue models DBQueue's status transitions for tests. Dequeue moves an
+// item out of the pending pool and into processing; Complete/Fail/Release
+// remove it from processing. Release additionally records the ID so tests
+// can assert that an item was returned to the pending pool without a failure
+// being recorded against it.
 type fakeQueue struct {
 	items       []queue.WorkItem
+	processing  []queue.WorkItem
 	completed   []int64
 	failed      []int64
+	released    []int64
 	failCauses  []error
 	completeErr error
 	failErr     error
+	releaseErr  error
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -29,6 +37,7 @@ func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
 	}
 	item := q.items[0]
 	q.items = q.items[1:]
+	q.processing = append(q.processing, item)
 	return item, nil
 }
 
@@ -36,6 +45,7 @@ func (q *fakeQueue) Complete(_ context.Context, id int64) error {
 	if q.completeErr != nil {
 		return q.completeErr
 	}
+	q.removeFromProcessing(id)
 	q.completed = append(q.completed, id)
 	return nil
 }
@@ -44,9 +54,28 @@ func (q *fakeQueue) Fail(_ context.Context, id int64, cause error) (queue.WorkIt
 	if q.failErr != nil {
 		return queue.WorkItem{}, q.failErr
 	}
+	q.removeFromProcessing(id)
 	q.failed = append(q.failed, id)
 	q.failCauses = append(q.failCauses, cause)
 	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
+}
+
+func (q *fakeQueue) Release(_ context.Context, id int64) error {
+	if q.releaseErr != nil {
+		return q.releaseErr
+	}
+	q.removeFromProcessing(id)
+	q.released = append(q.released, id)
+	return nil
+}
+
+func (q *fakeQueue) removeFromProcessing(id int64) {
+	for i, item := range q.processing {
+		if item.ID == id {
+			q.processing = append(q.processing[:i], q.processing[i+1:]...)
+			return
+		}
+	}
 }
 
 type cacheStore struct {
@@ -684,6 +713,12 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 			}
 			if len(q.failed) != 0 {
 				t.Fatalf("failed = %v; want none on circuit-open trip", q.failed)
+			}
+			if got := q.released; len(got) != 1 || got[0] != 900 {
+				t.Fatalf("released = %v; want [900] (dequeued item must return to pending pool, not stay in processing)", got)
+			}
+			if len(q.processing) != 0 {
+				t.Fatalf("processing = %v; want empty after release", q.processing)
 			}
 			if w.circuitOpenUntil.IsZero() {
 				t.Fatal("circuitOpenUntil = zero; want circuit opened")

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 )
@@ -654,6 +656,84 @@ func TestRunCounterIncrementsOnWriteFailure(t *testing.T) {
 		if sleeps[i] != want[i] {
 			t.Fatalf("sleeps[%d] = %s; want %s", i, sleeps[i], want[i])
 		}
+	}
+}
+
+func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
+	for name, sentinel := range map[string]error{
+		"rate limited": musixmatch.ErrRateLimited,
+		"unauthorized": musixmatch.ErrUnauthorized,
+	} {
+		t.Run(name, func(t *testing.T) {
+			track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+			q := &fakeQueue{items: []queue.WorkItem{
+				{ID: 900, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+				{ID: 901, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "b.lrc"}},
+			}}
+			fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", sentinel)}
+			w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+			fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+			w.now = func() time.Time { return fixed }
+			w.SetCircuitOpenDuration(30 * time.Minute)
+
+			// First call dequeues, hits sentinel, opens circuit.
+			if err := w.RunOnce(context.Background()); err != nil {
+				if !errors.Is(err, errQueueEmpty) {
+					t.Fatalf("RunOnce: %v; want nil or errQueueEmpty", err)
+				}
+			}
+			if len(q.failed) != 0 {
+				t.Fatalf("failed = %v; want none on circuit-open trip", q.failed)
+			}
+			if w.circuitOpenUntil.IsZero() {
+				t.Fatal("circuitOpenUntil = zero; want circuit opened")
+			}
+			if got, want := w.circuitOpenUntil, fixed.Add(30*time.Minute); !got.Equal(want) {
+				t.Fatalf("circuitOpenUntil = %v; want %v", got, want)
+			}
+
+			// Subsequent call must skip dequeue entirely while circuit open.
+			callsBefore := fetcher.calls
+			itemsBefore := len(q.items)
+			err := w.RunOnce(context.Background())
+			if !errors.Is(err, errQueueEmpty) {
+				t.Fatalf("RunOnce while open = %v; want errQueueEmpty", err)
+			}
+			if fetcher.calls != callsBefore {
+				t.Fatalf("fetcher.calls = %d; want unchanged %d (no dequeue while open)", fetcher.calls, callsBefore)
+			}
+			if len(q.items) != itemsBefore {
+				t.Fatalf("queue items = %d; want unchanged %d (no dequeue while open)", len(q.items), itemsBefore)
+			}
+			if len(q.failed) != 0 {
+				t.Fatalf("failed = %v; want none while circuit open", q.failed)
+			}
+
+			// Advance the clock past the window; next RunOnce closes the circuit
+			// and resumes processing (and trips again on the same fetcher).
+			w.now = func() time.Time { return fixed.Add(31 * time.Minute) }
+			err = w.RunOnce(context.Background())
+			if err != nil && !errors.Is(err, errQueueEmpty) {
+				t.Fatalf("RunOnce after window = %v; want nil or errQueueEmpty", err)
+			}
+			if fetcher.calls == callsBefore {
+				t.Fatalf("fetcher.calls = %d; want >%d after circuit closed", fetcher.calls, callsBefore)
+			}
+		})
+	}
+}
+
+func TestRunOnceWithOpenCircuitDoesNotIncrementBackoff(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.now = func() time.Time { return fixed }
+	w.circuitOpenUntil = fixed.Add(10 * time.Minute)
+
+	if err := w.RunOnce(context.Background()); !errors.Is(err, errQueueEmpty) {
+		t.Fatalf("RunOnce = %v; want errQueueEmpty", err)
+	}
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (open-circuit must not trip backoff)", w.consecutiveFailures)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -772,6 +772,39 @@ func TestRunOnceWithOpenCircuitDoesNotIncrementBackoff(t *testing.T) {
 	}
 }
 
+func TestRunOnceSurfacesReleaseFailureAfterCircuitTrip(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{
+		items: []queue.WorkItem{
+			{ID: 950, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		},
+		releaseErr: errors.New("db down"),
+	}
+	fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", musixmatch.ErrRateLimited)}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.SetCircuitOpenDuration(30 * time.Minute)
+
+	err := w.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("RunOnce returned nil; want release-failure error to be surfaced")
+	}
+	if errors.Is(err, errQueueEmpty) {
+		t.Fatalf("RunOnce returned errQueueEmpty; want a real error so the outer loop can react. got %v", err)
+	}
+	if !errors.Is(err, q.releaseErr) {
+		t.Fatalf("RunOnce error %v; want errors.Is(_, releaseErr) so the cause is preserved", err)
+	}
+	// Circuit must still be opened even though release failed; we want the
+	// quiet window applied to upstream while operators investigate the
+	// orphaned row.
+	if w.circuitOpenUntil.IsZero() {
+		t.Fatal("circuitOpenUntil = zero; want circuit opened despite release failure")
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none on circuit-open trip even when release fails", q.failed)
+	}
+}
+
 type fakeCacheToggle struct {
 	hits    []bool
 	payload string


### PR DESCRIPTION
## Summary

Closes #87.

Fixes two coupled problems in the Musixmatch error handling that were observed during `v1.0.2-dev.6` UAT:

**Part 1 — distinguish 401 / 429 / 404** (`internal/musixmatch`)
- Added sentinel errors `ErrUnauthorized`, `ErrRateLimited`, `ErrNotFound`. Wrapped via `fmt.Errorf("%w: %s", ...)` so `errors.Is` works.
- 401 now returns `"unauthorized: token may be invalid or expired"` instead of the misleading `"too many requests"` message.
- 429 (previously falling through to the generic `default` arm) now returns `ErrRateLimited`.
- 404 standardized to `ErrNotFound`.

**Part 2 — global circuit breaker** (`internal/worker`)
- New `circuitOpenUntil` field on `Worker`. While the circuit is open, `RunOnce` returns `errQueueEmpty` without dequeuing.
- Triggered by either `ErrRateLimited` or `ErrUnauthorized` from the fetcher (Musixmatch appears to use 401 for IP throttling in some cases).
- Critically: while open, the worker does NOT mark queue rows `failed` and does NOT increment `consecutiveFailures`. Fixes the cascade where geometric backoff was still burning through the pending pool, one item per backoff window.
- Logs once on open (`worker circuit opened`) and once on close (`worker circuit closed`). No noise during the open window.

**Config**
- New `api.circuit_open_duration` TOML key + `MXLRC_API_CIRCUIT_OPEN_DURATION` env var.
- Default 1800 s (30 min), floor 300 s with clamp warning.
- Exposed through `mxlrcgo-svc config get/set`.

## Test plan

- [x] `go test ./...` passes (all packages green, coverage maintained)
- [x] `golangci-lint run` reports 0 issues
- [x] `gofmt -l .` empty
- [x] New unit tests: sentinel errors via `errors.Is` for 401/429/404
- [x] New worker integration tests: circuit opens on either sentinel, queue rows not marked `failed` while open, no further dequeues, no `consecutiveFailures` increment, resumes after window
- [x] New config tests: default, env override, clamp-with-warning
- [x] Manual: invalid-token call now shows clear "unauthorized" message
- [ ] Container UAT: deploy `:dev` image, verify `SELECT status, COUNT(*) FROM work_queue GROUP BY status` shows no growth in `failed` during a circuit-open window

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Circuit-breaker that pauses dequeuing when upstream returns rate-limit (429) or unauthorized (401).
  * New api.circuit_open_duration setting (default 30m, minimum 5m) configurable via file, env var, or CLI.
  * When the circuit trips, dequeued items are returned to the pending queue for later retry.

* **Tests**
  * Added tests covering the new circuit behavior and configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->