### PR TITLE
feat: add queue and scan inspection commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,15 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - Purpose: Represent a single work item in the processing queue
 - Location: `internal/models/models.go`
 - Pattern: Bundles a `Track` (what to search for) with `Outdir` and `Filename` (where to write output)
+- Purpose: Durable SQLite-backed work queue for serve/worker mode
+- Location: `internal/queue/queue.go`
+- Pattern: `DBQueue` struct with `Enqueue`, `Dequeue`, `Complete`, `Fail`, `Cleanup`, plus inspection/maintenance methods `List(ctx, ListFilter)`, `Retry(ctx, id)` (rejects non-failed rows with `ErrNotRetryable`), `ClearDone(ctx)`, and `CountDone(ctx)`. Used by the `queue list / failed / retry / clear` CLI subcommands and the worker.
+- Purpose: Persistence for library scan_results rows
+- Location: `internal/scan/repository.go`
+- Pattern: `Repo` struct with `Upsert`, `ListByLibrary`, `ListPendingByLibrary`, `SetStatus`, plus inspection/maintenance methods `List(ctx, Filter)` (filters by optional `LibraryID` and `Status`), `ClearByLibrary(ctx, libraryID)`, and `CountByLibrary(ctx, libraryID)`. Used by the `scan results` and `scan clear` CLI subcommands and the scheduler.
+- Purpose: Library root CRUD (with name lookup for CLI ergonomics)
+- Location: `internal/library/repository.go`
+- Pattern: `Repo` struct with `Add`, `List`, `Get`, `GetByName`, `Update`, `Remove`. `GetByName` lets `scan` and other commands accept either a numeric library id or a human-readable name from `--library`.
 ## Entry Points
 - Location: `cmd/mxlrcgo-svc/main.go` (`func main()`)
 - Triggers: Direct CLI invocation (`mxlrcgo-svc [args]`)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,38 @@ mxlrcgo-svc keys list
 mxlrcgo-svc config get db.path
 ```
 
+### Inspection commands
+
+The `queue` and `scan` subcommands expose the durable work queue and persisted
+scan results so you can debug what the service is doing without opening the
+SQLite database by hand.
+
+```sh
+# List the next 50 work_queue rows.
+mxlrcgo-svc queue list
+
+# Filter by status; failed is also exposed as a convenience subcommand.
+mxlrcgo-svc queue list --status pending --limit 100
+mxlrcgo-svc queue failed
+
+# Reset a single failed row back to pending. Refused if the row is not failed.
+mxlrcgo-svc queue retry 42
+
+# Delete completed rows. Without --yes, prints what would be deleted.
+mxlrcgo-svc queue clear --done
+mxlrcgo-svc queue clear --done --yes
+
+# List persisted scan_results, optionally filtered by library (name or id) and status.
+mxlrcgo-svc scan results
+mxlrcgo-svc scan results --library Music --status pending
+mxlrcgo-svc scan results --library 1 --limit 200
+
+# Delete every scan_results row for a single library. Without --yes, prints what would be deleted.
+# The library row itself is left intact.
+mxlrcgo-svc scan clear --library Music
+mxlrcgo-svc scan clear --library Music --yes
+```
+
 ## Docker
 
 The container runs the webhook service on port `50705` and stores its config and SQLite database under `/config`. Mount your music library at `/music`.
@@ -134,6 +166,8 @@ docker compose up -d
 ```
 
 `MXLRC_DOCKER=true` makes default storage paths resolve to `/config/config.toml` and `/config/mxlrcgo.db`.
+
+To inspect or maintain the queue and scan state inside the container, exec the same `mxlrcgo-svc queue` and `mxlrcgo-svc scan results` / `mxlrcgo-svc scan clear` commands documented in the Inspection commands section above (for example `docker exec mxlrcgo-svc mxlrcgo-svc queue failed`).
 
 ## Unraid
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1087,10 +1087,39 @@ func resolveLibrary(ctx context.Context, repo *library.Repo, ref string) (models
 	if ref == "" {
 		return models.Library{}, fmt.Errorf("library reference must not be empty")
 	}
-	if id, err := strconv.ParseInt(ref, 10, 64); err == nil {
-		return repo.Get(ctx, id)
+	id, parseErr := strconv.ParseInt(ref, 10, 64)
+	if parseErr != nil {
+		return repo.GetByName(ctx, ref)
 	}
-	return repo.GetByName(ctx, ref)
+	// All-digit ref: query both interpretations so a library literally named
+	// "123" can never silently mask the ID match (and vice versa).
+	byID, idErr := repo.Get(ctx, id)
+	byName, nameErr := repo.GetByName(ctx, ref)
+	idFound := idErr == nil
+	nameFound := nameErr == nil
+	switch {
+	case idFound && nameFound:
+		if byID.ID == byName.ID {
+			return byID, nil
+		}
+		return models.Library{}, fmt.Errorf("library reference %q is ambiguous: matches id %d and name %q (id %d); pass an unambiguous form", ref, byID.ID, byName.Name, byName.ID)
+	case idFound:
+		if !errors.Is(nameErr, sql.ErrNoRows) {
+			return models.Library{}, nameErr
+		}
+		return byID, nil
+	case nameFound:
+		if !errors.Is(idErr, sql.ErrNoRows) {
+			return models.Library{}, idErr
+		}
+		return byName, nil
+	case errors.Is(idErr, sql.ErrNoRows) && errors.Is(nameErr, sql.ErrNoRows):
+		return models.Library{}, fmt.Errorf("library reference %q: %w", ref, sql.ErrNoRows)
+	case !errors.Is(idErr, sql.ErrNoRows):
+		return models.Library{}, idErr
+	default:
+		return models.Library{}, nameErr
+	}
 }
 
 // validateQueueStatus checks --status for queue commands.
@@ -1284,7 +1313,7 @@ func runScanResults(ctx context.Context, out io.Writer, args ScanResultsCmd) int
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	filter := scan.Filter{Status: args.Status}
+	filter := scan.Filter{Status: args.Status, Limit: args.Limit}
 	libNames := map[int64]string{}
 	if strings.TrimSpace(args.Library) != "" {
 		lib, err := resolveLibrary(ctx, libRepo, args.Library)
@@ -1313,9 +1342,6 @@ func runScanResults(ctx context.Context, out io.Writer, args ScanResultsCmd) int
 	if err != nil {
 		slog.Error("failed to list scan results", "error", err)
 		return 1
-	}
-	if args.Limit > 0 && len(results) > args.Limit {
-		results = results[:args.Limit]
 	}
 
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -109,7 +109,7 @@ type ScanCmd struct {
 // ScanResultsCmd lists persisted scan results, optionally filtered.
 type ScanResultsCmd struct {
 	Library    string `arg:"--library" help:"library name or numeric id" default:""`
-	Status     string `arg:"--status" help:"filter by status (pending, processing, done, failed)" default:""`
+	Status     string `arg:"--status" help:"filter by status (pending, processing, done)" default:""`
 	Limit      int    `arg:"--limit" help:"maximum number of rows to return (0 = unlimited)" default:"0"`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
@@ -1135,16 +1135,19 @@ func validateQueueStatus(s string) error {
 	}
 }
 
-// validateScanStatus checks --status for scan results commands.
+// validateScanStatus checks --status for scan results commands. scan_results
+// rows only transition pending -> processing -> done; no code path writes
+// "failed" to a scan_results row, so we deliberately reject it here even
+// though the constant exists in the scan package.
 func validateScanStatus(s string) error {
 	if s == "" {
 		return nil
 	}
 	switch s {
-	case scan.StatusPending, scan.StatusProcessing, scan.StatusDone, scan.StatusFailed:
+	case scan.StatusPending, scan.StatusProcessing, scan.StatusDone:
 		return nil
 	default:
-		return fmt.Errorf("invalid status %q (want pending, processing, done, or failed)", s)
+		return fmt.Errorf("invalid status %q (want pending, processing, or done)", s)
 	}
 }
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -46,6 +47,7 @@ type Args struct {
 	Library *LibraryCmd `arg:"subcommand:library" help:"manage library roots"`
 	Keys    *KeysCmd    `arg:"subcommand:keys" help:"manage API keys"`
 	Config  *ConfigCmd  `arg:"subcommand:config" help:"inspect or update configuration"`
+	Queue   *QueueCmd   `arg:"subcommand:queue" help:"inspect or maintain the durable work queue"`
 }
 
 // LegacyArgs preserves the pre-subcommand CLI surface.
@@ -90,13 +92,67 @@ type ServeCmd struct {
 	WorkInterval *int    `arg:"--work-interval" help:"worker cooldown interval in seconds (default: api.cooldown; minimum 15)"`
 }
 
-// ScanCmd scans libraries once and enqueues cache misses.
+// ScanCmd scans libraries once and enqueues cache misses. It also hosts
+// nested inspection subcommands (results, clear). When neither nested
+// subcommand is set, the legacy run-once scan path is taken.
 type ScanCmd struct {
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 	Depth      int    `arg:"-d,--depth" help:"maximum recursion depth" default:"100"`
 	Update     bool   `arg:"-u,--update" help:"re-fetch and overwrite existing .lrc files"`
 	Upgrade    bool   `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
 	BFS        bool   `arg:"--bfs" help:"use breadth-first traversal"`
+
+	Results *ScanResultsCmd `arg:"subcommand:results" help:"list persisted scan_results rows"`
+	Clear   *ScanClearCmd   `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
+}
+
+// ScanResultsCmd lists persisted scan results, optionally filtered.
+type ScanResultsCmd struct {
+	Library    string `arg:"--library" help:"library name or numeric id" default:""`
+	Status     string `arg:"--status" help:"filter by status (pending, processing, done, failed)" default:""`
+	Limit      int    `arg:"--limit" help:"maximum number of rows to return (0 = unlimited)" default:"0"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// ScanClearCmd deletes scan_results rows for the named library only.
+type ScanClearCmd struct {
+	Library    string `arg:"--library,required" help:"library name or numeric id"`
+	Yes        bool   `arg:"--yes" help:"actually delete (without it, prints what would be deleted)"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// QueueCmd contains nested queue inspection and maintenance subcommands.
+type QueueCmd struct {
+	List   *QueueListCmd   `arg:"subcommand:list" help:"list work_queue rows"`
+	Failed *QueueFailedCmd `arg:"subcommand:failed" help:"list failed work_queue rows"`
+	Retry  *QueueRetryCmd  `arg:"subcommand:retry" help:"reset a failed work item back to pending"`
+	Clear  *QueueClearCmd  `arg:"subcommand:clear" help:"delete completed work_queue rows"`
+}
+
+// QueueListCmd lists work_queue rows.
+type QueueListCmd struct {
+	Status     string `arg:"--status" help:"filter by status (pending, processing, failed, done)" default:""`
+	Limit      int    `arg:"--limit" help:"maximum number of rows to return" default:"50"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// QueueFailedCmd is a convenience for `queue list --status failed`.
+type QueueFailedCmd struct {
+	Limit      int    `arg:"--limit" help:"maximum number of rows to return" default:"50"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// QueueRetryCmd resets a single failed row back to pending.
+type QueueRetryCmd struct {
+	ID         int64  `arg:"positional,required" help:"work_queue row id"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// QueueClearCmd deletes completed (status=done) work_queue rows.
+type QueueClearCmd struct {
+	Done       bool   `arg:"--done,required" help:"delete rows whose status is done"`
+	Yes        bool   `arg:"--yes" help:"actually delete (without it, prints what would be deleted)"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // LibraryCmd contains nested library subcommands.
@@ -259,13 +315,15 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 	case args.Serve != nil:
 		return runServe(ctx, *args.Serve, deps.NewFetcher, deps.NewWriter)
 	case args.Scan != nil:
-		return runScan(ctx, *args.Scan)
+		return runScanCmd(ctx, out, *args.Scan)
 	case args.Library != nil:
 		return runLibrary(ctx, out, *args.Library)
 	case args.Keys != nil:
 		return runKeys(ctx, out, *args.Keys)
 	case args.Config != nil:
 		return runConfig(out, *args.Config)
+	case args.Queue != nil:
+		return runQueueCmd(ctx, out, *args.Queue)
 	default:
 		_, _ = fmt.Fprintln(out, "missing subcommand")
 		return 2
@@ -280,7 +338,7 @@ func usesSubcommand(rawArgs []string) bool {
 		return true
 	}
 	commands := map[string]bool{
-		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "config": true,
+		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "config": true, "queue": true,
 	}
 	return commands[rawArgs[0]]
 }
@@ -530,6 +588,30 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, args ServeCmd) {
 	s.Interval = interval
 	if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		slog.Warn("scheduler failed", "error", err)
+	}
+}
+
+// runScanCmd dispatches the scan subcommand. When neither nested subcommand
+// is set, it runs the legacy one-shot scan. Otherwise it routes to the
+// requested inspection or maintenance subcommand. The parent --config flag
+// is forwarded to the nested subcommand when the subcommand did not specify
+// its own --config value.
+func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
+	switch {
+	case args.Results != nil:
+		sub := *args.Results
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runScanResults(ctx, out, sub)
+	case args.Clear != nil:
+		sub := *args.Clear
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runScanClear(ctx, out, sub)
+	default:
+		return runScan(ctx, args)
 	}
 }
 
@@ -997,4 +1079,309 @@ func encodeScopes(scopes []auth.Scope) string {
 	}
 	slices.Sort(parts)
 	return strings.Join(parts, ",")
+}
+
+// resolveLibrary looks up a library by either numeric ID or name.
+func resolveLibrary(ctx context.Context, repo *library.Repo, ref string) (models.Library, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return models.Library{}, fmt.Errorf("library reference must not be empty")
+	}
+	if id, err := strconv.ParseInt(ref, 10, 64); err == nil {
+		return repo.Get(ctx, id)
+	}
+	return repo.GetByName(ctx, ref)
+}
+
+// validateQueueStatus checks --status for queue commands.
+func validateQueueStatus(s string) error {
+	if s == "" {
+		return nil
+	}
+	switch s {
+	case queue.StatusPending, queue.StatusProcessing, queue.StatusFailed, queue.StatusDone:
+		return nil
+	default:
+		return fmt.Errorf("invalid status %q (want pending, processing, failed, or done)", s)
+	}
+}
+
+// validateScanStatus checks --status for scan results commands.
+func validateScanStatus(s string) error {
+	if s == "" {
+		return nil
+	}
+	switch s {
+	case scan.StatusPending, scan.StatusProcessing, scan.StatusDone, scan.StatusFailed:
+		return nil
+	default:
+		return fmt.Errorf("invalid status %q (want pending, processing, done, or failed)", s)
+	}
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}
+
+func runQueueCmd(ctx context.Context, out io.Writer, args QueueCmd) int {
+	switch {
+	case args.List != nil:
+		return runQueueList(ctx, out, *args.List)
+	case args.Failed != nil:
+		return runQueueList(ctx, out, QueueListCmd{
+			Status:     queue.StatusFailed,
+			Limit:      args.Failed.Limit,
+			ConfigPath: args.Failed.ConfigPath,
+		})
+	case args.Retry != nil:
+		return runQueueRetry(ctx, out, *args.Retry)
+	case args.Clear != nil:
+		return runQueueClear(ctx, out, *args.Clear)
+	default:
+		_, _ = fmt.Fprintln(out, "missing queue subcommand")
+		return 2
+	}
+}
+
+func runQueueList(ctx context.Context, out io.Writer, args QueueListCmd) int {
+	if err := validateQueueStatus(args.Status); err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 2
+	}
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	q := queue.NewDBQueue(sqlDB)
+	limit := args.Limit
+	if limit < 0 {
+		limit = 0
+	}
+	items, err := q.List(ctx, queue.ListFilter{Status: args.Status, Limit: limit})
+	if err != nil {
+		slog.Error("failed to list queue", "error", err)
+		return 1
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ID\tStatus\tPriority\tAttempts\tNextAttempt\tArtist\tTitle\tLastError")
+	for _, item := range items {
+		_, _ = fmt.Fprintf(tw, "%d\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n",
+			item.ID,
+			item.Status,
+			item.Priority,
+			item.Attempts,
+			item.NextAttemptAt.UTC().Format(time.RFC3339),
+			item.Inputs.Track.ArtistName,
+			item.Inputs.Track.TrackName,
+			truncate(item.LastError, 80),
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		slog.Error("failed to write queue list", "error", err)
+		return 1
+	}
+	return 0
+}
+
+func runQueueRetry(ctx context.Context, out io.Writer, args QueueRetryCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Retry(ctx, args.ID)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		_, _ = fmt.Fprintf(out, "queue: work item %d not found\n", args.ID)
+		return 1
+	case errors.Is(err, queue.ErrNotRetryable):
+		_, _ = fmt.Fprintf(out, "queue: work item %d is not in failed status; refusing to retry\n", args.ID)
+		return 1
+	case err != nil:
+		slog.Error("failed to retry queue item", "error", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(out, "retried %d (status=%s, attempts=%d)\n", item.ID, item.Status, item.Attempts)
+	return 0
+}
+
+func runQueueClear(ctx context.Context, out io.Writer, args QueueClearCmd) int {
+	if !args.Done {
+		_, _ = fmt.Fprintln(out, "queue clear requires --done")
+		return 2
+	}
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	q := queue.NewDBQueue(sqlDB)
+	if !args.Yes {
+		count, err := q.CountDone(ctx)
+		if err != nil {
+			slog.Error("failed to count done queue rows", "error", err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(out, "would delete %d completed queue rows; pass --yes to confirm\n", count)
+		return 0
+	}
+	deleted, err := q.ClearDone(ctx)
+	if err != nil {
+		slog.Error("failed to clear done queue rows", "error", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(out, "deleted %d completed queue rows\n", deleted)
+	return 0
+}
+
+func runScanResults(ctx context.Context, out io.Writer, args ScanResultsCmd) int {
+	if err := validateScanStatus(args.Status); err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 2
+	}
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	filter := scan.Filter{Status: args.Status}
+	libNames := map[int64]string{}
+	if strings.TrimSpace(args.Library) != "" {
+		lib, err := resolveLibrary(ctx, libRepo, args.Library)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
+				return 1
+			}
+			slog.Error("failed to resolve library", "error", err)
+			return 1
+		}
+		filter.LibraryID = &lib.ID
+		libNames[lib.ID] = lib.Name
+	} else {
+		libs, err := libRepo.List(ctx)
+		if err != nil {
+			slog.Error("failed to list libraries", "error", err)
+			return 1
+		}
+		for _, v := range libs {
+			libNames[v.ID] = v.Name
+		}
+	}
+
+	results, err := scanRepo.List(ctx, filter)
+	if err != nil {
+		slog.Error("failed to list scan results", "error", err)
+		return 1
+	}
+	if args.Limit > 0 && len(results) > args.Limit {
+		results = results[:args.Limit]
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ID\tLibrary\tStatus\tArtist\tTitle\tFilePath\tOutDir\tFilename")
+	for _, r := range results {
+		name, ok := libNames[r.LibraryID]
+		if !ok {
+			name = strconv.FormatInt(r.LibraryID, 10)
+		}
+		_, _ = fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.ID,
+			name,
+			r.Status,
+			r.Track.ArtistName,
+			r.Track.TrackName,
+			r.FilePath,
+			r.Outdir,
+			r.Filename,
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		slog.Error("failed to write scan results", "error", err)
+		return 1
+	}
+	return 0
+}
+
+func runScanClear(ctx context.Context, out io.Writer, args ScanClearCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	libRepo := library.New(sqlDB)
+	lib, err := resolveLibrary(ctx, libRepo, args.Library)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
+			return 1
+		}
+		slog.Error("failed to resolve library", "error", err)
+		return 1
+	}
+
+	scanRepo := scan.New(sqlDB)
+	if !args.Yes {
+		count, err := scanRepo.CountByLibrary(ctx, lib.ID)
+		if err != nil {
+			slog.Error("failed to count scan results", "error", err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(out, "would delete %d scan_results rows for library %q (id=%d); pass --yes to confirm\n", count, lib.Name, lib.ID)
+		return 0
+	}
+	deleted, err := scanRepo.ClearByLibrary(ctx, lib.ID)
+	if err != nil {
+		slog.Error("failed to clear scan results", "error", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(out, "deleted %d scan_results rows for library %q (id=%d)\n", deleted, lib.Name, lib.ID)
+	return 0
 }

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -731,12 +731,15 @@ func TestValidateQueueStatus(t *testing.T) {
 }
 
 func TestValidateScanStatus(t *testing.T) {
-	for _, ok := range []string{"", "pending", "processing", "done", "failed"} {
+	for _, ok := range []string{"", "pending", "processing", "done"} {
 		if err := validateScanStatus(ok); err != nil {
 			t.Errorf("validateScanStatus(%q) = %v; want nil", ok, err)
 		}
 	}
-	for _, bad := range []string{"queued", "DONE", "?"} {
+	// scan_results never transitions to "failed" anywhere in the codebase, so
+	// validateScanStatus deliberately rejects it to avoid surfacing an
+	// always-empty filter.
+	for _, bad := range []string{"failed", "queued", "DONE", "?"} {
 		if err := validateScanStatus(bad); err == nil {
 			t.Errorf("validateScanStatus(%q) = nil; want error", bad)
 		}
@@ -1040,4 +1043,147 @@ func TestResolveLibrary_NumericRefAmbiguousIDvsName(t *testing.T) {
 		t.Fatalf("err = %v; want substring 'ambiguous'", err)
 	}
 	_ = cfg
+}
+
+func TestRunScanResults_FilterByStatus(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	rows := []models.ScanResult{
+		{FilePath: "/music/a.mp3", Track: models.Track{ArtistName: "A", TrackName: "Pending"}, Outdir: "/music", Filename: "a.lrc", Status: scan.StatusPending},
+		{FilePath: "/music/b.mp3", Track: models.Track{ArtistName: "B", TrackName: "Done"}, Outdir: "/music", Filename: "b.lrc", Status: scan.StatusPending},
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, rows, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE scan_results SET status = 'done' WHERE artist = 'B'`); err != nil {
+		t.Fatalf("set status done: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := runScanResults(ctx, &out, ScanResultsCmd{ConfigPath: cfg, Status: "done"})
+	if code != 0 {
+		t.Fatalf("scan results --status done: %d. out=%s", code, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "/music/b.mp3") {
+		t.Fatalf("want done row in output: %q", got)
+	}
+	if strings.Contains(got, "/music/a.mp3") {
+		t.Fatalf("filter leaked pending row: %q", got)
+	}
+}
+
+func TestRunScanResults_LimitTrimsResults(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	var rows []models.ScanResult
+	for i := 0; i < 5; i++ {
+		rows = append(rows, models.ScanResult{
+			FilePath: "/music/" + strconv.Itoa(i) + ".mp3",
+			Track:    models.Track{ArtistName: "A", TrackName: strconv.Itoa(i)},
+			Outdir:   "/music",
+			Filename: strconv.Itoa(i) + ".lrc",
+			Status:   scan.StatusPending,
+		})
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, rows, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := runScanResults(ctx, &out, ScanResultsCmd{ConfigPath: cfg, Limit: 2})
+	if code != 0 {
+		t.Fatalf("scan results --limit 2: %d. out=%s", code, out.String())
+	}
+	count := strings.Count(out.String(), "/music/")
+	if count != 2 {
+		t.Fatalf("limit 2 returned %d data rows; want 2. out=%s", count, out.String())
+	}
+}
+
+func TestRunQueueRetry_ResetsLinkedScanResults(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/song.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+		Outdir:   "/music",
+		Filename: "song.lrc",
+		Status:   scan.StatusPending,
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	var scanID int64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT id FROM scan_results LIMIT 1`).Scan(&scanID); err != nil {
+		t.Fatalf("scan id: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Song"},
+		ScanResultID: scanID,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, item.ID, errors.New("rate limited")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE scan_results SET status = 'processing' WHERE id = ?`, scanID); err != nil {
+		t.Fatalf("seed processing: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "retry", "--config", cfg, strconv.FormatInt(item.ID, 10)}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("queue retry: %d. out=%s", code, out.String())
+	}
+
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var scanStatus string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM scan_results WHERE id = ?`, scanID).Scan(&scanStatus); err != nil {
+		t.Fatalf("read scan_results status: %v", err)
+	}
+	if scanStatus != "pending" {
+		t.Fatalf("scan_results status = %q after retry; want pending", scanStatus)
+	}
 }

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -3,9 +3,11 @@ package commands
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -425,3 +427,428 @@ func writeCommandsConfig(t *testing.T, dbPath string) string {
 }
 
 var _ lyrics.Writer = fakeWriter{}
+
+// commandsTestEnv prepares an isolated config + DB and pre-seeds a library and
+// optional queue/scan rows. Returns the config path used by run* helpers.
+func commandsTestEnv(t *testing.T) (cfgPath string, dbPath string) {
+	t.Helper()
+	isolateCommandsEnv(t)
+	dir := t.TempDir()
+	dbPath = filepath.Join(dir, "state", "test.db")
+	cfgPath = writeCommandsConfig(t, dbPath)
+	return cfgPath, dbPath
+}
+
+func TestRunQueueList_FiltersByStatus(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Pending", TrackName: "Track"}}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Failing", TrackName: "Track"}}, 1); err != nil {
+		t.Fatalf("Enqueue 2: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, claimed.ID, errorsNew("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "list", "--status", "failed", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("Run exit code = %d; want 0; out=%s", code, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "ID") || !strings.Contains(got, "Status") || !strings.Contains(got, "LastError") {
+		t.Fatalf("missing header in output: %q", got)
+	}
+	// The first dequeue (FIFO) claims the row inserted first ("Pending"),
+	// which is then failed. So a single failed row shows up; the "Failing"
+	// row stays pending and must NOT appear under --status=failed.
+	if !strings.Contains(got, "Pending") {
+		t.Fatalf("expected failed row (artist=Pending) in output: %q", got)
+	}
+	if strings.Contains(got, "Failing") {
+		t.Fatalf("status filter leaked pending row: %q", got)
+	}
+}
+
+func TestRunQueueRetry_RejectsNonFailedRow(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Pending"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "retry", strconvFormatInt(item.ID), "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("Run exit code = 0; want non-zero (retry on pending must fail). out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "not in failed status") {
+		t.Fatalf("expected not-retryable message; got %q", out.String())
+	}
+}
+
+func TestRunQueueRetry_ResetsFailedRow(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, claimed.ID, errorsNew("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "retry", strconvFormatInt(claimed.ID), "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("Run exit code = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "retried") {
+		t.Fatalf("expected retried message; got %q", out.String())
+	}
+
+	// Verify state.
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer sqlDB.Close()
+	items, err := queue.NewDBQueue(sqlDB).List(ctx, queue.ListFilter{Status: queue.StatusPending})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 || items[0].Attempts != 0 {
+		t.Fatalf("post-retry pending items = %+v; want one with attempts=0", items)
+	}
+}
+
+func TestRunQueueClear_DryRunDoesNotDelete(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.Complete(ctx, claimed.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "clear", "--done", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("Run dry-run exit code = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "would delete 1") {
+		t.Fatalf("expected dry-run message; got %q", out.String())
+	}
+
+	// Re-open and confirm row still there.
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	c, err := queue.NewDBQueue(sqlDB).CountDone(ctx)
+	if err != nil {
+		t.Fatalf("CountDone: %v", err)
+	}
+	_ = sqlDB.Close()
+	if c != 1 {
+		t.Fatalf("dry-run deleted rows: CountDone=%d, want 1", c)
+	}
+
+	// Now actually delete.
+	out.Reset()
+	code = Run(ctx, []string{"queue", "clear", "--done", "--yes", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("Run --yes exit code = %d; want 0", code)
+	}
+	if !strings.Contains(out.String(), "deleted 1") {
+		t.Fatalf("expected deletion message; got %q", out.String())
+	}
+}
+
+func TestRunScanResults_ResolvesLibraryByNameAndID(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	for _, ref := range []string{"MusicLib", strconvFormatInt(lib.ID)} {
+		var out bytes.Buffer
+		code := Run(ctx, []string{"scan", "results", "--library", ref, "--config", cfg}, &out, Deps{})
+		if code != 0 {
+			t.Fatalf("Run --library=%q exit code = %d; want 0; out=%s", ref, code, out.String())
+		}
+		if !strings.Contains(out.String(), "/music/a.mp3") {
+			t.Fatalf("expected scan_result row for ref=%q; got %q", ref, out.String())
+		}
+		if !strings.Contains(out.String(), "MusicLib") {
+			t.Fatalf("expected library name in output for ref=%q; got %q", ref, out.String())
+		}
+	}
+}
+
+func TestRunScanClear_DryRunAndConfirm(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{
+		{FilePath: "/music/a.mp3", Track: models.Track{ArtistName: "Artist", TrackName: "A"}},
+		{FilePath: "/music/b.mp3", Track: models.Track{ArtistName: "Artist", TrackName: "B"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	// Dry run.
+	var out bytes.Buffer
+	code := Run(ctx, []string{"scan", "clear", "--library", "MusicLib", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("dry-run exit code = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "would delete 2") {
+		t.Fatalf("expected dry-run message; got %q", out.String())
+	}
+
+	// Confirm dry run did nothing.
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	c, err := scan.New(sqlDB).CountByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("CountByLibrary: %v", err)
+	}
+	_ = sqlDB.Close()
+	if c != 2 {
+		t.Fatalf("CountByLibrary post dry-run = %d; want 2", c)
+	}
+
+	// Confirm.
+	out.Reset()
+	code = Run(ctx, []string{"scan", "clear", "--library", "MusicLib", "--yes", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("--yes exit code = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "deleted 2") {
+		t.Fatalf("expected deletion message; got %q", out.String())
+	}
+
+	// Confirm library still exists.
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer sqlDB.Close()
+	if _, err := library.New(sqlDB).Get(ctx, lib.ID); err != nil {
+		t.Fatalf("library removed by scan clear: %v", err)
+	}
+}
+
+func errorsNew(s string) error { return errors.New(s) }
+
+func strconvFormatInt(i int64) string { return strconv.FormatInt(i, 10) }
+
+func TestValidateQueueStatus(t *testing.T) {
+	for _, ok := range []string{"", "pending", "processing", "failed", "done"} {
+		if err := validateQueueStatus(ok); err != nil {
+			t.Errorf("validateQueueStatus(%q) = %v; want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"running", "PENDING", "x"} {
+		if err := validateQueueStatus(bad); err == nil {
+			t.Errorf("validateQueueStatus(%q) = nil; want error", bad)
+		}
+	}
+}
+
+func TestValidateScanStatus(t *testing.T) {
+	for _, ok := range []string{"", "pending", "processing", "done", "failed"} {
+		if err := validateScanStatus(ok); err != nil {
+			t.Errorf("validateScanStatus(%q) = %v; want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"queued", "DONE", "?"} {
+		if err := validateScanStatus(bad); err == nil {
+			t.Errorf("validateScanStatus(%q) = nil; want error", bad)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"", 5, ""},
+		{"abc", 5, "abc"},
+		{"abcdef", 6, "abcdef"},
+		{"abcdef", 5, "ab..."},
+		{"abcdef", 3, "abc"},
+		{"abcdef", 1, "a"},
+		{"abcdef", 0, "abcdef"},
+		{"abcdef", -1, "abcdef"},
+	}
+	for _, tc := range cases {
+		got := truncate(tc.in, tc.max)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q; want %q", tc.in, tc.max, got, tc.want)
+		}
+	}
+}
+
+func TestRunQueueList_InvalidStatusReturnsError(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"queue", "list", "--status", "bogus", "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("queue list with bogus status: exit code 0; want non-zero. out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "invalid status") {
+		t.Fatalf("output missing 'invalid status': %q", out.String())
+	}
+}
+
+func TestRunQueueRetry_MissingIDSurfacesNotFound(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"queue", "retry", "--config", cfg, "9999"}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("queue retry of missing id: exit code 0; want non-zero. out=%s", out.String())
+	}
+}
+
+func TestRunQueueClear_ConfirmDeletes(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Done"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "clear", "--done", "--yes", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("queue clear --yes exit code = %d; want 0. out=%s", code, out.String())
+	}
+}
+
+func TestRunScanResults_InvalidStatusReturnsError(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"scan", "results", "--status", "bogus", "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("scan results bogus status: exit code 0; want non-zero. out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "invalid status") {
+		t.Fatalf("output missing 'invalid status': %q", out.String())
+	}
+}
+
+func TestRunScanClear_RequiresLibrary(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"scan", "clear", "--library", "Nonexistent", "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("scan clear unknown library: exit code 0; want non-zero. out=%s", out.String())
+	}
+}
+
+func TestResolveLibraryRejectsBlankRef(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	repo := library.New(sqlDB)
+	if _, err := resolveLibrary(ctx, repo, ""); err == nil {
+		t.Fatal("resolveLibrary empty ref returned nil error")
+	}
+	if _, err := resolveLibrary(ctx, repo, "  "); err == nil {
+		t.Fatal("resolveLibrary whitespace ref returned nil error")
+	}
+	_ = cfg
+}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -852,3 +852,192 @@ func TestResolveLibraryRejectsBlankRef(t *testing.T) {
 	}
 	_ = cfg
 }
+
+func TestRunQueueCmd_MissingSubcommand(t *testing.T) {
+	var out bytes.Buffer
+	code := runQueueCmd(context.Background(), &out, QueueCmd{})
+	if code != 2 {
+		t.Fatalf("runQueueCmd empty = %d; want 2", code)
+	}
+	if !strings.Contains(out.String(), "missing queue subcommand") {
+		t.Fatalf("output = %q; want missing-subcommand message", out.String())
+	}
+}
+
+func TestRunQueueCmd_FailedRoutesToList(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runQueueCmd(context.Background(), &out, QueueCmd{Failed: &QueueFailedCmd{ConfigPath: cfg, Limit: 5}})
+	if code != 0 {
+		t.Fatalf("queue failed = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "ID") {
+		t.Fatalf("queue failed missing header: %q", out.String())
+	}
+}
+
+func TestRunQueueClear_RequiresDoneFlag(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runQueueClear(context.Background(), &out, QueueClearCmd{ConfigPath: cfg, Done: false})
+	if code != 2 {
+		t.Fatalf("queue clear without --done = %d; want 2", code)
+	}
+	if !strings.Contains(out.String(), "requires --done") {
+		t.Fatalf("output = %q; want --done required message", out.String())
+	}
+}
+
+func TestRunScanResults_EmptyDBPrintsHeaderOnly(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runScanResults(context.Background(), &out, ScanResultsCmd{ConfigPath: cfg})
+	if code != 0 {
+		t.Fatalf("scan results empty = %d; want 0. out=%s", code, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "ID") || !strings.Contains(got, "Library") {
+		t.Fatalf("output missing header: %q", got)
+	}
+}
+
+func TestRunQueueList_EmptyDBPrintsHeaderOnly(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runQueueList(context.Background(), &out, QueueListCmd{ConfigPath: cfg})
+	if code != 0 {
+		t.Fatalf("queue list empty = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "ID") {
+		t.Fatalf("output missing header: %q", out.String())
+	}
+}
+
+func TestRunQueueClear_DryRunCountsZero(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runQueueClear(context.Background(), &out, QueueClearCmd{ConfigPath: cfg, Done: true, Yes: false})
+	if code != 0 {
+		t.Fatalf("dry-run on empty db = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "would delete 0") {
+		t.Fatalf("dry-run output = %q; want 'would delete 0'", out.String())
+	}
+}
+
+func TestRunScanClear_DryRunOnEmpty(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	if _, err := libRepo.Add(ctx, "/music", "Music"); err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := runScanClear(ctx, &out, ScanClearCmd{ConfigPath: cfg, Library: "Music", Yes: false})
+	if code != 0 {
+		t.Fatalf("scan clear dry-run = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "would delete 0") {
+		t.Fatalf("scan clear dry-run output = %q; want 'would delete 0'", out.String())
+	}
+}
+
+func TestRunScanClear_RequiresLibraryFlag(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := runScanClear(context.Background(), &out, ScanClearCmd{ConfigPath: cfg})
+	if code == 0 {
+		t.Fatalf("scan clear without --library = 0; want non-zero")
+	}
+}
+
+func TestRunScanResults_FilterByLibraryByID(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "A", TrackName: "Track"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+		Status:   scan.StatusPending,
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := runScanResults(ctx, &out, ScanResultsCmd{ConfigPath: cfg, Library: strconv.FormatInt(lib.ID, 10)})
+	if code != 0 {
+		t.Fatalf("scan results --library <id> = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "/music/a.mp3") {
+		t.Fatalf("scan results --library <id> missing row: %q", out.String())
+	}
+}
+
+func TestResolveLibrary_NumericNameLooksUpByName(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	repo := library.New(sqlDB)
+	added, err := repo.Add(ctx, "/music/numeric", "9999")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got, err := resolveLibrary(ctx, repo, "9999")
+	if err != nil {
+		t.Fatalf("resolveLibrary numeric-name: %v", err)
+	}
+	if got.ID != added.ID {
+		t.Fatalf("resolveLibrary id = %d; want %d", got.ID, added.ID)
+	}
+	_ = cfg
+}
+
+func TestResolveLibrary_NumericRefAmbiguousIDvsName(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	repo := library.New(sqlDB)
+	// Library #1 (Music)
+	if _, err := repo.Add(ctx, "/music/a", "Music"); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+	// Library #2 named "1" — ref "1" now matches BOTH id=1 and name="1".
+	if _, err := repo.Add(ctx, "/music/b", "1"); err != nil {
+		t.Fatalf("Add b: %v", err)
+	}
+
+	_, err = resolveLibrary(ctx, repo, "1")
+	if err == nil {
+		t.Fatal("resolveLibrary returned nil error for ambiguous ID-vs-name match")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("err = %v; want substring 'ambiguous'", err)
+	}
+	_ = cfg
+}

--- a/internal/library/repository.go
+++ b/internal/library/repository.go
@@ -80,6 +80,24 @@ func (r *Repo) Get(ctx context.Context, id int64) (models.Library, error) {
 	return lib, nil
 }
 
+// GetByName returns the library root whose name matches name. It returns
+// sql.ErrNoRows when not found.
+func (r *Repo) GetByName(ctx context.Context, name string) (models.Library, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return models.Library{}, fmt.Errorf("library: name must not be empty")
+	}
+	var lib models.Library
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE name = ?`,
+		name,
+	).Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt)
+	if err != nil {
+		return models.Library{}, fmt.Errorf("library: get by name: %w", err)
+	}
+	return lib, nil
+}
+
 // Update changes the path and name for an existing library root.
 func (r *Repo) Update(ctx context.Context, id int64, path, name string) (models.Library, error) {
 	path, name, err := validate(path, name)

--- a/internal/library/repository.go
+++ b/internal/library/repository.go
@@ -3,6 +3,7 @@ package library
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -80,19 +81,43 @@ func (r *Repo) Get(ctx context.Context, id int64) (models.Library, error) {
 	return lib, nil
 }
 
+// ErrAmbiguousLibraryName is returned when a name lookup matches more than
+// one library row. The schema does not enforce uniqueness on name (only path),
+// so callers must disambiguate by ID rather than have the lookup silently pick
+// an arbitrary row.
+var ErrAmbiguousLibraryName = errors.New("library: ambiguous name (multiple rows match)")
+
 // GetByName returns the library root whose name matches name. It returns
-// sql.ErrNoRows when not found.
+// sql.ErrNoRows when not found and ErrAmbiguousLibraryName when more than one
+// row shares the same name (schema only enforces unique path).
 func (r *Repo) GetByName(ctx context.Context, name string) (models.Library, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return models.Library{}, fmt.Errorf("library: name must not be empty")
 	}
-	var lib models.Library
-	err := r.db.QueryRowContext(ctx,
-		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE name = ?`,
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE name = ? LIMIT 2`,
 		name,
-	).Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt)
+	)
 	if err != nil {
+		return models.Library{}, fmt.Errorf("library: get by name: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return models.Library{}, fmt.Errorf("library: get by name: %w", err)
+		}
+		return models.Library{}, fmt.Errorf("library: get by name: %w", sql.ErrNoRows)
+	}
+	var lib models.Library
+	if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt); err != nil {
+		return models.Library{}, fmt.Errorf("library: get by name: %w", err)
+	}
+	if rows.Next() {
+		return models.Library{}, fmt.Errorf("library: get by name %q: %w", name, ErrAmbiguousLibraryName)
+	}
+	if err := rows.Err(); err != nil {
 		return models.Library{}, fmt.Errorf("library: get by name: %w", err)
 	}
 	return lib, nil

--- a/internal/library/repository_test.go
+++ b/internal/library/repository_test.go
@@ -150,3 +150,23 @@ func TestUpdateRemove_NotFound(t *testing.T) {
 		t.Fatalf("Remove missing got %v; want sql.ErrNoRows", err)
 	}
 }
+
+func TestGetByName_AmbiguousReturnsError(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	if _, err := repo.Add(ctx, "/music/a", "Music"); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+	if _, err := repo.Add(ctx, "/music/b", "Music"); err != nil {
+		t.Fatalf("Add b: %v", err)
+	}
+
+	_, err := repo.GetByName(ctx, "Music")
+	if err == nil {
+		t.Fatal("GetByName ambiguous returned nil error")
+	}
+	if !errors.Is(err, library.ErrAmbiguousLibraryName) {
+		t.Fatalf("err = %v; want errors.Is(_, ErrAmbiguousLibraryName)", err)
+	}
+}

--- a/internal/library/repository_test.go
+++ b/internal/library/repository_test.go
@@ -104,6 +104,39 @@ func TestAdd_ValidatesRequiredFields(t *testing.T) {
 	}
 }
 
+func TestGetByName(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	added, err := repo.Add(ctx, "/music/rock", "Rock")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := repo.GetByName(ctx, "Rock")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if got != added {
+		t.Fatalf("GetByName = %+v; want %+v", got, added)
+	}
+
+	if _, err := repo.GetByName(ctx, "  Rock  "); err != nil {
+		t.Fatalf("GetByName trimmed: %v", err)
+	}
+
+	if _, err := repo.GetByName(ctx, ""); err == nil {
+		t.Fatal("GetByName empty name returned nil error")
+	}
+	if _, err := repo.GetByName(ctx, "    "); err == nil {
+		t.Fatal("GetByName whitespace name returned nil error")
+	}
+
+	if _, err := repo.GetByName(ctx, "Missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetByName missing = %v; want sql.ErrNoRows", err)
+	}
+}
+
 func TestUpdateRemove_NotFound(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -435,7 +435,13 @@ func (q *DBQueue) List(ctx context.Context, filter ListFilter) (items []WorkItem
 // processing rows or undoing a successful completion.
 func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
 	now := formatTime(q.now())
-	row := q.db.QueryRowContext(ctx,
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: begin retry tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	row := tx.QueryRowContext(ctx,
 		`UPDATE work_queue
          SET status = 'pending',
              attempts = 0,
@@ -454,7 +460,7 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
 		// caller cannot tell those apart here; existence is checked separately
 		// so the user gets a clear error message either way.
 		var exists int
-		if err := q.db.QueryRowContext(ctx,
+		if err := tx.QueryRowContext(ctx,
 			`SELECT 1 FROM work_queue WHERE id = ?`, id,
 		).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -466,6 +472,21 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
 	}
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: retry: %w", err)
+	}
+	// Reset every linked scan_results row so `scan results` reflects the
+	// retried state. Skip rows already in 'pending' or 'done' so we never
+	// overwrite a terminal outcome.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+         SET status = 'pending'
+         WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+           AND status = 'processing'`,
+		id,
+	); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: retry scan_results reset: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: commit retry tx: %w", err)
 	}
 	return item, nil
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -26,6 +26,11 @@ const (
 
 const timeFormat = time.RFC3339
 
+// ErrNotRetryable is returned by Retry when the targeted work item is not in
+// the failed state and therefore cannot be safely reset (e.g. processing or
+// done). This avoids racing the worker on rows it currently owns.
+var ErrNotRetryable = errors.New("queue: work item is not in failed status")
+
 // InputsQueue is a FIFO queue for processing work items.
 type InputsQueue struct {
 	Queue []models.Inputs
@@ -365,6 +370,133 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 		return WorkItem{}, fmt.Errorf("queue: commit fail tx: %w", err)
 	}
 	return item, nil
+}
+
+// ListFilter narrows the rows returned by List.
+type ListFilter struct {
+	// Status optionally restricts results to a single status value (e.g.
+	// "pending", "processing", "failed", "done"). Empty means no filter.
+	Status string
+	// Limit caps the number of rows returned. Zero or negative means no cap.
+	Limit int
+}
+
+// List returns work items ordered by priority desc, created_at asc, id asc,
+// optionally filtered by status and capped by limit.
+func (q *DBQueue) List(ctx context.Context, filter ListFilter) (items []WorkItem, retErr error) {
+	const baseQuery = `SELECT id, artist, title, outdir, filename, source_path, status, priority, attempts,
+                       next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       FROM work_queue`
+	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
+	const limitClause = ` LIMIT ?`
+	var args []any
+	var query string
+	switch {
+	case filter.Status != "" && filter.Limit > 0:
+		query = baseQuery + ` WHERE status = ?` + orderClause + limitClause
+		args = append(args, filter.Status, filter.Limit)
+	case filter.Status != "":
+		query = baseQuery + ` WHERE status = ?` + orderClause
+		args = append(args, filter.Status)
+	case filter.Limit > 0:
+		query = baseQuery + orderClause + limitClause
+		args = append(args, filter.Limit)
+	default:
+		query = baseQuery + orderClause
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("queue: list: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close list rows: %w", err)
+		}
+	}()
+
+	for rows.Next() {
+		item, err := scanWorkItem(rows)
+		if err != nil {
+			return nil, fmt.Errorf("queue: list scan: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list rows: %w", err)
+	}
+	return items, nil
+}
+
+// Retry resets a failed work item back to pending so the worker picks it up on
+// the next dequeue. attempts is reset to zero, last_error is cleared, and
+// next_attempt_at is set to now. Retry returns ErrNotRetryable when the row's
+// current status is not "failed", which avoids racing the worker on
+// processing rows or undoing a successful completion.
+func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
+	now := formatTime(q.now())
+	row := q.db.QueryRowContext(ctx,
+		`UPDATE work_queue
+         SET status = 'pending',
+             attempts = 0,
+             next_attempt_at = ?,
+             last_error = ''
+         WHERE id = ?
+           AND status = 'failed'
+         RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+		now,
+		id,
+	)
+	item, err := scanWorkItem(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Either the row does not exist, or its status is not 'failed'. The
+		// caller cannot tell those apart here; existence is checked separately
+		// so the user gets a clear error message either way.
+		var exists int
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT 1 FROM work_queue WHERE id = ?`, id,
+		).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return WorkItem{}, sql.ErrNoRows
+			}
+			return WorkItem{}, fmt.Errorf("queue: retry existence check: %w", err)
+		}
+		return WorkItem{}, ErrNotRetryable
+	}
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: retry: %w", err)
+	}
+	return item, nil
+}
+
+// ClearDone removes every work_queue row whose status is "done" and returns
+// the number of rows deleted.
+func (q *DBQueue) ClearDone(ctx context.Context) (int64, error) {
+	res, err := q.db.ExecContext(ctx,
+		`DELETE FROM work_queue WHERE status = 'done'`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("queue: clear done: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("queue: clear done rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// CountDone returns the number of work_queue rows whose status is "done".
+// It is useful for reporting what ClearDone would delete without actually
+// deleting anything.
+func (q *DBQueue) CountDone(ctx context.Context) (int64, error) {
+	var n int64
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue WHERE status = 'done'`,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("queue: count done: %w", err)
+	}
+	return n, nil
 }
 
 type rowScanner interface {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -812,6 +813,202 @@ func TestDBQueue_ReleaseRequiresProcessingStatus(t *testing.T) {
 	}
 	if err := q.Release(ctx, item.ID); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("Release on pending row = %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestDBQueue_ListFiltersByStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Pending"}}, 1); err != nil {
+		t.Fatalf("Enqueue pending: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "B", TrackName: "Failing"}}, 1); err != nil {
+		t.Fatalf("Enqueue failing: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, claimed.ID, errors.New("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+
+	items, err := q.List(ctx, ListFilter{Status: StatusFailed})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != claimed.ID {
+		t.Fatalf("List(failed) = %+v; want one row with id %d", items, claimed.ID)
+	}
+
+	items, err = q.List(ctx, ListFilter{Status: StatusPending})
+	if err != nil {
+		t.Fatalf("List pending: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("List(pending) returned %d; want 1", len(items))
+	}
+
+	items, err = q.List(ctx, ListFilter{})
+	if err != nil {
+		t.Fatalf("List no filter: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("List(no filter) = %d rows; want 2", len(items))
+	}
+}
+
+func TestDBQueue_ListHonorsLimit(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	for i := 0; i < 5; i++ {
+		if _, err := q.Enqueue(ctx, models.Inputs{
+			Track: models.Track{ArtistName: "Artist", TrackName: fmt.Sprintf("Track%d", i)},
+		}, 1); err != nil {
+			t.Fatalf("Enqueue %d: %v", i, err)
+		}
+	}
+	items, err := q.List(ctx, ListFilter{Limit: 3})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("List(limit=3) returned %d rows; want 3", len(items))
+	}
+}
+
+func TestDBQueue_RetryResetsFailedRow(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	failed, err := q.Fail(ctx, claimed.ID, errors.New("rate limited"))
+	if err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if failed.Attempts != 1 || failed.LastError == "" {
+		t.Fatalf("pre-retry attempts=%d last_error=%q; want attempts>0, non-empty error", failed.Attempts, failed.LastError)
+	}
+
+	q.now = func() time.Time { return now.Add(time.Hour) }
+	retried, err := q.Retry(ctx, claimed.ID)
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if retried.Status != StatusPending {
+		t.Fatalf("retried status = %q; want pending", retried.Status)
+	}
+	if retried.Attempts != 0 {
+		t.Fatalf("retried attempts = %d; want 0", retried.Attempts)
+	}
+	if retried.LastError != "" {
+		t.Fatalf("retried last_error = %q; want empty", retried.LastError)
+	}
+	if !retried.NextAttemptAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("retried next_attempt_at = %s; want %s", retried.NextAttemptAt, now.Add(time.Hour))
+	}
+}
+
+func TestDBQueue_RetryRejectsNonFailedStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	pending, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Pending"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Retry(ctx, pending.ID); !errors.Is(err, ErrNotRetryable) {
+		t.Fatalf("Retry pending error = %v; want ErrNotRetryable", err)
+	}
+
+	processing, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Retry(ctx, processing.ID); !errors.Is(err, ErrNotRetryable) {
+		t.Fatalf("Retry processing error = %v; want ErrNotRetryable", err)
+	}
+
+	if err := q.Complete(ctx, processing.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if _, err := q.Retry(ctx, processing.ID); !errors.Is(err, ErrNotRetryable) {
+		t.Fatalf("Retry done error = %v; want ErrNotRetryable", err)
+	}
+
+	if _, err := q.Retry(ctx, 9999); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Retry missing id error = %v; want sql.ErrNoRows", err)
+	}
+}
+
+func TestDBQueue_ClearDoneRemovesOnlyDoneRows(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	// pending (will stay)
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Pending"}}, 1); err != nil {
+		t.Fatalf("Enqueue pending: %v", err)
+	}
+	// done
+	doneItem, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "B", TrackName: "Done"}}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue done: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil { // claims pending first by FIFO; need to claim 'Done' instead
+		t.Fatalf("Dequeue: %v", err)
+	}
+	// Above claimed the pending row. Claim again to get the done one.
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue 2: %v", err)
+	}
+	if err := q.Complete(ctx, doneItem.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	count, err := q.CountDone(ctx)
+	if err != nil {
+		t.Fatalf("CountDone: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("CountDone = %d; want 1", count)
+	}
+
+	deleted, err := q.ClearDone(ctx)
+	if err != nil {
+		t.Fatalf("ClearDone: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("ClearDone deleted = %d; want 1", deleted)
+	}
+
+	// The other (non-done) rows must still exist.
+	items, err := q.List(ctx, ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("ClearDone removed non-done rows; remaining = 0")
+	}
+	for _, it := range items {
+		if it.Status == StatusDone {
+			t.Fatalf("ClearDone left a done row: %+v", it)
+		}
 	}
 }
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1044,3 +1044,60 @@ func TestDBQueue_CompleteMarksDone(t *testing.T) {
 		t.Fatalf("completed_at = %q; want %q", completedAt, formatTime(now))
 	}
 }
+
+func TestDBQueue_RetryResetsLinkedScanResults(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	scanID1 := insertScanResult(t, sqlDB, "/music/lib-a/song.mp3")
+	scanID2 := insertScanResult(t, sqlDB, "/music/lib-b/song.mp3")
+
+	q := NewDBQueue(sqlDB)
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	// Two scan_results with the same normalized key collapse into one queue row.
+	first, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Song"},
+		ScanResultID: scanID1,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue first: %v", err)
+	}
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Song"},
+		ScanResultID: scanID2,
+	}, 1); err != nil {
+		t.Fatalf("Enqueue second: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, first.ID, errors.New("rate limited")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	// EnqueuePending in scan flips both scan_results to 'processing' on enqueue.
+	// Verify that's the starting state we're testing the reset against.
+	for _, id := range []int64{scanID1, scanID2} {
+		if _, err := sqlDB.ExecContext(ctx,
+			`UPDATE scan_results SET status = 'processing' WHERE id = ?`, id,
+		); err != nil {
+			t.Fatalf("seed processing on scan %d: %v", id, err)
+		}
+	}
+
+	if _, err := q.Retry(ctx, first.ID); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+
+	for _, id := range []int64{scanID1, scanID2} {
+		var status string
+		if err := sqlDB.QueryRowContext(ctx,
+			`SELECT status FROM scan_results WHERE id = ?`, id,
+		).Scan(&status); err != nil {
+			t.Fatalf("read scan_results %d: %v", id, err)
+		}
+		if status != StatusPending {
+			t.Fatalf("scan_results %d status = %q; want %q (Retry must reset every linked processing row)", id, status, StatusPending)
+		}
+	}
+}

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -169,6 +169,10 @@ type Filter struct {
 	// Status optionally restricts results to a single status value (e.g.
 	// "pending", "processing", "done", "failed"). Empty means no filter.
 	Status string
+	// Limit caps the number of returned rows. Zero or negative means no
+	// limit. Applied as a SQL LIMIT so the database does not materialize
+	// the full result set when the caller only wants a slice.
+	Limit int
 }
 
 // List returns persisted scan results matching filter in stable ID order.
@@ -190,6 +194,10 @@ func (r *Repo) List(ctx context.Context, filter Filter) (results []models.ScanRe
 		args = append(args, filter.Status)
 	default:
 		query = baseQuery + orderClause
+	}
+	if filter.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, filter.Limit)
 	}
 
 	rows, err := r.db.QueryContext(ctx, query, args...)

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -162,6 +162,84 @@ func scanResultRows(rows *sql.Rows) ([]models.ScanResult, error) {
 	return results, nil
 }
 
+// Filter narrows the rows returned by List.
+type Filter struct {
+	// LibraryID, when non-nil, restricts results to a specific library row.
+	LibraryID *int64
+	// Status optionally restricts results to a single status value (e.g.
+	// "pending", "processing", "done", "failed"). Empty means no filter.
+	Status string
+}
+
+// List returns persisted scan results matching filter in stable ID order.
+func (r *Repo) List(ctx context.Context, filter Filter) (results []models.ScanResult, retErr error) {
+	const baseQuery = `SELECT id, library_id, file_path, artist, title, outdir, filename, status, created_at
+                       FROM scan_results`
+	const orderClause = ` ORDER BY id ASC`
+	var args []any
+	var query string
+	switch {
+	case filter.LibraryID != nil && filter.Status != "":
+		query = baseQuery + ` WHERE library_id = ? AND status = ?` + orderClause
+		args = append(args, *filter.LibraryID, filter.Status)
+	case filter.LibraryID != nil:
+		query = baseQuery + ` WHERE library_id = ?` + orderClause
+		args = append(args, *filter.LibraryID)
+	case filter.Status != "":
+		query = baseQuery + ` WHERE status = ?` + orderClause
+		args = append(args, filter.Status)
+	default:
+		query = baseQuery + orderClause
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("scan: list: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("scan: close list rows: %w", err)
+		}
+	}()
+
+	results, err = scanResultRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan: list rows: %w", err)
+	}
+	return results, nil
+}
+
+// ClearByLibrary deletes every scan_results row belonging to libraryID and
+// returns the number of rows deleted. The library row itself is left intact.
+func (r *Repo) ClearByLibrary(ctx context.Context, libraryID int64) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM scan_results WHERE library_id = ?`,
+		libraryID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("scan: clear by library: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("scan: clear by library rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// CountByLibrary returns the number of scan_results rows belonging to
+// libraryID. It is useful for reporting what ClearByLibrary would delete
+// without actually deleting anything.
+func (r *Repo) CountByLibrary(ctx context.Context, libraryID int64) (int64, error) {
+	var n int64
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM scan_results WHERE library_id = ?`,
+		libraryID,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("scan: count by library: %w", err)
+	}
+	return n, nil
+}
+
 // SetStatus updates scan result status for each id.
 func (r *Repo) SetStatus(ctx context.Context, ids []int64, status string) error {
 	if len(ids) == 0 {

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -229,6 +229,132 @@ func TestRepo_ListByLibrary_IsolatedByLibrary(t *testing.T) {
 	}
 }
 
+func TestRepo_ListWithFilters(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	if err != nil {
+		t.Fatalf("Add library A: %v", err)
+	}
+	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	if err != nil {
+		t.Fatalf("Add library B: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libA.ID, []models.ScanResult{
+		{FilePath: "/music/a/1.mp3", Track: models.Track{ArtistName: "A1", TrackName: "T1"}, Status: scan.StatusPending},
+		{FilePath: "/music/a/2.mp3", Track: models.Track{ArtistName: "A2", TrackName: "T2"}, Status: scan.StatusDone},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert A: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libB.ID, []models.ScanResult{
+		{FilePath: "/music/b/1.mp3", Track: models.Track{ArtistName: "B1", TrackName: "T1"}, Status: scan.StatusPending},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert B: %v", err)
+	}
+
+	// No filter returns all rows.
+	all, err := scanRepo.List(ctx, scan.Filter{})
+	if err != nil {
+		t.Fatalf("List no filter: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("List no filter = %d rows; want 3", len(all))
+	}
+
+	// Filter by library.
+	libAOnly, err := scanRepo.List(ctx, scan.Filter{LibraryID: &libA.ID})
+	if err != nil {
+		t.Fatalf("List by library: %v", err)
+	}
+	if len(libAOnly) != 2 {
+		t.Fatalf("List(libA) = %d rows; want 2", len(libAOnly))
+	}
+
+	// Filter by library + status.
+	pendingA, err := scanRepo.List(ctx, scan.Filter{LibraryID: &libA.ID, Status: scan.StatusPending})
+	if err != nil {
+		t.Fatalf("List pending in A: %v", err)
+	}
+	if len(pendingA) != 1 || pendingA[0].FilePath != "/music/a/1.mp3" {
+		t.Fatalf("List pending in A = %+v; want one row for /music/a/1.mp3", pendingA)
+	}
+
+	// Filter by status only.
+	pending, err := scanRepo.List(ctx, scan.Filter{Status: scan.StatusPending})
+	if err != nil {
+		t.Fatalf("List pending: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("List pending = %d rows; want 2", len(pending))
+	}
+}
+
+func TestRepo_ClearByLibraryOnlyAffectsTargetedLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	if err != nil {
+		t.Fatalf("Add library A: %v", err)
+	}
+	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	if err != nil {
+		t.Fatalf("Add library B: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libA.ID, []models.ScanResult{
+		{FilePath: "/music/a/1.mp3", Track: models.Track{ArtistName: "A", TrackName: "1"}},
+		{FilePath: "/music/a/2.mp3", Track: models.Track{ArtistName: "A", TrackName: "2"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert A: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libB.ID, []models.ScanResult{
+		{FilePath: "/music/b/1.mp3", Track: models.Track{ArtistName: "B", TrackName: "1"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert B: %v", err)
+	}
+
+	count, err := scanRepo.CountByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("CountByLibrary A: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("CountByLibrary A = %d; want 2", count)
+	}
+
+	deleted, err := scanRepo.ClearByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("ClearByLibrary A: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("ClearByLibrary A deleted %d; want 2", deleted)
+	}
+
+	leftA, err := scanRepo.ListByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary A: %v", err)
+	}
+	if len(leftA) != 0 {
+		t.Fatalf("library A still has %d scan_results; want 0", len(leftA))
+	}
+	leftB, err := scanRepo.ListByLibrary(ctx, libB.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary B: %v", err)
+	}
+	if len(leftB) != 1 {
+		t.Fatalf("library B = %d scan_results; want 1 (ClearByLibrary leaked across libraries)", len(leftB))
+	}
+
+	// The library row itself is still there.
+	if _, err := libRepo.Get(ctx, libA.ID); err != nil {
+		t.Fatalf("library A row removed by ClearByLibrary: %v", err)
+	}
+}
+
 func TestRepo_ListPendingByLibraryAndSetStatus(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)


### PR DESCRIPTION
## Summary

Closes #74. Closes #75.

Adds CLI command groups for inspecting and maintaining the durable work queue and persisted scan results, plus a name/ID library resolver shared by the new flags.

### Queue commands (#74)
- `queue list [--status pending|processing|failed|done] [--limit N]`
- `queue failed [--limit N]` (alias for `queue list --status failed`)
- `queue retry <id>` (resets a failed row only; rejects non-failed status with a clear error)
- `queue clear --done [--yes]` (dry-run prints count without `--yes`)

### Scan inspection commands (#75)
- `scan results [--library NAME_OR_ID] [--status pending|processing|done|failed] [--limit N]`
- `scan clear --library NAME_OR_ID [--yes]` (dry-run without `--yes`; never removes the library row itself)

### Other changes
- New `DBQueue.List`, `DBQueue.Retry` (with `ErrNotRetryable`), `DBQueue.ClearDone`, `DBQueue.CountDone`.
- New `scan.Repo.List` (filter by library + status), `scan.Repo.ClearByLibrary`, `scan.Repo.CountByLibrary`.
- New `library.Repo.GetByName` so `--library` accepts a name or numeric ID.
- New `runScanCmd` dispatcher: `scan` with no nested subcommand still runs the legacy one-shot scan (verified by existing tests).
- Tabular plain-text output via `text/tabwriter`. No JSON output (out of scope).
- Destructive commands always require explicit `--yes`.

### Tests
- Real-SQLite tests for new queue and scan repo methods (`TestDBQueue_List*`, `TestDBQueue_Retry*`, `TestDBQueue_ClearDone*`, `TestRepo_ListWithFilters`, `TestRepo_ClearByLibraryOnlyAffectsTargetedLibrary`).
- Library name resolution test (`TestGetByName`).
- End-to-end command tests for happy paths and error paths (invalid status, unknown library, dry-run vs `--yes`, missing-id retry).
- Patch coverage 71.75% (above the 70% threshold pinned in `codecov.yml`).

### Documentation
- `README.md`: new "Inspection commands" section with examples; one-line pointer in the Docker section.
- `AGENTS.md`: package summaries updated with the new repo methods.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `gofmt -l .` empty
- [x] Patch coverage above 70% threshold (71.75%)
- [x] `mxlrcgo-svc scan` with no nested subcommand still runs the legacy one-shot scan
- [x] Destructive commands without `--yes` print count and do not delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level queue command (list, view failed, retry failed items, clear completed).
  * Extended scan command with results listing and clear operations (filter by library/status, limit).

* **Documentation**
  * Added "Inspection commands" docs and architecture notes describing persistence and queue/scan inspection.
  * README updated with Docker exec examples for running inspection commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->