### PR TITLE
feat: cancel queue rows on scan clear; add scan --only selector

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -96,11 +96,12 @@ type ServeCmd struct {
 // nested inspection subcommands (results, clear). When neither nested
 // subcommand is set, the legacy run-once scan path is taken.
 type ScanCmd struct {
-	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
-	Depth      int    `arg:"-d,--depth" help:"maximum recursion depth" default:"100"`
-	Update     bool   `arg:"-u,--update" help:"re-fetch and overwrite existing .lrc files"`
-	Upgrade    bool   `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
-	BFS        bool   `arg:"--bfs" help:"use breadth-first traversal"`
+	ConfigPath string   `arg:"--config" help:"path to config file (default: XDG)" default:""`
+	Depth      int      `arg:"-d,--depth" help:"maximum recursion depth" default:"100"`
+	Update     bool     `arg:"-u,--update" help:"re-fetch and overwrite existing .lrc files"`
+	Upgrade    bool     `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
+	BFS        bool     `arg:"--bfs" help:"use breadth-first traversal"`
+	Libraries  []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
 	Results *ScanResultsCmd `arg:"subcommand:results" help:"list persisted scan_results rows"`
 	Clear   *ScanClearCmd   `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
@@ -611,11 +612,11 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 		}
 		return runScanClear(ctx, out, sub)
 	default:
-		return runScan(ctx, args)
+		return runScan(ctx, out, args)
 	}
 }
 
-func runScan(ctx context.Context, args ScanCmd) int {
+func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 	cfg, err := config.Load(args.ConfigPath)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
@@ -634,6 +635,27 @@ func runScan(ctx context.Context, args ScanCmd) int {
 		MaxDepth: args.Depth,
 		BFS:      args.BFS,
 	})
+	if len(args.Libraries) > 0 {
+		libRepo := library.New(sqlDB)
+		libs := make([]models.Library, 0, len(args.Libraries))
+		for _, ref := range args.Libraries {
+			lib, err := resolveLibrary(ctx, libRepo, ref)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					_, _ = fmt.Fprintf(out, "library %q not found\n", ref)
+					return 1
+				}
+				_, _ = fmt.Fprintf(out, "library %q: %v\n", ref, err)
+				return 1
+			}
+			libs = append(libs, lib)
+		}
+		if err := s.RunOnceFor(ctx, libs); err != nil {
+			slog.Error("scan failed", "error", err)
+			return 1
+		}
+		return 0
+	}
 	if err := s.RunOnce(ctx); err != nil {
 		slog.Error("scan failed", "error", err)
 		return 1
@@ -1397,20 +1419,34 @@ func runScanClear(ctx context.Context, out io.Writer, args ScanClearCmd) int {
 	}
 
 	scanRepo := scan.New(sqlDB)
+	workQueue := queue.NewDBQueue(sqlDB)
 	if !args.Yes {
 		count, err := scanRepo.CountByLibrary(ctx, lib.ID)
 		if err != nil {
 			slog.Error("failed to count scan results", "error", err)
 			return 1
 		}
-		_, _ = fmt.Fprintf(out, "would delete %d scan_results rows for library %q (id=%d); pass --yes to confirm\n", count, lib.Name, lib.ID)
+		qDel, qUpd, err := workQueue.CountCancelByLibrary(ctx, lib.ID)
+		if err != nil {
+			slog.Error("failed to count work_queue cancellations", "error", err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(out, "would delete %d scan_results rows and cancel %d / update %d work_queue rows for library %q (id=%d); pass --yes to confirm\n", count, qDel, qUpd, lib.Name, lib.ID)
 		return 0
+	}
+	// Cancel work_queue first so the junction is still populated when the
+	// keep-set query runs. ClearByLibrary then cascades the junction away
+	// along with the scan_results rows themselves.
+	qDel, qUpd, err := workQueue.CancelByLibrary(ctx, lib.ID)
+	if err != nil {
+		slog.Error("failed to cancel work_queue rows", "error", err)
+		return 1
 	}
 	deleted, err := scanRepo.ClearByLibrary(ctx, lib.ID)
 	if err != nil {
 		slog.Error("failed to clear scan results", "error", err)
 		return 1
 	}
-	_, _ = fmt.Fprintf(out, "deleted %d scan_results rows for library %q (id=%d)\n", deleted, lib.Name, lib.ID)
+	_, _ = fmt.Fprintf(out, "deleted %d scan_results rows and canceled %d / updated %d work_queue rows for library %q (id=%d)\n", deleted, qDel, qUpd, lib.Name, lib.ID)
 	return 0
 }

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1434,17 +1434,28 @@ func runScanClear(ctx context.Context, out io.Writer, args ScanClearCmd) int {
 		_, _ = fmt.Fprintf(out, "would delete %d scan_results rows and cancel %d / update %d work_queue rows for library %q (id=%d); pass --yes to confirm\n", count, qDel, qUpd, lib.Name, lib.ID)
 		return 0
 	}
-	// Cancel work_queue first so the junction is still populated when the
-	// keep-set query runs. ClearByLibrary then cascades the junction away
-	// along with the scan_results rows themselves.
-	qDel, qUpd, err := workQueue.CancelByLibrary(ctx, lib.ID)
+	// One transaction wraps both mutations so a failure on the scan_results
+	// delete cannot leave the queue canceled while scan_results survive.
+	// Cancel first: it reads the junction (work_queue_scan_results) which
+	// cascades away when ClearByLibraryTx then deletes the scan_results.
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("failed to begin scan clear tx", "error", err)
+		return 1
+	}
+	defer func() { _ = tx.Rollback() }() //nolint:errcheck // rollback is a no-op after commit
+	qDel, qUpd, err := workQueue.CancelByLibraryTx(ctx, tx, lib.ID)
 	if err != nil {
 		slog.Error("failed to cancel work_queue rows", "error", err)
 		return 1
 	}
-	deleted, err := scanRepo.ClearByLibrary(ctx, lib.ID)
+	deleted, err := scanRepo.ClearByLibraryTx(ctx, tx, lib.ID)
 	if err != nil {
 		slog.Error("failed to clear scan results", "error", err)
+		return 1
+	}
+	if err := tx.Commit(); err != nil {
+		slog.Error("failed to commit scan clear tx", "error", err)
 		return 1
 	}
 	_, _ = fmt.Fprintf(out, "deleted %d scan_results rows and canceled %d / updated %d work_queue rows for library %q (id=%d)\n", deleted, qDel, qUpd, lib.Name, lib.ID)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -713,6 +713,188 @@ func TestRunScanClear_DryRunAndConfirm(t *testing.T) {
 	}
 }
 
+func TestRunScanClear_CancelsLinkedWorkQueueRow(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	pending, err := scanRepo.ListPendingByLibrary(ctx, lib.ID)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPendingByLibrary: %v / %d rows", err, len(pending))
+	}
+	q := queue.NewDBQueue(sqlDB)
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Title"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music", Filename: "a.lrc"}},
+		ScanResultID: pending[0].ID,
+	}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	// Dry run: must report the queue cancellation.
+	var out bytes.Buffer
+	code := Run(ctx, []string{"scan", "clear", "--library", "MusicLib", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("dry-run exit = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "cancel 1") {
+		t.Fatalf("dry-run output missing queue cancel count: %q", out.String())
+	}
+
+	// Confirm: queue row must be gone.
+	out.Reset()
+	code = Run(ctx, []string{"scan", "clear", "--library", "MusicLib", "--yes", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("--yes exit = %d; want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "canceled 1") {
+		t.Fatalf("--yes output missing queue cancel count: %q", out.String())
+	}
+
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer sqlDB.Close()
+	var qCount int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM work_queue`).Scan(&qCount); err != nil {
+		t.Fatalf("count work_queue: %v", err)
+	}
+	if qCount != 0 {
+		t.Fatalf("work_queue rows after scan clear = %d; want 0", qCount)
+	}
+}
+
+func TestRunScan_LibrarySelectorScansOnlyTheNamedLibrary(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	// Two real, empty directories so scanner.ScanLibrary does not error.
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	libA, err := libRepo.Add(ctx, dirA, "Alpha")
+	if err != nil {
+		t.Fatalf("Add Alpha: %v", err)
+	}
+	libB, err := libRepo.Add(ctx, dirB, "Beta")
+	if err != nil {
+		t.Fatalf("Add Beta: %v", err)
+	}
+	// Seed a stale scan_results row in each library; the scan should leave
+	// the unselected library's row alone (the scanner walks the empty dir
+	// and finds nothing, but Upsert is not invoked for unselected libs).
+	scanRepo := scan.New(sqlDB)
+	if err := scanRepo.Upsert(ctx, libA.ID, []models.ScanResult{{
+		FilePath: filepath.Join(dirA, "stale.mp3"),
+		Track:    models.Track{ArtistName: "Stale", TrackName: "A"},
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert A: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libB.ID, []models.ScanResult{{
+		FilePath: filepath.Join(dirB, "stale.mp3"),
+		Track:    models.Track{ArtistName: "Stale", TrackName: "B"},
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert B: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"scan", "--only", "Alpha", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("scan --library Alpha exit = %d; want 0; out=%s", code, out.String())
+	}
+
+	// Reopen and confirm: Alpha was rescanned (Upsert ran against an empty
+	// directory, so its only seeded row is preserved by default UpsertOptions
+	// status-preserving semantics). Beta must not have been touched at all.
+	// We assert behaviorally by checking both libraries still hold their seed
+	// row; the more meaningful assertion is that the run exited 0 with a
+	// non-existent Beta directory would have errored had it been scanned.
+	sqlDB, err = db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer sqlDB.Close()
+	countA, err := scan.New(sqlDB).CountByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("CountByLibrary A: %v", err)
+	}
+	countB, err := scan.New(sqlDB).CountByLibrary(ctx, libB.ID)
+	if err != nil {
+		t.Fatalf("CountByLibrary B: %v", err)
+	}
+	if countA != 1 || countB != 1 {
+		t.Fatalf("CountByLibrary A=%d B=%d; want 1 each", countA, countB)
+	}
+}
+
+func TestRunScan_LibrarySelectorRejectsUnknownName(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"scan", "--only", "no-such-library", "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("unknown library: exit code 0; want non-zero. out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "no-such-library") {
+		t.Fatalf("output missing offending library reference: %q", out.String())
+	}
+}
+
+func TestRunScan_LibrarySelectorRejectsAmbiguousName(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	libRepo := library.New(sqlDB)
+	// Two libraries where the second one is literally named after the first
+	// one's numeric id. Looking up "1" resolves to both: ID match (lib1) and
+	// name match (lib2). resolveLibrary must reject that as ambiguous.
+	lib1, err := libRepo.Add(ctx, t.TempDir(), "music")
+	if err != nil {
+		t.Fatalf("Add lib1: %v", err)
+	}
+	if _, err := libRepo.Add(ctx, t.TempDir(), strconvFormatInt(lib1.ID)); err != nil {
+		t.Fatalf("Add lib2: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"scan", "--only", strconvFormatInt(lib1.ID), "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("ambiguous library: exit code 0; want non-zero. out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "ambiguous") {
+		t.Fatalf("output missing 'ambiguous': %q", out.String())
+	}
+}
+
 func errorsNew(s string) error { return errors.New(s) }
 
 func strconvFormatInt(i int64) string { return strconv.FormatInt(i, 10) }

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -820,6 +820,15 @@ func TestRunScan_LibrarySelectorScansOnlyTheNamedLibrary(t *testing.T) {
 	}}, scan.UpsertOptions{}); err != nil {
 		t.Fatalf("Upsert B: %v", err)
 	}
+	// Make Beta's directory unscannable. With --only Alpha, Beta is never
+	// walked, so this is harmless; but if the selector were broken and Beta
+	// got scanned, scanner.ScanLibrary would hit the missing directory and
+	// error (scheduler propagates it), forcing a non-zero exit and failing
+	// the test. Without this, both seed rows survive and the test passes even
+	// if nothing was scanned at all.
+	if err := os.RemoveAll(dirB); err != nil {
+		t.Fatalf("remove Beta dir: %v", err)
+	}
 	_ = sqlDB.Close()
 
 	var out bytes.Buffer
@@ -849,6 +858,35 @@ func TestRunScan_LibrarySelectorScansOnlyTheNamedLibrary(t *testing.T) {
 	}
 	if countA != 1 || countB != 1 {
 		t.Fatalf("CountByLibrary A=%d B=%d; want 1 each", countA, countB)
+	}
+}
+
+func TestRunScan_LibrarySelectorReportsScanFailure(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := library.New(sqlDB).Add(ctx, dir, "Alpha"); err != nil {
+		t.Fatalf("Add Alpha: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	// Remove the selected library's directory so scanner.ScanLibrary errors
+	// when the scheduler walks it. The selector path must surface that as a
+	// non-zero exit rather than swallowing it.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"scan", "--only", "Alpha", "--config", cfg}, &out, Deps{})
+	if code != 1 {
+		t.Fatalf("scan --only Alpha with missing dir: exit = %d; want 1; out=%s", code, out.String())
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -520,6 +520,165 @@ func (q *DBQueue) CountDone(ctx context.Context) (int64, error) {
 	return n, nil
 }
 
+// CancelByLibrary rebuilds or deletes pending/failed work_queue rows whose
+// output_paths derive from libraryID. Each affected row's output_paths JSON is
+// filtered to retain only entries that appear in scan_results from libraries
+// other than libraryID. Rows whose filtered list is empty are deleted; the
+// rest are updated in place. Processing and done rows are left alone so the
+// worker is not raced and historical writes are preserved.
+//
+// Returns the count of rows deleted and rows updated. Caller is expected to
+// invoke this before scan.ClearByLibrary so the work_queue_scan_results
+// junction is still populated when the operation runs.
+func (q *DBQueue) CancelByLibrary(ctx context.Context, libraryID int64) (deleted int64, updated int64, retErr error) {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("queue: begin cancel-by-library tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleted, updated, err = cancelByLibrary(ctx, tx, libraryID, false)
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, 0, fmt.Errorf("queue: commit cancel-by-library tx: %w", err)
+	}
+	return deleted, updated, nil
+}
+
+// CountCancelByLibrary returns the (deleted, updated) projection that
+// CancelByLibrary would produce, without writing. Intended for dry-run output.
+func (q *DBQueue) CountCancelByLibrary(ctx context.Context, libraryID int64) (deleted int64, updated int64, retErr error) {
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("queue: begin count-cancel tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	return cancelByLibrary(ctx, tx, libraryID, true)
+}
+
+func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bool) (int64, int64, error) {
+	type candidate struct {
+		id          int64
+		outputPaths string
+	}
+	candidateRows, err := tx.QueryContext(ctx,
+		`SELECT DISTINCT wq.id, wq.output_paths
+         FROM work_queue wq
+         JOIN work_queue_scan_results j ON j.work_queue_id = wq.id
+         JOIN scan_results sr ON sr.id = j.scan_result_id
+         WHERE sr.library_id = ?
+           AND wq.status IN ('pending', 'failed')
+         ORDER BY wq.id ASC`,
+		libraryID,
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("queue: cancel-by-library candidates: %w", err)
+	}
+	var candidates []candidate
+	for candidateRows.Next() {
+		var c candidate
+		if err := candidateRows.Scan(&c.id, &c.outputPaths); err != nil {
+			_ = candidateRows.Close()
+			return 0, 0, fmt.Errorf("queue: scan cancel candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	if err := candidateRows.Err(); err != nil {
+		_ = candidateRows.Close()
+		return 0, 0, fmt.Errorf("queue: cancel candidates rows: %w", err)
+	}
+	if err := candidateRows.Close(); err != nil {
+		return 0, 0, fmt.Errorf("queue: close cancel candidates: %w", err)
+	}
+
+	var deleted, updated int64
+	for _, c := range candidates {
+		keep, err := keepSetForRow(ctx, tx, c.id, libraryID)
+		if err != nil {
+			return 0, 0, err
+		}
+		var paths []models.OutputPath
+		if c.outputPaths != "" {
+			if err := json.Unmarshal([]byte(c.outputPaths), &paths); err != nil {
+				return 0, 0, fmt.Errorf("queue: unmarshal output_paths for row %d: %w", c.id, err)
+			}
+		}
+		filtered := paths[:0:0]
+		for _, p := range paths {
+			if _, ok := keep[outputPathKey(p)]; ok {
+				filtered = append(filtered, p)
+			}
+		}
+		if len(filtered) == 0 {
+			deleted++
+			if dryRun {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM work_queue WHERE id = ?`, c.id,
+			); err != nil {
+				return 0, 0, fmt.Errorf("queue: cancel delete row %d: %w", c.id, err)
+			}
+			continue
+		}
+		if len(filtered) == len(paths) {
+			// Defensive: candidate matched but every output_path entry was
+			// also present in a non-X scan_result. Nothing to change.
+			continue
+		}
+		updated++
+		if dryRun {
+			continue
+		}
+		newJSON, err := json.Marshal(filtered)
+		if err != nil {
+			return 0, 0, fmt.Errorf("queue: marshal filtered output_paths for row %d: %w", c.id, err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE work_queue SET output_paths = ? WHERE id = ?`,
+			string(newJSON), c.id,
+		); err != nil {
+			return 0, 0, fmt.Errorf("queue: cancel update row %d: %w", c.id, err)
+		}
+	}
+	return deleted, updated, nil
+}
+
+func keepSetForRow(ctx context.Context, tx *sql.Tx, workQueueID int64, libraryID int64) (map[string]struct{}, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT sr.outdir, sr.filename
+         FROM scan_results sr
+         JOIN work_queue_scan_results j ON j.scan_result_id = sr.id
+         WHERE j.work_queue_id = ?
+           AND sr.library_id != ?`,
+		workQueueID, libraryID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue: keep-set query row %d: %w", workQueueID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	keep := make(map[string]struct{})
+	for rows.Next() {
+		var outdir, filename string
+		if err := rows.Scan(&outdir, &filename); err != nil {
+			return nil, fmt.Errorf("queue: scan keep-set row %d: %w", workQueueID, err)
+		}
+		keep[outputPathKey(models.OutputPath{Outdir: outdir, Filename: filename})] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: keep-set rows %d: %w", workQueueID, err)
+	}
+	return keep, nil
+}
+
+func outputPathKey(p models.OutputPath) string {
+	return p.Outdir + "\x00" + p.Filename
+}
+
 type rowScanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -547,6 +547,13 @@ func (q *DBQueue) CancelByLibrary(ctx context.Context, libraryID int64) (deleted
 	return deleted, updated, nil
 }
 
+// CancelByLibraryTx runs the same logic as CancelByLibrary inside a caller-
+// supplied transaction so the queue mutation can be committed atomically with
+// other writes (e.g. scan_results delete). The caller owns Begin and Commit.
+func (q *DBQueue) CancelByLibraryTx(ctx context.Context, tx *sql.Tx, libraryID int64) (deleted int64, updated int64, retErr error) {
+	return cancelByLibrary(ctx, tx, libraryID, false)
+}
+
 // CountCancelByLibrary returns the (deleted, updated) projection that
 // CancelByLibrary would produce, without writing. Intended for dry-run output.
 func (q *DBQueue) CountCancelByLibrary(ctx context.Context, libraryID int64) (deleted int64, updated int64, retErr error) {
@@ -613,14 +620,31 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
 			}
 		}
 		if len(filtered) == 0 {
-			deleted++
 			if dryRun {
+				deleted++
 				continue
 			}
-			if _, err := tx.ExecContext(ctx,
-				`DELETE FROM work_queue WHERE id = ?`, c.id,
-			); err != nil {
+			// The status guard here is belt-and-suspenders: candidates were
+			// selected with status IN ('pending', 'failed'), but SQLite WAL
+			// admits a small window between candidate selection and this
+			// per-row write during which the worker could move the row to
+			// 'processing'. A 0 affected-rows result means the row moved on
+			// and we skip counting it without raising an error.
+			res, err := tx.ExecContext(ctx,
+				`DELETE FROM work_queue
+                 WHERE id = ?
+                   AND status IN ('pending', 'failed')`,
+				c.id,
+			)
+			if err != nil {
 				return 0, 0, fmt.Errorf("queue: cancel delete row %d: %w", c.id, err)
+			}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return 0, 0, fmt.Errorf("queue: cancel delete rows affected %d: %w", c.id, err)
+			}
+			if n == 1 {
+				deleted++
 			}
 			continue
 		}
@@ -629,19 +653,30 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
 			// also present in a non-X scan_result. Nothing to change.
 			continue
 		}
-		updated++
 		if dryRun {
+			updated++
 			continue
 		}
 		newJSON, err := json.Marshal(filtered)
 		if err != nil {
 			return 0, 0, fmt.Errorf("queue: marshal filtered output_paths for row %d: %w", c.id, err)
 		}
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE work_queue SET output_paths = ? WHERE id = ?`,
+		res, err := tx.ExecContext(ctx,
+			`UPDATE work_queue
+             SET output_paths = ?
+             WHERE id = ?
+               AND status IN ('pending', 'failed')`,
 			string(newJSON), c.id,
-		); err != nil {
+		)
+		if err != nil {
 			return 0, 0, fmt.Errorf("queue: cancel update row %d: %w", c.id, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return 0, 0, fmt.Errorf("queue: cancel update rows affected %d: %w", c.id, err)
+		}
+		if n == 1 {
+			updated++
 		}
 	}
 	return deleted, updated, nil

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -1099,5 +1100,272 @@ func TestDBQueue_RetryResetsLinkedScanResults(t *testing.T) {
 		if status != StatusPending {
 			t.Fatalf("scan_results %d status = %q; want %q (Retry must reset every linked processing row)", id, status, StatusPending)
 		}
+	}
+}
+
+func addLibrary(t *testing.T, sqlDB *sql.DB, name, path string) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO libraries (path, name) VALUES (?, ?)`, path, name)
+	if err != nil {
+		t.Fatalf("insert library %q: %v", name, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("library %q id: %v", name, err)
+	}
+	return id
+}
+
+func addScanResultIn(t *testing.T, sqlDB *sql.DB, libraryID int64, filePath, outdir, filename string) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO scan_results (library_id, file_path, outdir, filename, status) VALUES (?, ?, ?, ?, 'pending')`,
+		libraryID, filePath, outdir, filename)
+	if err != nil {
+		t.Fatalf("insert scan_result %s: %v", filePath, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("scan_result id %s: %v", filePath, err)
+	}
+	return id
+}
+
+func linkScanResult(t *testing.T, sqlDB *sql.DB, workQueueID, scanResultID int64) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+		workQueueID, scanResultID); err != nil {
+		t.Fatalf("link work_queue %d -> scan_result %d: %v", workQueueID, scanResultID, err)
+	}
+}
+
+func TestDBQueue_CancelByLibrary_DeletesSingleLibraryRow(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	srA := addScanResultIn(t, sqlDB, libA, "/music/a/1.mp3", "/music/a", "track.lrc")
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Solo"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "track.lrc"}},
+		ScanResultID: srA,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	deleted, updated, err := q.CancelByLibrary(ctx, libA)
+	if err != nil {
+		t.Fatalf("CancelByLibrary: %v", err)
+	}
+	if deleted != 1 || updated != 0 {
+		t.Fatalf("CancelByLibrary = (deleted=%d, updated=%d); want (1, 0)", deleted, updated)
+	}
+
+	var count int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count work_queue: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("work_queue row %d still present after CancelByLibrary", item.ID)
+	}
+}
+
+func TestDBQueue_CancelByLibrary_UpdatesSharedRowAndLeavesOtherLibraryUntouched(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	libB := addLibrary(t, sqlDB, "B", "/music/b")
+
+	// Shared row: same artist/title, present in both libraries.
+	srA := addScanResultIn(t, sqlDB, libA, "/music/a/shared.mp3", "/music/a", "shared.lrc")
+	srB := addScanResultIn(t, sqlDB, libB, "/music/b/shared.mp3", "/music/b", "shared.lrc")
+	shared, err := q.Enqueue(ctx, models.Inputs{
+		Track: models.Track{ArtistName: "Both", TrackName: "Shared"},
+		OutputPaths: []models.OutputPath{
+			{Outdir: "/music/a", Filename: "shared.lrc"},
+			{Outdir: "/music/b", Filename: "shared.lrc"},
+		},
+		ScanResultID: srA,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue shared: %v", err)
+	}
+	linkScanResult(t, sqlDB, shared.ID, srB)
+
+	// Library Y only: must remain untouched.
+	srBOnly := addScanResultIn(t, sqlDB, libB, "/music/b/only.mp3", "/music/b", "only.lrc")
+	bOnly, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Just", TrackName: "B"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/b", Filename: "only.lrc"}},
+		ScanResultID: srBOnly,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue bOnly: %v", err)
+	}
+
+	deleted, updated, err := q.CancelByLibrary(ctx, libA)
+	if err != nil {
+		t.Fatalf("CancelByLibrary: %v", err)
+	}
+	if deleted != 0 || updated != 1 {
+		t.Fatalf("CancelByLibrary = (deleted=%d, updated=%d); want (0, 1)", deleted, updated)
+	}
+
+	// Shared row still present, output_paths shrunk to library B's entry only.
+	var rawPaths string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT output_paths FROM work_queue WHERE id = ?`, shared.ID,
+	).Scan(&rawPaths); err != nil {
+		t.Fatalf("read shared output_paths: %v", err)
+	}
+	var paths []models.OutputPath
+	if err := json.Unmarshal([]byte(rawPaths), &paths); err != nil {
+		t.Fatalf("unmarshal shared output_paths %q: %v", rawPaths, err)
+	}
+	if len(paths) != 1 || paths[0].Outdir != "/music/b" || paths[0].Filename != "shared.lrc" {
+		t.Fatalf("shared output_paths = %+v; want one /music/b entry", paths)
+	}
+
+	// Library B's standalone row is untouched.
+	var bOnlyPaths string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT output_paths FROM work_queue WHERE id = ?`, bOnly.ID,
+	).Scan(&bOnlyPaths); err != nil {
+		t.Fatalf("read bOnly output_paths: %v", err)
+	}
+	if bOnlyPaths == "" {
+		t.Fatalf("bOnly output_paths empty; want preserved")
+	}
+}
+
+func TestDBQueue_CancelByLibrary_LeavesProcessingAndDoneRowsUntouched(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	srProc := addScanResultIn(t, sqlDB, libA, "/music/a/proc.mp3", "/music/a", "proc.lrc")
+	srDone := addScanResultIn(t, sqlDB, libA, "/music/a/done.mp3", "/music/a", "done.lrc")
+
+	proc, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Processing"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "proc.lrc"}},
+		ScanResultID: srProc,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue proc: %v", err)
+	}
+	done, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Done"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "done.lrc"}},
+		ScanResultID: srDone,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue done: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET status = 'processing' WHERE id = ?`, proc.ID); err != nil {
+		t.Fatalf("force processing: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET status = 'done' WHERE id = ?`, done.ID); err != nil {
+		t.Fatalf("force done: %v", err)
+	}
+
+	deleted, updated, err := q.CancelByLibrary(ctx, libA)
+	if err != nil {
+		t.Fatalf("CancelByLibrary: %v", err)
+	}
+	if deleted != 0 || updated != 0 {
+		t.Fatalf("CancelByLibrary = (deleted=%d, updated=%d); want (0, 0) for processing+done", deleted, updated)
+	}
+
+	for _, id := range []int64{proc.ID, done.ID} {
+		var count int
+		if err := sqlDB.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM work_queue WHERE id = ?`, id,
+		).Scan(&count); err != nil {
+			t.Fatalf("count work_queue %d: %v", id, err)
+		}
+		if count != 1 {
+			t.Fatalf("work_queue %d count = %d; want 1 (processing/done must not be deleted)", id, count)
+		}
+	}
+}
+
+func TestDBQueue_CountCancelByLibrary_ProjectsWithoutWriting(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	libB := addLibrary(t, sqlDB, "B", "/music/b")
+
+	srSolo := addScanResultIn(t, sqlDB, libA, "/music/a/1.mp3", "/music/a", "1.lrc")
+	solo, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Solo", TrackName: "A"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "1.lrc"}},
+		ScanResultID: srSolo,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue solo: %v", err)
+	}
+
+	srA2 := addScanResultIn(t, sqlDB, libA, "/music/a/2.mp3", "/music/a", "2.lrc")
+	srB2 := addScanResultIn(t, sqlDB, libB, "/music/b/2.mp3", "/music/b", "2.lrc")
+	shared, err := q.Enqueue(ctx, models.Inputs{
+		Track: models.Track{ArtistName: "Shared", TrackName: "B"},
+		OutputPaths: []models.OutputPath{
+			{Outdir: "/music/a", Filename: "2.lrc"},
+			{Outdir: "/music/b", Filename: "2.lrc"},
+		},
+		ScanResultID: srA2,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue shared: %v", err)
+	}
+	linkScanResult(t, sqlDB, shared.ID, srB2)
+
+	deleted, updated, err := q.CountCancelByLibrary(ctx, libA)
+	if err != nil {
+		t.Fatalf("CountCancelByLibrary: %v", err)
+	}
+	if deleted != 1 || updated != 1 {
+		t.Fatalf("CountCancelByLibrary = (deleted=%d, updated=%d); want (1, 1)", deleted, updated)
+	}
+
+	// Both rows must still exist with original output_paths unchanged.
+	for _, id := range []int64{solo.ID, shared.ID} {
+		var count int
+		if err := sqlDB.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM work_queue WHERE id = ?`, id,
+		).Scan(&count); err != nil {
+			t.Fatalf("count work_queue %d: %v", id, err)
+		}
+		if count != 1 {
+			t.Fatalf("work_queue %d count = %d; want 1 (dry-run must not delete)", id, count)
+		}
+	}
+	var sharedPaths string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT output_paths FROM work_queue WHERE id = ?`, shared.ID,
+	).Scan(&sharedPaths); err != nil {
+		t.Fatalf("read shared output_paths: %v", err)
+	}
+	var paths []models.OutputPath
+	if err := json.Unmarshal([]byte(sharedPaths), &paths); err != nil {
+		t.Fatalf("unmarshal shared output_paths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("shared output_paths after dry-run = %+v; want 2 (unchanged)", paths)
 	}
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1247,6 +1247,120 @@ func TestDBQueue_CancelByLibrary_UpdatesSharedRowAndLeavesOtherLibraryUntouched(
 	}
 }
 
+func TestDBQueue_CancelByLibrary_LeavesSharedRowWhenAllPathsBelongToOtherLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	libB := addLibrary(t, sqlDB, "B", "/music/b")
+
+	// The row is a cancel candidate because it links to library A, but every
+	// output_path it carries also belongs to library B's scan_result. The
+	// keep-set therefore retains all paths and the row needs no change: this
+	// exercises the defensive "filtered == paths" branch in cancelByLibrary.
+	srA := addScanResultIn(t, sqlDB, libA, "/music/a/shared.mp3", "/music/a", "shared.lrc")
+	srB := addScanResultIn(t, sqlDB, libB, "/music/b/shared.mp3", "/music/b", "shared.lrc")
+	row, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Both", TrackName: "Shared"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/b", Filename: "shared.lrc"}},
+		ScanResultID: srA,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	linkScanResult(t, sqlDB, row.ID, srB)
+
+	deleted, updated, err := q.CancelByLibrary(ctx, libA)
+	if err != nil {
+		t.Fatalf("CancelByLibrary: %v", err)
+	}
+	if deleted != 0 || updated != 0 {
+		t.Fatalf("CancelByLibrary = (deleted=%d, updated=%d); want (0, 0) when no paths change", deleted, updated)
+	}
+
+	// Row preserved with its single library-B path intact.
+	var rawPaths string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT output_paths FROM work_queue WHERE id = ?`, row.ID,
+	).Scan(&rawPaths); err != nil {
+		t.Fatalf("read output_paths: %v", err)
+	}
+	var paths []models.OutputPath
+	if err := json.Unmarshal([]byte(rawPaths), &paths); err != nil {
+		t.Fatalf("unmarshal output_paths %q: %v", rawPaths, err)
+	}
+	if len(paths) != 1 || paths[0].Outdir != "/music/b" || paths[0].Filename != "shared.lrc" {
+		t.Fatalf("output_paths = %+v; want one /music/b entry unchanged", paths)
+	}
+}
+
+func TestDBQueue_CancelByLibrary_ErrorsOnCorruptOutputPaths(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	srA := addScanResultIn(t, sqlDB, libA, "/music/a/x.mp3", "/music/a", "x.lrc")
+	row, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "X"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "x.lrc"}},
+		ScanResultID: srA,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// Corrupt the persisted output_paths so cancelByLibrary's json.Unmarshal of
+	// the candidate row fails and the error is surfaced rather than swallowed.
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET output_paths = ? WHERE id = ?`, "{not-valid-json", row.ID); err != nil {
+		t.Fatalf("corrupt output_paths: %v", err)
+	}
+	if _, _, err := q.CancelByLibrary(ctx, libA); err == nil {
+		t.Fatalf("CancelByLibrary: want error on corrupt output_paths, got nil")
+	}
+}
+
+func TestDBQueue_CancelByLibrary_ErrorsWhenDBClosed(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	if _, _, err := q.CancelByLibrary(ctx, 1); err == nil {
+		t.Fatalf("CancelByLibrary on closed DB: want error, got nil")
+	}
+}
+
+func TestDBQueue_CountCancelByLibrary_ErrorsWhenDBClosed(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	if _, _, err := q.CountCancelByLibrary(ctx, 1); err == nil {
+		t.Fatalf("CountCancelByLibrary on closed DB: want error, got nil")
+	}
+}
+
+func TestDBQueue_CancelByLibrary_ErrorsWhenJunctionMissing(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	// Drop the junction table so the candidate-selection query fails inside
+	// the cancel transaction; the error must propagate to the caller rather
+	// than be swallowed.
+	if _, err := sqlDB.ExecContext(ctx, `DROP TABLE work_queue_scan_results`); err != nil {
+		t.Fatalf("drop junction table: %v", err)
+	}
+	if _, _, err := q.CancelByLibrary(ctx, libA); err == nil {
+		t.Fatalf("CancelByLibrary with missing junction table: want error, got nil")
+	}
+}
+
 func TestDBQueue_CancelByLibrary_LeavesProcessingAndDoneRowsUntouched(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openQueueTestDB(t)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1369,3 +1369,72 @@ func TestDBQueue_CountCancelByLibrary_ProjectsWithoutWriting(t *testing.T) {
 		t.Fatalf("shared output_paths after dry-run = %+v; want 2 (unchanged)", paths)
 	}
 }
+
+func TestDBQueue_CancelByLibraryTx_RunsInExternalTransaction(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA := addLibrary(t, sqlDB, "A", "/music/a")
+	srA := addScanResultIn(t, sqlDB, libA, "/music/a/1.mp3", "/music/a", "track.lrc")
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Solo"},
+		OutputPaths:  []models.OutputPath{{Outdir: "/music/a", Filename: "track.lrc"}},
+		ScanResultID: srA,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	deleted, updated, err := q.CancelByLibraryTx(ctx, tx, libA)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("CancelByLibraryTx: %v", err)
+	}
+	if deleted != 1 || updated != 0 {
+		_ = tx.Rollback()
+		t.Fatalf("CancelByLibraryTx = (deleted=%d, updated=%d); want (1, 0)", deleted, updated)
+	}
+
+	// Before commit, the row must still be visible on a separate read because
+	// the change is uncommitted. Verify rollback restores it.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	var preCommit int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&preCommit); err != nil {
+		t.Fatalf("post-rollback count: %v", err)
+	}
+	if preCommit != 1 {
+		t.Fatalf("work_queue row %d count after rollback = %d; want 1", item.ID, preCommit)
+	}
+
+	// Now commit a second invocation and verify the row is gone.
+	tx2, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx 2: %v", err)
+	}
+	if _, _, err := q.CancelByLibraryTx(ctx, tx2, libA); err != nil {
+		_ = tx2.Rollback()
+		t.Fatalf("CancelByLibraryTx 2: %v", err)
+	}
+	if err := tx2.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	var postCommit int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&postCommit); err != nil {
+		t.Fatalf("post-commit count: %v", err)
+	}
+	if postCommit != 0 {
+		t.Fatalf("work_queue row %d count after commit = %d; want 0", item.ID, postCommit)
+	}
+}

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -234,6 +234,25 @@ func (r *Repo) ClearByLibrary(ctx context.Context, libraryID int64) (int64, erro
 	return n, nil
 }
 
+// ClearByLibraryTx runs the same DELETE as ClearByLibrary inside a caller-
+// supplied transaction so the scan_results delete can be committed atomically
+// with other writes (e.g. work_queue cancellation). The caller owns Begin and
+// Commit.
+func (r *Repo) ClearByLibraryTx(ctx context.Context, tx *sql.Tx, libraryID int64) (int64, error) {
+	res, err := tx.ExecContext(ctx,
+		`DELETE FROM scan_results WHERE library_id = ?`,
+		libraryID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("scan: clear by library tx: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("scan: clear by library tx rows affected: %w", err)
+	}
+	return n, nil
+}
+
 // CountByLibrary returns the number of scan_results rows belonging to
 // libraryID. It is useful for reporting what ClearByLibrary would delete
 // without actually deleting anything.

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -405,3 +405,99 @@ func TestRepo_ListPendingByLibraryAndSetStatus(t *testing.T) {
 		t.Fatalf("pending results after SetStatus = %+v; want none", pending)
 	}
 }
+
+func TestRepo_ClearByLibraryTx_CommitsViaCaller(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	if err != nil {
+		t.Fatalf("Add library A: %v", err)
+	}
+	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	if err != nil {
+		t.Fatalf("Add library B: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libA.ID, []models.ScanResult{
+		{FilePath: "/music/a/1.mp3", Track: models.Track{ArtistName: "A", TrackName: "1"}},
+		{FilePath: "/music/a/2.mp3", Track: models.Track{ArtistName: "A", TrackName: "2"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert A: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, libB.ID, []models.ScanResult{
+		{FilePath: "/music/b/1.mp3", Track: models.Track{ArtistName: "B", TrackName: "1"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert B: %v", err)
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	deleted, err := scanRepo.ClearByLibraryTx(ctx, tx, libA.ID)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("ClearByLibraryTx: %v", err)
+	}
+	if deleted != 2 {
+		_ = tx.Rollback()
+		t.Fatalf("ClearByLibraryTx deleted = %d; want 2", deleted)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	leftA, err := scanRepo.ListByLibrary(ctx, libA.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary A: %v", err)
+	}
+	if len(leftA) != 0 {
+		t.Fatalf("library A still has %d scan_results after committed tx; want 0", len(leftA))
+	}
+	leftB, err := scanRepo.ListByLibrary(ctx, libB.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary B: %v", err)
+	}
+	if len(leftB) != 1 {
+		t.Fatalf("library B has %d scan_results; want 1 (ClearByLibraryTx leaked across libraries)", len(leftB))
+	}
+}
+
+func TestRepo_ClearByLibraryTx_RollbackPreservesRows(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, []models.ScanResult{
+		{FilePath: "/music/1.mp3", Track: models.Track{ArtistName: "A", TrackName: "1"}},
+	}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if _, err := scanRepo.ClearByLibraryTx(ctx, tx, lib.ID); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("ClearByLibraryTx: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	left, err := scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(left) != 1 {
+		t.Fatalf("library scan_results after rollback = %d; want 1 (delete must roll back with the tx)", len(left))
+	}
+}

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -465,6 +465,26 @@ func TestRepo_ClearByLibraryTx_CommitsViaCaller(t *testing.T) {
 	}
 }
 
+func TestRepo_ClearByLibraryTx_ErrorsWhenTableMissing(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	scanRepo := scan.New(sqlDB)
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	// Drop scan_results inside the same transaction so the DELETE fails; the
+	// error must be surfaced to the caller rather than swallowed.
+	if _, err := tx.ExecContext(ctx, `DROP TABLE scan_results`); err != nil {
+		t.Fatalf("drop scan_results: %v", err)
+	}
+	if _, err := scanRepo.ClearByLibraryTx(ctx, tx, 1); err == nil {
+		t.Fatalf("ClearByLibraryTx with missing table: want error, got nil")
+	}
+}
+
 func TestRepo_ClearByLibraryTx_RollbackPreservesRows(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -43,6 +43,21 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 	if s.Libraries == nil {
 		return fmt.Errorf("scan: scheduler libraries dependency is nil")
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	libs, err := s.Libraries.List(ctx)
+	if err != nil {
+		return fmt.Errorf("scan: list libraries: %w", err)
+	}
+	return s.RunOnceFor(ctx, libs)
+}
+
+// RunOnceFor scans the supplied libraries exactly once. Callers that need to
+// restrict a scan to a subset of configured libraries resolve them upstream
+// and pass the slice directly; RunOnce delegates here after listing all
+// configured libraries.
+func (s *Scheduler) RunOnceFor(ctx context.Context, libs []models.Library) error {
 	if s.Results == nil {
 		return fmt.Errorf("scan: scheduler results dependency is nil")
 	}
@@ -51,11 +66,6 @@ func (s *Scheduler) RunOnce(ctx context.Context) error {
 	}
 	if err := ctx.Err(); err != nil {
 		return err
-	}
-
-	libs, err := s.Libraries.List(ctx)
-	if err != nil {
-		return fmt.Errorf("scan: list libraries: %w", err)
 	}
 	for _, v := range libs {
 		if err := ctx.Err(); err != nil {

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -237,6 +237,40 @@ func TestScheduler_RunOnceRequiresDependencies(t *testing.T) {
 	}
 }
 
+func TestScheduler_RunOnceForScansOnlyProvidedLibraries(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	// fakeLibraries.List would return all three; passing a subset to
+	// RunOnceFor must skip the unselected ones entirely.
+	all := []models.Library{
+		{ID: 7, Path: "/music/a", Name: "A"},
+		{ID: 8, Path: "/music/b", Name: "B"},
+		{ID: 9, Path: "/music/c", Name: "C"},
+	}
+	s := scan.Scheduler{
+		Libraries: fakeLibraries{libs: all},
+		Results:   store,
+		Scanner: fakeScanner{results: []models.ScanResult{{
+			FilePath: "/music/x.mp3",
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		}}},
+	}
+
+	if err := s.RunOnceFor(ctx, []models.Library{all[0], all[2]}); err != nil {
+		t.Fatalf("RunOnceFor: %v", err)
+	}
+	if len(store.calls) != 2 {
+		t.Fatalf("Upsert calls = %d; want 2 (one per selected library)", len(store.calls))
+	}
+	gotIDs := []int64{store.calls[0].libraryID, store.calls[1].libraryID}
+	wantIDs := []int64{7, 9}
+	for i := range gotIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Fatalf("Upsert call %d libraryID = %d; want %d", i, gotIDs[i], wantIDs[i])
+		}
+	}
+}
+
 func TestScheduler_RunOncePropagatesErrors(t *testing.T) {
 	ctx := context.Background()
 	listErr := errors.New("list failed")


### PR DESCRIPTION
## Summary

Bundles two scan-surface enhancements into one PR (CR-budget aware).

- **Closes #90** -- `scan clear --library X` now drops or shrinks `work_queue`
  rows whose `output_paths` derive from the cleared library. The keep-set is
  built from non-X scan_results linked via `work_queue_scan_results`, so a
  shared row keeps library Y's entries while losing library X's. Fully
  cleared rows are deleted; partially cleared rows are updated in place.
  Processing/done rows are intentionally left alone to avoid racing the
  worker and to preserve historical writes. A new `CountCancelByLibrary`
  backs the dry-run projection so users see both the scan_results and
  work_queue counts before confirming.

- **Closes #69** -- `scan` grows an `--only` selector that limits a run to
  one or more named or numeric libraries (repeatable). The flag is named
  `--only` rather than `--library` because `go-arg` resolves long flag
  names globally per parse: a parent `[]string` field on `ScanCmd` silently
  absorbs `--library` values intended for the subcommand-level
  `--library` flags on `scan results` / `scan clear`, leaving those
  subcommand fields empty (and breaking the `required` check on
  `scan clear`). The `--only` rename preserves the existing subcommand
  flag semantics. Unknown or ambiguous selectors fail fast before any
  scan starts. `scan.Scheduler` gains `RunOnceFor` for the subset path;
  `RunOnce` delegates to it after listing all libraries.

## Test plan

- [x] `make test` -- all packages pass
- [x] `make lint` -- 0 issues
- [x] `make build` -- clean
- [x] govulncheck (via pre-commit hook) -- clean
- [x] `scan clear --library X` dry-run prints both scan_results and work_queue projections; `--yes` deletes/updates as projected
- [x] `scan results --library X` and `scan clear --library X` still resolve their own --library flag (no parent collision)
- [x] `scan --only Music` scans only the named library; `--only nope` and ambiguous numeric/name selectors exit non-zero with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `scan --only` runs scans for explicitly specified libraries (name or ID) and reports unresolved or ambiguous references.
  * `scan clear` now coordinates cancelling/updating related queued work and deleting scan results; dry-run reports counts, `--yes` performs the coordinated operation atomically.

* **Bug Fixes**
  * Scan runner checks for cancellation between libraries to stop promptly when requested.

* **Tests**
  * Expanded tests for library selection, clear behavior, queue cancellation, and transaction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->