### PR TITLE
feat: serve operability: intervals, health endpoints, webhook retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key mxlrcgo
 
 The server listens on `MXLRC_SERVER_ADDR` when `--listen` is not provided. Configure one or more webhook keys with `MXLRC_WEBHOOK_API_KEY`, use `mxlrcgo-svc keys create`, or put the server address and webhook keys in a config file and start with `mxlrcgo-svc serve --config path/to/config.toml`.
 
+Webhook events are enqueued at high priority. If a webhook arrives for an artist/title that previously failed and is waiting out a retry backoff, the high-priority enqueue resets its retry timer so it becomes eligible immediately, jumping the queue. Scan-enqueued duplicates keep their existing backoff, so bulk scan traffic stays rate-limit protected. The worker's circuit breaker still pauses dequeuing globally when the upstream API signals rate limiting.
+
+The scheduler scan interval and worker poll interval are configurable for Docker/Unraid deployments. Set `scan_interval_seconds` and `work_interval_seconds` under `[server]` in the config file, or override with `MXLRC_SCAN_INTERVAL` and `MXLRC_WORK_INTERVAL`. Precedence is CLI flag (`--scan-interval`, `--work-interval`) > environment variable > config file > default. Defaults preserve current behavior: scan interval 900 seconds, and worker interval falls back to `api.cooldown` (clamped to a 15-second floor). A scan interval of 0 scans once without repeating.
+
+### Health and status endpoints
+
+`serve` exposes lightweight endpoints for container orchestration:
+
+- `GET /healthz` (unauthenticated) returns `200` with `{"status":"ok"}` whenever the HTTP server is accepting requests. Use it for Docker/Unraid liveness probes.
+- `GET /readyz` (unauthenticated) verifies database reachability and returns `200` when ready or `503` when the database is unavailable. Error detail is omitted so it never leaks paths or connection strings.
+- `GET /api/v1/status` (requires an `admin`-scoped API key) returns a queue summary grouped by status, for example `{"status":"ok","queue":{"pending":3,"failed":1}}`. It exposes no tokens, webhook keys, or filesystem paths.
+
+Example Docker healthcheck: `curl -fsS http://127.0.0.1:3876/readyz`.
+
 ### Provider and verification config
 
 Musixmatch is currently the only supported lyrics provider. The config file still exposes provider selection so future providers can be added without changing the fetch and worker paths:

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,6 +41,16 @@ addr = "127.0.0.1:3876"
 # when possible; MXLRC_WEBHOOK_API_KEY can also provide one or more comma-separated keys.
 # webhook_api_keys = ["mxlrc_your-webhook-key"]
 
+# Scheduler scan interval in seconds for `serve` mode (env: MXLRC_SCAN_INTERVAL).
+# Default 900. Set to 0 to scan once and not repeat. The --scan-interval flag
+# overrides this value.
+# scan_interval_seconds = 900
+
+# Worker poll interval in seconds for `serve` mode (env: MXLRC_WORK_INTERVAL).
+# Default 0, which falls back to api.cooldown. Clamped to a 15-second floor.
+# The --work-interval flag overrides this value.
+# work_interval_seconds = 0
+
 [providers]
 # Active lyrics provider. Musixmatch is currently the only supported provider.
 primary = "musixmatch"

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -37,8 +37,6 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/worker"
 )
 
-const defaultScanInterval = 15 * time.Minute
-
 // Args defines the CLI arguments for the application.
 type Args struct {
 	Fetch   *FetchCmd   `arg:"subcommand:fetch" help:"fetch lyrics once without HTTP server or DB queue"`
@@ -88,8 +86,8 @@ type ServeCmd struct {
 	Update       bool    `arg:"-u,--update" help:"scheduler re-fetches existing .lrc files"`
 	Upgrade      bool    `arg:"--upgrade" help:"scheduler re-fetches .txt lyrics to promote them"`
 	BFS          bool    `arg:"--bfs" help:"scheduler uses breadth-first traversal"`
-	ScanInterval int     `arg:"--scan-interval" help:"scheduler interval in seconds (default: 900; 0 disables repeat)" default:"900"`
-	WorkInterval *int    `arg:"--work-interval" help:"worker cooldown interval in seconds (default: api.cooldown; minimum 15)"`
+	ScanInterval *int    `arg:"--scan-interval" help:"scheduler interval in seconds (default: server.scan_interval_seconds or 900; 0 disables repeat)"`
+	WorkInterval *int    `arg:"--work-interval" help:"worker poll interval in seconds (default: server.work_interval_seconds or api.cooldown; minimum 15)"`
 }
 
 // ScanCmd scans libraries once and enqueues cache misses. It also hosts
@@ -480,7 +478,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	}()
 	go func() {
 		defer wg.Done()
-		runScheduler(runCtx, sqlDB, args)
+		runScheduler(runCtx, sqlDB, cfg, args)
 	}()
 
 	addr := cfg.Server.Addr
@@ -488,8 +486,11 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		addr = *args.Listen
 	}
 	srv := &http.Server{
-		Addr:              addr,
-		Handler:           server.NewHandler(authSvc, workQ, outdir),
+		Addr: addr,
+		Handler: server.NewHandler(authSvc, workQ, outdir,
+			server.WithReadiness(sqlDB),
+			server.WithStatusReporter(workQ),
+		),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       15 * time.Second,
 		WriteTimeout:      15 * time.Second,
@@ -533,12 +534,29 @@ func runWorkerLoop(ctx context.Context, w *worker.Worker, interval time.Duration
 	}
 }
 
+// serveWorkerInterval resolves the worker poll interval. Precedence:
+// CLI --work-interval > config server.work_interval_seconds > api.cooldown.
+// A zero server.work_interval_seconds means "fall back to api.cooldown".
 func serveWorkerInterval(cfg config.Config, args ServeCmd) time.Duration {
 	interval := cfg.API.Cooldown
+	if cfg.Server.WorkIntervalSeconds > 0 {
+		interval = cfg.Server.WorkIntervalSeconds
+	}
 	if args.WorkInterval != nil {
 		interval = *args.WorkInterval
 	}
 	return time.Duration(interval) * time.Second
+}
+
+// serveScanInterval resolves the scheduler scan interval. Precedence:
+// CLI --scan-interval > config server.scan_interval_seconds (default 900).
+// A zero result disables repeat scanning (scan once).
+func serveScanInterval(cfg config.Config, args ServeCmd) time.Duration {
+	seconds := cfg.Server.ScanIntervalSeconds
+	if args.ScanInterval != nil {
+		seconds = *args.ScanInterval
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func normalizeWorkerInterval(interval time.Duration) time.Duration {
@@ -575,18 +593,14 @@ func configureWorkerVerification(w *worker.Worker, cfg config.Config, verifier v
 	w.EnableVerification(verifier, cfg.Verification.MinConfidence)
 }
 
-func runScheduler(ctx context.Context, sqlDB *sql.DB, args ServeCmd) {
-	interval := defaultScanInterval
-	if args.ScanInterval >= 0 {
-		interval = time.Duration(args.ScanInterval) * time.Second
-	}
+func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd) {
 	s := scheduler(sqlDB, scanner.ScanOptions{
 		Update:   args.Update,
 		Upgrade:  args.Upgrade,
 		MaxDepth: args.Depth,
 		BFS:      args.BFS,
 	})
-	s.Interval = interval
+	s.Interval = serveScanInterval(cfg, args)
 	if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		slog.Warn("scheduler failed", "error", err)
 	}
@@ -960,6 +974,8 @@ func configKeys() []string {
 		"db.path",
 		"server.addr",
 		"server.webhook_api_keys",
+		"server.scan_interval_seconds",
+		"server.work_interval_seconds",
 		"providers.primary",
 		"providers.disabled",
 		"verification.enabled",
@@ -987,6 +1003,10 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return cfg.Server.Addr, true
 	case "server.webhook_api_keys":
 		return strings.Join(cfg.Server.WebhookAPIKeys, ","), true
+	case "server.scan_interval_seconds":
+		return strconv.Itoa(cfg.Server.ScanIntervalSeconds), true
+	case "server.work_interval_seconds":
+		return strconv.Itoa(cfg.Server.WorkIntervalSeconds), true
 	case "providers.primary":
 		return cfg.Providers.Primary, true
 	case "providers.disabled":
@@ -1032,6 +1052,18 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 		cfg.Server.Addr = value
 	case "server.webhook_api_keys":
 		cfg.Server.WebhookAPIKeys = splitCSV(value)
+	case "server.scan_interval_seconds":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return fmt.Errorf("server.scan_interval_seconds must be a non-negative integer (seconds; 0 disables repeat)")
+		}
+		cfg.Server.ScanIntervalSeconds = n
+	case "server.work_interval_seconds":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return fmt.Errorf("server.work_interval_seconds must be a non-negative integer (seconds; 0 uses api.cooldown)")
+		}
+		cfg.Server.WorkIntervalSeconds = n
 	case "providers.primary":
 		cfg.Providers.Primary = value
 	case "providers.disabled":

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -174,6 +174,50 @@ func TestServeWorkerIntervalUsesConfigUnlessFlagProvided(t *testing.T) {
 	}
 }
 
+// TestServeWorkerIntervalPrecedence verifies CLI flag > server.work_interval_seconds
+// > api.cooldown. A zero server.work_interval_seconds means "fall back to cooldown".
+func TestServeWorkerIntervalPrecedence(t *testing.T) {
+	cfg := config.Config{
+		API:    config.APIConfig{Cooldown: 45},
+		Server: config.ServerConfig{WorkIntervalSeconds: 25},
+	}
+
+	if got := serveWorkerInterval(cfg, ServeCmd{}); got != 25*time.Second {
+		t.Fatalf("serveWorkerInterval config = %s; want 25s (server config over cooldown)", got)
+	}
+
+	cfgNoServer := config.Config{API: config.APIConfig{Cooldown: 45}}
+	if got := serveWorkerInterval(cfgNoServer, ServeCmd{}); got != 45*time.Second {
+		t.Fatalf("serveWorkerInterval cooldown fallback = %s; want 45s", got)
+	}
+
+	flag := 30
+	if got := serveWorkerInterval(cfg, ServeCmd{WorkInterval: &flag}); got != 30*time.Second {
+		t.Fatalf("serveWorkerInterval flag = %s; want 30s (flag wins)", got)
+	}
+}
+
+// TestServeScanIntervalPrecedence verifies CLI flag > server.scan_interval_seconds.
+func TestServeScanIntervalPrecedence(t *testing.T) {
+	cfg := config.Config{
+		Server: config.ServerConfig{ScanIntervalSeconds: 600},
+	}
+
+	if got := serveScanInterval(cfg, ServeCmd{}); got != 600*time.Second {
+		t.Fatalf("serveScanInterval config = %s; want 600s", got)
+	}
+
+	flag := 120
+	if got := serveScanInterval(cfg, ServeCmd{ScanInterval: &flag}); got != 120*time.Second {
+		t.Fatalf("serveScanInterval flag = %s; want 120s (flag wins)", got)
+	}
+
+	zero := 0
+	if got := serveScanInterval(cfg, ServeCmd{ScanInterval: &zero}); got != 0 {
+		t.Fatalf("serveScanInterval zero flag = %s; want 0 (disables repeat)", got)
+	}
+}
+
 func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
@@ -396,6 +440,47 @@ func TestCircuitOpenDurationConfigKey(t *testing.T) {
 
 	if !slices.Contains(configKeys(), "api.circuit_open_duration") {
 		t.Fatal("configKeys missing api.circuit_open_duration")
+	}
+}
+
+func TestServerIntervalConfigKeys(t *testing.T) {
+	cfg := config.Config{Server: config.ServerConfig{ScanIntervalSeconds: 900, WorkIntervalSeconds: 20}}
+
+	for key, want := range map[string]string{
+		"server.scan_interval_seconds": "900",
+		"server.work_interval_seconds": "20",
+	} {
+		got, ok := configValue(cfg, key)
+		if !ok {
+			t.Fatalf("configValue(%s) ok = false; want true", key)
+		}
+		if got != want {
+			t.Fatalf("configValue(%s) = %q; want %q", key, got, want)
+		}
+		if !slices.Contains(configKeys(), key) {
+			t.Fatalf("configKeys missing %s", key)
+		}
+	}
+
+	if err := setConfigValue(&cfg, "server.scan_interval_seconds", "0"); err != nil {
+		t.Fatalf("setConfigValue scan 0: %v (zero must be allowed to disable repeat)", err)
+	}
+	if cfg.Server.ScanIntervalSeconds != 0 {
+		t.Fatalf("ScanIntervalSeconds = %d; want 0", cfg.Server.ScanIntervalSeconds)
+	}
+	if err := setConfigValue(&cfg, "server.work_interval_seconds", "30"); err != nil {
+		t.Fatalf("setConfigValue work 30: %v", err)
+	}
+	if cfg.Server.WorkIntervalSeconds != 30 {
+		t.Fatalf("WorkIntervalSeconds = %d; want 30", cfg.Server.WorkIntervalSeconds)
+	}
+	for _, bad := range []string{"", "abc", "-1"} {
+		if err := setConfigValue(&cfg, "server.scan_interval_seconds", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid server.scan_interval_seconds %q", bad)
+		}
+		if err := setConfigValue(&cfg, "server.work_interval_seconds", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid server.work_interval_seconds %q", bad)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,17 @@ type DBConfig struct {
 type ServerConfig struct {
 	Addr           string   `toml:"addr"`
 	WebhookAPIKeys []string `toml:"webhook_api_keys"`
+	// ScanIntervalSeconds is the scheduler scan interval in seconds for serve
+	// mode. Default 900. A value of 0 disables repeat scanning (scan once).
+	ScanIntervalSeconds int `toml:"scan_interval_seconds"`
+	// WorkIntervalSeconds is the worker poll interval in seconds for serve mode.
+	// Default 0, which means "fall back to api.cooldown". The effective interval
+	// is clamped to a 15-second floor at runtime.
+	WorkIntervalSeconds int `toml:"work_interval_seconds"`
 }
+
+// defaultScanIntervalSeconds is the built-in scheduler scan interval (15 min).
+const defaultScanIntervalSeconds = 900
 
 // ProvidersConfig holds lyrics provider selection settings.
 type ProvidersConfig struct {
@@ -77,7 +87,7 @@ func defaults() Config {
 		API:          APIConfig{Cooldown: 15, CircuitOpenDuration: circuitOpenDefaultSeconds},
 		Output:       OutputConfig{Dir: "lyrics"},
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
-		Server:       ServerConfig{Addr: "127.0.0.1:3876"},
+		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
 		Providers:    ProvidersConfig{Primary: "musixmatch"},
 		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
 	}
@@ -147,7 +157,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -192,6 +202,22 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("MXLRC_WEBHOOK_API_KEY"); v != "" {
 		cfg.Server.WebhookAPIKeys = splitCSV(v)
+	}
+	if v := os.Getenv("MXLRC_SCAN_INTERVAL"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_SCAN_INTERVAL", "value", v, "current", cfg.Server.ScanIntervalSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Server.ScanIntervalSeconds = n
+		}
+	}
+	if v := os.Getenv("MXLRC_WORK_INTERVAL"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_WORK_INTERVAL", "value", v, "current", cfg.Server.WorkIntervalSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Server.WorkIntervalSeconds = n
+		}
 	}
 	if v := os.Getenv("MXLRC_PROVIDER_PRIMARY"); v != "" {
 		cfg.Providers.Primary = v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ func isolateEnv(t *testing.T) {
 		"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN",
 		"MXLRC_API_CIRCUIT_OPEN_DURATION",
 		"MXLRC_OUTPUT_DIR", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
+		"MXLRC_SCAN_INTERVAL", "MXLRC_WORK_INTERVAL",
 		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
 		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
 		"MXLRC_VERIFICATION_FFMPEG_PATH",
@@ -219,6 +220,76 @@ func TestLoad_EnvCooldownInvalidIsIgnored(t *testing.T) {
 	}
 	if cfg.API.Cooldown != 15 {
 		t.Errorf("cooldown = %d; want 15 (default) after invalid env var", cfg.API.Cooldown)
+	}
+}
+
+// TestLoad_ServerIntervalDefaults verifies the service-loop intervals fall back
+// to their built-in defaults: scan 900s and work 0 (meaning "use api.cooldown").
+func TestLoad_ServerIntervalDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.ScanIntervalSeconds != 900 {
+		t.Errorf("scan_interval_seconds = %d; want 900", cfg.Server.ScanIntervalSeconds)
+	}
+	if cfg.Server.WorkIntervalSeconds != 0 {
+		t.Errorf("work_interval_seconds = %d; want 0 (fall back to api.cooldown)", cfg.Server.WorkIntervalSeconds)
+	}
+}
+
+// TestLoad_EnvServerIntervals verifies MXLRC_SCAN_INTERVAL and MXLRC_WORK_INTERVAL
+// override the config values.
+func TestLoad_EnvServerIntervals(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_SCAN_INTERVAL", "300")
+	t.Setenv("MXLRC_WORK_INTERVAL", "20")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.ScanIntervalSeconds != 300 {
+		t.Errorf("scan_interval_seconds = %d; want 300", cfg.Server.ScanIntervalSeconds)
+	}
+	if cfg.Server.WorkIntervalSeconds != 20 {
+		t.Errorf("work_interval_seconds = %d; want 20", cfg.Server.WorkIntervalSeconds)
+	}
+}
+
+// TestLoad_EnvServerIntervalZeroIsValid verifies a zero scan interval is honored
+// (it disables repeat scanning) rather than being re-defaulted.
+func TestLoad_EnvServerIntervalZeroIsValid(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_SCAN_INTERVAL", "0")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.ScanIntervalSeconds != 0 {
+		t.Errorf("scan_interval_seconds = %d; want 0", cfg.Server.ScanIntervalSeconds)
+	}
+}
+
+// TestLoad_EnvServerIntervalInvalidIsIgnored verifies a non-numeric interval env
+// var falls back to the current value rather than crashing.
+func TestLoad_EnvServerIntervalInvalidIsIgnored(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_SCAN_INTERVAL", "notanumber")
+	t.Setenv("MXLRC_WORK_INTERVAL", "-5")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.ScanIntervalSeconds != 900 {
+		t.Errorf("scan_interval_seconds = %d; want 900 (default) after invalid env var", cfg.Server.ScanIntervalSeconds)
+	}
+	if cfg.Server.WorkIntervalSeconds != 0 {
+		t.Errorf("work_interval_seconds = %d; want 0 (default) after invalid env var", cfg.Server.WorkIntervalSeconds)
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -118,6 +118,15 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 	if err != nil {
 		return WorkItem{}, err
 	}
+	// High-priority (webhook) duplicates of a failed row reset next_attempt_at to
+	// now so the work becomes immediately retry-eligible rather than waiting out
+	// the previous backoff. Scan-priority duplicates preserve the existing backoff
+	// so rate-limit protection stays in effect for bulk scan traffic. The worker's
+	// global circuit breaker still guards against actual upstream rate limits.
+	refreshFailedBackoff := 0
+	if priority >= PriorityWebhook {
+		refreshFailedBackoff = 1
+	}
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: begin enqueue tx: %w", err)
@@ -161,7 +170,9 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE 'pending'
              END,
              next_attempt_at = CASE
-                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.next_attempt_at
+                 WHEN work_queue.status IN ('done', 'processing') THEN work_queue.next_attempt_at
+                 WHEN work_queue.status = 'failed' AND ? = 1 THEN excluded.next_attempt_at
+                 WHEN work_queue.status = 'failed' THEN work_queue.next_attempt_at
                  ELSE excluded.next_attempt_at
              END,
              last_error = CASE
@@ -186,6 +197,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 		StatusPending,
 		priority,
 		now,
+		refreshFailedBackoff,
 	)
 	item, err := scanWorkItem(row)
 	if err != nil {
@@ -518,6 +530,31 @@ func (q *DBQueue) CountDone(ctx context.Context) (int64, error) {
 		return 0, fmt.Errorf("queue: count done: %w", err)
 	}
 	return n, nil
+}
+
+// CountByStatus returns the number of work_queue rows grouped by status.
+// Statuses with no rows are omitted from the map.
+func (q *DBQueue) CountByStatus(ctx context.Context) (map[string]int64, error) {
+	rows, err := q.db.QueryContext(ctx,
+		`SELECT status, COUNT(*) FROM work_queue GROUP BY status`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue: count by status: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var status string
+		var n int64
+		if err := rows.Scan(&status, &n); err != nil {
+			return nil, fmt.Errorf("queue: scan status count: %w", err)
+		}
+		counts[status] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: count by status rows: %w", err)
+	}
+	return counts, nil
 }
 
 // CancelByLibrary rebuilds or deletes pending/failed work_queue rows whose

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -119,6 +119,49 @@ func TestDBQueue_EnqueueDedupesNormalizedArtistTitle(t *testing.T) {
 	}
 }
 
+func TestDBQueue_CountByStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	// Empty queue: no rows, so no status keys.
+	counts, err := q.CountByStatus(ctx)
+	if err != nil {
+		t.Fatalf("CountByStatus empty: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("empty counts = %v; want no entries", counts)
+	}
+
+	// Two pending rows.
+	for _, name := range []string{"One", "Two"} {
+		if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: name}}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %s: %v", name, err)
+		}
+	}
+	// Claim one (pending -> processing) and complete it (processing -> done).
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.Complete(ctx, claimed.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	counts, err = q.CountByStatus(ctx)
+	if err != nil {
+		t.Fatalf("CountByStatus: %v", err)
+	}
+	if counts[StatusPending] != 1 {
+		t.Errorf("pending = %d; want 1", counts[StatusPending])
+	}
+	if counts[StatusDone] != 1 {
+		t.Errorf("done = %d; want 1", counts[StatusDone])
+	}
+	if _, ok := counts[StatusProcessing]; ok {
+		t.Errorf("processing present = %v; want absent (no processing rows)", counts[StatusProcessing])
+	}
+}
+
 func TestDBQueue_DequeueClaimsHighestPriorityReadyItem(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))
@@ -283,7 +326,7 @@ func TestDBQueue_EnqueueDuplicatePreservesFailedBackoff(t *testing.T) {
 		Track:    models.Track{ArtistName: " artist ", TrackName: "title"},
 		Outdir:   "duplicate-out",
 		Filename: "duplicate.lrc",
-	}, 10)
+	}, PriorityScan)
 	if err != nil {
 		t.Fatalf("Enqueue duplicate: %v", err)
 	}
@@ -304,6 +347,66 @@ func TestDBQueue_EnqueueDuplicatePreservesFailedBackoff(t *testing.T) {
 	}
 	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("Dequeue during preserved backoff error = %v; want sql.ErrNoRows", err)
+	}
+}
+
+// TestDBQueue_EnqueueWebhookDuplicateResetsFailedBackoff verifies a webhook
+// (high-priority) duplicate of a failed row resets next_attempt_at to now so the
+// work becomes immediately retry-eligible, without changing the attempt count.
+func TestDBQueue_EnqueueWebhookDuplicateResetsFailedBackoff(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "failed-out",
+		Filename: "failed.lrc",
+	}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	failed, err := q.Fail(ctx, claimed.ID, errors.New("rate limited"))
+	if err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if !failed.NextAttemptAt.After(now) {
+		t.Fatalf("failed next attempt = %s; want a future backoff after %s", failed.NextAttemptAt, now)
+	}
+
+	dup, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: " artist ", TrackName: "title"},
+		Outdir:   "duplicate-out",
+		Filename: "duplicate.lrc",
+	}, PriorityWebhook)
+	if err != nil {
+		t.Fatalf("Enqueue webhook duplicate: %v", err)
+	}
+	if dup.ID != failed.ID {
+		t.Fatalf("duplicate ID = %d; want %d", dup.ID, failed.ID)
+	}
+	if dup.Status != StatusFailed {
+		t.Fatalf("duplicate status = %q; want %q (status is unchanged)", dup.Status, StatusFailed)
+	}
+	if dup.Attempts != failed.Attempts {
+		t.Fatalf("duplicate attempts = %d; want %d (attempts preserved)", dup.Attempts, failed.Attempts)
+	}
+	if !dup.NextAttemptAt.Equal(now) {
+		t.Fatalf("duplicate next attempt = %s; want %s (reset to now)", dup.NextAttemptAt, now)
+	}
+	if dup.Priority != PriorityWebhook {
+		t.Fatalf("duplicate priority = %d; want %d", dup.Priority, PriorityWebhook)
+	}
+	claimed2, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after webhook reset = %v; want the reset row to be claimable", err)
+	}
+	if claimed2.ID != failed.ID {
+		t.Fatalf("Dequeue claimed ID = %d; want %d", claimed2.ID, failed.ID)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,19 +99,22 @@ func (h *Handler) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 }
 
 // handleReadyz reports readiness by checking database reachability. When no
-// readiness checker is configured the endpoint reports ready, since there is
-// nothing to verify. Error detail is intentionally omitted to avoid leaking
-// filesystem paths or connection strings.
+// readiness checker is configured the endpoint still reports ready, but omits
+// the database check from the response rather than claiming a check that never
+// ran. Error detail is intentionally omitted to avoid leaking filesystem paths
+// or connection strings.
 func (h *Handler) handleReadyz(w http.ResponseWriter, r *http.Request) {
-	if h.ready != nil {
-		if err := h.ready.PingContext(r.Context()); err != nil {
-			slog.Warn("readiness check failed", "error", err)
-			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
-				"status": "unavailable",
-				"checks": map[string]string{"database": "error"},
-			})
-			return
-		}
+	if h.ready == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ready"})
+		return
+	}
+	if err := h.ready.PingContext(r.Context()); err != nil {
+		slog.Warn("readiness check failed", "error", err)
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"status": "unavailable",
+			"checks": map[string]string{"database": "error"},
+		})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status": "ready",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,17 +28,43 @@ type WorkQueue interface {
 	Cleanup(ctx context.Context, inputs models.Inputs) (int64, error)
 }
 
+// Readiness reports whether backing dependencies (e.g. the database) are
+// reachable. *sql.DB satisfies this interface via PingContext.
+type Readiness interface {
+	PingContext(ctx context.Context) error
+}
+
+// StatusReporter returns queue depth grouped by status for the status endpoint.
+type StatusReporter interface {
+	CountByStatus(ctx context.Context) (map[string]int64, error)
+}
+
 // Handler serves the HTTP API.
 type Handler struct {
 	auth     Authenticator
 	queue    WorkQueue
 	outdir   string
 	priority int
+	ready    Readiness
+	stats    StatusReporter
 	mux      *http.ServeMux
 }
 
+// Option configures optional Handler dependencies.
+type Option func(*Handler)
+
+// WithReadiness wires a readiness checker used by GET /readyz.
+func WithReadiness(r Readiness) Option {
+	return func(h *Handler) { h.ready = r }
+}
+
+// WithStatusReporter wires a queue summary source used by GET /api/v1/status.
+func WithStatusReporter(s StatusReporter) Option {
+	return func(h *Handler) { h.stats = s }
+}
+
 // NewHandler creates an HTTP API handler.
-func NewHandler(a Authenticator, q WorkQueue, outdir string) *Handler {
+func NewHandler(a Authenticator, q WorkQueue, outdir string, opts ...Option) *Handler {
 	h := &Handler{
 		auth:     a,
 		queue:    q,
@@ -46,8 +72,85 @@ func NewHandler(a Authenticator, q WorkQueue, outdir string) *Handler {
 		priority: queue.PriorityWebhook,
 		mux:      http.NewServeMux(),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
 	h.mux.HandleFunc("POST /api/v1/webhooks/lidarr", h.handleLidarr)
+	h.mux.HandleFunc("GET /healthz", h.handleHealthz)
+	h.mux.HandleFunc("GET /readyz", h.handleReadyz)
+	h.mux.HandleFunc("GET /api/v1/status", h.handleStatus)
 	return h
+}
+
+// writeJSON serializes v as JSON with the given status code. Encoding failures
+// are logged rather than surfaced because the status line is already written.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Warn("failed to encode JSON response", "error", err)
+	}
+}
+
+// handleHealthz reports process liveness. It performs no dependency checks so a
+// 200 means only that the HTTP server is accepting requests.
+func (h *Handler) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleReadyz reports readiness by checking database reachability. When no
+// readiness checker is configured the endpoint reports ready, since there is
+// nothing to verify. Error detail is intentionally omitted to avoid leaking
+// filesystem paths or connection strings.
+func (h *Handler) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	if h.ready != nil {
+		if err := h.ready.PingContext(r.Context()); err != nil {
+			slog.Warn("readiness check failed", "error", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"status": "unavailable",
+				"checks": map[string]string{"database": "error"},
+			})
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "ready",
+		"checks": map[string]string{"database": "ok"},
+	})
+}
+
+// handleStatus returns a queue summary. It requires an admin-scoped API key so
+// operational detail is not exposed to unauthenticated callers, and never
+// includes tokens, webhook keys, or filesystem paths.
+func (h *Handler) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if h.auth == nil {
+		http.Error(w, "auth unavailable", http.StatusInternalServerError)
+		return
+	}
+	if _, err := h.auth.ValidateKey(r.Context(), apiKey(r), auth.ScopeAdmin); err != nil {
+		switch {
+		case errors.Is(err, auth.ErrForbiddenScope):
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		case errors.Is(err, auth.ErrInvalidKey), errors.Is(err, auth.ErrRevokedKey):
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		default:
+			slog.Error("status authentication failed", "error", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	resp := map[string]any{"status": "ok"}
+	if h.stats != nil {
+		counts, err := h.stats.CountByStatus(r.Context())
+		if err != nil {
+			slog.Error("status queue summary failed", "error", err)
+			http.Error(w, "status unavailable", http.StatusInternalServerError)
+			return
+		}
+		resp["queue"] = counts
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // ServeHTTP logs requests and dispatches them to API routes.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -227,6 +227,89 @@ func TestLidarrWebhookAuthAndEnqueueErrors(t *testing.T) {
 	})
 }
 
+type fakeReadiness struct{ err error }
+
+func (f *fakeReadiness) PingContext(_ context.Context) error { return f.err }
+
+type fakeStats struct {
+	counts map[string]int64
+	err    error
+}
+
+func (f *fakeStats) CountByStatus(_ context.Context) (map[string]int64, error) {
+	return f.counts, f.err
+}
+
+func TestHealthzReturnsOK(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthz status = %d; want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"ok"`) {
+		t.Fatalf("healthz body = %q; want status ok", rec.Body.String())
+	}
+}
+
+func TestReadyzReportsDatabase(t *testing.T) {
+	t.Run("ready", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics", WithReadiness(&fakeReadiness{}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("readyz status = %d; want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `"database":"ok"`) {
+			t.Fatalf("readyz body = %q; want database ok", rec.Body.String())
+		}
+	})
+
+	t.Run("database unavailable", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics", WithReadiness(&fakeReadiness{err: errors.New("db file /secret/path down")}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("readyz status = %d; want 503", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "secret") {
+			t.Fatalf("readyz body = %q; leaked error detail", rec.Body.String())
+		}
+	})
+}
+
+func TestStatusRequiresAdminAndReportsQueue(t *testing.T) {
+	a := &fakeAuth{}
+	stats := &fakeStats{counts: map[string]int64{"pending": 3, "failed": 1}}
+	h := NewHandler(a, &fakeQueue{}, "lyrics", WithReadiness(&fakeReadiness{}), WithStatusReporter(stats))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/status?apikey=secret", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d; want 200", rec.Code)
+	}
+	if a.required != auth.ScopeAdmin {
+		t.Fatalf("status required scope = %q; want admin", a.required)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"pending":3`) || !strings.Contains(body, `"failed":1`) {
+		t.Fatalf("status body = %q; want queue counts", body)
+	}
+}
+
+func TestStatusForbiddenWithoutAdminScope(t *testing.T) {
+	h := NewHandler(&fakeAuth{err: auth.ErrForbiddenScope}, &fakeQueue{}, "lyrics", WithStatusReporter(&fakeStats{}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/status?apikey=key", nil))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status code = %d; want 403", rec.Code)
+	}
+}
+
 func TestRedactURIHidesAPIKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/lidarr?apikey=secret&x=1", nil)
 	got := redactURI(req.URL)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -267,6 +267,22 @@ func TestReadyzReportsDatabase(t *testing.T) {
 		}
 	})
 
+	t.Run("no checker omits database claim", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics") // no WithReadiness
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("readyz status = %d; want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `"status":"ready"`) {
+			t.Fatalf("readyz body = %q; want status ready", rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), "database") {
+			t.Fatalf("readyz body = %q; must not claim a database check when none is configured", rec.Body.String())
+		}
+	})
+
 	t.Run("database unavailable", func(t *testing.T) {
 		h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics", WithReadiness(&fakeReadiness{err: errors.New("db file /secret/path down")}))
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Harden `serve` mode for Docker/Unraid deployments, bundling three related operability issues:

- **Configurable intervals (#76):** the scheduler scan interval and worker poll interval are now set via `server.scan_interval_seconds` / `server.work_interval_seconds` (TOML) and `MXLRC_SCAN_INTERVAL` / `MXLRC_WORK_INTERVAL` (env), with precedence CLI flag > env > config file > default. Defaults preserve current behavior. `--scan-interval` became a pointer so an unset flag defers to config/env instead of always winning at its static default.
- **Health/status endpoints (#77):** `GET /healthz` (liveness), `GET /readyz` (database readiness; 503 when the DB is unreachable), and an admin-scoped `GET /api/v1/status` queue summary. Responses never expose tokens, webhook keys, or filesystem paths; readiness error detail is logged, not returned. Wired via functional options so existing `NewHandler` callers are unaffected.
- **Webhook retry timing (#71):** a high-priority (webhook) re-enqueue of a failed item resets its retry backoff so it becomes retry-eligible immediately, while scan-priority duplicates keep their backoff. Attempt count and failed status are unchanged, so later failures still escalate normally.

## Linked issues

Closes #76
Closes #77
Closes #71

## Test plan

- [x] `go test ./...` passes
- [x] Patch coverage 75% (local gate, threshold 70%)
- [x] golangci-lint + govulncheck clean (pre-commit gate)
- [ ] Manual UAT in a Docker/Unraid deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints (`/healthz`, `/readyz`) for monitoring service availability
  * Added `/api/v1/status` endpoint displaying queue counts (admin-scoped)
  * Introduced configurable scheduler and worker scan intervals with environment variable overrides

* **Documentation**
  * Documented webhook queue priority behavior and health/status endpoints with Docker healthcheck example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->