### PR TITLE
feat: library scan enhancements - fsnotify watcher (#83) + webhook inventory (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ The server listens on `MXLRC_SERVER_ADDR` when `--listen` is not provided. Confi
 
 Webhook events are enqueued at high priority. If a webhook arrives for an artist/title that previously failed and is waiting out a retry backoff, the high-priority enqueue resets its retry timer so it becomes eligible immediately, jumping the queue. Scan-enqueued duplicates keep their existing backoff, so bulk scan traffic stays rate-limit protected. The worker's circuit breaker still pauses dequeuing globally when the upstream API signals rate limiting.
 
+#### Path resolution (Docker/Unraid)
+
+Configured library scans are the source of truth for filesystem paths. When a Lidarr webhook arrives, `mxlrcgo-svc` resolves the target file in this order:
+
+1. **Scanned inventory.** The webhook artist/title is matched against persisted scan results (using the same normalization as the cache), and a match reuses the exact container-visible source path and output destination the scan recorded. This is why you should add and scan your libraries (`mxlrcgo-svc library add ...`, then `mxlrcgo-svc scan`) before relying on webhooks.
+2. **Direct payload path.** If there is no inventory match but the webhook payload carries a `trackFiles` path that, after cleaning, lies inside one of your configured library roots and exists inside the `mxlrcgo-svc` container, that path is used directly. Payload paths outside every configured root are never used as a write target; they fall back to metadata. This confinement is a security guard: it stops a webhook from directing a lyric write to an arbitrary location. As a result, raw payload-path resolution requires at least one configured library; with no libraries configured, step 2 is disabled and resolution goes straight from inventory to metadata.
+3. **Metadata fallback.** Otherwise the lyrics are written to the configured `output.dir` using the webhook metadata.
+
+On Unraid, Lidarr and `mxlrcgo-svc` often see the same media through different mount paths. Because resolution prefers the scanned inventory, you do not need to maintain host-to-container path mappings: a payload path that is not visible inside the container, or that falls outside your configured library roots, simply falls back to metadata rather than failing.
+
+Two operational notes:
+
+- The library roots used to confine payload paths (step 2) are snapshotted when `serve` starts. A library added with `mxlrcgo-svc library add ...` while `serve` is running is not recognized for raw-payload-path resolution until `serve` is restarted. (The periodic scheduler and watcher still pick up new libraries without a restart; only the webhook payload-path confinement uses the startup snapshot.)
+- Inventory matching for tracks with non-ASCII artist/title metadata converges after one rescan following an upgrade. The key-backfill migration applies a best-effort ASCII fold to pre-existing rows; the exact normalized keys are written on the next library scan, so run `mxlrcgo-svc scan` once after upgrading to make non-ASCII webhook matches reliable.
+
 The scheduler scan interval and worker poll interval are configurable for Docker/Unraid deployments. Set `scan_interval_seconds` and `work_interval_seconds` under `[server]` in the config file, or override with `MXLRC_SCAN_INTERVAL` and `MXLRC_WORK_INTERVAL`. Precedence is CLI flag (`--scan-interval`, `--work-interval`) > environment variable > config file > default. Defaults preserve current behavior: scan interval 900 seconds, and worker interval falls back to `api.cooldown` (clamped to a 15-second floor). A scan interval of 0 scans once without repeating.
 
 ### Health and status endpoints
@@ -112,6 +127,26 @@ mxlrcgo-svc keys create --name lidarr --scope webhook
 mxlrcgo-svc keys list
 mxlrcgo-svc config get db.path
 ```
+
+### Filesystem watcher (optional, low-latency scans)
+
+By default, `serve` only scans on the scheduler's tick (`--scan-interval`, default 900s), so a new track dropped into the library waits up to that interval before lyrics are fetched. An optional filesystem watcher reacts within seconds for the common single-host case. It is disabled by default and configured entirely through environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MXLRCGO_WATCH_ENABLED` | `false` | Master switch. When unset/false, behavior is exactly as before. |
+| `MXLRCGO_WATCH_DEBOUNCE_MS` | `2000` | Quiet period after the last event before a directory is scanned. Coalesces the event storms that taggers (Beets, Picard) produce when rewriting an album. |
+| `MXLRCGO_WATCH_MAX_DIRS` | `100000` | Safety cap. Startup fails loudly if the configured roots contain more directories than this, rather than silently exceeding the kernel watch budget. |
+
+When a file appears or changes, the watcher scans the affected directory (and its subtree, up to the configured scan depth) under the owning library and enqueues any cache misses at scan priority.
+
+The watcher is **best-effort and in addition to** the periodic scan, never a replacement:
+
+- Bind-mounted volumes, NFS, SMB, and Docker Desktop on macOS frequently drop or never emit filesystem events.
+- Events that fire while the container is down are lost; there is no replay. The periodic scan reconciles them.
+- On Linux, very large libraries may require raising the inotify watch limit, e.g. `sysctl fs.inotify.max_user_watches=524288`.
+
+Because the periodic scheduler remains the source of truth, you can safely raise `--scan-interval` to a long backstop (e.g. 6h) when the watcher is enabled.
 
 ### Inspection commands
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/joho/godotenv v1.5.1
 	github.com/pressly/goose/v3 v3.27.0
+	github.com/rjeczalik/notify v0.9.3
 	github.com/valyala/fastjson v1.6.10
 	golang.org/x/text v0.36.0
 	modernc.org/sqlite v1.48.2

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/pressly/goose/v3 v3.27.0 h1:/D30gVTuQhu0WsNZYbJi4DMOsx1lNq+6SkLe+Wp59
 github.com/pressly/goose/v3 v3.27.0/go.mod h1:3ZBeCXqzkgIRvrEMDkYh1guvtoJTU5oMMuDdkutoM78=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
+github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -43,6 +45,7 @@ golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 	"github.com/sydlexius/mxlrcgo-svc/internal/server"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
+	"github.com/sydlexius/mxlrcgo-svc/internal/watcher"
 	"github.com/sydlexius/mxlrcgo-svc/internal/worker"
 )
 
@@ -480,16 +481,30 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		defer wg.Done()
 		runScheduler(runCtx, sqlDB, cfg, args)
 	}()
+	if watchCfg := watcher.ConfigFromEnv(); watchCfg.Enabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runWatcher(runCtx, sqlDB, args, watchCfg)
+		}()
+	}
 
 	addr := cfg.Server.Addr
 	if args.Listen != nil {
 		addr = *args.Listen
 	}
+	// Snapshot the configured library roots so the webhook handler can confine
+	// raw payload paths to them (path-injection guard). Listing failure is not
+	// fatal: the handler simply disables raw-payload-path resolution and falls
+	// back to inventory or metadata.
+	allowedRoots := webhookAllowedRoots(runCtx, sqlDB)
 	srv := &http.Server{
 		Addr: addr,
 		Handler: server.NewHandler(authSvc, workQ, outdir,
 			server.WithReadiness(sqlDB),
 			server.WithStatusReporter(workQ),
+			server.WithInventory(scan.New(sqlDB)),
+			server.WithAllowedRoots(allowedRoots),
 		),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       15 * time.Second,
@@ -604,6 +619,46 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 	if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		slog.Warn("scheduler failed", "error", err)
 	}
+}
+
+// runWatcher runs the optional filesystem watcher, triggering a targeted scan of
+// the changed directory under the owning library. The periodic scheduler remains
+// the reconciliation backstop; the watcher only lowers latency for new files.
+func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, cfg watcher.Config) {
+	sched := scheduler(sqlDB, scanner.ScanOptions{
+		Update:   args.Update,
+		Upgrade:  args.Upgrade,
+		MaxDepth: args.Depth,
+		BFS:      args.BFS,
+	})
+	wch := watcher.New(cfg, library.New(sqlDB), func(ctx context.Context, lib models.Library, path string) error {
+		return sched.RunOnceForPath(ctx, lib, path)
+	})
+	// The watcher is best-effort and explicitly never a replacement for the
+	// periodic scheduler (see README), so a setup or runtime failure must not
+	// take down serve. Surface it at error level so an operator who enabled the
+	// watcher sees the failure loudly while the scheduler keeps reconciling.
+	if err := wch.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("watcher stopped; continuing without it (periodic scheduler remains the source of truth)", "error", err)
+	}
+}
+
+// webhookAllowedRoots returns the configured library root paths used to confine
+// webhook payload paths. A listing failure is logged and treated as "no roots",
+// which disables raw-payload-path resolution rather than failing startup.
+func webhookAllowedRoots(ctx context.Context, sqlDB *sql.DB) []string {
+	libs, err := library.New(sqlDB).List(ctx)
+	if err != nil {
+		slog.Warn("failed to list libraries for webhook path confinement; raw payload-path resolution disabled", "error", err)
+		return nil
+	}
+	roots := make([]string, 0, len(libs))
+	for _, lib := range libs {
+		if lib.Path != "" {
+			roots = append(roots, lib.Path)
+		}
+	}
+	return roots
 }
 
 // runScanCmd dispatches the scan subcommand. When neither nested subcommand

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,9 +2,12 @@ package db
 
 import (
 	"context"
+	"database/sql"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
+	"github.com/pressly/goose/v3"
 	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
 )
 
@@ -289,6 +292,87 @@ func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 	}
 	if dequeueIndexCount != 1 {
 		t.Fatalf("work queue dequeue index count = %d; want 1", dequeueIndexCount)
+	}
+}
+
+// TestMigration011BackfillsKeysAndDownMigrates drives migration 011 directly:
+// it migrates to v10, seeds a pre-011 row with non-ASCII metadata, applies 011,
+// and asserts the artist_key/title_key backfill and index, then down-migrates
+// and asserts the columns are removed.
+func TestMigration011BackfillsKeysAndDownMigrates(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig011.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	sqlDB.SetMaxOpenConns(1)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+
+	// Migrate to v10: scan_results has no artist_key/title_key yet.
+	if _, err := provider.UpTo(ctx, 10); err != nil {
+		t.Fatalf("UpTo(10): %v", err)
+	}
+
+	// Seed a pre-011 row with non-ASCII, space-padded metadata.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?)`, "/music", "Music"); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title) VALUES (?, ?, ?, ?)`,
+		1, "/music/x.flac", "  Beyoncé ", " Café Tacvba "); err != nil {
+		t.Fatalf("insert scan_result: %v", err)
+	}
+
+	// Apply 011 and verify the best-effort backfill (lower(trim())).
+	if _, err := provider.UpTo(ctx, 11); err != nil {
+		t.Fatalf("UpTo(11): %v", err)
+	}
+	var artistKey, titleKey string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT artist_key, title_key FROM scan_results WHERE file_path = ?`, "/music/x.flac").
+		Scan(&artistKey, &titleKey); err != nil {
+		t.Fatalf("query keys: %v", err)
+	}
+	if artistKey != "beyoncé" {
+		t.Errorf("artist_key = %q; want %q (lower(trim(artist)))", artistKey, "beyoncé")
+	}
+	if titleKey != "café tacvba" {
+		t.Errorf("title_key = %q; want %q", titleKey, "café tacvba")
+	}
+
+	var idxCount int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_scan_results_keys'`).
+		Scan(&idxCount); err != nil {
+		t.Fatalf("query index: %v", err)
+	}
+	if idxCount != 1 {
+		t.Errorf("idx_scan_results_keys count = %d; want 1", idxCount)
+	}
+
+	// Down-migrate 011 and confirm the added columns are gone.
+	if _, err := provider.Down(ctx); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+	var colCount int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('scan_results') WHERE name IN ('artist_key','title_key')`).
+		Scan(&colCount); err != nil {
+		t.Fatalf("query columns after down: %v", err)
+	}
+	if colCount != 0 {
+		t.Errorf("artist_key/title_key columns after down-migration = %d; want 0", colCount)
 	}
 }
 

--- a/internal/db/migrations/011_scan_results_keys.sql
+++ b/internal/db/migrations/011_scan_results_keys.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scan_results ADD COLUMN artist_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE scan_results ADD COLUMN title_key TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_scan_results_keys
+    ON scan_results(artist_key, title_key);
+
+-- Best-effort ASCII backfill for existing rows. Full Unicode NFKD/diacritic
+-- folding cannot be expressed in SQL, so rows with non-ASCII metadata get a
+-- close-but-imperfect key here and are corrected to the exact NormalizeKey
+-- value on the next library scan upsert.
+UPDATE scan_results
+   SET artist_key = lower(trim(artist)),
+       title_key = lower(trim(title));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_scan_results_keys;
+ALTER TABLE scan_results DROP COLUMN title_key;
+ALTER TABLE scan_results DROP COLUMN artist_key;
+-- +goose StatementEnd

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,86 @@
+// Package pathutil provides path-containment checks used to confine filesystem
+// targets to configured roots. It centralizes the containment logic that was
+// previously duplicated across the server, watcher, and scan packages.
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// WithinRoot reports whether p is root or sits under root using purely lexical
+// analysis (filepath.Clean + filepath.Rel). It does NOT resolve symlinks, so a
+// symlink inside root that points outside it still passes. It is the right check
+// when the paths are already trusted or may not exist yet (matching filesystem
+// event paths to their owning library, or comparing two configured roots). For
+// an untrusted path that will be used as a real filesystem target, use
+// ResolveWithinRoot instead.
+func WithinRoot(root, p string) bool {
+	// Fail closed on empty inputs so the helper is safe in isolation rather than
+	// relying on callers to pre-filter: both "" clean to ".", which would
+	// otherwise report a nonsensical empty path as contained.
+	if root == "" || p == "" {
+		return false
+	}
+	_, ok := relWithin(filepath.Clean(root), filepath.Clean(p))
+	return ok
+}
+
+// ResolveWithinRoot reports whether p resolves to a location inside root and, on
+// success, returns the fully resolved (symlink-free) path so callers can use the
+// exact value they validated as the filesystem target (check path == write
+// path).
+//
+// It derives the relative component of p against root and rejects any upward
+// traversal, then rebuilds the candidate by joining the symlink-resolved root
+// with that traversal-checked relative component. It resolves the result with
+// filepath.EvalSymlinks and re-confirms containment, so the value handed back is
+// anchored to the operator-configured root rather than to raw caller input, and
+// a symlink that lives inside root but points outside it is rejected. Any
+// resolve error (including a path that does not exist) yields ok=false, so
+// callers fail closed.
+//
+// Note: this validates at check time only. A caller that later opens the
+// returned path is still subject to a time-of-check/time-of-use race if an
+// attacker can swap a component for a symlink in between; closing that fully
+// requires resolving at open time (e.g. O_NOFOLLOW / openat) in the writing
+// layer.
+func ResolveWithinRoot(root, p string) (string, bool) {
+	if root == "" || p == "" {
+		return "", false
+	}
+	cleanRoot := filepath.Clean(root)
+	rel, ok := relWithin(cleanRoot, filepath.Clean(p))
+	if !ok {
+		return "", false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(cleanRoot)
+	if err != nil {
+		return "", false
+	}
+	// Rebuild from the trusted resolved root + the traversal-checked relative
+	// component, then resolve symlinks and re-confine so an in-root symlink
+	// cannot escape.
+	resolved, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, rel))
+	if err != nil {
+		return "", false
+	}
+	if _, ok := relWithin(resolvedRoot, resolved); !ok {
+		return "", false
+	}
+	return resolved, true
+}
+
+// relWithin returns the cleaned relative path from root to p and reports whether
+// p is root itself or sits below it with no upward traversal. root and p are
+// expected to already be cleaned.
+func relWithin(root, p string) (string, bool) {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return rel, true
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,114 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWithinRoot(t *testing.T) {
+	cases := []struct {
+		root, p string
+		want    bool
+	}{
+		{"/music", "/music", true},
+		{"/music", "/music/a/b.mp3", true},
+		{"/music", "/musicother/x", false},
+		{"/music", "/other", false},
+		{"/music/sub", "/music", false},
+		{"/music", "/music/../etc/passwd", false}, // cleans to /etc/passwd
+		{"/music/", "/music/a", true},             // trailing slash on root
+	}
+	for _, c := range cases {
+		if got := WithinRoot(c.root, c.p); got != c.want {
+			t.Errorf("WithinRoot(%q, %q) = %v; want %v", c.root, c.p, got, c.want)
+		}
+	}
+}
+
+func TestEmptyInputsFailClosed(t *testing.T) {
+	for _, c := range []struct{ root, p string }{
+		{"", ""},
+		{"", "/music/a"},
+		{"/music", ""},
+	} {
+		if WithinRoot(c.root, c.p) {
+			t.Errorf("WithinRoot(%q, %q) = true; want false (empty inputs must fail closed)", c.root, c.p)
+		}
+	}
+	// ResolveWithinRoot delegates to WithinRoot first, so it inherits the guard.
+	if _, ok := ResolveWithinRoot("", "/x"); ok {
+		t.Error("ResolveWithinRoot with empty root ok = true; want false")
+	}
+	if _, ok := ResolveWithinRoot("/x", ""); ok {
+		t.Error("ResolveWithinRoot with empty candidate ok = true; want false")
+	}
+}
+
+func TestResolveWithinRootAcceptsRealFileInRoot(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "Artist")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(sub, "song.flac")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, ok := ResolveWithinRoot(root, file)
+	if !ok {
+		t.Fatal("ResolveWithinRoot ok = false; want true for a real file inside the root")
+	}
+	// The returned path is symlink-resolved (handles e.g. /var -> /private/var on
+	// macOS), so compare against the resolved file path, not the raw temp path.
+	want, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got != want {
+		t.Errorf("resolved = %q; want %q", got, want)
+	}
+}
+
+func TestResolveWithinRootRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.flac")
+	if err := os.WriteFile(secret, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	link := filepath.Join(root, "link.flac")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	// Precondition: the symlink is lexically inside the root, so the old
+	// lexical-only check would have accepted it.
+	if !WithinRoot(root, link) {
+		t.Fatal("precondition failed: symlink should be lexically within the root")
+	}
+	// Symlink resolution must reject it because it points outside the root.
+	if got, ok := ResolveWithinRoot(root, link); ok {
+		t.Errorf("ResolveWithinRoot returned %q, ok=true for a symlink escaping the root; want rejected", got)
+	}
+}
+
+func TestResolveWithinRootRejectsNonexistent(t *testing.T) {
+	root := t.TempDir()
+	if _, ok := ResolveWithinRoot(root, filepath.Join(root, "missing.flac")); ok {
+		t.Error("ResolveWithinRoot ok = true for a nonexistent path; want rejected (fail closed)")
+	}
+}
+
+func TestResolveWithinRootRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	file := filepath.Join(outside, "song.flac")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, ok := ResolveWithinRoot(root, file); ok {
+		t.Error("ResolveWithinRoot ok = true for a path outside the root; want rejected")
+	}
+}

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -98,6 +98,14 @@ func (e *Enqueuer) OnScanComplete(ctx context.Context, lib models.Library, _ []m
 	return e.EnqueuePending(ctx, lib.ID)
 }
 
+// ResultInputs converts a scan result into queue inputs using the same outdir,
+// filename, source path, and output-path derivation as scan-created work. The
+// webhook resolver uses this so inventory-matched work is enqueued identically
+// to work the scheduler enqueues.
+func ResultInputs(res models.ScanResult) (models.Inputs, error) {
+	return scanInputs(res)
+}
+
 func scanInputs(res models.ScanResult) (models.Inputs, error) {
 	outdir := res.Outdir
 	if outdir == "" && res.FilePath != "" {

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
 )
 
+func TestResultInputs(t *testing.T) {
+	in, err := scan.ResultInputs(models.ScanResult{
+		ID:       4,
+		FilePath: "/music/Artist/song.flac",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+	})
+	if err != nil {
+		t.Fatalf("ResultInputs: %v", err)
+	}
+	if in.SourcePath != "/music/Artist/song.flac" {
+		t.Errorf("SourcePath = %q; want the file path", in.SourcePath)
+	}
+	if in.Outdir != "/music/Artist" {
+		t.Errorf("Outdir = %q; want the file's directory", in.Outdir)
+	}
+	if in.Filename != "song.lrc" {
+		t.Errorf("Filename = %q; want song.lrc", in.Filename)
+	}
+	if in.ScanResultID != 4 {
+		t.Errorf("ScanResultID = %d; want 4", in.ScanResultID)
+	}
+	if _, err := scan.ResultInputs(models.ScanResult{}); err == nil {
+		t.Error("ResultInputs with empty result = nil error; want failure")
+	}
+}
+
 type fakePendingStore struct {
 	results   []models.ScanResult
 	status    []statusCall

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
 )
 
 const (
@@ -48,11 +49,13 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const baseUpsert = `INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
+	const baseUpsert = `INSERT INTO scan_results (library_id, file_path, artist, title, artist_key, title_key, outdir, filename, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(library_id, file_path) DO UPDATE SET
                  artist = excluded.artist,
                  title = excluded.title,
+                 artist_key = excluded.artist_key,
+                 title_key = excluded.title_key,
                  outdir = excluded.outdir,
                  filename = excluded.filename`
 	stmt := baseUpsert
@@ -71,6 +74,8 @@ func (r *Repo) Upsert(ctx context.Context, libraryID int64, results []models.Sca
 			res.FilePath,
 			res.Track.ArtistName,
 			res.Track.TrackName,
+			normalize.NormalizeKey(res.Track.ArtistName),
+			normalize.NormalizeKey(res.Track.TrackName),
 			res.Outdir,
 			res.Filename,
 			insertStatus,
@@ -213,6 +218,47 @@ func (r *Repo) List(ctx context.Context, filter Filter) (results []models.ScanRe
 	results, err = scanResultRows(rows)
 	if err != nil {
 		return nil, fmt.Errorf("scan: list rows: %w", err)
+	}
+	return results, nil
+}
+
+// FindByTrack returns scan results whose normalized artist and title keys match
+// the given artist and title. The inputs are normalized with the same function
+// used when rows are stored, so callers pass raw artist/title strings. Results
+// are ordered so rows not yet done (pending, processing, failed) come first,
+// then by id, so a caller that wants a single match can prefer work that still
+// needs doing.
+//
+// Matching is by normalized key only and is NOT scoped to a library: if the same
+// artist/title exists under multiple configured libraries, rows from all of them
+// are returned and the cross-library order is just the id tiebreak. This is low
+// impact in practice (the caller picks one via pickByAlbum) but means a match is
+// not guaranteed to come from any particular library.
+func (r *Repo) FindByTrack(ctx context.Context, artist, title string) (results []models.ScanResult, retErr error) {
+	artistKey := normalize.NormalizeKey(artist)
+	titleKey := normalize.NormalizeKey(title)
+	if artistKey == "" || titleKey == "" {
+		return nil, nil
+	}
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, library_id, file_path, artist, title, outdir, filename, status, created_at
+                       FROM scan_results
+                       WHERE artist_key = ? AND title_key = ?
+                       ORDER BY CASE status WHEN 'done' THEN 1 ELSE 0 END ASC, id ASC`,
+		artistKey, titleKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan: find by track: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("scan: close find rows: %w", err)
+		}
+	}()
+
+	results, err = scanResultRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan: find by track rows: %w", err)
 	}
 	return results, nil
 }

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -72,6 +72,88 @@ func TestRepo_UpsertAndListByLibrary(t *testing.T) {
 	}
 }
 
+func TestRepo_FindByTrackMatchesNormalizedKeys(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	results := []models.ScanResult{{
+		FilePath: "/music/Bjork/Joga.mp3",
+		Track:    models.Track{ArtistName: "Björk", TrackName: "Jóga"},
+		Outdir:   "/music/Bjork",
+		Filename: "Joga.lrc",
+		Status:   scan.StatusPending,
+	}}
+	if err := scanRepo.Upsert(ctx, lib.ID, results, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Webhook metadata that differs by diacritics and case must still match
+	// because both sides go through NormalizeKey.
+	got, err := scanRepo.FindByTrack(ctx, "bjork", "joga")
+	if err != nil {
+		t.Fatalf("FindByTrack: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FindByTrack returned %d; want 1", len(got))
+	}
+	if got[0].FilePath != "/music/Bjork/Joga.mp3" {
+		t.Errorf("FilePath = %q; want /music/Bjork/Joga.mp3", got[0].FilePath)
+	}
+
+	none, err := scanRepo.FindByTrack(ctx, "Unknown", "Nothing")
+	if err != nil {
+		t.Fatalf("FindByTrack miss: %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("FindByTrack miss returned %d; want 0", len(none))
+	}
+}
+
+func TestRepo_FindByTrackOrdersNonTerminalFirst(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music")
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	// Same artist/title on two albums: one already done, one still pending.
+	results := []models.ScanResult{
+		{
+			FilePath: "/music/live/song.mp3",
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+			Status:   scan.StatusDone,
+		},
+		{
+			FilePath: "/music/studio/song.mp3",
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+			Status:   scan.StatusPending,
+		},
+	}
+	if err := scanRepo.Upsert(ctx, lib.ID, results, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := scanRepo.FindByTrack(ctx, "Artist", "Song")
+	if err != nil {
+		t.Fatalf("FindByTrack: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FindByTrack returned %d; want 2", len(got))
+	}
+	if got[0].Status != scan.StatusPending {
+		t.Errorf("first result status = %q; want pending (non-terminal rows first)", got[0].Status)
+	}
+}
+
 func TestRepo_UpsertWithForceStatusOverwritesExisting(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 )
 
@@ -71,24 +72,57 @@ func (s *Scheduler) RunOnceFor(ctx context.Context, libs []models.Library) error
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		results, err := s.Scanner.ScanLibrary(ctx, v.Path, s.Options)
-		if err != nil {
-			return fmt.Errorf("scan: scan library %d: %w", v.ID, err)
+		if err := s.scanAndPersist(ctx, v, v.Path); err != nil {
+			return err
 		}
-		for i := range results {
-			results[i].LibraryID = v.ID
-			if results[i].Status == "" {
-				results[i].Status = StatusPending
-			}
+	}
+	return nil
+}
+
+// RunOnceForPath scans a single directory subtree and persists the results
+// against lib, then runs the completion callback. The filesystem watcher uses
+// this to react to events without rescanning every configured library. path
+// should be a directory within lib.Path; because results are keyed by
+// (library_id, file_path), only the touched files are upserted.
+func (s *Scheduler) RunOnceForPath(ctx context.Context, lib models.Library, path string) error {
+	if s.Results == nil {
+		return fmt.Errorf("scan: scheduler results dependency is nil")
+	}
+	if s.Scanner == nil {
+		return fmt.Errorf("scan: scheduler scanner dependency is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// The path originates from a filesystem watcher reacting to events; refuse to
+	// scan or persist anything outside the owning library root so an unexpected
+	// event path can never widen the scan beyond the configured library.
+	if !pathutil.WithinRoot(lib.Path, path) {
+		return fmt.Errorf("scan: path %q is outside library root %q", path, lib.Path)
+	}
+	return s.scanAndPersist(ctx, lib, path)
+}
+
+// scanAndPersist scans path, stamps results with lib.ID and a default status,
+// upserts them, and invokes OnScanComplete.
+func (s *Scheduler) scanAndPersist(ctx context.Context, lib models.Library, path string) error {
+	results, err := s.Scanner.ScanLibrary(ctx, path, s.Options)
+	if err != nil {
+		return fmt.Errorf("scan: scan library %d: %w", lib.ID, err)
+	}
+	for i := range results {
+		results[i].LibraryID = lib.ID
+		if results[i].Status == "" {
+			results[i].Status = StatusPending
 		}
-		upsertOpts := UpsertOptions{ForceStatus: s.Options.Update || s.Options.Upgrade}
-		if err := s.Results.Upsert(ctx, v.ID, results, upsertOpts); err != nil {
-			return fmt.Errorf("scan: persist library %d: %w", v.ID, err)
-		}
-		if s.OnScanComplete != nil {
-			if err := s.OnScanComplete(ctx, v, results); err != nil {
-				return fmt.Errorf("scan: complete library %d: %w", v.ID, err)
-			}
+	}
+	upsertOpts := UpsertOptions{ForceStatus: s.Options.Update || s.Options.Upgrade}
+	if err := s.Results.Upsert(ctx, lib.ID, results, upsertOpts); err != nil {
+		return fmt.Errorf("scan: persist library %d: %w", lib.ID, err)
+	}
+	if s.OnScanComplete != nil {
+		if err := s.OnScanComplete(ctx, lib, results); err != nil {
+			return fmt.Errorf("scan: complete library %d: %w", lib.ID, err)
 		}
 	}
 	return nil

--- a/internal/scan/scheduler_test.go
+++ b/internal/scan/scheduler_test.go
@@ -95,6 +95,90 @@ func TestScheduler_RunOncePersistsAndCallsCallback(t *testing.T) {
 	}
 }
 
+type recordingScanner struct {
+	results []models.ScanResult
+	paths   []string
+}
+
+func (r *recordingScanner) ScanLibrary(_ context.Context, root string, _ scanner.ScanOptions) ([]models.ScanResult, error) {
+	r.paths = append(r.paths, root)
+	return r.results, nil
+}
+
+func TestScheduler_RunOnceForPathScansGivenSubtree(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	rec := &recordingScanner{results: []models.ScanResult{{
+		FilePath: "/music/Artist/Album/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+	}}}
+	var callbackLib models.Library
+	s := scan.Scheduler{
+		Results: store,
+		Scanner: rec,
+		OnScanComplete: func(_ context.Context, lib models.Library, _ []models.ScanResult) error {
+			callbackLib = lib
+			return nil
+		},
+	}
+	lib := models.Library{ID: 9, Path: "/music", Name: "Music"}
+
+	if err := s.RunOnceForPath(ctx, lib, "/music/Artist/Album"); err != nil {
+		t.Fatalf("RunOnceForPath: %v", err)
+	}
+	if len(rec.paths) != 1 || rec.paths[0] != "/music/Artist/Album" {
+		t.Fatalf("scanned paths = %v; want [/music/Artist/Album]", rec.paths)
+	}
+	if len(store.calls) != 1 || store.calls[0].libraryID != 9 {
+		t.Fatalf("Upsert calls = %+v; want one call for library 9", store.calls)
+	}
+	if store.calls[0].results[0].LibraryID != 9 || store.calls[0].results[0].Status != scan.StatusPending {
+		t.Errorf("result = %+v; want library 9, pending", store.calls[0].results[0])
+	}
+	if callbackLib.ID != 9 {
+		t.Errorf("callback lib ID = %d; want 9", callbackLib.ID)
+	}
+}
+
+func TestScheduler_RunOnceForPathRequiresDependencies(t *testing.T) {
+	ctx := context.Background()
+	s := scan.Scheduler{}
+	if err := s.RunOnceForPath(ctx, models.Library{ID: 1, Path: "/m"}, "/m/sub"); err == nil {
+		t.Fatal("RunOnceForPath with nil deps = nil error; want failure")
+	}
+}
+
+func TestScheduler_RunOnceForPathRejectsPathOutsideLibrary(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	rec := &recordingScanner{}
+	s := scan.Scheduler{Results: store, Scanner: rec}
+
+	err := s.RunOnceForPath(ctx, models.Library{ID: 1, Path: "/music"}, "/etc/passwd")
+	if err == nil {
+		t.Fatal("RunOnceForPath with path outside library root = nil error; want rejection")
+	}
+	if len(rec.paths) != 0 || len(store.calls) != 0 {
+		t.Fatalf("scanner/store were invoked (%v / %d calls); want none for a path outside the library", rec.paths, len(store.calls))
+	}
+}
+
+func TestScheduler_RunOnceForPathRejectsTraversal(t *testing.T) {
+	ctx := context.Background()
+	store := &fakeResults{}
+	rec := &recordingScanner{}
+	s := scan.Scheduler{Results: store, Scanner: rec}
+
+	// Lexically rooted at /music but uses ../ to climb out; must be rejected.
+	err := s.RunOnceForPath(ctx, models.Library{ID: 1, Path: "/music"}, "/music/../etc")
+	if err == nil {
+		t.Fatal("RunOnceForPath with ../ traversal = nil error; want rejection")
+	}
+	if len(rec.paths) != 0 || len(store.calls) != 0 {
+		t.Fatalf("scanner/store were invoked (%v / %d calls); want none for a traversal path", rec.paths, len(store.calls))
+	}
+}
+
 func TestScheduler_PassesForceStatusOnUpdateOrUpgrade(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,11 +8,16 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
+	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
 )
 
 const maxWebhookBody = 1 << 20 // 1 MiB
@@ -39,15 +44,41 @@ type StatusReporter interface {
 	CountByStatus(ctx context.Context) (map[string]int64, error)
 }
 
+// Inventory resolves webhook track metadata against persisted scan results so
+// webhooks can reuse the container-visible file paths discovered by scans.
+type Inventory interface {
+	FindByTrack(ctx context.Context, artist, title string) ([]models.ScanResult, error)
+}
+
+// defaultPathChecker reports whether path is usable inside the running
+// container. A nil error means the path exists as a regular file and can be
+// targeted directly. Directories are rejected because a .lrc target is derived
+// from a file path; a directory would produce an invalid synthetic destination.
+// Callers confine path to a configured library root before calling this (see
+// Handler.confinedPayloadPath), so it only ever stats operator-trusted roots.
+func defaultPathChecker(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path %q is a directory, not a file", path)
+	}
+	return nil
+}
+
 // Handler serves the HTTP API.
 type Handler struct {
-	auth     Authenticator
-	queue    WorkQueue
-	outdir   string
-	priority int
-	ready    Readiness
-	stats    StatusReporter
-	mux      *http.ServeMux
+	auth         Authenticator
+	queue        WorkQueue
+	outdir       string
+	priority     int
+	ready        Readiness
+	stats        StatusReporter
+	inventory    Inventory
+	allowedRoots []string
+	pathChecker  func(string) error
+	mux          *http.ServeMux
 }
 
 // Option configures optional Handler dependencies.
@@ -63,14 +94,47 @@ func WithStatusReporter(s StatusReporter) Option {
 	return func(h *Handler) { h.stats = s }
 }
 
+// WithInventory wires the scan-result inventory used to resolve webhook events
+// to container-visible file paths.
+func WithInventory(inv Inventory) Option {
+	return func(h *Handler) { h.inventory = inv }
+}
+
+// WithAllowedRoots confines raw webhook-provided payload paths to the configured
+// library roots. A trackFiles path is only used directly when it resolves
+// (lexically and through symlinks) to a location inside one of these roots;
+// anything else falls back to metadata. The roots are the operator-declared
+// source of truth, so this prevents an authenticated webhook from directing a
+// lyric write to an arbitrary location (path injection). With no roots
+// configured, raw payload paths are never trusted and resolution always falls
+// back to inventory or metadata. Roots are snapshotted at handler construction.
+func WithAllowedRoots(roots []string) Option {
+	return func(h *Handler) {
+		cleaned := make([]string, 0, len(roots))
+		for _, r := range roots {
+			if r = strings.TrimSpace(r); r != "" {
+				cleaned = append(cleaned, filepath.Clean(r))
+			}
+		}
+		h.allowedRoots = cleaned
+	}
+}
+
+// WithPathChecker overrides how the handler tests whether a webhook-provided
+// path is usable inside the container. Used in tests; production uses os.Stat.
+func WithPathChecker(check func(string) error) Option {
+	return func(h *Handler) { h.pathChecker = check }
+}
+
 // NewHandler creates an HTTP API handler.
 func NewHandler(a Authenticator, q WorkQueue, outdir string, opts ...Option) *Handler {
 	h := &Handler{
-		auth:     a,
-		queue:    q,
-		outdir:   outdir,
-		priority: queue.PriorityWebhook,
-		mux:      http.NewServeMux(),
+		auth:        a,
+		queue:       q,
+		outdir:      outdir,
+		priority:    queue.PriorityWebhook,
+		pathChecker: defaultPathChecker,
+		mux:         http.NewServeMux(),
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -195,7 +259,7 @@ func (h *Handler) handleLidarr(w http.ResponseWriter, r *http.Request) {
 	event := strings.TrimSpace(payload.EventType)
 	switch event {
 	case "Download", "TrackRetag":
-		inputs, err := h.inputs(payload)
+		inputs, err := h.resolveInputs(r.Context(), payload)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -213,7 +277,7 @@ func (h *Handler) handleLidarr(w http.ResponseWriter, r *http.Request) {
 	case "Rename":
 		slog.Info("lidarr rename received", "artist", payload.Artist.ArtistName, "album", payload.Album.Title)
 	case "Delete":
-		inputs, err := h.inputs(payload)
+		inputs, err := h.metadataInputs(payload)
 		if err != nil {
 			slog.Info("lidarr delete received without cleanup target", "artist", payload.Artist.ArtistName, "album", payload.Album.Title)
 			break
@@ -238,38 +302,209 @@ func (h *Handler) handleLidarr(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok\n"))
 }
 
-func (h *Handler) inputs(payload lidarrWebhook) ([]models.Inputs, error) {
-	artist := strings.TrimSpace(payload.Artist.ArtistName)
+// webhookTracks validates the payload and returns the artist, album, and the
+// list of track titles to process.
+func (h *Handler) webhookTracks(payload lidarrWebhook) (artist, album string, titles []string, err error) {
+	artist = strings.TrimSpace(payload.Artist.ArtistName)
 	if artist == "" {
-		return nil, fmt.Errorf("missing artist")
+		return "", "", nil, fmt.Errorf("missing artist")
 	}
-	album := strings.TrimSpace(payload.Album.Title)
+	album = strings.TrimSpace(payload.Album.Title)
 	tracks := payload.Tracks
 	if len(tracks) == 0 && payload.Track.Title != "" {
 		tracks = []lidarrTrack{payload.Track}
 	}
 	if len(tracks) == 0 {
-		return nil, fmt.Errorf("missing tracks")
+		return "", "", nil, fmt.Errorf("missing tracks")
 	}
-	inputs := make([]models.Inputs, 0, len(tracks))
+	titles = make([]string, 0, len(tracks))
 	for _, track := range tracks {
 		title := strings.TrimSpace(track.Title)
 		if title == "" {
-			return nil, fmt.Errorf("missing track title")
+			return "", "", nil, fmt.Errorf("missing track title")
 		}
-		inputs = append(inputs, models.Inputs{
-			Track: models.Track{
-				ArtistName: artist,
-				TrackName:  title,
-				AlbumName:  album,
-			},
-			Outdir: h.outdir,
-			OutputPaths: []models.OutputPath{{
-				Outdir: h.outdir,
-			}},
-		})
+		titles = append(titles, title)
+	}
+	return artist, album, titles, nil
+}
+
+// metadataInputs builds queue inputs from webhook metadata only, writing to the
+// configured output directory. This is the resolution fallback and the form
+// used for cleanup, which matches queue rows by normalized artist/title.
+func (h *Handler) metadataInputs(payload lidarrWebhook) ([]models.Inputs, error) {
+	artist, album, titles, err := h.webhookTracks(payload)
+	if err != nil {
+		return nil, err
+	}
+	inputs := make([]models.Inputs, 0, len(titles))
+	for _, title := range titles {
+		inputs = append(inputs, h.metadataInput(artist, title, album))
 	}
 	return inputs, nil
+}
+
+func (h *Handler) metadataInput(artist, title, album string) models.Inputs {
+	return models.Inputs{
+		Track: models.Track{
+			ArtistName: artist,
+			TrackName:  title,
+			AlbumName:  album,
+		},
+		Outdir: h.outdir,
+		OutputPaths: []models.OutputPath{{
+			Outdir: h.outdir,
+		}},
+	}
+}
+
+// resolveInputs builds queue inputs for ingestion events, resolving each track
+// through the scanned library inventory first, then a directly usable payload
+// path, then metadata. The configured library scans are the source of truth for
+// container-visible filesystem paths, so inventory matches reuse the exact
+// Outdir, Filename, and OutputPaths recorded by the scheduler, with SourcePath
+// taken from the scan result's FilePath via scan.ResultInputs.
+func (h *Handler) resolveInputs(ctx context.Context, payload lidarrWebhook) ([]models.Inputs, error) {
+	artist, album, titles, err := h.webhookTracks(payload)
+	if err != nil {
+		return nil, err
+	}
+	paths := payload.payloadPaths()
+	single := len(titles) == 1
+	inputs := make([]models.Inputs, 0, len(titles))
+	for _, title := range titles {
+		inputs = append(inputs, h.resolveTrack(ctx, artist, title, album, paths, single))
+	}
+	return inputs, nil
+}
+
+// resolveTrack resolves a single track to queue inputs. Inventory matches win;
+// then a payload path that is usable inside the container; then metadata.
+func (h *Handler) resolveTrack(ctx context.Context, artist, title, album string, paths []string, single bool) models.Inputs {
+	if h.inventory != nil {
+		results, err := h.inventory.FindByTrack(ctx, artist, title)
+		if err != nil {
+			// Inventory lookup failure must not hard-fail the webhook; fall back.
+			slog.Warn("inventory lookup failed; falling back", "artist", artist, "title", title, "error", err)
+		} else if best, ok := pickByAlbum(results, album); ok {
+			in, err := scan.ResultInputs(best)
+			if err == nil {
+				return in
+			}
+			// Mirror the inventory-lookup-failure branch above: log and fall
+			// through rather than silently dropping the conversion error.
+			slog.Warn("inventory match could not be converted to inputs; falling back", "artist", artist, "title", title, "error", err)
+		}
+	}
+	if path := h.usablePath(paths, title, single); path != "" {
+		return pathInput(artist, title, album, path)
+	}
+	return h.metadataInput(artist, title, album)
+}
+
+// pickByAlbum chooses the best scan result for a track. When the album hint is
+// present it prefers a result whose file path matches the album; otherwise it
+// returns the first result (FindByTrack orders non-terminal rows first).
+func pickByAlbum(results []models.ScanResult, album string) (models.ScanResult, bool) {
+	if len(results) == 0 {
+		return models.ScanResult{}, false
+	}
+	if albumKey := normalize.NormalizeKey(album); albumKey != "" {
+		for _, res := range results {
+			if strings.Contains(normalize.NormalizeKey(res.FilePath), albumKey) {
+				return res, true
+			}
+		}
+	}
+	return results[0], true
+}
+
+// usablePath returns a payload path that exists inside the container for the
+// given track, or "" when none applies. With a single track and a single path
+// they are paired directly; otherwise a path is matched by basename to the
+// track title so multi-track payloads target the right file.
+func (h *Handler) usablePath(paths []string, title string, single bool) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	if single && len(paths) == 1 {
+		if safe, ok := h.confinedPayloadPath(paths[0]); ok && h.pathExists(safe) {
+			return safe
+		}
+		return ""
+	}
+	titleKey := normalize.NormalizeKey(title)
+	for _, path := range paths {
+		safe, ok := h.confinedPayloadPath(path)
+		if !ok {
+			continue
+		}
+		base := strings.TrimSuffix(filepath.Base(safe), filepath.Ext(safe))
+		if titleKey != "" && strings.Contains(normalize.NormalizeKey(base), titleKey) && h.pathExists(safe) {
+			return safe
+		}
+	}
+	return ""
+}
+
+// confinedPayloadPath returns a raw webhook payload path only when it resolves
+// to a location inside a configured library root, and returns that fully
+// resolved (symlink-free) path so the value validated here is the exact value
+// later stat-ed and written to. Confinement provides lexical + symlink
+// containment against the operator-declared roots, which blocks an authenticated
+// webhook from steering a lyric write outside them (path-injection guard). It
+// returns ok=false when no roots are configured, the path lies outside every
+// root, a symlink escapes its root, or the path does not exist (fail closed).
+//
+// Containment is enforced lexically and via EvalSymlinks at request time; the
+// residual write-time symlink-swap TOCTOU (a path component swapped for a
+// symlink before the worker writes) is not closed here and is tracked in #102
+// for the writing layer.
+func (h *Handler) confinedPayloadPath(path string) (string, bool) {
+	for _, root := range h.allowedRoots {
+		if resolved, ok := pathutil.ResolveWithinRoot(root, path); ok {
+			return resolved, true
+		}
+	}
+	if len(h.allowedRoots) > 0 {
+		// Observability for a misconfiguration or an injection attempt: a payload
+		// path was supplied but matched no configured root after resolution.
+		slog.Info("webhook payload path rejected by library-root confinement; falling back", "path", path)
+	}
+	return "", false
+}
+
+func (h *Handler) pathExists(path string) bool {
+	check := h.pathChecker
+	if check == nil {
+		check = defaultPathChecker
+	}
+	if err := check(path); err != nil {
+		slog.Info("webhook payload path not usable inside container; falling back", "path", path, "error", err)
+		return false
+	}
+	return true
+}
+
+// pathInput builds queue inputs that write the .lrc next to a directly usable
+// audio file path, mirroring how scan-created work derives its destination.
+func pathInput(artist, title, album, path string) models.Inputs {
+	outdir := filepath.Dir(path)
+	base := filepath.Base(path)
+	filename := strings.TrimSuffix(base, filepath.Ext(base)) + ".lrc"
+	return models.Inputs{
+		Track: models.Track{
+			ArtistName: artist,
+			TrackName:  title,
+			AlbumName:  album,
+		},
+		Outdir:     outdir,
+		Filename:   filename,
+		SourcePath: path,
+		OutputPaths: []models.OutputPath{{
+			Outdir:   outdir,
+			Filename: filename,
+		}},
+	}
 }
 
 func apiKey(r *http.Request) string {
@@ -309,11 +544,27 @@ func (r *statusRecorder) WriteHeader(status int) {
 }
 
 type lidarrWebhook struct {
-	EventType string        `json:"eventType"`
-	Artist    lidarrArtist  `json:"artist"`
-	Album     lidarrAlbum   `json:"album"`
-	Track     lidarrTrack   `json:"track"`
-	Tracks    []lidarrTrack `json:"tracks"`
+	EventType  string            `json:"eventType"`
+	Artist     lidarrArtist      `json:"artist"`
+	Album      lidarrAlbum       `json:"album"`
+	Track      lidarrTrack       `json:"track"`
+	Tracks     []lidarrTrack     `json:"tracks"`
+	TrackFiles []lidarrTrackFile `json:"trackFiles"`
+}
+
+type lidarrTrackFile struct {
+	Path string `json:"path"`
+}
+
+// payloadPaths returns the non-empty trackFile paths carried by the webhook.
+func (p lidarrWebhook) payloadPaths() []string {
+	paths := make([]string, 0, len(p.TrackFiles))
+	for _, tf := range p.TrackFiles {
+		if path := strings.TrimSpace(tf.Path); path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
 }
 
 type lidarrArtist struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -225,6 +228,351 @@ func TestLidarrWebhookAuthAndEnqueueErrors(t *testing.T) {
 			t.Fatalf("status = %d; want %d", rec.Code, http.StatusInternalServerError)
 		}
 	})
+}
+
+type fakeInventory struct {
+	results []models.ScanResult
+	err     error
+	artist  string
+	title   string
+}
+
+func (f *fakeInventory) FindByTrack(_ context.Context, artist, title string) ([]models.ScanResult, error) {
+	f.artist = artist
+	f.title = title
+	return f.results, f.err
+}
+
+const downloadBody = `{"eventType":"Download","artist":{"artistName":"Artist"},"album":{"title":"Album"},"tracks":[{"title":"Song"}]}`
+
+func postWebhook(t *testing.T, h *Handler, body string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/lidarr?apikey=key", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("webhook status = %d; want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+}
+
+// postDownloadWithPaths posts a Download webhook with the given track titles and
+// trackFiles paths, JSON-encoding the body so real filesystem paths (which may
+// contain characters needing escaping) are transmitted safely.
+func postDownloadWithPaths(t *testing.T, h *Handler, titles, paths []string) {
+	t.Helper()
+	tracks := make([]map[string]string, len(titles))
+	for i, title := range titles {
+		tracks[i] = map[string]string{"title": title}
+	}
+	trackFiles := make([]map[string]string, len(paths))
+	for i, p := range paths {
+		trackFiles[i] = map[string]string{"path": p}
+	}
+	body, err := json.Marshal(map[string]any{
+		"eventType":  "Download",
+		"artist":     map[string]string{"artistName": "Artist"},
+		"album":      map[string]string{"title": "Album"},
+		"tracks":     tracks,
+		"trackFiles": trackFiles,
+	})
+	if err != nil {
+		t.Fatalf("marshal webhook body: %v", err)
+	}
+	postWebhook(t, h, string(body))
+}
+
+func TestLidarrWebhookResolvesThroughInventory(t *testing.T) {
+	q := &fakeQueue{}
+	inv := &fakeInventory{results: []models.ScanResult{{
+		ID:       7,
+		FilePath: "/music/Artist/Album/song.flac",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+		Outdir:   "/music/Artist/Album",
+		Filename: "song.lrc",
+		Status:   "pending",
+	}}}
+	h := NewHandler(&fakeAuth{}, q, "lyrics", WithInventory(inv))
+	postWebhook(t, h, downloadBody)
+
+	if inv.artist != "Artist" || inv.title != "Song" {
+		t.Fatalf("FindByTrack args = %q/%q; want Artist/Song", inv.artist, inv.title)
+	}
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	if got.SourcePath != "/music/Artist/Album/song.flac" {
+		t.Errorf("SourcePath = %q; want the inventory file path", got.SourcePath)
+	}
+	if got.Outdir != "/music/Artist/Album" || got.Filename != "song.lrc" {
+		t.Errorf("output = %q/%q; want inventory outdir/filename", got.Outdir, got.Filename)
+	}
+	if got.ScanResultID != 7 {
+		t.Errorf("ScanResultID = %d; want 7 (linked to scan result)", got.ScanResultID)
+	}
+	if len(got.OutputPaths) != 1 || got.OutputPaths[0].Outdir != "/music/Artist/Album" {
+		t.Errorf("OutputPaths = %+v; want single inventory destination", got.OutputPaths)
+	}
+}
+
+func TestLidarrWebhookUsesDirectPayloadPath(t *testing.T) {
+	root := t.TempDir()
+	artistDir := filepath.Join(root, "Artist")
+	if err := os.MkdirAll(artistDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(artistDir, "song.flac")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{root}),
+	)
+	postDownloadWithPaths(t, h, []string{"Song"}, []string{file})
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	// The handler must carry the resolved (symlink-free) path forward so the
+	// checked path and the written path are identical.
+	if got.SourcePath != resolved {
+		t.Errorf("SourcePath = %q; want the resolved payload path %q", got.SourcePath, resolved)
+	}
+	if got.Outdir != filepath.Dir(resolved) || got.Filename != "song.lrc" {
+		t.Errorf("output = %q/%q; want resolved path-derived destination", got.Outdir, got.Filename)
+	}
+}
+
+func TestLidarrWebhookFallsBackWhenPayloadPathUnusable(t *testing.T) {
+	// The path is within a configured root but does not exist, so resolution
+	// fails and the handler falls back to metadata rather than targeting it.
+	root := t.TempDir()
+	missing := filepath.Join(root, "Artist", "song.flac")
+
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{root}),
+	)
+	postDownloadWithPaths(t, h, []string{"Song"}, []string{missing})
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	if got.SourcePath != "" {
+		t.Errorf("SourcePath = %q; want empty (unusable path must not be used)", got.SourcePath)
+	}
+	if got.Outdir != "lyrics" {
+		t.Errorf("Outdir = %q; want metadata fallback to configured outdir", got.Outdir)
+	}
+}
+
+func TestLidarrWebhookRejectsSymlinkEscape(t *testing.T) {
+	// A symlink that lives inside a configured root but points outside it passes
+	// the lexical check yet must be rejected once symlinks are resolved, so the
+	// .lrc write cannot be steered out of the root. (Fails before the symlink
+	// hardening, passes after.)
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.flac")
+	if err := os.WriteFile(secret, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	link := filepath.Join(root, "song.flac")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{root}),
+	)
+	postDownloadWithPaths(t, h, []string{"Song"}, []string{link})
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	if got.SourcePath != "" {
+		t.Errorf("SourcePath = %q; want empty (symlink escaping the root must be rejected)", got.SourcePath)
+	}
+	if got.Outdir != "lyrics" {
+		t.Errorf("Outdir = %q; want metadata fallback, not the symlink target's directory", got.Outdir)
+	}
+}
+
+func TestLidarrWebhookMultiTrackPayloadPathConfinement(t *testing.T) {
+	// Two tracks: one payload path inside the root (usable) and one outside it
+	// (rejected). Confinement must be applied per path within the multi-track
+	// loop, not just to the first.
+	root := t.TempDir()
+	inRoot := filepath.Join(root, "SongOne.flac")
+	if err := os.WriteFile(inRoot, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write in-root file: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(inRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "SongTwo.flac")
+
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{root}),
+	)
+	postDownloadWithPaths(t, h, []string{"SongOne", "SongTwo"}, []string{inRoot, outside})
+
+	if len(q.items) != 2 {
+		t.Fatalf("enqueued %d items; want 2", len(q.items))
+	}
+	if q.items[0].SourcePath != resolved {
+		t.Errorf("SongOne SourcePath = %q; want the resolved in-root path %q", q.items[0].SourcePath, resolved)
+	}
+	if q.items[1].SourcePath != "" || q.items[1].Outdir != "lyrics" {
+		t.Errorf("SongTwo = %q/%q; want metadata fallback (path outside root)", q.items[1].SourcePath, q.items[1].Outdir)
+	}
+}
+
+func TestPickByAlbumDisambiguatesByAlbum(t *testing.T) {
+	results := []models.ScanResult{
+		{ID: 1, FilePath: "/music/Artist/Greatest Hits/song.flac"},
+		{ID: 2, FilePath: "/music/Artist/Live Album/song.flac"},
+	}
+	got, ok := pickByAlbum(results, "Live Album")
+	if !ok || got.ID != 2 {
+		t.Errorf("pickByAlbum(Live Album) = %+v, ok=%v; want ID 2", got, ok)
+	}
+	// No album hint falls back to the first result (FindByTrack's ordering).
+	got, ok = pickByAlbum(results, "")
+	if !ok || got.ID != 1 {
+		t.Errorf("pickByAlbum(empty) = %+v, ok=%v; want first result ID 1", got, ok)
+	}
+	// An album hint that matches nothing also falls back to the first result.
+	got, ok = pickByAlbum(results, "Nonexistent Album")
+	if !ok || got.ID != 1 {
+		t.Errorf("pickByAlbum(no match) = %+v, ok=%v; want first result ID 1", got, ok)
+	}
+	if _, ok := pickByAlbum(nil, "x"); ok {
+		t.Error("pickByAlbum(nil) ok = true; want false")
+	}
+}
+
+func TestLidarrWebhookRejectsPayloadPathOutsideRoots(t *testing.T) {
+	// A payload path that "exists" (checker always succeeds) but lies outside
+	// every configured library root must NOT be used as a write target; it falls
+	// back to metadata. This is the path-injection guard for alert #14.
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{"/media/music"}),
+		WithPathChecker(func(string) error { return nil }), // pretend everything exists
+	)
+	body := `{"eventType":"Download","artist":{"artistName":"Artist"},"tracks":[{"title":"Song"}],"trackFiles":[{"path":"/etc/cron.d/evil"}]}`
+	postWebhook(t, h, body)
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	if got.SourcePath != "" {
+		t.Errorf("SourcePath = %q; want empty (path outside library roots must be rejected)", got.SourcePath)
+	}
+	if got.Outdir != "lyrics" {
+		t.Errorf("Outdir = %q; want metadata fallback, not the attacker-chosen directory", got.Outdir)
+	}
+}
+
+func TestLidarrWebhookRejectsTraversalOutOfRoot(t *testing.T) {
+	// A traversal payload path that resolves outside the root after cleaning is
+	// rejected even though its textual prefix matches the root.
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithAllowedRoots([]string{"/media/music"}),
+		WithPathChecker(func(string) error { return nil }),
+	)
+	body := `{"eventType":"Download","artist":{"artistName":"Artist"},"tracks":[{"title":"Song"}],"trackFiles":[{"path":"/media/music/../../etc/evil.mp3"}]}`
+	postWebhook(t, h, body)
+
+	got := q.items[0]
+	if got.SourcePath != "" || got.Outdir != "lyrics" {
+		t.Errorf("got %q/%q; want metadata fallback (traversal escaped the root)", got.SourcePath, got.Outdir)
+	}
+}
+
+func TestLidarrWebhookPayloadPathDisabledWithoutRoots(t *testing.T) {
+	// With no configured roots there is no trusted base to confine against, so
+	// raw payload paths are never used regardless of whether they "exist".
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics",
+		WithInventory(&fakeInventory{}),
+		WithPathChecker(func(string) error { return nil }),
+	)
+	body := `{"eventType":"Download","artist":{"artistName":"Artist"},"tracks":[{"title":"Song"}],"trackFiles":[{"path":"/media/music/Artist/song.mp3"}]}`
+	postWebhook(t, h, body)
+
+	got := q.items[0]
+	if got.SourcePath != "" || got.Outdir != "lyrics" {
+		t.Errorf("got %q/%q; want metadata fallback when no roots are configured", got.SourcePath, got.Outdir)
+	}
+}
+
+func TestDefaultPathCheckerRejectsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := defaultPathChecker(dir); err == nil {
+		t.Error("defaultPathChecker(dir) = nil; want error (directories are not valid targets)")
+	}
+	file := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := defaultPathChecker(file); err != nil {
+		t.Errorf("defaultPathChecker(file) = %v; want nil for a regular file", err)
+	}
+	if err := defaultPathChecker(filepath.Join(dir, "missing.flac")); err == nil {
+		t.Error("defaultPathChecker(missing) = nil; want error for a nonexistent path")
+	}
+}
+
+func TestLidarrWebhookFallsBackToMetadata(t *testing.T) {
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics", WithInventory(&fakeInventory{}))
+	postWebhook(t, h, downloadBody)
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1", len(q.items))
+	}
+	got := q.items[0]
+	if got.SourcePath != "" || got.Outdir != "lyrics" {
+		t.Errorf("got %q/%q; want empty source and configured outdir fallback", got.SourcePath, got.Outdir)
+	}
+	if got.Track.AlbumName != "Album" {
+		t.Errorf("AlbumName = %q; want Album carried through metadata fallback", got.Track.AlbumName)
+	}
+}
+
+func TestLidarrWebhookInventoryErrorDoesNotHardFail(t *testing.T) {
+	q := &fakeQueue{}
+	h := NewHandler(&fakeAuth{}, q, "lyrics", WithInventory(&fakeInventory{err: errors.New("inventory db down")}))
+	postWebhook(t, h, downloadBody)
+
+	if len(q.items) != 1 {
+		t.Fatalf("enqueued %d items; want 1 (inventory error must fall back, not fail)", len(q.items))
+	}
+	if q.items[0].Outdir != "lyrics" {
+		t.Errorf("Outdir = %q; want metadata fallback after inventory error", q.items[0].Outdir)
+	}
 }
 
 type fakeReadiness struct{ err error }

--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -1,0 +1,80 @@
+// Package watcher provides an optional filesystem watcher that triggers
+// targeted library scans when files change under configured library roots. It
+// complements, and never replaces, the periodic scheduler: bind mounts, NFS,
+// SMB, and Docker Desktop on macOS frequently drop or never emit events, and
+// events that fire while the process is down are lost. The periodic scan
+// remains the source of truth; the watcher only lowers latency for the common
+// single-host case.
+//
+// Event delivery is also best-effort under load: raw filesystem events are read
+// into a fixed-size buffered channel (see eventBuffer). During a large burst
+// (for example a bulk import or a tagger rewriting an entire library at once)
+// the underlying notify library drops events it cannot enqueue rather than
+// blocking. Dropped events are not replayed; the periodic scheduler reconciles
+// whatever the watcher missed on its next tick. Treat the watcher as a latency
+// optimization, never as a guarantee that every change is observed.
+package watcher
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// EnvEnabled is the master switch for the watcher. Default off.
+	EnvEnabled = "MXLRCGO_WATCH_ENABLED"
+	// EnvDebounceMS coalesces event storms (taggers rewrite albums in bursts).
+	EnvDebounceMS = "MXLRCGO_WATCH_DEBOUNCE_MS"
+	// EnvMaxDirs is a safety cap so a misconfigured root fails fast instead of
+	// silently exhausting the kernel inotify watch budget.
+	EnvMaxDirs = "MXLRCGO_WATCH_MAX_DIRS"
+
+	defaultDebounceMS = 2000
+	defaultMaxDirs    = 100000
+)
+
+// Config holds watcher tuning resolved from the environment. Debounce and
+// MaxDirs must be positive; New clamps any non-positive value to the package
+// default (a zero Debounce would disable coalescing, and a non-positive MaxDirs
+// would reject every root).
+type Config struct {
+	// Enabled reports whether the watcher should run at all.
+	Enabled bool
+	// Debounce is the quiet period after the last event before a scan fires.
+	// Must be positive; New clamps <= 0 to the default.
+	Debounce time.Duration
+	// MaxDirs caps how many directories may be watched before startup fails.
+	// Must be positive; New clamps <= 0 to the default.
+	MaxDirs int
+}
+
+// ConfigFromEnv builds a Config from the MXLRCGO_WATCH_* environment variables,
+// falling back to defaults and logging a warning when a value is invalid.
+func ConfigFromEnv() Config {
+	return Config{
+		Enabled:  envBool(EnvEnabled),
+		Debounce: time.Duration(envInt(EnvDebounceMS, defaultDebounceMS)) * time.Millisecond,
+		MaxDirs:  envInt(EnvMaxDirs, defaultMaxDirs),
+	}
+}
+
+func envBool(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	return strings.EqualFold(v, "true") || v == "1"
+}
+
+func envInt(name string, fallback int) int {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		slog.Warn("env var is invalid; using default", "var", name, "value", v, "default", fallback) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); slog escapes values
+		return fallback
+	}
+	return n
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,265 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rjeczalik/notify"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
+)
+
+// LibraryLister lists configured library roots.
+type LibraryLister interface {
+	List(ctx context.Context) ([]models.Library, error)
+}
+
+// ScanFunc performs a targeted scan of path on behalf of lib.
+type ScanFunc func(ctx context.Context, lib models.Library, path string) error
+
+// Watcher watches configured library roots and triggers targeted scans.
+type Watcher struct {
+	cfg       Config
+	libraries LibraryLister
+	scan      ScanFunc
+}
+
+// New creates a Watcher. scan is invoked (after debouncing) with the owning
+// library and the directory that changed. Non-positive Debounce or MaxDirs are
+// clamped to the package defaults: a zero Debounce would disable debouncing
+// (scan on every raw event), and a non-positive MaxDirs would reject all roots.
+func New(cfg Config, libraries LibraryLister, scan ScanFunc) *Watcher {
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = defaultDebounceMS * time.Millisecond
+	}
+	if cfg.MaxDirs <= 0 {
+		cfg.MaxDirs = defaultMaxDirs
+	}
+	return &Watcher{cfg: cfg, libraries: libraries, scan: scan}
+}
+
+// libEvent is a debounced, library-resolved scan request.
+type libEvent struct {
+	lib  models.Library
+	path string
+}
+
+// Run registers recursive watches for every configured library root and
+// dispatches debounced scans until ctx is canceled. It fails fast if the watch
+// budget would be exceeded rather than silently truncating coverage.
+func (w *Watcher) Run(ctx context.Context) error {
+	libs, err := w.libraries.List(ctx)
+	if err != nil {
+		return fmt.Errorf("watcher: list libraries: %w", err)
+	}
+	if len(libs) == 0 {
+		slog.Info("watcher: no libraries configured; nothing to watch")
+		return nil
+	}
+
+	// Overlapping roots (e.g. /music and /music/classical) would otherwise be
+	// counted and watched twice, inflating the dir count toward MaxDirs and
+	// delivering duplicate events. Watch only the top-level roots; the full
+	// libs slice is still used for ownership resolution in eventTarget.
+	watched := dedupeRoots(libs)
+
+	dirs, err := countDirs(watched)
+	if err != nil {
+		return err
+	}
+	if dirs > w.cfg.MaxDirs {
+		return fmt.Errorf("watcher: %d directories under configured roots exceed %s=%d; raise the limit or narrow the roots", dirs, EnvMaxDirs, w.cfg.MaxDirs)
+	}
+
+	c := make(chan notify.EventInfo, eventBuffer)
+	for _, lib := range watched {
+		// "<root>/..." asks notify for a recursive watch over the subtree,
+		// which also covers directories created after registration.
+		if err := notify.Watch(filepath.Join(lib.Path, "..."), c, notify.Create, notify.Write, notify.Rename, notify.Remove); err != nil {
+			notify.Stop(c)
+			return fmt.Errorf("watcher: watch %s: %w", lib.Path, err)
+		}
+	}
+	defer notify.Stop(c)
+	slog.Info("watcher started", "libraries", len(watched), "directories", dirs, "debounce", w.cfg.Debounce)
+
+	events := make(chan libEvent)
+	go w.translate(ctx, c, libs, events)
+	w.dispatch(ctx, events)
+	return ctx.Err()
+}
+
+const eventBuffer = 1024
+
+// translate maps raw filesystem events to library-resolved scan targets and
+// forwards them until ctx is canceled.
+func (w *Watcher) translate(ctx context.Context, c <-chan notify.EventInfo, libs []models.Library, out chan<- libEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ei := <-c:
+			lib, dir, ok := eventTarget(libs, ei.Path())
+			if !ok {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- libEvent{lib: lib, path: dir}:
+			}
+		}
+	}
+}
+
+// dispatch debounces incoming events with a per-directory quiet period and runs
+// a scan once a directory has been idle for the debounce window. Each directory
+// keeps its own timer, so a burst on one directory (a tagger rewriting an album)
+// coalesces into a single scan without delaying scans of unrelated directories.
+func (w *Watcher) dispatch(ctx context.Context, events <-chan libEvent) {
+	type pending struct {
+		lib   models.Library
+		timer *time.Timer
+	}
+	timers := make(map[string]*pending)
+	fired := make(chan string, eventBuffer)
+
+	// Stop any in-flight timers when the loop exits so no goroutine outlives ctx.
+	defer func() {
+		for _, p := range timers {
+			p.timer.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-events:
+			if p, ok := timers[ev.path]; ok {
+				p.lib = ev.lib
+				p.timer.Stop()
+				p.timer.Reset(w.cfg.Debounce)
+				continue
+			}
+			path := ev.path
+			timers[path] = &pending{
+				lib: ev.lib,
+				timer: time.AfterFunc(w.cfg.Debounce, func() {
+					select {
+					case fired <- path:
+					case <-ctx.Done():
+					}
+				}),
+			}
+		case path := <-fired:
+			p, ok := timers[path]
+			if !ok {
+				continue
+			}
+			delete(timers, path)
+			if err := w.scan(ctx, p.lib, path); err != nil {
+				slog.Warn("watcher scan failed", "path", path, "library", p.lib.ID, "error", err)
+			}
+		}
+	}
+}
+
+// eventTarget returns the library that owns path and the directory to scan. A
+// file event scans the file's directory; a directory event scans that
+// directory. When path no longer exists (delete/rename), its parent directory
+// is rescanned to pick up sibling adds/changes; stale rows are not deleted here
+// (the upsert never removes rows; the periodic scheduler reconciles deletions).
+// ok is false when no configured library contains path.
+func eventTarget(libs []models.Library, path string) (models.Library, string, bool) {
+	var best models.Library
+	found := false
+	for _, lib := range libs {
+		if pathutil.WithinRoot(lib.Path, path) && (!found || len(lib.Path) > len(best.Path)) {
+			best = lib
+			found = true
+		}
+	}
+	if !found {
+		return models.Library{}, "", false
+	}
+	dir := path
+	if info, err := os.Stat(path); err != nil {
+		// A missing path is the expected case for delete/rename events; only
+		// unexpected stat errors (permissions, I/O) are worth surfacing.
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("watcher: stat event path failed; scanning parent directory", "path", path, "error", err)
+		}
+		dir = filepath.Dir(path)
+	} else if !info.IsDir() {
+		dir = filepath.Dir(path)
+	}
+	// When path is the library root itself and no longer exists (a deleted or
+	// renamed root), filepath.Dir walks above the root. Clamp back to the owning
+	// library so a scan target never escapes the library it belongs to.
+	if !pathutil.WithinRoot(best.Path, dir) {
+		dir = best.Path
+	}
+	return best, dir, true
+}
+
+// dedupeRoots returns the libraries whose paths are not nested within another
+// library's path, so overlapping roots (e.g. /music and /music/classical) are
+// neither counted nor watched twice. Identical paths keep their first
+// occurrence. The original libs slice is left intact for ownership resolution.
+func dedupeRoots(libs []models.Library) []models.Library {
+	kept := make([]models.Library, 0, len(libs))
+	for i, lib := range libs {
+		nested := false
+		for j, other := range libs {
+			if i == j {
+				continue
+			}
+			// For identical paths, suppress only the later occurrence so exactly
+			// one copy survives.
+			if filepath.Clean(other.Path) == filepath.Clean(lib.Path) {
+				if j < i {
+					nested = true
+					break
+				}
+				continue
+			}
+			if pathutil.WithinRoot(other.Path, lib.Path) {
+				nested = true
+				break
+			}
+		}
+		if !nested {
+			kept = append(kept, lib)
+		}
+	}
+	return kept
+}
+
+// countDirs returns the number of directories under the library roots, used to
+// enforce the watch budget before any watches are registered.
+func countDirs(libs []models.Library) (int, error) {
+	total := 0
+	for _, lib := range libs {
+		err := filepath.WalkDir(lib.Path, func(_ string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				total++
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, fmt.Errorf("watcher: count directories under %s: %w", lib.Path, err)
+		}
+	}
+	return total, nil
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,357 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+type fakeLister struct {
+	libs []models.Library
+	err  error
+}
+
+func (f fakeLister) List(context.Context) ([]models.Library, error) {
+	return f.libs, f.err
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		t.Setenv(EnvEnabled, "")
+		t.Setenv(EnvDebounceMS, "")
+		t.Setenv(EnvMaxDirs, "")
+		cfg := ConfigFromEnv()
+		if cfg.Enabled {
+			t.Error("Enabled = true; want false by default")
+		}
+		if cfg.Debounce != defaultDebounceMS*time.Millisecond {
+			t.Errorf("Debounce = %s; want %dms", cfg.Debounce, defaultDebounceMS)
+		}
+		if cfg.MaxDirs != defaultMaxDirs {
+			t.Errorf("MaxDirs = %d; want %d", cfg.MaxDirs, defaultMaxDirs)
+		}
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		t.Setenv(EnvEnabled, "true")
+		t.Setenv(EnvDebounceMS, "500")
+		t.Setenv(EnvMaxDirs, "42")
+		cfg := ConfigFromEnv()
+		if !cfg.Enabled {
+			t.Error("Enabled = false; want true")
+		}
+		if cfg.Debounce != 500*time.Millisecond {
+			t.Errorf("Debounce = %s; want 500ms", cfg.Debounce)
+		}
+		if cfg.MaxDirs != 42 {
+			t.Errorf("MaxDirs = %d; want 42", cfg.MaxDirs)
+		}
+	})
+
+	t.Run("invalid falls back", func(t *testing.T) {
+		t.Setenv(EnvDebounceMS, "notanumber")
+		t.Setenv(EnvMaxDirs, "-5")
+		cfg := ConfigFromEnv()
+		if cfg.Debounce != defaultDebounceMS*time.Millisecond {
+			t.Errorf("Debounce = %s; want default after invalid", cfg.Debounce)
+		}
+		if cfg.MaxDirs != defaultMaxDirs {
+			t.Errorf("MaxDirs = %d; want default after invalid", cfg.MaxDirs)
+		}
+	})
+}
+
+func TestEventTargetResolvesOwningLibrary(t *testing.T) {
+	libs := []models.Library{
+		{ID: 1, Path: "/music"},
+		{ID: 2, Path: "/music/classical"}, // nested, more specific
+	}
+
+	// A file under the nested library resolves to the most specific root, and
+	// the scan target is the file's directory.
+	lib, dir, ok := eventTarget(libs, "/music/classical/Bach/aria.flac")
+	if !ok {
+		t.Fatal("eventTarget ok = false; want true")
+	}
+	if lib.ID != 2 {
+		t.Errorf("lib ID = %d; want 2 (most specific root)", lib.ID)
+	}
+	if dir != "/music/classical/Bach" {
+		t.Errorf("dir = %q; want the file's directory", dir)
+	}
+
+	// A path outside every library is not a target.
+	if _, _, ok := eventTarget(libs, "/somewhere/else/x.mp3"); ok {
+		t.Error("eventTarget for outside path ok = true; want false")
+	}
+}
+
+func TestEventTargetClampsDeletedRootToLibrary(t *testing.T) {
+	// The library root itself no longer exists (deleted/renamed). filepath.Dir
+	// would walk above the root, so eventTarget must clamp the scan target back
+	// to the owning library rather than scanning its parent.
+	libs := []models.Library{{ID: 1, Path: "/music/library"}}
+	lib, dir, ok := eventTarget(libs, "/music/library")
+	if !ok {
+		t.Fatal("eventTarget ok = false; want true")
+	}
+	if lib.ID != 1 {
+		t.Errorf("lib ID = %d; want 1", lib.ID)
+	}
+	if dir != "/music/library" {
+		t.Errorf("dir = %q; want the library root (clamped, not its parent)", dir)
+	}
+}
+
+func TestDedupeRoots(t *testing.T) {
+	t.Run("drops nested roots", func(t *testing.T) {
+		libs := []models.Library{
+			{ID: 1, Path: "/music"},
+			{ID: 2, Path: "/music/classical"}, // nested under /music
+			{ID: 3, Path: "/other"},
+		}
+		got := dedupeRoots(libs)
+		if len(got) != 2 {
+			t.Fatalf("dedupeRoots len = %d; want 2", len(got))
+		}
+		ids := map[int64]bool{got[0].ID: true, got[1].ID: true}
+		if !ids[1] || !ids[3] || ids[2] {
+			t.Errorf("kept IDs = %v; want top-level roots 1 and 3 only", ids)
+		}
+	})
+
+	t.Run("keeps one of identical paths", func(t *testing.T) {
+		libs := []models.Library{
+			{ID: 1, Path: "/music"},
+			{ID: 2, Path: "/music"},
+		}
+		got := dedupeRoots(libs)
+		if len(got) != 1 || got[0].ID != 1 {
+			t.Errorf("dedupeRoots = %+v; want a single entry keeping the first occurrence", got)
+		}
+	})
+}
+
+func TestEventTargetClampsDeletedNestedRoot(t *testing.T) {
+	libs := []models.Library{
+		{ID: 1, Path: "/music"},
+		{ID: 2, Path: "/music/classical"},
+	}
+	// The nested root itself is the event path and no longer exists. The target
+	// must clamp to the nested root (ID 2), not walk up into the broader /music
+	// library, which would scan far more than the event warranted.
+	lib, dir, ok := eventTarget(libs, "/music/classical")
+	if !ok {
+		t.Fatal("eventTarget ok = false; want true")
+	}
+	if lib.ID != 2 {
+		t.Errorf("lib ID = %d; want 2 (most specific root)", lib.ID)
+	}
+	if dir != "/music/classical" {
+		t.Errorf("dir = %q; want /music/classical (clamped, not parent /music)", dir)
+	}
+}
+
+func TestCountDirs(t *testing.T) {
+	root := t.TempDir()
+	for _, sub := range []string{"a", "a/b", "c"} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	n, err := countDirs([]models.Library{{Path: root}})
+	if err != nil {
+		t.Fatalf("countDirs: %v", err)
+	}
+	// root + a + a/b + c = 4
+	if n != 4 {
+		t.Errorf("countDirs = %d; want 4", n)
+	}
+}
+
+func TestDispatchCoalescesBurstIntoSingleScan(t *testing.T) {
+	var mu sync.Mutex
+	calls := map[string]int{}
+	scan := func(_ context.Context, _ models.Library, path string) error {
+		mu.Lock()
+		calls[path]++
+		mu.Unlock()
+		return nil
+	}
+	w := New(Config{Debounce: 30 * time.Millisecond}, nil, scan)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan libEvent)
+	done := make(chan struct{})
+	go func() { w.dispatch(ctx, events); close(done) }()
+
+	lib := models.Library{ID: 1, Path: "/m"}
+	for i := 0; i < 5; i++ { // burst on one dir
+		events <- libEvent{lib: lib, path: "/m/Album"}
+	}
+	events <- libEvent{lib: lib, path: "/m/Other"} // a second dir
+
+	time.Sleep(150 * time.Millisecond) // let the debounce window elapse and flush
+
+	mu.Lock()
+	album, other := calls["/m/Album"], calls["/m/Other"]
+	mu.Unlock()
+	if album != 1 {
+		t.Errorf("scans for /m/Album = %d; want 1 (burst coalesced)", album)
+	}
+	if other != 1 {
+		t.Errorf("scans for /m/Other = %d; want 1", other)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestDispatchTrailingEdgeResetsTimer(t *testing.T) {
+	var mu sync.Mutex
+	scans := 0
+	scan := func(_ context.Context, _ models.Library, _ string) error {
+		mu.Lock()
+		scans++
+		mu.Unlock()
+		return nil
+	}
+	const debounce = 100 * time.Millisecond
+	w := New(Config{Debounce: debounce}, nil, scan)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan libEvent)
+	done := make(chan struct{})
+	go func() { w.dispatch(ctx, events); close(done) }()
+
+	lib := models.Library{ID: 1, Path: "/m"}
+	events <- libEvent{lib: lib, path: "/m/Album"}
+	time.Sleep(debounce / 2)                       // t ~= 50ms, within the window
+	events <- libEvent{lib: lib, path: "/m/Album"} // resets the timer to ~150ms
+	time.Sleep(debounce / 2)                       // t ~= 100ms: first deadline would have hit if not reset
+
+	mu.Lock()
+	early := scans
+	mu.Unlock()
+	if early != 0 {
+		t.Fatalf("scans at ~1 debounce window = %d; want 0 (each event must reset the trailing-edge timer)", early)
+	}
+
+	time.Sleep(debounce + 50*time.Millisecond) // wait out the reset window
+	mu.Lock()
+	final := scans
+	mu.Unlock()
+	if final != 1 {
+		t.Errorf("scans after the reset window = %d; want exactly 1", final)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestDispatchNoScanAfterCancelMidDebounce(t *testing.T) {
+	var mu sync.Mutex
+	scans := 0
+	scan := func(_ context.Context, _ models.Library, _ string) error {
+		mu.Lock()
+		scans++
+		mu.Unlock()
+		return nil
+	}
+	w := New(Config{Debounce: 50 * time.Millisecond}, nil, scan)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	events := make(chan libEvent)
+	done := make(chan struct{})
+	go func() { w.dispatch(ctx, events); close(done) }()
+
+	events <- libEvent{lib: models.Library{ID: 1}, path: "/m/Album"} // arms a debounce timer
+	cancel()                                                         // cancel before the window elapses
+	<-done                                                           // dispatch returns and its deferred Stop runs
+
+	time.Sleep(120 * time.Millisecond) // well past the debounce window
+	mu.Lock()
+	got := scans
+	mu.Unlock()
+	if got != 0 {
+		t.Errorf("scans after cancel mid-debounce = %d; want 0 (pending timer must not fire a scan)", got)
+	}
+}
+
+func TestRunReturnsNilWhenNoLibraries(t *testing.T) {
+	w := New(Config{MaxDirs: defaultMaxDirs}, fakeLister{}, func(context.Context, models.Library, string) error { return nil })
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run with no libraries = %v; want nil", err)
+	}
+}
+
+func TestRunFailsWhenWatchBudgetExceeded(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// root + sub = 2 directories, over the MaxDirs=1 cap. (MaxDirs must be
+	// positive now; New clamps <= 0 to the default, so 0 no longer forces this.)
+	w := New(Config{MaxDirs: 1, Debounce: time.Millisecond}, fakeLister{libs: []models.Library{{ID: 1, Path: root}}},
+		func(context.Context, models.Library, string) error { return nil })
+	err := w.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run with exceeded budget = nil; want a loud failure")
+	}
+}
+
+func TestCountDirsErrorsOnMissingRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := countDirs([]models.Library{{ID: 1, Path: missing}}); err == nil {
+		t.Fatal("countDirs on a missing root = nil error; want failure")
+	}
+}
+
+// TestRunTriggersScanOnFileCreate exercises the real notify integration: a file
+// created under a watched root must trigger a scan within the debounce window.
+// Filesystem event delivery is best-effort and platform dependent, so the test
+// allows a generous timeout.
+func TestRunTriggersScanOnFileCreate(t *testing.T) {
+	root := t.TempDir()
+	scanned := make(chan string, 1)
+	w := New(
+		Config{Debounce: 20 * time.Millisecond, MaxDirs: defaultMaxDirs},
+		fakeLister{libs: []models.Library{{ID: 5, Path: root}}},
+		func(_ context.Context, _ models.Library, path string) error {
+			select {
+			case scanned <- path:
+			default:
+			}
+			return nil
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- w.Run(ctx) }()
+
+	time.Sleep(200 * time.Millisecond) // allow watch registration
+	if err := os.WriteFile(filepath.Join(root, "new.mp3"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	select {
+	case got := <-scanned:
+		if got != root {
+			t.Errorf("scanned path = %q; want %q", got, root)
+		}
+	case <-time.After(5 * time.Second):
+		t.Skip("no filesystem event delivered within 5s (best-effort watcher; may be unsupported here)")
+	}
+
+	cancel()
+	<-runErr
+}


### PR DESCRIPTION
Combines two library-scan features into one PR to keep CodeRabbit review cycles minimal. Both live in the `internal/scan` subsystem and were verified together: build, vet, full `go test ./...`, gofmt, and golangci-lint all green on the combined tree.

## #83 - optional fsnotify watcher for low-latency library scans

Adds `internal/watcher/` (config + watcher) and a scheduler hook so filesystem changes trigger scans without waiting for the poll interval. Uses `rjeczalik/notify`.

## #72 - resolve Lidarr webhooks through scanned library inventory

Extends `internal/scan` (enqueuer + repository) and `internal/server` so Lidarr webhooks resolve against the persisted scan-result inventory. Adds migration `011_scan_results_keys.sql`.

## Integration notes

- The two parked branches auto-merged cleanly: the only overlapping files (`internal/commands/commands.go`, `README.md`) had disjoint additive regions, so no conflicts.
- Migration `011` is the next free sequential number (main tops out at `010`); no renumbering needed.
- `go mod tidy` promoted `rjeczalik/notify` from `// indirect` to a direct require (the watcher branch had left it indirect).
- Synergy: watcher-triggered scans populate the same inventory the webhook resolution reads from. Complementary, not conflicting; integration tests pass together.

Closes #83
Closes #72

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional filesystem watcher for low-latency library scans with configurable debounce and directory limits (environment-variable controlled)
  * Enhanced Lidarr webhook payload resolution with inventory lookup and container-aware path matching for improved reliability

* **Documentation**
  * Updated with Docker/Unraid deployment guidance including webhook resolution precedence order and filesystem watcher configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->