### PR TITLE
feat: benign-miss cooldown, tooling/CI/hooks port, write-time TOCTOU hardening

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -38,6 +38,20 @@ warn() {
 }
 
 # --------------------------------------------------------------------------
+# 0. conflict markers -- reject unresolved merge markers in staged content
+# --------------------------------------------------------------------------
+# git diff --check flags leftover conflict markers (and whitespace errors); we
+# grep for just the conflict-marker lines so whitespace nits are left to the
+# dedicated hooks. git's own detector avoids markdown setext false positives.
+CONFLICT_HITS=$(git diff --cached --check 2>/dev/null | grep -i 'conflict marker' || true)
+if [ -n "$CONFLICT_HITS" ]; then
+    echo -e "${RED}${BOLD}FAIL${RESET} conflict markers:"
+    echo "$CONFLICT_HITS"
+    exit 1
+fi
+pass "conflict markers"
+
+# --------------------------------------------------------------------------
 # 1. typos -- spell check staged files
 # --------------------------------------------------------------------------
 if git diff --cached --name-only --diff-filter=ACM -- | grep -q .; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# pre-push hook: run the full deterministic gate before any push so a broken
+# build, failing test, lint/vuln finding, workflow-lint error, or unresolved
+# conflict marker is caught locally instead of in CI.
+#
+# Wire with: make hooks  (sets core.hooksPath=.githooks, so every worktree
+# inherits both this hook and .githooks/pre-commit).
+#
+# Skip with: git push --no-verify  (use sparingly).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec bash "$REPO_ROOT/scripts/pre-push-gate.sh"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,27 @@ updates:
       - dependencies
       - ci
     open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - docker
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /build/docker
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - docker
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
@@ -35,6 +37,8 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.goreleaser.yml'
               - '.golangci.yml'
+              - 'Dockerfile'
+              - 'build/docker/**'
 
   lint:
     name: Lint
@@ -43,6 +47,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
@@ -63,6 +69,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
@@ -78,6 +86,28 @@ jobs:
           fail_ci_if_error: true
           use_oidc: true
 
+  scan:
+    name: Image Scan
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Build image
+        run: docker build -t mxlrcgo-svc:scan -f Dockerfile .
+
+      - name: Scan image for HIGH+ CVEs
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: mxlrcgo-svc:scan
+          severity-cutoff: high
+          fail-build: true
+
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
@@ -92,6 +122,8 @@ jobs:
             goarch: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0b1b62002952733671bde978d429b50b51c51c85 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -41,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0b1b62002952733671bde978d429b50b51c51c85 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -47,4 +48,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.3
+    rev: v2.11.4
     hooks:
       - id: golangci-lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - None - Pure Go standard library for HTTP, I/O, and CLI orchestration
 - `github.com/alexflint/go-arg` v1.6.1 - CLI argument parsing via struct tags (`Args` in `cmd/mxlrcgo-svc/main.go`)
 - Go standard `testing` package - No third-party test framework
-- Make (`Makefile`) - Build orchestration (build, test, lint, fmt, clean)
+- Make (`Makefile`) - Build orchestration and the quality gate (build, run, test, test-shuffle, test-cover, patch-cover, gate, scan, vulncheck, coverage-floor, lint, fmt, hooks, doctor, sync-tool-versions, smoke, clean). `make help` lists every target with a one-liner
 - GoReleaser (`.goreleaser.yml`) - Cross-platform release builds
 - golangci-lint v2.11.4 (`.golangci.yml`) - Linter aggregator with 12 enabled linters
 ## Key Dependencies
@@ -56,25 +56,35 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - `.gitattributes` - Line ending normalization (LF everywhere)
 - `.typos.toml` - Spell-checker config (excludes `go.sum`)
 - `.pre-commit-config.yaml` - Pre-commit framework hooks: trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files (500KB), check-merge-conflict, typos, gitleaks, golangci-lint, gofmt, conventional-pre-commit
-- `.githooks/pre-commit` - Manual pre-commit hook: typos, gofmt, go build, golangci-lint, govulncheck
+- `.githooks/pre-commit` - Tracked pre-commit hook: conflict-marker check, typos, gofmt, go build, golangci-lint, govulncheck
+- `.githooks/pre-push` - Tracked pre-push hook: runs the full gate (`scripts/pre-push-gate.sh`). Wired via `make hooks` (`core.hooksPath=.githooks`, a relative shared setting so every worktree inherits both hooks); `scripts/check-hooks.sh` / `make doctor` verify the wiring
+- `scripts/pre-push-gate.sh` - Deterministic gate: conflict markers, gofmt, build, race tests, patch coverage, golangci-lint, actionlint, govulncheck, behind a per-worktree run-lock
+- `scripts/check-tool-versions.sh` - Asserts the golangci-lint pin agrees across `ci.yml` and `.pre-commit-config.yaml` (`make sync-tool-versions`)
+- `scripts/coverage-floor.sh` + `scripts/coverage-floor.json` - One-way per-package coverage floor (`make coverage-floor`)
 ## Platform Requirements
 - Go 1.26.2+
 - golangci-lint v2.11+ (for linting)
 - typos-cli (for spell checking)
-- govulncheck (for vulnerability scanning)
+- govulncheck (for vulnerability scanning; the gate/`make vulncheck` pin `v1.1.4`)
+- actionlint (for workflow linting in the gate)
 - goimports (optional, for import formatting)
 - pre-commit (optional, for `.pre-commit-config.yaml` hooks)
+- grype + Docker (optional, for `make scan` image CVE scanning; CI runs it regardless)
+- jq (optional, for `make coverage-floor`)
 - Standalone static binary (CGO_ENABLED=0)
 - No runtime dependencies
 - Supported platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
 ## CI/CD Pipeline
-- `ci.yml` - Lint + Test + Build matrix (linux/darwin/windows x amd64/arm64). Uses `dorny/paths-filter` to skip on non-code changes. Build requires lint+test to pass first.
+- `ci.yml` - Lint + Test + image CVE Scan (grype via `anchore/scan-action`, fail on HIGH+) + Build matrix (linux/darwin/windows x amd64/arm64). Uses `dorny/paths-filter` to skip on non-code changes. Build requires lint+test to pass first.
 - `release.yml` - GoReleaser on `v*.*.*` tags. Produces cross-platform archives with conventional-commit changelogs.
+- `nightly.yml` - Nightly Docker image build/push to GHCR from `main`.
 - `codeql.yml` - GitHub CodeQL security analysis for Go. Runs on push/PR to main and weekly (Monday 04:17 UTC).
+- `claude.yml` / `claude-code-review.yml` - Claude bot (issue/PR assist + auto review). All actions SHA-pinned with `persist-credentials: false`.
 - `dependabot-auto-approve.yml` - Auto-approves Dependabot PRs for patch/minor updates.
 - `dependabot-merge.yml` - Auto-merges approved Dependabot PRs after CI passes (squash merge, delete branch).
-- Weekly updates (Monday) for `gomod` and `github-actions` ecosystems
-- Conventional commit prefixes (`chore(deps)` for Go, `ci` for Actions)
+- All workflow actions are SHA-pinned (`# vX` comment) with `persist-credentials: false` on checkouts; job-level `permissions` include `contents: read`.
+- Weekly updates (Monday) for `gomod`, `github-actions`, and `docker` ecosystems
+- Conventional commit prefixes (`chore(deps)` for Go/Docker, `ci` for Actions)
 
 ## Conventions
 
@@ -83,7 +93,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - `internal/<package>/<file>.go` - lowercase single-word filenames per package: `client.go`, `fetcher.go`, `writer.go`, `slugify.go`, `scanner.go`, `app.go`, `queue.go`, `models.go`
 - Test files use Go's standard `_test.go` suffix: `slugify_test.go`
 - PascalCase for all exported identifiers: `NewClient()`, `FindLyrics()`, `WriteLRC()`, `InputsQueue`, `Track`, `Song`
-- camelCase for unexported identifiers: `writeSyncedLRC()`, `writeUnsyncedLRC()`, `writeInstrumentalLRC()`
+- camelCase for unexported identifiers: `writeSyncedLRC()`, `writeUnsyncedLRC()`, `writeInstrumental()`
 - Method receivers are short abbreviations: `c` for `Client`, `w` for `LRCWriter`, `q` for `InputsQueue`, `sc` for `Scanner`
 - Short, abbreviated names preferred: `fn` (filename), `fp` (filepath), `cur` (current), `res` (response)
 - Loop variables are single-letter: `i`, `f`, `m`, `v`
@@ -173,7 +183,7 @@ A Go CLI tool that fetches synced lyrics from the Musixmatch API and saves them 
 - Used by: `internal/app` (via `Fetcher` interface)
 - Purpose: Format song data into LRC format and write to disk
 - Location: `internal/lyrics/writer.go`, `internal/lyrics/slugify.go`
-- Contains: `LRCWriter`, `WriteLRC()`, `writeSyncedLRC()`, `writeUnsyncedLRC()`, `writeInstrumentalLRC()`, `Slugify()`, `Writer` interface
+- Contains: `LRCWriter`, `WriteLRC()`, `writeSyncedLRC()`, `writeUnsyncedLRC()`, `writeInstrumental()`, `Slugify()`, `Writer` interface
 - Depends on: `internal/models`, `golang.org/x/text/unicode/norm`
 - Used by: `internal/app` (via `Writer` interface)
 - Purpose: Input parsing and directory scanning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,19 +19,23 @@ When the user says **"next"**, **"what's next"**, **"keep going"**, or any equiv
 - The entrypoint lives in `cmd/mxlrcgo-svc`, so `go run .` does not work. Use `go run ./cmd/mxlrcgo-svc [args]`.
 - A single test: `go test -run TestFoo ./internal/<pkg>` (tests live next to the code they cover under `internal/`).
 
+Run `make hooks` once to enable the tracked git hooks, and `make gate` before pushing. See "Quality gating and CI" below for the full target list.
+
 ## Architecture (one-paragraph orientation)
 
 Cmd/internal layout. `cmd/mxlrcgo-svc/main.go` is the only entry point and owns no business logic; it parses args, loads config + DB, builds the dependency graph, and runs `app.App.Run`. Under `internal/`: `app` owns the processing loop and queues; `musixmatch` calls the API (exposes a `Fetcher` interface); `lyrics` writes `.lrc` / `.txt` / instrumental output (exposes a `Writer` interface); `scanner` parses CLI/text-file/directory input into the queue; `config` resolves TOML config (XDG paths) with token precedence CLI > env > file; `db` is pure-Go SQLite (`modernc.org/sqlite`, no CGO) with goose migrations in `internal/db/migrations/`; `cache` is the lyrics cache repo over the DB; `normalize` builds NFKC cache lookup keys; `models` holds the shared data types and depends on nothing else internal. `app` depends on `Fetcher` and `Writer` interfaces, never concrete types -- mock at those boundaries. There is no global mutable state. See `AGENTS.md` for full layer/data-flow detail.
 
 ## CLI usage and input modes
 
-See `README.md` for flags and examples. Worth flagging: directory mode overrides `--outdir` (writes `.lrc` next to the audio file), and `--upgrade` re-fetches songs that previously got `.txt` (unsynced) to promote them when synced lyrics become available.
+See `README.md` for flags and examples. Worth flagging: directory mode overrides `--outdir` (writes the output next to the audio file; the extension depends on lyric type - `.lrc` when synced lyrics are found, `.txt` when only unsynced lyrics or an instrumental marker is written), and `--upgrade` re-fetches songs that previously got `.txt` (unsynced) to promote them when synced lyrics become available.
 
 ## Quality gating and CI
 
-- Pre-commit hook: `make hooks` installs `.githooks/pre-commit` (typos -> gofmt -> build -> golangci-lint -> govulncheck).
-- Linter config: `.golangci.yml`. Always include a `// reason` comment after any `//nolint:linter` directive.
-- CI workflows live in `.github/workflows/` (`ci.yml`, `release.yml`, `codeql.yml`).
+- Local gate: `make gate` (`scripts/pre-push-gate.sh`) runs the full pre-push chain behind a per-worktree run-lock: conflict-marker check, gofmt, build, race tests, patch coverage (Codecov parity; skipped if the estimator is absent), golangci-lint, actionlint, govulncheck.
+- Git hooks: `make hooks` sets `core.hooksPath=.githooks` (a relative, shared git setting), so every worktree -- including new ones -- inherits the hooks with no per-worktree setup. `.githooks/pre-commit` runs a conflict-marker check then typos -> gofmt -> build -> golangci-lint -> govulncheck; `.githooks/pre-push` runs the full gate. Verify the wiring with `make doctor` (or `scripts/check-hooks.sh`).
+- Make targets (`make help` lists all): `gate` (full pre-push gate), `doctor` (verify hook wiring + tool-version pins), `scan` (build the Docker image and grype it for HIGH+ CVEs), `test-shuffle` (`go test -race -shuffle=on`), `sync-tool-versions` (assert the golangci-lint pin agrees across CI and pre-commit, via `scripts/check-tool-versions.sh`), `vulncheck` (pinned `govulncheck@v1.1.4`), `coverage-floor` (one-way per-package coverage floor, `scripts/coverage-floor.sh` + `scripts/coverage-floor.json`).
+- Linter config: `.golangci.yml`. Always include a `// reason` comment after any `//nolint:linter` directive. Keep the golangci-lint pin aligned across `ci.yml` and `.pre-commit-config.yaml` (`make sync-tool-versions` enforces it).
+- CI workflows live in `.github/workflows/` (`ci.yml` -- incl. an image CVE `scan` job, `release.yml`, `nightly.yml`, `codeql.yml`). Pin every action to a commit SHA with a `# vX` comment and set `persist-credentials: false` on checkouts.
 - Releases: `git tag vX.Y.Z && git push --tags` triggers GoReleaser.
 
 ## Style (non-discoverable rules)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS build
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS build
 
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: build run test test-cover patch-cover gate smoke lint fmt hooks clean help
+.PHONY: build run test test-shuffle test-cover patch-cover gate scan vulncheck \
+        doctor sync-tool-versions coverage-floor smoke lint fmt hooks clean help
 
 # Binary name
 BINARY=mxlrcgo-svc
+
+# Pinned govulncheck version for reproducible vulnerability scans. Manual pin:
+# scripts/check-tool-versions.sh currently asserts only the golangci-lint pin.
+GOVULNCHECK_VERSION=v1.1.4
 
 ## build: Build the binary
 build:
@@ -14,6 +19,10 @@ run: build
 ## test: Run all tests
 test:
 	go test -v -race -count=1 ./...
+
+## test-shuffle: Run tests with race + randomized order to surface order-dependent tests
+test-shuffle:
+	go test -race -shuffle=on -count=1 ./...
 
 ## test-cover: Run tests with coverage
 test-cover:
@@ -35,6 +44,28 @@ patch-cover:
 gate:
 	bash scripts/pre-push-gate.sh
 
+## scan: Build the Docker image and scan it for HIGH+ CVEs with grype
+scan:
+	docker build -t $(BINARY):scan -f Dockerfile .
+	grype $(BINARY):scan --fail-on high
+
+## vulncheck: Run govulncheck pinned to a fixed version for reproducible scans
+vulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+
+## coverage-floor: Enforce the one-way per-package coverage floor (scripts/coverage-floor.sh)
+coverage-floor:
+	bash scripts/coverage-floor.sh
+
+## doctor: Verify local dev tooling and git-hook wiring
+doctor:
+	bash scripts/check-hooks.sh
+	bash scripts/check-tool-versions.sh
+
+## sync-tool-versions: Assert pinned tool versions agree across CI and pre-commit
+sync-tool-versions:
+	bash scripts/check-tool-versions.sh
+
 ## smoke: Run CLI smoke tests
 smoke:
 	./scripts/smoke.sh
@@ -48,11 +79,11 @@ fmt:
 	gofmt -w .
 	@command -v goimports >/dev/null 2>&1 && goimports -w . || true
 
-## hooks: Install git pre-commit hook
+## hooks: Wire git to the tracked .githooks dir (pre-commit + pre-push, every worktree)
 hooks:
-	cp .githooks/pre-commit .git/hooks/pre-commit
-	chmod +x .git/hooks/pre-commit
-	@echo "Pre-commit hook installed."
+	git config core.hooksPath .githooks
+	@echo "core.hooksPath set to .githooks (pre-commit + pre-push enforced)."
+	@bash scripts/check-hooks.sh
 
 ## clean: Remove build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ mxlrcgo-svc "Dream Theater"
 ```
 > **_This option overrides the `-o/--outdir` argument which means the lyrics will be saved in the same directory as the given input._**
 >
+> **_The output extension depends on the lyric type: `.lrc` when synced lyrics are found, and `.txt` when only unsynced lyrics or an instrumental marker is written._**
+>
 > **_The `-d/--depth` argument limits the depth of subdirectories to scan; use `-d 0` or `--depth 0` to only scan the specified directory._**
 
 ### Lidarr webhook server
@@ -224,16 +226,30 @@ An Unraid Community Applications template is provided at `unraid/mxlrcgo-svc.xml
 
 ## Development
 
-Run the lightweight CLI smoke test:
+`make help` lists every target. The entrypoint is `cmd/mxlrcgo-svc`, so use `go run ./cmd/mxlrcgo-svc [args]` (not `go run .`).
+
+### Quality gate and git hooks
+
+Wire the tracked git hooks once (sets `core.hooksPath=.githooks`, a relative shared setting, so every worktree -- including any you add later -- inherits them with no extra setup):
 
 ```sh
-make smoke
+make hooks      # enable the pre-commit + pre-push hooks
+make doctor     # verify the hooks are wired and tool-version pins agree
 ```
 
-Generate a local coverage profile and HTML report:
+`make gate` runs the full pre-push gate (the same chain `.githooks/pre-push` runs): conflict-marker check, gofmt, build, race tests, patch coverage, golangci-lint, actionlint, and govulncheck. The pre-commit hook runs a faster subset on each commit.
+
+Other useful targets:
 
 ```sh
-make test-cover
+make smoke               # lightweight CLI smoke test
+make test                # race tests
+make test-shuffle        # race tests with randomized order (-shuffle=on)
+make test-cover          # coverage profile + HTML report
+make coverage-floor      # enforce the per-package coverage floor
+make vulncheck           # govulncheck (pinned)
+make scan                # build the Docker image and scan it for HIGH+ CVEs (needs Docker + grype)
+make sync-tool-versions  # assert the golangci-lint pin matches across CI and pre-commit
 ```
 
 ---

--- a/cmd/mxlrcgo-svc/main.go
+++ b/cmd/mxlrcgo-svc/main.go
@@ -27,7 +27,7 @@ type runOptions struct {
 	ctx        context.Context
 	loadDotenv func() error
 	newFetcher func(token string) musixmatch.Fetcher
-	newWriter  func() lyrics.Writer
+	newWriter  func(roots ...string) lyrics.Writer
 	newApp     func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) commands.AppRunner
 }
 
@@ -61,7 +61,7 @@ func runWithOptions(opts runOptions) int {
 	}
 	newWriter := opts.newWriter
 	if newWriter == nil {
-		newWriter = func() lyrics.Writer { return lyrics.NewLRCWriter() }
+		newWriter = func(roots ...string) lyrics.Writer { return lyrics.NewLRCWriter(roots...) }
 	}
 	newApp := opts.newApp
 	if newApp == nil {

--- a/cmd/mxlrcgo-svc/main_test.go
+++ b/cmd/mxlrcgo-svc/main_test.go
@@ -99,7 +99,7 @@ func runStartupWithDotenv(t *testing.T, args []string, rec *runRecord, loadDoten
 			rec.token = token
 			return &fakeFetcher{rec: rec}
 		},
-		newWriter: func() lyrics.Writer {
+		newWriter: func(roots ...string) lyrics.Writer {
 			return fakeWriter{}
 		},
 		newApp: func(_ musixmatch.Fetcher, _ lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) appRunner {
@@ -134,7 +134,7 @@ func TestRunWithOptions_HelpDoesNotStartApplication(t *testing.T) {
 			rec.token = token
 			return &fakeFetcher{rec: rec}
 		},
-		newWriter: func() lyrics.Writer { return fakeWriter{} },
+		newWriter: func(roots ...string) lyrics.Writer { return fakeWriter{} },
 		newApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
 			rec.appCreated = true
 			return fakeRunner{rec: rec}
@@ -193,7 +193,7 @@ func TestRunWithOptions_SubcommandHelpShowsSelectedCommand(t *testing.T) {
 					rec.token = token
 					return &fakeFetcher{rec: rec}
 				},
-				newWriter: func() lyrics.Writer { return fakeWriter{} },
+				newWriter: func(roots ...string) lyrics.Writer { return fakeWriter{} },
 				newApp: func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) appRunner {
 					rec.appCreated = true
 					return fakeRunner{rec: rec}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sydlexius/mxlrcgo-svc
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,12 @@ func (a *App) Run(ctx context.Context) error {
 		}
 		slog.Info("searching song", "artist", cur.Track.ArtistName, "track", cur.Track.TrackName)
 		song, err := a.fetcher.FindLyrics(ctx, cur.Track)
+		// A benign miss (no matching track, or a match with no fetchable lyrics)
+		// means the upstream result is stable and will not change on a near-term
+		// retry, so it must not trip the geometric backoff or increment the
+		// failure counter. It still goes to the failed bucket so it is reported
+		// as not-fetched.
+		benignMiss := err != nil && musixmatch.IsBenignMiss(err)
 		if err == nil {
 			a.failureCount = 0
 			cur, err = a.inputs.Pop()
@@ -75,8 +81,12 @@ func (a *App) Run(ctx context.Context) error {
 				a.failed.Push(cur)
 			}
 		} else {
-			a.failureCount++
-			slog.Error("lyrics fetch failed", "error", err)
+			if benignMiss {
+				slog.Info("no lyrics available", "artist", cur.Track.ArtistName, "track", cur.Track.TrackName, "reason", err)
+			} else {
+				a.failureCount++
+				slog.Error("lyrics fetch failed", "error", err)
+			}
 			item, popErr := a.inputs.Pop()
 			if popErr != nil {
 				slog.Error("unexpected empty queue on pop", "error", popErr)
@@ -84,7 +94,7 @@ func (a *App) Run(ctx context.Context) error {
 			}
 			a.failed.Push(item)
 		}
-		if err != nil {
+		if err != nil && !benignMiss {
 			a.backoffTimer(ctx, a.failureCount)
 		} else {
 			a.timer(ctx)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
 
@@ -130,6 +132,44 @@ func TestRunWritesFailedFileOnFetchFailure(t *testing.T) {
 	}
 	if string(got) != "Failure Artist,Failure Song\n" {
 		t.Fatalf("failed file content = %q", got)
+	}
+}
+
+func TestRunBenignMissDoesNotBackOff(t *testing.T) {
+	for name, sentinel := range map[string]error{
+		"not found": musixmatch.ErrNotFound,
+		"no lyrics": musixmatch.ErrNoLyrics,
+	} {
+		t.Run(name, func(t *testing.T) {
+			inputs := queue.NewInputsQueue()
+			inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}})
+			inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Two"}})
+			inputs.Push(models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Three"}})
+			fetcher := &fakeFetcher{err: fmt.Errorf("lookup: %w", sentinel)}
+
+			a := NewApp(fetcher, lyrics.NewLRCWriter(), inputs, 0, "dir")
+			a.baseBackoff = time.Second
+			a.maxBackoff = time.Hour
+			var sleeps []time.Duration
+			a.sleep = func(_ context.Context, d time.Duration) bool {
+				sleeps = append(sleeps, d)
+				return true
+			}
+
+			if err := a.Run(context.Background()); err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if len(sleeps) != 0 {
+				t.Fatalf("sleeps = %v; want none (benign misses must not trip the backoff timer)", sleeps)
+			}
+			if a.failureCount != 0 {
+				t.Fatalf("failureCount = %d; want 0 (benign misses must not increment the failure counter)", a.failureCount)
+			}
+			if a.failed.Len() != 3 {
+				t.Fatalf("failed bucket = %d; want 3 (benign misses are still reported as not-fetched)", a.failed.Len())
+			}
+		})
 	}
 }
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -248,7 +248,7 @@ type AppRunner interface {
 type Deps struct {
 	LoadDotenv func() error
 	NewFetcher func(token string) musixmatch.Fetcher
-	NewWriter  func() lyrics.Writer
+	NewWriter  func(roots ...string) lyrics.Writer
 	NewApp     func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) AppRunner
 }
 
@@ -267,7 +267,7 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 		deps.NewFetcher = func(token string) musixmatch.Fetcher { return musixmatch.NewClient(token) }
 	}
 	if deps.NewWriter == nil {
-		deps.NewWriter = func() lyrics.Writer { return lyrics.NewLRCWriter() }
+		deps.NewWriter = func(roots ...string) lyrics.Writer { return lyrics.NewLRCWriter(roots...) }
 	}
 	if deps.NewApp == nil {
 		deps.NewApp = func(fetcher musixmatch.Fetcher, writer lyrics.Writer, inputs *queue.InputsQueue, cooldown int, mode string) AppRunner {
@@ -370,7 +370,7 @@ func legacyServe(args LegacyArgs) ServeCmd {
 	}
 }
 
-func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func() lyrics.Writer, newApp func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) AppRunner) int {
+func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer, newApp func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) AppRunner) int {
 	if len(args.Song) == 0 {
 		_, _ = fmt.Fprintln(out, "missing required positional argument: Song")
 		return 2
@@ -425,7 +425,7 @@ func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func
 	return 0
 }
 
-func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func() lyrics.Writer) int {
+func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer) int {
 	cfg, err := config.Load(args.ConfigPath)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
@@ -466,7 +466,14 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		return 1
 	}
 	workQ := queue.NewDBQueue(sqlDB)
-	w := worker.New(workQ, cache.New(sqlDB), fetcher, newWriter())
+	// Snapshot the configured library roots once at startup. They confine both
+	// the webhook handler's raw payload paths (path-injection guard) and the
+	// worker's write-time output, so a symlink swapped in below a root after the
+	// handler check cannot redirect the .lrc write outside the root. Listing
+	// failure is not fatal: confinement is simply skipped (the writer falls back
+	// to its unconfined path) and the handler degrades as documented below.
+	allowedRoots := webhookAllowedRoots(ctx, sqlDB)
+	w := worker.New(workQ, cache.New(sqlDB), fetcher, newWriter(allowedRoots...))
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	configureWorkerVerification(w, cfg, verifier)
 
@@ -493,11 +500,6 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	if args.Listen != nil {
 		addr = *args.Listen
 	}
-	// Snapshot the configured library roots so the webhook handler can confine
-	// raw payload paths to them (path-injection guard). Listing failure is not
-	// fatal: the handler simply disables raw-payload-path resolution and falls
-	// back to inventory or metadata.
-	allowedRoots := webhookAllowedRoots(runCtx, sqlDB)
 	srv := &http.Server{
 		Addr: addr,
 		Handler: server.NewHandler(authSvc, workQ, outdir,
@@ -649,7 +651,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, cfg watcher.C
 func webhookAllowedRoots(ctx context.Context, sqlDB *sql.DB) []string {
 	libs, err := library.New(sqlDB).List(ctx)
 	if err != nil {
-		slog.Warn("failed to list libraries for webhook path confinement; raw payload-path resolution disabled", "error", err)
+		slog.Warn("failed to list libraries for path confinement; confinement disabled for both the webhook handler (raw payload-path resolution) and worker writes (write-time output confinement)", "error", err)
 		return nil
 	}
 	roots := make([]string, 0, len(libs))

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
 )
 
 // Writer abstracts LRC file output.
@@ -17,51 +18,101 @@ type Writer interface {
 }
 
 // LRCWriter writes songs to .lrc files.
-type LRCWriter struct{}
+//
+// When constructed with one or more confinement roots, a write whose output
+// directory falls under a root is re-resolved and re-confined to that root
+// immediately before the write (pathutil.ResolveWithinRoot, which follows
+// symlinks with filepath.EvalSymlinks). This is the write-time half of the
+// fix for #102 and closes the realistic write-time TOCTOU left open by the
+// handler-side check in PR #98: a directory component swapped for a symlink
+// that escapes the root between the handler check and the worker write is
+// rejected here instead of redirecting the write outside the root, while
+// legitimate in-root symlinks (e.g. a symlinked album directory) still resolve
+// and write normally. Output outside every configured root, and writers built
+// with no roots (e.g. directory mode), use the plain path.
+//
+// This re-confine-before-write narrows the exposure from the handler-to-worker
+// queue latency to the microseconds between the resolve and the open; it is not
+// a fully race-free guarantee. An open-time guard (os.Root / openat2) would be,
+// but os.Root rejects every symlinked path component, including in-root ones,
+// which would break symlinked library layouts -- so it is intentionally not used
+// here.
+type LRCWriter struct {
+	roots []string
+}
 
-// NewLRCWriter creates a new LRCWriter.
-func NewLRCWriter() *LRCWriter {
-	return &LRCWriter{}
+// NewLRCWriter creates a new LRCWriter. Any non-empty roots passed become
+// write-time confinement boundaries (see LRCWriter); pass none for unconfined
+// writes. Roots are cleaned once here so confinement checks need not re-derive
+// them on every write.
+func NewLRCWriter(roots ...string) *LRCWriter {
+	cleaned := make([]string, 0, len(roots))
+	for _, r := range roots {
+		if r != "" {
+			cleaned = append(cleaned, filepath.Clean(r))
+		}
+	}
+	return &LRCWriter{roots: cleaned}
 }
 
 // WriteLRC writes the song lyrics to an LRC or TXT file in the given output directory.
-// Synced lyrics and instrumentals are written as .lrc; unsynced lyrics are written as .txt.
+// Only synced lyrics are written as .lrc; unsynced lyrics and instrumentals are
+// written as .txt (the .lrc extension is reserved for timed/synced content).
 func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (retErr error) {
-	// Eligibility gate -- determine content type before touching disk.
+	// Eligibility gate -- determine content type before touching disk. synced
+	// drives the file extension (.lrc only for synced lyrics, .txt otherwise);
+	// writeTags drives whether the LRC metadata header is emitted.
 	var writeContent func(*bufio.Writer) error
 	var writeTags bool
+	var synced bool
 	switch {
 	case len(song.Subtitles.Lines) > 0:
 		slog.Info("saving synced lyrics")
 		writeContent = func(buf *bufio.Writer) error { return writeSyncedLRC(song, buf) }
 		writeTags = true
+		synced = true
 	case song.Lyrics.LyricsBody != "":
 		slog.Info("saving unsynced lyrics")
 		writeContent = func(buf *bufio.Writer) error { return writeUnsyncedLRC(song, buf) }
-		writeTags = false
 	case song.Track.Instrumental == 1:
 		slog.Info("saving instrumental")
-		writeContent = writeInstrumentalLRC
-		writeTags = true
+		writeContent = writeInstrumental
+		// Instrumentals are a plain .txt marker: no timestamp, no tag headers.
 	default:
 		return fmt.Errorf("nothing to save for %s - %s", song.Track.ArtistName, song.Track.TrackName)
 	}
 
+	ext := ".txt"
+	if synced {
+		ext = ".lrc"
+	}
+
 	var fn string
-	switch {
-	case filename != "":
-		// In dir mode the scanner sets an explicit .lrc filename. For unsynced
-		// content, swap the extension to .txt so the file type matches content.
-		if !writeTags {
-			fn = strings.TrimSuffix(filename, filepath.Ext(filename)) + ".txt"
-			slog.Info("save unsynced lyrics", "path", filepath.Join(outdir, fn))
-		} else {
-			fn = filename
+	if filename != "" {
+		// In dir mode the scanner sets an explicit .lrc filename. Swap the
+		// extension to match the content type (.lrc only for synced lyrics).
+		fn = strings.TrimSuffix(filename, filepath.Ext(filename)) + ext
+	} else {
+		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ext
+	}
+
+	// When the output directory falls under a confinement root, re-resolve and
+	// re-confine it right before the write so a symlink swapped in since the
+	// caller validated the path cannot redirect the write outside the root.
+	if root, ok := w.matchRoot(outdir); ok {
+		resolved, ok := pathutil.ResolveWithinRoot(root, outdir)
+		if !ok {
+			// ResolveWithinRoot fails (EvalSymlinks) both when the dir does not
+			// exist and when it escapes the root via a symlink. Distinguish the
+			// two so the error is not misleading: a missing dir is a plain setup
+			// error, not a confinement violation. (No MkdirAll here -- behavior is
+			// unchanged; os.CreateTemp below already requires the dir to exist.)
+			if _, statErr := os.Stat(outdir); os.IsNotExist(statErr) {
+				return fmt.Errorf("refusing to write: output dir %q does not exist", outdir)
+			}
+			return fmt.Errorf("refusing to write to %q: output dir escapes confinement root %q or is unresolvable", outdir, root)
 		}
-	case writeTags:
-		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ".lrc"
-	default:
-		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ".txt"
+		outdir = resolved
 	}
 	fp := filepath.Join(outdir, fn)
 
@@ -144,6 +195,19 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	return nil
 }
 
+// matchRoot returns the longest configured confinement root that outdir is
+// lexically under, or ok=false when outdir is under none. Roots are already
+// cleaned by NewLRCWriter.
+func (w *LRCWriter) matchRoot(outdir string) (string, bool) {
+	best := ""
+	for _, r := range w.roots {
+		if pathutil.WithinRoot(r, outdir) && len(r) > len(best) {
+			best = r
+		}
+	}
+	return best, best != ""
+}
+
 func writeSyncedLRC(song models.Song, buff *bufio.Writer) error {
 	var text string
 	var fLine string
@@ -173,8 +237,10 @@ func writeUnsyncedLRC(song models.Song, buff *bufio.Writer) error {
 	return nil
 }
 
-func writeInstrumentalLRC(buff *bufio.Writer) error {
-	line := "[00:00.00]\u266a Instrumental \u266a"
+// writeInstrumental emits a plain instrumental marker (no [00:00.00] timestamp,
+// no tag headers) so the .txt output carries only the single marker line.
+func writeInstrumental(buff *bufio.Writer) error {
+	line := "\u266a Instrumental \u266a"
 	if _, err := buff.WriteString(line + "\n"); err != nil {
 		return fmt.Errorf("writing instrumental line: %w", err)
 	}

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -96,6 +96,14 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ext
 	}
 
+	// The output filename must be a single path component. Reject path
+	// separators or an absolute path so a crafted filename cannot traverse out
+	// of outdir via filepath.Join below (defense in depth alongside the
+	// confinement-root re-resolution that follows).
+	if filepath.IsAbs(fn) || strings.ContainsAny(fn, `/\`) {
+		return fmt.Errorf("refusing to write: output filename %q is not a base name", fn)
+	}
+
 	// When the output directory falls under a confinement root, re-resolve and
 	// re-confine it right before the write so a symlink swapped in since the
 	// caller validated the path cannot redirect the write outside the root.

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -89,19 +89,21 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 
 	var fn string
 	if filename != "" {
+		// The provided filename must be a single path component. Reject ".",
+		// "..", any path separator, or an absolute path so a crafted filename
+		// cannot traverse out of outdir (or target outdir/its parent) via the
+		// filepath.Join below -- defense in depth alongside the confinement-root
+		// re-resolution that follows. Validate the raw input here, before the
+		// extension swap turns "."/".." into harmless-looking ".lrc"/"..lrc".
+		if filename == "." || filename == ".." || filename != filepath.Base(filename) ||
+			filepath.IsAbs(filename) || strings.ContainsAny(filename, `/\`) {
+			return fmt.Errorf("refusing to write: output filename %q is not a base name", filename)
+		}
 		// In dir mode the scanner sets an explicit .lrc filename. Swap the
 		// extension to match the content type (.lrc only for synced lyrics).
 		fn = strings.TrimSuffix(filename, filepath.Ext(filename)) + ext
 	} else {
 		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ext
-	}
-
-	// The output filename must be a single path component. Reject path
-	// separators or an absolute path so a crafted filename cannot traverse out
-	// of outdir via filepath.Join below (defense in depth alongside the
-	// confinement-root re-resolution that follows).
-	if filepath.IsAbs(fn) || strings.ContainsAny(fn, `/\`) {
-		return fmt.Errorf("refusing to write: output filename %q is not a base name", fn)
 	}
 
 	// When the output directory falls under a confinement root, re-resolve and

--- a/internal/lyrics/writer_confine_test.go
+++ b/internal/lyrics/writer_confine_test.go
@@ -1,0 +1,294 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func syncedSong() models.Song {
+	return models.Song{
+		Track: models.Track{ArtistName: "Artist", TrackName: "Track"},
+		Subtitles: models.Synced{Lines: []models.Lines{
+			{Text: "hello", Time: models.Time{Minutes: 0, Seconds: 1, Hundredths: 0}},
+		}},
+	}
+}
+
+// TestWriteLRC_ConfinedInRootUnchanged verifies that a writer configured with a
+// confinement root still writes legitimate in-root output normally (acceptance:
+// behavior unchanged for legitimate in-root writes).
+func TestWriteLRC_ConfinedInRootUnchanged(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "albums", "one")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+
+	w := NewLRCWriter(root)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", sub); err != nil {
+		t.Fatalf("confined write into root: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(sub, "song.lrc"))
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if !strings.Contains(string(got), "[ar:Artist]") || !strings.Contains(string(got), "hello") {
+		t.Fatalf("unexpected file content: %q", got)
+	}
+	// No leftover temp files.
+	entries, err := os.ReadDir(sub)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+// TestWriteLRC_ConfinedRefusesEscapingSymlinkSwap is the core #102 guard: a
+// directory component inside the root is swapped for a symlink that escapes the
+// root AFTER the caller validated the path. The confined write must fail the
+// open rather than follow the symlink and write outside the root.
+func TestWriteLRC_ConfinedRefusesEscapingSymlinkSwap(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir() // a sibling dir, NOT under root
+
+	// Legit-looking directory the caller would have validated.
+	sub := filepath.Join(root, "albums")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	// Attacker swaps the component for a symlink escaping the root.
+	if err := os.Remove(sub); err != nil {
+		t.Fatalf("remove sub: %v", err)
+	}
+	if err := os.Symlink(external, sub); err != nil {
+		t.Fatalf("symlink swap: %v", err)
+	}
+
+	w := NewLRCWriter(root)
+	err := w.WriteLRC(syncedSong(), "song.lrc", sub)
+	if err == nil {
+		t.Fatal("expected confined write to refuse the escaping symlink, got nil error")
+	}
+
+	// Nothing must have been written into the symlink target outside the root.
+	entries, readErr := os.ReadDir(external)
+	if readErr != nil {
+		t.Fatalf("readdir external: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("write escaped the root into %s: %v", external, entries)
+	}
+}
+
+// TestWriteLRC_ConfinedRefusesSymlinkedOutdir covers the outdir itself being a
+// symlink that escapes the root.
+func TestWriteLRC_ConfinedRefusesSymlinkedOutdir(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+
+	link := filepath.Join(root, "out")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	w := NewLRCWriter(root)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", link); err == nil {
+		t.Fatal("expected refusal writing through a symlinked outdir, got nil error")
+	}
+
+	entries, err := os.ReadDir(external)
+	if err != nil {
+		t.Fatalf("readdir external: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("write escaped the root into %s: %v", external, entries)
+	}
+}
+
+// TestWriteLRC_ConfinedUnsyncedAndInstrumental exercises the confined path for
+// the .txt (unsynced) and instrumental content types.
+func TestWriteLRC_ConfinedUnsyncedAndInstrumental(t *testing.T) {
+	root := t.TempDir()
+	w := NewLRCWriter(root)
+
+	unsynced := models.Song{
+		Track:  models.Track{ArtistName: "A", TrackName: "B"},
+		Lyrics: models.Lyrics{LyricsBody: "plain lyrics"},
+	}
+	if err := w.WriteLRC(unsynced, "song.lrc", root); err != nil {
+		t.Fatalf("confined unsynced write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "song.txt")); err != nil {
+		t.Fatalf("expected .txt output for unsynced content: %v", err)
+	}
+
+	instrumental := models.Song{Track: models.Track{ArtistName: "A", TrackName: "C", Instrumental: 1}}
+	if err := w.WriteLRC(instrumental, "inst.lrc", root); err != nil {
+		t.Fatalf("confined instrumental write: %v", err)
+	}
+	// Instrumentals are unsynced content and are written as .txt, not .lrc.
+	got, err := os.ReadFile(filepath.Join(root, "inst.txt"))
+	if err != nil {
+		t.Fatalf("reading instrumental: %v", err)
+	}
+	content := string(got)
+	// Plain marker: no timestamp, no tag headers.
+	const want = "♪ Instrumental ♪\n"
+	if content != want {
+		t.Fatalf("instrumental content = %q, want %q", content, want)
+	}
+	if strings.Contains(content, "[00:00.00]") {
+		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
+	}
+	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	}
+}
+
+// TestWriteLRC_ConfinedOverwriteAndStaleSidecar covers the confined overwrite
+// (removing an existing target) and stale-sidecar removal (writing .lrc deletes
+// an existing .txt).
+func TestWriteLRC_ConfinedOverwriteAndStaleSidecar(t *testing.T) {
+	root := t.TempDir()
+	w := NewLRCWriter(root)
+
+	// Seed an existing target and a stale .txt sidecar.
+	if err := os.WriteFile(filepath.Join(root, "song.lrc"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed lrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "song.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed txt: %v", err)
+	}
+
+	if err := w.WriteLRC(syncedSong(), "song.lrc", root); err != nil {
+		t.Fatalf("confined overwrite: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "song.lrc"))
+	if err != nil {
+		t.Fatalf("reading overwritten file: %v", err)
+	}
+	if string(got) == "old" || !strings.Contains(string(got), "[ar:Artist]") {
+		t.Fatalf("file was not overwritten: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "song.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale .txt sidecar should have been removed, stat err = %v", err)
+	}
+}
+
+// TestWriteLRC_ConfinedInRootSymlinkResolves verifies the key advantage of the
+// re-resolve approach over an open-time os.Root guard: a directory component
+// that is a symlink pointing to ANOTHER location inside the same root resolves
+// and writes normally (common in symlinked library layouts), rather than being
+// refused. The file must land at the symlink's real in-root target.
+func TestWriteLRC_ConfinedInRootSymlinkResolves(t *testing.T) {
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	if err := os.Mkdir(real, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	link := filepath.Join(root, "albums") // in-root symlink -> root/real
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	w := NewLRCWriter(root)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", link); err != nil {
+		t.Fatalf("in-root symlinked dir must resolve and write, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(real, "song.lrc")); err != nil {
+		t.Fatalf("expected file at the symlink's real in-root target: %v", err)
+	}
+}
+
+// TestWriteLRC_ConfinedRefusesUnresolvableDir covers the confined refusal when
+// the output dir is lexically under a root but cannot be resolved (it does not
+// exist), so containment cannot be re-confirmed before the write.
+func TestWriteLRC_ConfinedRefusesUnresolvableDir(t *testing.T) {
+	root := t.TempDir()
+	missingSub := filepath.Join(root, "no", "such", "dir")
+	w := NewLRCWriter(root)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", missingSub); err == nil {
+		t.Fatal("expected refusal writing to an unresolvable confined dir, got nil")
+	}
+}
+
+// TestWriteLRC_ConfinedNestedRootsAnchorTightest verifies multi-root and
+// longest-root selection: with both a parent and a nested child root configured,
+// a write under the child must still resolve and confine correctly (the tightest
+// matching root wins).
+func TestWriteLRC_ConfinedNestedRootsAnchorTightest(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "library", "music")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+
+	// Roots given in parent-first order; the child (longest match) should win.
+	w := NewLRCWriter(parent, child)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", child); err != nil {
+		t.Fatalf("nested-root confined write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(child, "song.lrc")); err != nil {
+		t.Fatalf("expected file written under the child root: %v", err)
+	}
+
+	// A write under only the parent root (not the child) must also work.
+	parentOnly := filepath.Join(parent, "other")
+	if err := os.Mkdir(parentOnly, 0o755); err != nil {
+		t.Fatalf("mkdir parentOnly: %v", err)
+	}
+	if err := w.WriteLRC(syncedSong(), "p.lrc", parentOnly); err != nil {
+		t.Fatalf("parent-root confined write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(parentOnly, "p.lrc")); err != nil {
+		t.Fatalf("expected file written under the parent root: %v", err)
+	}
+}
+
+// TestWriteLRC_UnconfinedFollowsSymlinkSwap documents the baseline the
+// confinement closes: with no roots (e.g. directory mode), the writer follows a
+// swapped symlink and the file lands outside. This proves the symlink setup in
+// the confined tests is a genuine escape, so their refusal is meaningful.
+func TestWriteLRC_UnconfinedFollowsSymlinkSwap(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+
+	link := filepath.Join(root, "out")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	w := NewLRCWriter() // no confinement roots
+	if err := w.WriteLRC(syncedSong(), "song.lrc", link); err != nil {
+		t.Fatalf("unconfined write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(external, "song.lrc")); err != nil {
+		t.Fatalf("expected unconfined write to follow the symlink into %s: %v", external, err)
+	}
+}
+
+// TestWriteLRC_OutsideRootsUsesUnconfinedPath verifies that an output directory
+// not under any configured root still writes (the confinement is additive: it
+// does not break writes the worker legitimately makes outside the library roots,
+// e.g. a configured default output dir).
+func TestWriteLRC_OutsideRootsUsesUnconfinedPath(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir() // not under root
+
+	w := NewLRCWriter(root)
+	if err := w.WriteLRC(syncedSong(), "song.lrc", other); err != nil {
+		t.Fatalf("write outside roots should fall back to unconfined path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(other, "song.lrc")); err != nil {
+		t.Fatalf("expected file written via unconfined path: %v", err)
+	}
+}

--- a/internal/lyrics/writer_confine_test.go
+++ b/internal/lyrics/writer_confine_test.go
@@ -89,6 +89,32 @@ func TestWriteLRC_ConfinedRefusesEscapingSymlinkSwap(t *testing.T) {
 	}
 }
 
+// TestWriteLRC_RefusesNonBaseFilename verifies the writer rejects a filename
+// that is not a single path component, so a crafted filename cannot traverse
+// out of outdir via filepath.Join, independent of the symlink re-resolution.
+func TestWriteLRC_RefusesNonBaseFilename(t *testing.T) {
+	root := t.TempDir()
+	w := NewLRCWriter(root)
+	cases := []string{
+		"../escape.lrc",
+		"sub/escape.lrc",
+		filepath.Join(t.TempDir(), "abs.lrc"), // absolute path
+	}
+	for _, name := range cases {
+		if err := w.WriteLRC(syncedSong(), name, root); err == nil {
+			t.Errorf("expected refusal of non-base filename %q, got nil error", name)
+		}
+	}
+	// The confined root must contain no files written by the rejected calls.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("readdir root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected non-base filenames still wrote into root: %v", entries)
+	}
+}
+
 // TestWriteLRC_ConfinedRefusesSymlinkedOutdir covers the outdir itself being a
 // symlink that escapes the root.
 func TestWriteLRC_ConfinedRefusesSymlinkedOutdir(t *testing.T) {

--- a/internal/lyrics/writer_confine_test.go
+++ b/internal/lyrics/writer_confine_test.go
@@ -99,6 +99,8 @@ func TestWriteLRC_RefusesNonBaseFilename(t *testing.T) {
 		"../escape.lrc",
 		"sub/escape.lrc",
 		filepath.Join(t.TempDir(), "abs.lrc"), // absolute path
+		".",                                   // current dir
+		"..",                                  // parent dir
 	}
 	for _, name := range cases {
 		if err := w.WriteLRC(syncedSong(), name, root); err == nil {

--- a/internal/lyrics/writer_test.go
+++ b/internal/lyrics/writer_test.go
@@ -57,7 +57,8 @@ func TestWriteLRC_Instrumental(t *testing.T) {
 		t.Fatalf("expected nil error for instrumental, got: %v", err)
 	}
 
-	fn := Slugify("Test Artist - Instrumental Track") + ".lrc"
+	// Instrumentals are unsynced content and must be saved as .txt, not .lrc.
+	fn := Slugify("Test Artist - Instrumental Track") + ".txt"
 	fp := filepath.Join(tmpDir, fn)
 	data, err := os.ReadFile(fp) //nolint:gosec // test path constructed from known test data
 	if err != nil {
@@ -67,9 +68,61 @@ func TestWriteLRC_Instrumental(t *testing.T) {
 	if len(content) == 0 {
 		t.Fatal("expected non-empty file content for instrumental")
 	}
-	const want = "[00:00.00]\u266a Instrumental \u266a"
-	if !strings.Contains(content, want) {
-		t.Fatalf("expected content to contain %q, got: %q", want, content)
+	// Instrumentals are a plain marker: the single line with no timestamp and no
+	// tag headers.
+	const want = "\u266a Instrumental \u266a\n"
+	if content != want {
+		t.Fatalf("expected content to equal %q, got: %q", want, content)
+	}
+	if strings.Contains(content, "[00:00.00]") {
+		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
+	}
+	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	}
+
+	// No .lrc file should have been created for an instrumental.
+	lrcFn := Slugify("Test Artist - Instrumental Track") + ".lrc"
+	if _, err := os.Stat(filepath.Join(tmpDir, lrcFn)); err == nil {
+		t.Fatal("expected no .lrc file for instrumental, but one was created")
+	}
+}
+
+func TestWriteLRC_InstrumentalExplicitFilename(t *testing.T) {
+	w := NewLRCWriter()
+	tmpDir := t.TempDir()
+
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:   "Test Artist",
+			TrackName:    "Instrumental Track",
+			Instrumental: 1,
+		},
+	}
+
+	// Dir mode passes an explicit .lrc filename; an instrumental must still be
+	// written as .txt.
+	if err := w.WriteLRC(song, "song.lrc", tmpDir); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	txtPath := filepath.Join(tmpDir, "song.txt")
+	data, err := os.ReadFile(txtPath) //nolint:gosec // test path constructed from known test data
+	if err != nil {
+		t.Fatalf("expected file song.txt to exist: %v", err)
+	}
+	content := string(data)
+	const want = "♪ Instrumental ♪\n"
+	if content != want {
+		t.Fatalf("expected content to equal %q, got: %q", want, content)
+	}
+	if strings.Contains(content, "[00:00.00]") {
+		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
+	}
+	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "song.lrc")); err == nil {
+		t.Fatal("expected no .lrc file for instrumental, but one was created")
 	}
 }
 

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -31,7 +31,26 @@ var (
 	// ErrNotFound indicates HTTP 404 or an inner status_code 404 from the
 	// Musixmatch API meaning no matching track or lyrics were found.
 	ErrNotFound = errors.New("musixmatch: no results found")
+	// ErrNoLyrics indicates the track was matched but no usable lyrics could be
+	// obtained: the catalog has no synced or plain lyrics, the lyrics are
+	// restricted, or the response omitted the lyrics payload. Like ErrNotFound,
+	// this is a benign miss (see IsBenignMiss): there are no fetchable lyrics
+	// now and the upstream result is stable (it will not change on a near-term
+	// retry), so callers must not count it as a fetch failure for backoff.
+	ErrNoLyrics = errors.New("musixmatch: no lyrics available")
 )
+
+// IsBenignMiss reports whether err represents a benign miss: the track has no
+// fetchable lyrics now (either no match at all, or a match with no usable
+// lyrics). These outcomes are not failures of the API or the network, and the
+// upstream result is stable -- it will not change on a near-term retry. Callers
+// (worker, app) use this to skip the geometric backoff and the immediate retry
+// that genuine, transient failures warrant. (This concerns only the upstream
+// result; the queue row is not retired -- the worker re-checks it later on a
+// generous cooldown as the catalog grows.)
+func IsBenignMiss(err error) bool {
+	return errors.Is(err, ErrNotFound) || errors.Is(err, ErrNoLyrics)
+}
 
 // Client communicates with the Musixmatch desktop API.
 type Client struct {
@@ -132,7 +151,10 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	case 200:
 		trackNode := mtg.Get("body", "track")
 		if trackNode == nil {
-			return song, errors.New("musixmatch API response missing track data")
+			// status_code 200 with no track body is an unexpected upstream shape,
+			// not a benign miss -- intentionally returned as a genuine/transient
+			// error (IsBenignMiss is false) so it retries rather than deferring.
+			return song, errors.New("musixmatch: matcher status_code 200 but response missing track data")
 		}
 		if err := json.Unmarshal(trackNode.MarshalTo(nil), &song.Track); err != nil {
 			return song, err
@@ -142,7 +164,11 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	case 404:
 		return song, ErrNotFound
 	default:
-		return song, errors.New("unknown error")
+		// An unexpected matcher status_code is a genuine/transient upstream
+		// condition, not a benign miss -- intentionally returned non-sentinel
+		// (IsBenignMiss is false) so it is retried, and it carries the observed
+		// code for diagnosis.
+		return song, fmt.Errorf("musixmatch: unexpected matcher status_code %d", mtg.GetInt("header", "status_code"))
 	}
 
 	if song.Track.HasSubtitles == 1 {
@@ -153,11 +179,11 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 		slog.Info("no synced lyrics found")
 		if song.Track.HasLyrics == 1 {
 			if tlg.GetInt("body", "lyrics", "restricted") == 1 {
-				return song, errors.New("restricted lyrics")
+				return song, fmt.Errorf("%w: restricted", ErrNoLyrics)
 			}
 			lyricsNode := tlg.Get("body", "lyrics")
 			if lyricsNode == nil {
-				return song, errors.New("musixmatch API response missing lyrics data")
+				return song, fmt.Errorf("%w: response missing lyrics data", ErrNoLyrics)
 			}
 			if err := json.Unmarshal(lyricsNode.MarshalTo(nil), &song.Lyrics); err != nil {
 				return song, err
@@ -165,7 +191,7 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 		} else if song.Track.Instrumental == 1 {
 			slog.Info("song is instrumental")
 		} else {
-			return song, errors.New("no lyrics found")
+			return song, fmt.Errorf("%w: no synced or unsynced lyrics", ErrNoLyrics)
 		}
 	}
 	return song, nil

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -37,6 +37,13 @@ var (
 	// this is a benign miss (see IsBenignMiss): there are no fetchable lyrics
 	// now and the upstream result is stable (it will not change on a near-term
 	// retry), so callers must not count it as a fetch failure for backoff.
+	//
+	// Restricted tracks (licensing) are also classified here. Such restrictions
+	// can be permanent, so a track wrapped as ErrNoLyrics may be re-checked on
+	// the fixed benign-miss cooldown indefinitely; Defer never increments the
+	// attempt count, so there is no natural ceiling. This is intentional:
+	// catalogs and licensing change over time, and the days-scale cadence keeps
+	// the cost negligible.
 	ErrNoLyrics = errors.New("musixmatch: no lyrics available")
 )
 

--- a/internal/musixmatch/client_test.go
+++ b/internal/musixmatch/client_test.go
@@ -235,7 +235,7 @@ func TestFindLyricsErrors(t *testing.T) {
 					}
 				}
 			}`),
-			wantErr: "restricted lyrics",
+			wantErr: "restricted",
 		},
 		"missing track": {
 			client: newTestClient(http.StatusOK, `{
@@ -290,6 +290,69 @@ func TestFindLyricsReturnsSentinelErrors(t *testing.T) {
 			}
 			if !errors.Is(err, tt.sentinel) {
 				t.Fatalf("error = %v; want errors.Is(_, %v)", err, tt.sentinel)
+			}
+		})
+	}
+}
+
+func TestFindLyricsBenignMissesAreClassifiable(t *testing.T) {
+	restricted := `{
+		"message": {"header": {"status_code": 200}, "body": {"macro_calls": {
+			"matcher.track.get": {"message": {"header": {"status_code": 200}, "body": {"track": {"track_name": "title", "artist_name": "artist", "has_subtitles": 0, "has_lyrics": 1}}}},
+			"track.lyrics.get": {"message": {"body": {"lyrics": {"restricted": 1}}}},
+			"track.subtitles.get": {"message": {"body": {}}}
+		}}}
+	}`
+	missingLyrics := `{
+		"message": {"header": {"status_code": 200}, "body": {"macro_calls": {
+			"matcher.track.get": {"message": {"header": {"status_code": 200}, "body": {"track": {"track_name": "title", "artist_name": "artist", "has_subtitles": 0, "has_lyrics": 1}}}},
+			"track.lyrics.get": {"message": {"body": {}}},
+			"track.subtitles.get": {"message": {"body": {}}}
+		}}}
+	}`
+	noLyrics := `{
+		"message": {"header": {"status_code": 200}, "body": {"macro_calls": {
+			"matcher.track.get": {"message": {"header": {"status_code": 200}, "body": {"track": {"track_name": "title", "artist_name": "artist", "has_subtitles": 0, "has_lyrics": 0}}}},
+			"track.lyrics.get": {"message": {"body": {}}},
+			"track.subtitles.get": {"message": {"body": {}}}
+		}}}
+	}`
+
+	tests := map[string]struct {
+		client   *Client
+		sentinel error
+	}{
+		"http 404":            {newTestClient(http.StatusNotFound, ""), ErrNotFound},
+		"restricted lyrics":   {newTestClient(http.StatusOK, restricted), ErrNoLyrics},
+		"missing lyrics data": {newTestClient(http.StatusOK, missingLyrics), ErrNoLyrics},
+		"no lyrics found":     {newTestClient(http.StatusOK, noLyrics), ErrNoLyrics},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := tt.client.FindLyrics(context.Background(), models.Track{TrackName: "title", ArtistName: "artist"})
+			if err == nil {
+				t.Fatal("FindLyrics returned nil error")
+			}
+			if !errors.Is(err, tt.sentinel) {
+				t.Fatalf("error = %v; want errors.Is(_, %v)", err, tt.sentinel)
+			}
+			if !IsBenignMiss(err) {
+				t.Fatalf("IsBenignMiss(%v) = false; want true (benign terminal miss)", err)
+			}
+		})
+	}
+}
+
+func TestIsBenignMissRejectsGenuineErrors(t *testing.T) {
+	for name, err := range map[string]error{
+		"unauthorized": ErrUnauthorized,
+		"rate limited": ErrRateLimited,
+		"transport":    errors.New("network down"),
+		"nil":          nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if IsBenignMiss(err) {
+				t.Fatalf("IsBenignMiss(%v) = true; want false", err)
 			}
 		})
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -384,6 +384,49 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 	return item, nil
 }
 
+// Defer reschedules a processing item after a fixed retryAfter delay without
+// counting the attempt against the retry budget. Unlike Fail, attempts is left
+// unchanged so the delay does not ramp into geometric backoff: every Defer of
+// the same row waits the same fixed window. The row is left in the 'failed'
+// state (not 'pending') on purpose -- Enqueue preserves next_attempt_at for
+// 'failed' rows but resets 'pending' rows to now, so keeping the deferred row
+// 'failed' is what makes the cooldown survive a later library scan rather than
+// being un-deferred on every scan. The reset is asymmetric, matching Enqueue's
+// refreshFailedBackoff logic: a scan-priority Enqueue preserves the deferred
+// next_attempt_at (the cooldown survives bulk scans), but a webhook-priority
+// Enqueue (priority >= PriorityWebhook) resets next_attempt_at to now, so an
+// explicit webhook can force an immediate re-check despite the cooldown. Used by
+// the worker for benign misses (no matching track, or a match with no usable
+// lyrics).
+func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration, cause error) (WorkItem, error) {
+	nextAttemptAt := formatTime(q.now().Add(retryAfter))
+	lastError := ""
+	if cause != nil {
+		lastError = cause.Error()
+	}
+	row := q.db.QueryRowContext(ctx,
+		`UPDATE work_queue
+         SET status = 'failed',
+             next_attempt_at = ?,
+             last_error = ?
+         WHERE id = ?
+           AND status = 'processing'
+         RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
+                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+		nextAttemptAt,
+		lastError,
+		id,
+	)
+	item, err := scanWorkItem(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkItem{}, sql.ErrNoRows
+	}
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: defer: %w", err)
+	}
+	return item, nil
+}
+
 // ListFilter narrows the rows returned by List.
 type ListFilter struct {
 	// Status optionally restricts results to a single status value (e.g.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -162,6 +162,122 @@ func TestDBQueue_CountByStatus(t *testing.T) {
 	}
 }
 
+func TestDBQueue_NoResultRequeueIsDeferredButReprocessable(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	// The worker requeues a no-result via Defer (fixed cooldown). It must NOT be
+	// terminal: the row stays re-dequeueable once the cooldown window elapses, so
+	// the track is re-attempted later as the catalog grows.
+	const cooldown = 7 * 24 * time.Hour
+	deferred, err := q.Defer(ctx, claimed.ID, cooldown, errors.New("musixmatch: no results found"))
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if deferred.Status != StatusFailed {
+		t.Fatalf("status = %q; want %q (deferred, not terminal)", deferred.Status, StatusFailed)
+	}
+
+	// The cooldown is fixed: next_attempt_at is exactly now+cooldown and attempts
+	// is unchanged (Defer does not ramp like geometric backoff).
+	if want := now.Add(cooldown); !deferred.NextAttemptAt.Equal(want) {
+		t.Fatalf("next_attempt_at = %v; want fixed %v", deferred.NextAttemptAt, want)
+	}
+	if deferred.Attempts != claimed.Attempts {
+		t.Fatalf("attempts = %d; want unchanged %d (a fixed cooldown must not ramp)", deferred.Attempts, claimed.Attempts)
+	}
+
+	// Deferred: not eligible immediately.
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("immediate Dequeue = %v; want sql.ErrNoRows (item is deferred by cooldown)", err)
+	}
+
+	// The cooldown survives a later library scan: re-enqueuing at scan priority
+	// must preserve next_attempt_at (the row stays 'failed', not reset to now),
+	// so the track is not re-queried upstream on every scan.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue (rescan): %v", err)
+	}
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue after rescan = %v; want sql.ErrNoRows (cooldown must survive a scan)", err)
+	}
+
+	// Re-processable: eligible again once the cooldown elapses.
+	q.now = func() time.Time { return deferred.NextAttemptAt.Add(time.Second) }
+	again, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after cooldown: %v", err)
+	}
+	if again.ID != claimed.ID {
+		t.Fatalf("re-dequeued ID = %d; want %d (a no-result must remain re-processable)", again.ID, claimed.ID)
+	}
+}
+
+// TestDBQueue_WebhookEnqueueResetsDeferredCooldown proves the asymmetry
+// documented on Defer: a webhook-priority Enqueue of a deferred (cooldown)
+// row resets next_attempt_at to now so an explicit webhook forces an immediate
+// re-check, while a scan-priority Enqueue preserves the cooldown.
+func TestDBQueue_WebhookEnqueueResetsDeferredCooldown(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	inputs := models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}
+	if _, err := q.Enqueue(ctx, inputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	// Defer the row into a future cooldown window.
+	const cooldown = 7 * 24 * time.Hour
+	deferred, err := q.Defer(ctx, claimed.ID, cooldown, errors.New("musixmatch: no results found"))
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if deferred.Status != StatusFailed {
+		t.Fatalf("status = %q; want %q", deferred.Status, StatusFailed)
+	}
+
+	// Control: a scan-priority Enqueue must NOT reset the cooldown.
+	if _, err := q.Enqueue(ctx, inputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue (scan): %v", err)
+	}
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue after scan Enqueue = %v; want sql.ErrNoRows (scan must preserve cooldown)", err)
+	}
+
+	// A webhook-priority Enqueue resets next_attempt_at to (approximately) now,
+	// so the row becomes immediately dequeueable despite the cooldown.
+	refreshed, err := q.Enqueue(ctx, inputs, PriorityWebhook)
+	if err != nil {
+		t.Fatalf("Enqueue (webhook): %v", err)
+	}
+	if !refreshed.NextAttemptAt.Equal(now) {
+		t.Fatalf("next_attempt_at = %v; want reset to now %v (webhook must force a re-check)", refreshed.NextAttemptAt, now)
+	}
+	again, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after webhook Enqueue: %v", err)
+	}
+	if again.ID != claimed.ID {
+		t.Fatalf("re-dequeued ID = %d; want %d (webhook reset must make the same row eligible)", again.ID, claimed.ID)
+	}
+}
+
 func TestDBQueue_DequeueClaimsHighestPriorityReadyItem(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -455,10 +455,12 @@ func (h *Handler) usablePath(paths []string, title string, single bool) string {
 // returns ok=false when no roots are configured, the path lies outside every
 // root, a symlink escapes its root, or the path does not exist (fail closed).
 //
-// Containment is enforced lexically and via EvalSymlinks at request time; the
+// Containment is enforced lexically and via EvalSymlinks at request time. The
 // residual write-time symlink-swap TOCTOU (a path component swapped for a
-// symlink before the worker writes) is not closed here and is tracked in #102
-// for the writing layer.
+// symlink before the worker writes) is not closed here but in the writing
+// layer: lyrics.LRCWriter re-resolves and re-confines the output dir
+// immediately before the write (#102), so the same roots passed here also
+// confine the worker's write.
 func (h *Handler) confinedPayloadPath(path string) (string, bool) {
 	for _, root := range h.allowedRoots {
 		if resolved, ok := pathutil.ResolveWithinRoot(root, path); ok {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -23,6 +23,7 @@ type Queue interface {
 	Dequeue(ctx context.Context) (queue.WorkItem, error)
 	Complete(ctx context.Context, id int64) error
 	Fail(ctx context.Context, id int64, cause error) (queue.WorkItem, error)
+	Defer(ctx context.Context, id int64, retryAfter time.Duration, cause error) (queue.WorkItem, error)
 	Release(ctx context.Context, id int64) error
 }
 
@@ -37,6 +38,16 @@ type Cache interface {
 // is configured via SetCircuitOpenDuration. Mirrors the config default so
 // non-server callers (tests, ad-hoc CLI runs) get sensible behavior.
 const defaultCircuitOpenDuration = 30 * time.Minute
+
+// benignMissCooldown is the fixed delay applied when a track resolves to a
+// benign miss (no matching track, or a match with no usable lyrics). A miss
+// is not our failure and does not retire the queue row, but the catalog
+// rarely gains the missing lyrics on an hourly cadence, so a generous
+// days-scale cooldown keeps
+// the worker from re-querying upstream for the same dead track on every
+// library scan. Unlike geometric backoff, this delay does not ramp with the
+// attempt count: each re-check waits the same fixed window.
+const benignMissCooldown = 7 * 24 * time.Hour
 
 // Worker consumes queued lyrics work one item at a time. The scan_results
 // writeback for successful completions is handled atomically inside
@@ -200,6 +211,15 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			}
 			return errQueueEmpty
 		}
+		// A no-result (no matching track, or a match with no usable lyrics) is
+		// not our failure and does NOT retire the queue row: the catalog grows
+		// and more sources may be added, so requeue it after a generous fixed
+		// cooldown but do NOT ratchet the consecutive-failure counter (which
+		// would otherwise spam geometric backoff on routine library scans).
+		if musixmatch.IsBenignMiss(err) {
+			slog.Info("worker no lyrics match; requeuing deferred", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", err)
+			return w.requeueDeferred(ctx, item, err)
+		}
 		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
 		return w.fail(ctx, item, err)
 	}
@@ -312,6 +332,35 @@ func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) err
 	if _, err := w.queue.Fail(context.WithoutCancel(ctx), item.ID, cause); err != nil {
 		return fmt.Errorf("worker: fail item %d after %v: %w", item.ID, cause, err)
 	}
+	return nil
+}
+
+// requeueDeferred re-queues a no-result item after a fixed cooldown
+// (benignMissCooldown, via Defer) WITHOUT tripping the consecutive-failure
+// counter. The queue row is not retired: it stays re-dequeueable once the
+// cooldown elapses and re-enqueueable by a later scan or webhook, so it is
+// retried eventually as the catalog grows, while the worker neither slows down
+// nor re-queries upstream hourly for the same dead track. Defer leaves the row
+// in the deferred 'failed' state and does not increment attempts, so the
+// cooldown is fixed (not geometric). On a SCAN-priority re-enqueue the cooldown
+// survives: Enqueue preserves next_attempt_at for 'failed' rows. A WEBHOOK
+// re-enqueue intentionally resets it to now to force an immediate retry (see
+// DBQueue.Enqueue).
+//
+// A sql.ErrNoRows from Defer is benign here: it means the row is no longer
+// 'processing' because it was canceled or re-dequeued out from under us
+// (a lost race), not a real failure. Log it at debug and return nil so the run
+// loop does not surface a scary "worker run failed" warning for a no-result.
+func (w *Worker) requeueDeferred(ctx context.Context, item queue.WorkItem, cause error) error {
+	deferred, err := w.queue.Defer(context.WithoutCancel(ctx), item.ID, benignMissCooldown, cause)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Debug("benign miss defer skipped; item moved on", "id", item.ID, "cause", cause)
+			return nil
+		}
+		return fmt.Errorf("worker: requeue item %d after %v: %w", item.ID, cause, err)
+	}
+	slog.Info("benign miss deferred", "id", item.ID, "retry_after", benignMissCooldown, "next_attempt_at", deferred.NextAttemptAt)
 	return nil
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -43,10 +43,10 @@ const defaultCircuitOpenDuration = 30 * time.Minute
 // benign miss (no matching track, or a match with no usable lyrics). A miss
 // is not our failure and does not retire the queue row, but the catalog
 // rarely gains the missing lyrics on an hourly cadence, so a generous
-// days-scale cooldown keeps
-// the worker from re-querying upstream for the same dead track on every
-// library scan. Unlike geometric backoff, this delay does not ramp with the
-// attempt count: each re-check waits the same fixed window.
+// days-scale cooldown keeps the worker from re-querying upstream for the
+// same dead track on every library scan. Unlike geometric backoff, this
+// delay does not ramp with the attempt count: each re-check waits the same
+// fixed window.
 const benignMissCooldown = 7 * 24 * time.Hour
 
 // Worker consumes queued lyrics work one item at a time. The scan_results

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -20,15 +20,19 @@ import (
 // can assert that an item was returned to the pending pool without a failure
 // being recorded against it.
 type fakeQueue struct {
-	items       []queue.WorkItem
-	processing  []queue.WorkItem
-	completed   []int64
-	failed      []int64
-	released    []int64
-	failCauses  []error
-	completeErr error
-	failErr     error
-	releaseErr  error
+	items          []queue.WorkItem
+	processing     []queue.WorkItem
+	completed      []int64
+	failed         []int64
+	released       []int64
+	deferred       []int64
+	failCauses     []error
+	deferCauses    []error
+	deferDurations []time.Duration
+	completeErr    error
+	failErr        error
+	deferErr       error
+	releaseErr     error
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -57,6 +61,17 @@ func (q *fakeQueue) Fail(_ context.Context, id int64, cause error) (queue.WorkIt
 	q.removeFromProcessing(id)
 	q.failed = append(q.failed, id)
 	q.failCauses = append(q.failCauses, cause)
+	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
+}
+
+func (q *fakeQueue) Defer(_ context.Context, id int64, retryAfter time.Duration, cause error) (queue.WorkItem, error) {
+	if q.deferErr != nil {
+		return queue.WorkItem{}, q.deferErr
+	}
+	q.removeFromProcessing(id)
+	q.deferred = append(q.deferred, id)
+	q.deferCauses = append(q.deferCauses, cause)
+	q.deferDurations = append(q.deferDurations, retryAfter)
 	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
 }
 
@@ -406,6 +421,130 @@ func TestRunOnceFailureMarksQueueFailed(t *testing.T) {
 	}
 	if !errors.Is(q.failCauses[0], wantErr) {
 		t.Fatalf("fail cause = %v; want %v", q.failCauses[0], wantErr)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+}
+
+func TestRunOnceBenignMissRequeuesDeferredWithoutCounter(t *testing.T) {
+	for name, sentinel := range map[string]error{
+		"not found": musixmatch.ErrNotFound,
+		"no lyrics": musixmatch.ErrNoLyrics,
+	} {
+		t.Run(name, func(t *testing.T) {
+			track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+			q := &fakeQueue{items: []queue.WorkItem{{
+				ID:     42,
+				Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+			}}}
+			fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", sentinel)}
+			w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+
+			if err := w.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+			// A no-result requeues via Defer (fixed cooldown) so it is
+			// re-attempted later -- it is NOT terminal -- but it must NOT bump
+			// the consecutive-failure counter and must NOT use Fail's geometric
+			// backoff.
+			if len(q.deferred) != 1 || q.deferred[0] != 42 {
+				t.Fatalf("deferred (requeued) = %v; want [42]", q.deferred)
+			}
+			if len(q.failed) != 0 {
+				t.Fatalf("failed = %v; want none (a benign miss defers, not fails)", q.failed)
+			}
+			if len(q.completed) != 0 {
+				t.Fatalf("completed = %v; want none (no lyrics written)", q.completed)
+			}
+			if w.consecutiveFailures != 0 {
+				t.Fatalf("consecutiveFailures = %d; want 0 (a no-result must not trip backoff)", w.consecutiveFailures)
+			}
+			if len(q.deferCauses) != 1 || !errors.Is(q.deferCauses[0], sentinel) {
+				t.Fatalf("requeue cause = %v; want errors.Is(_, %v)", q.deferCauses, sentinel)
+			}
+			if len(q.deferDurations) != 1 || q.deferDurations[0] != benignMissCooldown {
+				t.Fatalf("defer cooldown = %v; want fixed %v", q.deferDurations, benignMissCooldown)
+			}
+		})
+	}
+}
+
+func TestRunOnceBenignMissSurfacesRequeueError(t *testing.T) {
+	deferErr := errors.New("requeue write failed")
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:     55,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}},
+		}},
+		deferErr: deferErr,
+	}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+
+	err := w.RunOnce(context.Background())
+	if !errors.Is(err, deferErr) {
+		t.Fatalf("RunOnce error = %v; want wrapped requeue failure", err)
+	}
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (a no-result never trips backoff, even when the requeue errors)", w.consecutiveFailures)
+	}
+}
+
+// TestRunOnceBenignMissDeferNoRowsIsBenign covers requeueDeferred treating a
+// sql.ErrNoRows from queue.Defer as a benign "item moved on" (the row is no
+// longer 'processing' because it was canceled or re-dequeued out from under us).
+// RunOnce must NOT propagate an error and must NOT trip the failure counter.
+func TestRunOnceBenignMissDeferNoRowsIsBenign(t *testing.T) {
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:     77,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}},
+		}},
+		deferErr: sql.ErrNoRows,
+	}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce = %v; want nil (a Defer no-rows is benign, the item moved on)", err)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none (a Defer no-rows must not be recorded as a failure)", q.failed)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (a benign Defer no-rows must not trip backoff)", w.consecutiveFailures)
+	}
+}
+
+func TestRunBenignMissesDoNotBackOff(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 500, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+		{ID: 501, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "b.lrc"}},
+		{ID: 502, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "c.lrc"}},
+	}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.baseBackoff = time.Second
+	w.maxBackoff = time.Hour
+	var sleeps []time.Duration
+	w.sleep = func(_ context.Context, d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+
+	if err := w.run(context.Background(), nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(sleeps) != 0 {
+		t.Fatalf("sleeps = %v; want none (no-results must not back off the worker)", sleeps)
+	}
+	// All three are requeued via Defer (fixed cooldown), not failed/terminal.
+	if len(q.deferred) != 3 {
+		t.Fatalf("deferred (requeued) = %v; want all 3 items", q.deferred)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none (benign misses defer, not fail)", q.failed)
 	}
 	if len(q.completed) != 0 {
 		t.Fatalf("completed = %v; want none", q.completed)

--- a/scripts/check-hooks.sh
+++ b/scripts/check-hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# check-hooks.sh -- verify git is wired to the tracked .githooks directory so the
+# pre-commit and pre-push gates actually run in every worktree. Invoked by
+# `make doctor` and `make hooks`. Exits non-zero with remediation guidance when
+# the wiring is missing.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+want=".githooks"
+got="$(git config --get core.hooksPath || true)"
+if [ "$got" != "$want" ]; then
+  echo "FAIL: core.hooksPath is '${got:-<unset>}'; expected '$want'." >&2
+  echo "      Run: make hooks" >&2
+  exit 1
+fi
+
+for hook in pre-commit pre-push; do
+  if [ ! -x "$want/$hook" ]; then
+    echo "FAIL: $want/$hook is missing or not executable." >&2
+    exit 1
+  fi
+done
+
+echo "OK: git hooks wired to $want (pre-commit + pre-push)."

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# check-tool-versions.sh -- assert tool version pins agree across CI and the
+# pre-commit config so local and CI checks cannot silently diverge. Run via
+# `make sync-tool-versions` (and `make doctor`). It catches CI-vs-pre-commit pin
+# drift, e.g. a golangci-lint version bumped in one file but not the other.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+status=0
+
+# golangci-lint: the version: input on the CI action vs the pre-commit rev.
+ci_glci="$(grep -oE 'version: v[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/ci.yml | head -1 | awk '{print $2}')"
+pc_glci="$(awk '/golangci\/golangci-lint/{f=1} f&&/rev:/{print $2; exit}' .pre-commit-config.yaml)"
+if [ -z "$ci_glci" ] || [ -z "$pc_glci" ]; then
+  echo "FAIL: could not parse golangci-lint version (ci='$ci_glci' pre-commit='$pc_glci')." >&2
+  status=1
+elif [ "$ci_glci" != "$pc_glci" ]; then
+  echo "FAIL: golangci-lint pin drift: ci.yml=$ci_glci vs .pre-commit-config.yaml=$pc_glci." >&2
+  echo "      Align both pins (and the local install) to the same version." >&2
+  status=1
+else
+  echo "OK: golangci-lint pinned to $ci_glci in ci.yml and .pre-commit-config.yaml."
+fi
+
+exit $status

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -11,8 +11,10 @@ cd "$REPO_ROOT"
 status=0
 
 # golangci-lint: the version: input on the CI action vs the pre-commit rev.
-ci_glci="$(grep -oE 'version: v[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/ci.yml | head -1 | awk '{print $2}')"
-pc_glci="$(awk '/golangci\/golangci-lint/{f=1} f&&/rev:/{print $2; exit}' .pre-commit-config.yaml)"
+# `|| true` keeps `set -euo pipefail` from aborting the script when a pattern or
+# file is absent; the `-z` checks below report the parse failure with context.
+ci_glci="$(grep -oE 'version: v[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/ci.yml 2>/dev/null | head -1 | awk '{print $2}' || true)"
+pc_glci="$(awk '/golangci\/golangci-lint/{f=1} f&&/rev:/{print $2; exit}' .pre-commit-config.yaml 2>/dev/null || true)"
 if [ -z "$ci_glci" ] || [ -z "$pc_glci" ]; then
   echo "FAIL: could not parse golangci-lint version (ci='$ci_glci' pre-commit='$pc_glci')." >&2
   status=1

--- a/scripts/coverage-floor.json
+++ b/scripts/coverage-floor.json
@@ -1,0 +1,23 @@
+{
+  "github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc": 66.7,
+  "github.com/sydlexius/mxlrcgo-svc/internal/app": 67.0,
+  "github.com/sydlexius/mxlrcgo-svc/internal/auth": 76.2,
+  "github.com/sydlexius/mxlrcgo-svc/internal/backoff": 91.7,
+  "github.com/sydlexius/mxlrcgo-svc/internal/cache": 84.2,
+  "github.com/sydlexius/mxlrcgo-svc/internal/commands": 42.8,
+  "github.com/sydlexius/mxlrcgo-svc/internal/config": 86.8,
+  "github.com/sydlexius/mxlrcgo-svc/internal/db": 60.5,
+  "github.com/sydlexius/mxlrcgo-svc/internal/library": 82.1,
+  "github.com/sydlexius/mxlrcgo-svc/internal/lyrics": 77.4,
+  "github.com/sydlexius/mxlrcgo-svc/internal/musixmatch": 80.0,
+  "github.com/sydlexius/mxlrcgo-svc/internal/normalize": 92.3,
+  "github.com/sydlexius/mxlrcgo-svc/internal/pathutil": 92.0,
+  "github.com/sydlexius/mxlrcgo-svc/internal/providers": 94.4,
+  "github.com/sydlexius/mxlrcgo-svc/internal/queue": 80.1,
+  "github.com/sydlexius/mxlrcgo-svc/internal/scan": 76.2,
+  "github.com/sydlexius/mxlrcgo-svc/internal/scanner": 50.0,
+  "github.com/sydlexius/mxlrcgo-svc/internal/server": 83.9,
+  "github.com/sydlexius/mxlrcgo-svc/internal/verification": 79.2,
+  "github.com/sydlexius/mxlrcgo-svc/internal/watcher": 90.5,
+  "github.com/sydlexius/mxlrcgo-svc/internal/worker": 76.6
+}

--- a/scripts/coverage-floor.sh
+++ b/scripts/coverage-floor.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# coverage-floor.sh -- one-way per-package coverage ratchet.
+#
+# Runs the suite with per-package coverage and fails if any package drops below
+# the floor recorded in scripts/coverage-floor.json. Floors are never lowered
+# automatically: raise them intentionally with
+#   bash scripts/coverage-floor.sh --update
+# after a deliberate coverage improvement. This complements Codecov's patch
+# coverage (which only sees the diff) by guarding whole-package regressions.
+#
+# jq is required; when it is absent the check is skipped (CI/Codecov still
+# enforce coverage), mirroring the optional-tool pattern of the patch-cover gate.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SEED="scripts/coverage-floor.json"
+MODE="check"
+[ "${1:-}" = "--update" ] && MODE="update"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "coverage-floor: jq not found; skipping (Codecov still enforces coverage)." >&2
+  exit 0
+fi
+
+# Collect "pkg pct" lines from the per-package coverage summary. Packages with
+# no test files print no "coverage:" token and are skipped.
+current="$(go test -count=1 -cover ./... \
+  | awk '/coverage: [0-9.]+% of statements/ {
+      pkg=""; pct="";
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^github\.com\//) pkg = $i;
+        if ($i == "coverage:") { pct = $(i + 1); gsub(/%/, "", pct); }
+      }
+      if (pkg != "" && pct != "") print pkg, pct;
+    }')"
+
+if [ "$MODE" = "update" ]; then
+  printf '%s\n' "$current" \
+    | jq -R -s 'split("\n") | map(select(length > 0) | split(" "))
+                | map({(.[0]): (.[1] | tonumber)}) | add // {}' \
+    | jq -S '.' > "$SEED"
+  echo "coverage-floor: wrote per-package floors to $SEED"
+  exit 0
+fi
+
+if [ ! -f "$SEED" ]; then
+  echo "coverage-floor: no seed at $SEED; create it with 'bash scripts/coverage-floor.sh --update'." >&2
+  exit 0
+fi
+
+status=0
+while read -r pkg pct; do
+  [ -z "$pkg" ] && continue
+  floor="$(jq -r --arg p "$pkg" '.[$p] // empty' "$SEED")"
+  [ -z "$floor" ] && continue
+  if awk "BEGIN { exit !($pct < $floor) }"; then
+    echo "FAIL: $pkg coverage ${pct}% < floor ${floor}%" >&2
+    status=1
+  fi
+done <<< "$current"
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: all packages meet their recorded coverage floor."
+fi
+exit $status

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -16,7 +16,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-fail() { echo "FAIL: $1" >&2; exit 1; }
+fail() { printf 'FAIL: %b\n' "$1" >&2; exit 1; }
+
+# Per-worktree run lock + artifact dir. The mkdir is atomic, so two gate runs in
+# the SAME worktree cannot clobber each other's coverage profile; the key is the
+# worktree path, so gates in DIFFERENT worktrees still run concurrently.
+RUN_KEY="$(printf '%s' "$REPO_ROOT" | cksum | cut -d' ' -f1)"
+RUN_DIR="${TMPDIR:-/tmp}/mxlrc-gate-$RUN_KEY"
+if ! mkdir "$RUN_DIR" 2>/dev/null; then
+  fail "another gate run is active for this worktree ($RUN_DIR); wait for it to finish, or 'rm -rf $RUN_DIR' if it is stale"
+fi
+trap 'rm -rf "$RUN_DIR"' EXIT
+
+echo "==> conflict markers"
+# Reject unresolved merge-conflict markers in tracked files. Only the
+# unambiguous opening/closing markers (7 '<' or '>' at column 0) are matched: a
+# real conflict always carries both, and neither appears in normal content, so
+# the middle '=======' marker is skipped to avoid flagging markdown setext
+# headings. The .githooks dir is excluded so this very pattern does not self-trip.
+CONFLICT_RE='^(<{7}|>{7})( |$)'
+if git grep -nIE "$CONFLICT_RE" -- ':!.githooks/*' >/dev/null 2>&1; then
+  echo "Unresolved conflict markers:" >&2
+  git grep -nIE "$CONFLICT_RE" -- ':!.githooks/*' >&2 || true
+  fail "resolve conflict markers before pushing"
+fi
 
 echo "==> gofmt"
 unformatted=$(gofmt -l . | grep -v '^vendor/' || true)
@@ -26,8 +49,9 @@ echo "==> go build"
 go build ./... || fail "build"
 
 echo "==> go test (race + coverage)"
-COVER_OUT="$(mktemp -t mxlrc-cover.XXXXXX.out)"
-trap 'rm -f "$COVER_OUT"' EXIT
+# Coverage profile lives inside the locked per-worktree run dir (cleaned by the
+# EXIT trap set above), so concurrent runs never share a path.
+COVER_OUT="$RUN_DIR/coverage.out"
 go test -race -count=1 -coverprofile="$COVER_OUT" ./... || fail "tests"
 
 echo "==> patch coverage (Codecov parity, conservative lower bound)"
@@ -50,6 +74,13 @@ fi
 
 echo "==> golangci-lint"
 golangci-lint run ./... || fail "lint"
+
+echo "==> actionlint (workflow lint)"
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint || fail "actionlint"
+else
+  echo "    actionlint not installed; skipping (CI still lints workflows)"
+fi
 
 echo "==> govulncheck"
 if command -v govulncheck >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Three related changes bundled into one PR to conserve CodeRabbit review budget:

- **#97 benign-miss cooldown:** benign misses (no matching track, or a match with no usable lyrics) now requeue after a fixed 7-day cooldown via a new `queue.Defer` op instead of geometric `Fail` backoff, so the worker stops re-querying upstream hourly for dead tracks. The deferred row stays `failed` with attempts unchanged, so the cooldown does not ramp and survives a later library scan (scan-priority `Enqueue` preserves `next_attempt_at`; a webhook-priority `Enqueue` resets it to now to force an immediate re-check). A miss stays non-terminal and never trips the consecutive-failure counter.
- **#100 tooling/CI/hooks port:** shared relative `core.hooksPath`, CI/workflow and Makefile additions (`run`, `patch-cover`), refreshed CLAUDE.md / AGENTS.md / README docs.
- **#102 write-time TOCTOU:** re-resolve and re-confine the output directory immediately before the `.lrc` write (`pathutil.ResolveWithinRoot`), rejecting a directory component swapped for an escaping symlink while still allowing legitimate in-root symlinked layouts.

Also: instrumental tracks are now written as a plain `.txt` marker (`♪ Instrumental ♪`, no timestamp/tags); `.lrc` is reserved for synced lyrics, `.txt` for unsynced and instrumentals.

Size note: larger than usual because it intentionally bundles three issues (much of the bulk is the low-risk #100 tooling/scripts/docs port plus tests).

## Linked issues

Closes #97
Closes #100
Closes #102

## Test plan

- [x] `go test -count=1 ./...` passes (all packages)
- [x] Patch coverage 81.75% (>= 70% threshold, Codecov parity)
- [x] golangci-lint clean, actionlint clean
- [x] govulncheck: no vulnerabilities
- [x] Commits squashed to one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-commit/pre-push hooks and a deterministic pre-push gate; CI now runs container image scanning and new quality targets.

* **Bug Fixes**
  * Instrumental tracks now write as .txt (no LRC timestamps).
  * "No lyrics available" is treated as a benign miss and no longer triggers exponential backoff.

* **Documentation**
  * Expanded contributor/dev guidance and quality-gate instructions.

* **Chores**
  * Pinned CI actions, Dependabot Docker updates, tooling/version checks.

* **Tests**
  * Expanded tests for confinement, benign-miss handling, and queue defer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->