### PR TITLE
ci: workflow hardening (dynamic build matrix, build/test decouple, Scorecard perms)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      # Emitted here so non-code PRs get an empty matrix (zero build legs, zero
+      # checks) instead of a skipped build job whose check surfaces the literal,
+      # unexpanded "Build (${{ matrix.goos }}, ${{ matrix.goarch }})" name.
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -39,6 +43,15 @@ jobs:
               - '.golangci.yml'
               - 'Dockerfile'
               - 'build/docker/**'
+
+      - name: Compute build matrix
+        id: matrix
+        run: |
+          if [ "${{ steps.filter.outputs.code }}" = "true" ]; then
+            echo 'matrix={"include":[{"goos":"linux","goarch":"amd64"},{"goos":"linux","goarch":"arm64"},{"goos":"darwin","goarch":"amd64"},{"goos":"darwin","goarch":"arm64"},{"goos":"windows","goarch":"amd64"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+          fi
 
   lint:
     name: Lint
@@ -112,14 +125,13 @@ jobs:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
     needs: [changes, lint, test]
-    if: needs.changes.outputs.code == 'true'
+    # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
+    # named with the literal, unexpanded ${{ matrix.* }} template. Running unless
+    # lint or test failed keeps the matrix empty on non-code PRs (see the `changes`
+    # job), so this expands to zero legs and zero checks.
+    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' }}
     strategy:
-      matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
-            goarch: arm64
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,13 +10,16 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Default to no privileges at the workflow level; the job below grants only what
+# it needs. Resolves Scorecard Token-Permissions (no top-level permission).
+permissions: {}
+
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip bot-authored PRs (e.g. Dependabot): bot-triggered runs don't receive
+    # repo secrets, so claude-code-action can't authenticate and the check fails
+    # noisily on every such PR with nothing actionable to review.
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Default to no privileges at the workflow level; the job below grants only what
+# it needs. Resolves Scorecard Token-Permissions (no top-level permission).
+permissions: {}
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## Summary

CI/workflow hardening, split out from the Dependabot auto-merge work. A companion dependency-refresh PR (`chore/update-deps`) follows separately.

### Changes
- **Dynamic build matrix** (`ci.yml`): the `changes` job now emits the build matrix - the full target list on code PRs, empty on non-code PRs. An empty matrix produces zero build legs (and zero checks), so non-Go PRs no longer show a skipped check named with the literal, unexpanded `Build (${{ matrix.goos }}, ${{ matrix.goarch }})` template. Code PRs still get clean `Build (linux, amd64)` names. `build-matrix` keeps `needs: [changes, lint, test]` per the repo guideline.
- **Skip Claude review on bot PRs** (`claude-code-review.yml`): `if: github.event.pull_request.user.type != 'Bot'`. Dependabot-triggered runs don't receive repo secrets, so the review check failed noisily on every such PR with nothing actionable to review.
- **Top-level `permissions: {}`** on `claude.yml` and `claude-code-review.yml`: resolves Scorecard `Token-Permissions` alerts #17/#16. Both jobs already declare their own permissions, so runtime privileges are unchanged.

### Scorecard triage
- **#17** (`claude.yml`) and **#16** (`claude-code-review.yml`): fixed here via top-level `permissions: {}`. They transition to `fixed` after Scorecard re-runs on `main` post-merge.
- **#15** (`dependabot-merge.yml` job-level `contents: write`): already dismissed as won't-fix - required to squash-merge approved Dependabot PRs and already scoped to the single merge job. Mirrors the equivalent dismissal in `sydlexius/stillwater`.

### Validation
- `actionlint` clean; local pre-commit gate passed.
- This PR touches `ci.yml`, so its own CI exercises the code path - clean `Build (<os>, <arch>)` names confirmed on the first run. The empty-matrix (zero-check) path is exercised by the next non-Go PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
