### PR TITLE
ci: build-flag parity (-trimpath) and Dockerfile sync guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
-        run: go build -ldflags="-s -w" -o mxlrcgo-svc ./cmd/mxlrcgo-svc
+        run: go build -trimpath -ldflags="-s -w" -o mxlrcgo-svc ./cmd/mxlrcgo-svc
 
   build:
     name: Build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,10 @@ builds:
     binary: mxlrcgo-svc
     env:
       - CGO_ENABLED=0
+    # -trimpath: reproducible builds; strips local source paths from the binary.
+    # Parity with the root Dockerfile and ci.yml build so every shipped artifact matches.
+    flags:
+      - -trimpath
     goos:
       - linux
       - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/mxlrcgo
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
+# Runtime stage. KEEP IN SYNC with build/docker/Dockerfile.goreleaser (the goreleaser
+# release image): identical base digest, apk packages, user, ENV, EXPOSE, VOLUME, entrypoint.
+# The two differ only in how the binary arrives (built here vs copied by goreleaser).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="MIT"

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -1,5 +1,8 @@
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
+# KEEP IN SYNC with the runtime stage of the root Dockerfile (used by nightly.yml and the
+# ci.yml CVE scan): identical base digest, apk packages, user, ENV, EXPOSE, VOLUME, entrypoint.
+# The two differ only in how the binary arrives (copied here vs built in the root Dockerfile).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="MIT"


### PR DESCRIPTION
## Summary

Part 2 of the stillwater CI handoff (build-flag parity + reconciliation). The mxlrc-go graft is otherwise clean - there are no CI vestiges to remove.

Closes #115 

### Changes
- **`-trimpath` parity** (`.goreleaser.yml`, `ci.yml`): add `-trimpath` to the goreleaser build and the CI build step. The root `Dockerfile` already built with it; this brings the released artifacts (release Docker image + CLI archives) and the CI build to parity, so every shipped binary is reproducible and no longer embeds local source paths.
- **Dockerfile sync guards** (`Dockerfile`, `build/docker/Dockerfile.goreleaser`): cross-reference comments on the two runtime stages, which are byte-identical today (same pinned alpine digest, apk packages, user, ENV, entrypoint) but maintained separately. The comments prevent a future edit to one from silently diverging the released image from the nightly/CI-scanned image.

### Validation
- `goreleaser check` passes, `actionlint` clean, `-trimpath` build smoke succeeds, local `make gate` green.

### Reviewed, no action
- No mxlrc-go CI vestiges to remove (the graft is clean).
- `.planning/` mxlrc-go references are legitimate history (fork lineage + rename records) - left as-is.
- Test sharding omitted - not worth it for this small/fast suite (per-shard compile floor outweighs the gain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
