### PR TITLE
feat: add deferred work-queue status (#103, slice 103a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,17 @@ SQLite database by hand.
 # List the next 50 work_queue rows.
 mxlrcgo-svc queue list
 
-# Filter by status; failed is also exposed as a convenience subcommand.
+# Filter by status; failed and deferred are also exposed as convenience subcommands.
 mxlrcgo-svc queue list --status pending --limit 100
 mxlrcgo-svc queue failed
 
-# Reset a single failed row back to pending. Refused if the row is not failed.
+# List deferred rows: benign misses (a track Musixmatch has no lyrics for yet)
+# waiting out a fixed cooldown before re-check. These are NOT failures and are
+# kept out of `queue failed`.
+mxlrcgo-svc queue deferred
+
+# Reset a single failed row back to pending. Refused if the row is not failed
+# (a deferred row is refused; let it re-check on its own, or re-trigger via webhook).
 mxlrcgo-svc queue retry 42
 
 # Delete completed rows. Without --yes, prints what would be deleted.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -123,21 +123,32 @@ type ScanClearCmd struct {
 
 // QueueCmd contains nested queue inspection and maintenance subcommands.
 type QueueCmd struct {
-	List   *QueueListCmd   `arg:"subcommand:list" help:"list work_queue rows"`
-	Failed *QueueFailedCmd `arg:"subcommand:failed" help:"list failed work_queue rows"`
-	Retry  *QueueRetryCmd  `arg:"subcommand:retry" help:"reset a failed work item back to pending"`
-	Clear  *QueueClearCmd  `arg:"subcommand:clear" help:"delete completed work_queue rows"`
+	List     *QueueListCmd     `arg:"subcommand:list" help:"list work_queue rows"`
+	Failed   *QueueFailedCmd   `arg:"subcommand:failed" help:"list failed work_queue rows"`
+	Deferred *QueueDeferredCmd `arg:"subcommand:deferred" help:"list deferred (benign-miss cooldown) work_queue rows"`
+	Retry    *QueueRetryCmd    `arg:"subcommand:retry" help:"reset a failed work item back to pending"`
+	Clear    *QueueClearCmd    `arg:"subcommand:clear" help:"delete completed work_queue rows"`
 }
 
 // QueueListCmd lists work_queue rows.
 type QueueListCmd struct {
-	Status     string `arg:"--status" help:"filter by status (pending, processing, failed, done)" default:""`
+	Status     string `arg:"--status" help:"filter by status (pending, processing, failed, deferred, done)" default:""`
 	Limit      int    `arg:"--limit" help:"maximum number of rows to return" default:"50"`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // QueueFailedCmd is a convenience for `queue list --status failed`.
 type QueueFailedCmd struct {
+	Limit      int    `arg:"--limit" help:"maximum number of rows to return" default:"50"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// QueueDeferredCmd is a convenience for `queue list --status deferred`.
+// Deferred rows are benign-miss cooldowns: no matching track or usable lyrics
+// was found, and the row is scheduled for re-check after a fixed window. Use
+// `queue retry` on a failed row to reset it immediately; deferred rows cannot
+// be retried via that path -- use a webhook-priority enqueue instead.
+type QueueDeferredCmd struct {
 	Limit      int    `arg:"--limit" help:"maximum number of rows to return" default:"50"`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
@@ -1243,10 +1254,10 @@ func validateQueueStatus(s string) error {
 		return nil
 	}
 	switch s {
-	case queue.StatusPending, queue.StatusProcessing, queue.StatusFailed, queue.StatusDone:
+	case queue.StatusPending, queue.StatusProcessing, queue.StatusFailed, queue.StatusDone, queue.StatusDeferred:
 		return nil
 	default:
-		return fmt.Errorf("invalid status %q (want pending, processing, failed, or done)", s)
+		return fmt.Errorf("invalid status %q (want pending, processing, failed, deferred, or done)", s)
 	}
 }
 
@@ -1285,6 +1296,12 @@ func runQueueCmd(ctx context.Context, out io.Writer, args QueueCmd) int {
 			Status:     queue.StatusFailed,
 			Limit:      args.Failed.Limit,
 			ConfigPath: args.Failed.ConfigPath,
+		})
+	case args.Deferred != nil:
+		return runQueueList(ctx, out, QueueListCmd{
+			Status:     queue.StatusDeferred,
+			Limit:      args.Deferred.Limit,
+			ConfigPath: args.Deferred.ConfigPath,
 		})
 	case args.Retry != nil:
 		return runQueueRetry(ctx, out, *args.Retry)
@@ -1365,7 +1382,9 @@ func runQueueRetry(ctx context.Context, out io.Writer, args QueueRetryCmd) int {
 		_, _ = fmt.Fprintf(out, "queue: work item %d not found\n", args.ID)
 		return 1
 	case errors.Is(err, queue.ErrNotRetryable):
-		_, _ = fmt.Fprintf(out, "queue: work item %d is not in failed status; refusing to retry\n", args.ID)
+		_, _ = fmt.Fprintf(out, "queue: work item %d is not in failed status; refusing to retry\n"+
+			"  (deferred rows are benign-miss cooldowns -- use `queue deferred` to inspect them;\n"+
+			"   force an immediate re-check by re-enqueueing via the webhook path)\n", args.ID)
 		return 1
 	case err != nil:
 		slog.Error("failed to retry queue item", "error", err)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1492,3 +1492,122 @@ func TestRunQueueRetry_ResetsLinkedScanResults(t *testing.T) {
 		t.Fatalf("scan_results status = %q after retry; want pending", scanStatus)
 	}
 }
+
+// TestValidateQueueStatus_AcceptsDeferred verifies the deferred status is
+// accepted by the validator (and that the error message names it).
+func TestValidateQueueStatus_AcceptsDeferred(t *testing.T) {
+	if err := validateQueueStatus(queue.StatusDeferred); err != nil {
+		t.Fatalf("validateQueueStatus(%q) = %v; want nil", queue.StatusDeferred, err)
+	}
+	err := validateQueueStatus("bogus")
+	if err == nil {
+		t.Fatal("validateQueueStatus(bogus) = nil; want error")
+	}
+	if !strings.Contains(err.Error(), "deferred") {
+		t.Fatalf("error message missing 'deferred': %q", err.Error())
+	}
+}
+
+// TestRunQueueRetry_RejectsDeferredRow verifies that retrying a deferred row
+// returns ErrNotRetryable with an informative message pointing at queue deferred.
+func TestRunQueueRetry_RejectsDeferredRow(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Deferred"}}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	claimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, claimed.ID, 7*24*time.Hour, errorsNew("no results")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := Run(ctx, []string{"queue", "retry", strconvFormatInt(claimed.ID), "--config", cfg}, &out, Deps{})
+	if code == 0 {
+		t.Fatalf("Run exit code = 0; want non-zero (retry on deferred must fail). out=%s", out.String())
+	}
+	if !strings.Contains(out.String(), "not in failed status") {
+		t.Fatalf("expected not-retryable message; got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "deferred") {
+		t.Fatalf("expected deferred hint in message; got %q", out.String())
+	}
+}
+
+// TestRunQueueCmd_DeferredRoutesToList verifies the `queue deferred` convenience
+// subcommand returns the table header (and only lists deferred rows, not failed).
+func TestRunQueueCmd_DeferredRoutesToList(t *testing.T) {
+	cfg, dbPath := commandsTestEnv(t)
+	ctx := context.Background()
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+
+	// Enqueue one item, defer it (becomes StatusDeferred).
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Missed", TrackName: "Song"}}, 1); err != nil {
+		t.Fatalf("Enqueue deferred: %v", err)
+	}
+	ditem, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, ditem.ID, 7*24*time.Hour, errorsNew("no results")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// Enqueue another item, fail it (becomes StatusFailed).
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Failed", TrackName: "Song"}}, 1); err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	fitem, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue failed: %v", err)
+	}
+	if _, err := q.Fail(ctx, fitem.ID, errorsNew("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	code := runQueueCmd(ctx, &out, QueueCmd{Deferred: &QueueDeferredCmd{ConfigPath: cfg, Limit: 50}})
+	if code != 0 {
+		t.Fatalf("queue deferred = %d; want 0. out=%s", code, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "ID") {
+		t.Fatalf("queue deferred missing header: %q", got)
+	}
+	// Deferred artist must appear; failed artist must not.
+	if !strings.Contains(got, "Missed") {
+		t.Fatalf("deferred row missing from output: %q", got)
+	}
+	if strings.Contains(got, "Failed") {
+		t.Fatalf("failed row must not appear in queue deferred output: %q", got)
+	}
+}
+
+// TestRunQueueList_StatusDeferred verifies `queue list --status deferred` works.
+func TestRunQueueList_StatusDeferred(t *testing.T) {
+	cfg, _ := commandsTestEnv(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"queue", "list", "--status", "deferred", "--config", cfg}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("queue list --status deferred = %d; want 0. out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "ID") {
+		t.Fatalf("output missing header: %q", out.String())
+	}
+}

--- a/internal/db/migrations/012_work_queue_deferred_status.sql
+++ b/internal/db/migrations/012_work_queue_deferred_status.sql
@@ -55,18 +55,24 @@ INSERT INTO work_queue_new (
 SELECT
     id, artist, title, artist_key, title_key, outdir, filename, source_path,
     output_paths, scan_result_id,
-    -- Backfill: rows with status='failed' AND attempts=0 AND next_attempt_at
-    -- > now were produced by Defer (which leaves attempts unchanged). Fail
-    -- always increments attempts to >=1, so this shape can only originate
-    -- from Defer. Reclassify them as 'deferred' so they appear in the right
-    -- query bucket.
+    -- Backfill: a 'failed' row with attempts=0 was produced by Defer, which
+    -- leaves attempts unchanged. Fail always increments attempts to >=1, so
+    -- that shape can only originate from Defer, regardless of next_attempt_at.
+    -- Reclassify every such row to 'deferred' (including ones whose cooldown
+    -- has already elapsed -- an overdue 'deferred' row is dequeue-eligible just
+    -- as it was as an overdue 'failed' row) so CountByStatus and /status stop
+    -- counting benign misses as failures. Seed miss_count=1 to record the miss
+    -- that already happened.
     CASE
-        WHEN status = 'failed' AND attempts = 0 AND next_attempt_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        WHEN status = 'failed' AND attempts = 0
         THEN 'deferred'
         ELSE status
     END AS status,
     priority, attempts,
-    0 AS miss_count,
+    CASE
+        WHEN status = 'failed' AND attempts = 0 THEN 1
+        ELSE 0
+    END AS miss_count,
     0 AS providers_version,
     next_attempt_at, last_error, completed_at,
     created_at, updated_at

--- a/internal/db/migrations/012_work_queue_deferred_status.sql
+++ b/internal/db/migrations/012_work_queue_deferred_status.sql
@@ -1,0 +1,171 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+-- SQLite cannot ALTER a CHECK constraint, so adding 'deferred' to the
+-- work_queue.status CHECK requires recreating the table. We also fold in
+-- two new columns (miss_count, providers_version) as seams for future slices
+-- (103b escalation and 103d multi-source sweep).
+--
+-- Crash safety: the destructive rebuild (DROP + RENAME) runs inside an explicit
+-- transaction so a crash mid-migration rolls back cleanly, leaving work_queue
+-- intact and goose's version unchanged, and the next startup re-runs the
+-- migration from a consistent state. PRAGMA foreign_keys must be toggled
+-- OUTSIDE the transaction (it is a no-op inside one), which is why this
+-- migration is NO TRANSACTION and manages BEGIN/COMMIT itself. FK references
+-- exist on work_queue (from work_queue_scan_results); toggling FK off prevents
+-- the implicit row-delete performed by DROP TABLE from cascading into the
+-- junction table. The junction rows survive because we rename rather than drop
+-- the rebuilt table.
+
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS work_queue_new;
+
+BEGIN;
+
+CREATE TABLE work_queue_new (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    artist           TEXT    NOT NULL,
+    title            TEXT    NOT NULL,
+    artist_key       TEXT    NOT NULL DEFAULT '',
+    title_key        TEXT    NOT NULL DEFAULT '',
+    outdir           TEXT    NOT NULL DEFAULT '',
+    filename         TEXT    NOT NULL DEFAULT '',
+    source_path      TEXT    NOT NULL DEFAULT '',
+    output_paths     TEXT    NOT NULL DEFAULT '',
+    scan_result_id   INTEGER REFERENCES scan_results(id) ON DELETE SET NULL,
+    status           TEXT    NOT NULL DEFAULT 'pending'
+                             CHECK(status IN ('pending', 'processing', 'done', 'failed', 'deferred')),
+    priority         INTEGER NOT NULL DEFAULT 0,
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    miss_count       INTEGER NOT NULL DEFAULT 0,
+    providers_version INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at  DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z',
+    last_error       TEXT    NOT NULL DEFAULT '',
+    completed_at     DATETIME,
+    created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+INSERT INTO work_queue_new (
+    id, artist, title, artist_key, title_key, outdir, filename, source_path,
+    output_paths, scan_result_id, status, priority, attempts, miss_count,
+    providers_version, next_attempt_at, last_error, completed_at,
+    created_at, updated_at
+)
+SELECT
+    id, artist, title, artist_key, title_key, outdir, filename, source_path,
+    output_paths, scan_result_id,
+    -- Backfill: rows with status='failed' AND attempts=0 AND next_attempt_at
+    -- > now were produced by Defer (which leaves attempts unchanged). Fail
+    -- always increments attempts to >=1, so this shape can only originate
+    -- from Defer. Reclassify them as 'deferred' so they appear in the right
+    -- query bucket.
+    CASE
+        WHEN status = 'failed' AND attempts = 0 AND next_attempt_at > strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        THEN 'deferred'
+        ELSE status
+    END AS status,
+    priority, attempts,
+    0 AS miss_count,
+    0 AS providers_version,
+    next_attempt_at, last_error, completed_at,
+    created_at, updated_at
+FROM work_queue;
+
+DROP TABLE work_queue;
+ALTER TABLE work_queue_new RENAME TO work_queue;
+
+-- Recreate indexes that existed on work_queue.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_work_queue_artist_title_key
+    ON work_queue(artist_key, title_key);
+
+CREATE INDEX IF NOT EXISTS idx_work_queue_dequeue
+    ON work_queue(status, next_attempt_at, priority, created_at, id);
+
+CREATE INDEX IF NOT EXISTS idx_work_queue_scan_result
+    ON work_queue(scan_result_id) WHERE scan_result_id IS NOT NULL;
+
+-- Recreate the updated_at trigger.
+CREATE TRIGGER IF NOT EXISTS update_work_queue_updated_at
+AFTER UPDATE ON work_queue
+BEGIN
+    UPDATE work_queue SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+    WHERE id = NEW.id;
+END;
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Reverse the deferred-status change: reclassify any 'deferred' rows back to
+-- 'failed' (non-lossy -- the next worker pass simply re-defers them, and this
+-- preserves the row rather than discarding queued work), drop the two added
+-- columns, and restore the original CHECK constraint. Same crash-safe
+-- transaction + FK-toggle pattern as Up.
+
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS work_queue_old;
+
+BEGIN;
+
+CREATE TABLE work_queue_old (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    artist           TEXT    NOT NULL,
+    title            TEXT    NOT NULL,
+    artist_key       TEXT    NOT NULL DEFAULT '',
+    title_key        TEXT    NOT NULL DEFAULT '',
+    outdir           TEXT    NOT NULL DEFAULT '',
+    filename         TEXT    NOT NULL DEFAULT '',
+    source_path      TEXT    NOT NULL DEFAULT '',
+    output_paths     TEXT    NOT NULL DEFAULT '',
+    scan_result_id   INTEGER REFERENCES scan_results(id) ON DELETE SET NULL,
+    status           TEXT    NOT NULL DEFAULT 'pending'
+                             CHECK(status IN ('pending', 'processing', 'done', 'failed')),
+    priority         INTEGER NOT NULL DEFAULT 0,
+    attempts         INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at  DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z',
+    last_error       TEXT    NOT NULL DEFAULT '',
+    completed_at     DATETIME,
+    created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+INSERT INTO work_queue_old (
+    id, artist, title, artist_key, title_key, outdir, filename, source_path,
+    output_paths, scan_result_id, status, priority, attempts, next_attempt_at,
+    last_error, completed_at, created_at, updated_at
+)
+SELECT
+    id, artist, title, artist_key, title_key, outdir, filename, source_path,
+    output_paths, scan_result_id,
+    CASE WHEN status = 'deferred' THEN 'failed' ELSE status END AS status,
+    priority, attempts, next_attempt_at,
+    last_error, completed_at, created_at, updated_at
+FROM work_queue;
+
+DROP TABLE work_queue;
+ALTER TABLE work_queue_old RENAME TO work_queue;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_work_queue_artist_title_key
+    ON work_queue(artist_key, title_key);
+
+CREATE INDEX IF NOT EXISTS idx_work_queue_dequeue
+    ON work_queue(status, next_attempt_at, priority, created_at, id);
+
+CREATE INDEX IF NOT EXISTS idx_work_queue_scan_result
+    ON work_queue(scan_result_id) WHERE scan_result_id IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS update_work_queue_updated_at
+AFTER UPDATE ON work_queue
+BEGIN
+    UPDATE work_queue SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+    WHERE id = NEW.id;
+END;
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -22,13 +22,24 @@ const (
 	StatusDone = "done"
 	// StatusFailed marks queued work that failed and may be retried after backoff.
 	StatusFailed = "failed"
+	// StatusDeferred marks queued work that produced a benign no-result miss and
+	// has been rescheduled after a fixed cooldown. Unlike StatusFailed, a deferred
+	// row does not count against the geometric retry budget: Defer leaves attempts
+	// unchanged so each re-check waits the same fixed window. Deferred rows are
+	// eligible for Dequeue once their next_attempt_at has elapsed, and they are
+	// preserved by scan-priority Enqueue so bulk library scans cannot un-defer
+	// them. A webhook-priority Enqueue resets next_attempt_at to now, providing
+	// an intentional force-recheck escape hatch.
+	StatusDeferred = "deferred"
 )
 
 const timeFormat = time.RFC3339
 
 // ErrNotRetryable is returned by Retry when the targeted work item is not in
-// the failed state and therefore cannot be safely reset (e.g. processing or
-// done). This avoids racing the worker on rows it currently owns.
+// the failed state and therefore cannot be safely reset (e.g. processing,
+// done, or deferred). Deferred rows must use the Enqueue webhook-priority path
+// to force an immediate re-check; Retry is intentionally not wired for them.
+// This avoids racing the worker on rows it currently owns.
 var ErrNotRetryable = errors.New("queue: work item is not in failed status")
 
 // InputsQueue is a FIFO queue for processing work items.
@@ -77,16 +88,21 @@ func (q *InputsQueue) Empty() bool {
 
 // WorkItem represents a persisted queue row.
 type WorkItem struct {
-	ID            int64
-	Inputs        models.Inputs
-	Status        string
-	Priority      int
-	Attempts      int
-	NextAttemptAt time.Time
-	LastError     string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	CompletedAt   *time.Time
+	ID        int64
+	Inputs    models.Inputs
+	Status    string
+	Priority  int
+	Attempts  int
+	MissCount int
+	// ProvidersVersion is a reserved seam for the future multi-source re-check
+	// sweep (issue #103, slice 103d). No code path writes it yet, so it is
+	// always 0 today; do not read a real provider generation from it.
+	ProvidersVersion int
+	NextAttemptAt    time.Time
+	LastError        string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	CompletedAt      *time.Time
 }
 
 // DBQueue is a SQLite-backed queue for durable lyrics work.
@@ -166,17 +182,19 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
              scan_result_id = COALESCE(work_queue.scan_result_id, excluded.scan_result_id),
              priority = max(work_queue.priority, excluded.priority),
              status = CASE
-                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.status
+                 WHEN work_queue.status IN ('done', 'processing', 'failed', 'deferred') THEN work_queue.status
                  ELSE 'pending'
              END,
              next_attempt_at = CASE
                  WHEN work_queue.status IN ('done', 'processing') THEN work_queue.next_attempt_at
                  WHEN work_queue.status = 'failed' AND ? = 1 THEN excluded.next_attempt_at
                  WHEN work_queue.status = 'failed' THEN work_queue.next_attempt_at
+                 WHEN work_queue.status = 'deferred' AND ? = 1 THEN excluded.next_attempt_at
+                 WHEN work_queue.status = 'deferred' THEN work_queue.next_attempt_at
                  ELSE excluded.next_attempt_at
              END,
              last_error = CASE
-                 WHEN work_queue.status IN ('done', 'processing', 'failed') THEN work_queue.last_error
+                 WHEN work_queue.status IN ('done', 'processing', 'failed', 'deferred') THEN work_queue.last_error
                  ELSE ''
              END,
              completed_at = CASE
@@ -184,7 +202,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE NULL
              END
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		inputs.Track.ArtistName,
 		inputs.Track.TrackName,
 		normalize.NormalizeKey(inputs.Track.ArtistName),
@@ -197,6 +215,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 		StatusPending,
 		priority,
 		now,
+		refreshFailedBackoff,
 		refreshFailedBackoff,
 	)
 	item, err := scanWorkItem(row)
@@ -227,13 +246,13 @@ func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
          WHERE id = (
              SELECT id
              FROM work_queue
-             WHERE status IN ('pending', 'failed')
+             WHERE status IN ('pending', 'failed', 'deferred')
                AND next_attempt_at <= ?
              ORDER BY priority DESC, created_at ASC, id ASC
              LIMIT 1
          )
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		now,
 	)
 	item, err := scanWorkItem(row)
@@ -320,7 +339,7 @@ func (q *DBQueue) Cleanup(ctx context.Context, inputs models.Inputs) (int64, err
 		`DELETE FROM work_queue
          WHERE artist_key = ?
            AND title_key = ?
-           AND status IN ('pending', 'failed')`,
+           AND status IN ('pending', 'failed', 'deferred')`,
 		normalize.NormalizeKey(inputs.Track.ArtistName),
 		normalize.NormalizeKey(inputs.Track.TrackName),
 	)
@@ -368,7 +387,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		nextAttempts,
 		nextAttemptAt,
 		lastError,
@@ -387,17 +406,19 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 // Defer reschedules a processing item after a fixed retryAfter delay without
 // counting the attempt against the retry budget. Unlike Fail, attempts is left
 // unchanged so the delay does not ramp into geometric backoff: every Defer of
-// the same row waits the same fixed window. The row is left in the 'failed'
-// state (not 'pending') on purpose -- Enqueue preserves next_attempt_at for
-// 'failed' rows but resets 'pending' rows to now, so keeping the deferred row
-// 'failed' is what makes the cooldown survive a later library scan rather than
-// being un-deferred on every scan. The reset is asymmetric, matching Enqueue's
-// refreshFailedBackoff logic: a scan-priority Enqueue preserves the deferred
-// next_attempt_at (the cooldown survives bulk scans), but a webhook-priority
-// Enqueue (priority >= PriorityWebhook) resets next_attempt_at to now, so an
-// explicit webhook can force an immediate re-check despite the cooldown. Used by
-// the worker for benign misses (no matching track, or a match with no usable
-// lyrics).
+// the same row waits the same fixed window. miss_count is incremented so the
+// number of benign misses on a row is observable and available to future
+// escalation logic. The row is moved to the distinct 'deferred' state (not
+// 'pending' or 'failed'): 'deferred' is its own queryable status, so benign
+// misses do not pollute the failures view, and Enqueue preserves next_attempt_at
+// for 'deferred' rows just as it does for 'failed' ones, so the cooldown survives
+// a later library scan rather than being un-deferred on every scan. The reset is
+// asymmetric, matching Enqueue's refreshFailedBackoff logic: a scan-priority
+// Enqueue preserves the deferred next_attempt_at (the cooldown survives bulk
+// scans), but a webhook-priority Enqueue (priority >= PriorityWebhook) resets
+// next_attempt_at to now, so an explicit webhook can force an immediate re-check
+// despite the cooldown. Used by the worker for benign misses (no matching track,
+// or a match with no usable lyrics).
 func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration, cause error) (WorkItem, error) {
 	nextAttemptAt := formatTime(q.now().Add(retryAfter))
 	lastError := ""
@@ -406,13 +427,14 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
 	}
 	row := q.db.QueryRowContext(ctx,
 		`UPDATE work_queue
-         SET status = 'failed',
+         SET status = 'deferred',
+             miss_count = miss_count + 1,
              next_attempt_at = ?,
              last_error = ?
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		nextAttemptAt,
 		lastError,
 		id,
@@ -440,7 +462,7 @@ type ListFilter struct {
 // optionally filtered by status and capped by limit.
 func (q *DBQueue) List(ctx context.Context, filter ListFilter) (items []WorkItem, retErr error) {
 	const baseQuery = `SELECT id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                       next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
                        FROM work_queue`
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	const limitClause = ` LIMIT ?`
@@ -505,7 +527,7 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
          WHERE id = ?
            AND status = 'failed'
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
-                   next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		now,
 		id,
 	)
@@ -600,7 +622,7 @@ func (q *DBQueue) CountByStatus(ctx context.Context) (map[string]int64, error) {
 	return counts, nil
 }
 
-// CancelByLibrary rebuilds or deletes pending/failed work_queue rows whose
+// CancelByLibrary rebuilds or deletes pending/failed/deferred work_queue rows whose
 // output_paths derive from libraryID. Each affected row's output_paths JSON is
 // filtered to retain only entries that appear in scan_results from libraries
 // other than libraryID. Rows whose filtered list is empty are deleted; the
@@ -657,7 +679,7 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
          JOIN work_queue_scan_results j ON j.work_queue_id = wq.id
          JOIN scan_results sr ON sr.id = j.scan_result_id
          WHERE sr.library_id = ?
-           AND wq.status IN ('pending', 'failed')
+           AND wq.status IN ('pending', 'failed', 'deferred')
          ORDER BY wq.id ASC`,
 		libraryID,
 	)
@@ -705,7 +727,7 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
 				continue
 			}
 			// The status guard here is belt-and-suspenders: candidates were
-			// selected with status IN ('pending', 'failed'), but SQLite WAL
+			// selected with status IN ('pending', 'failed', 'deferred'), but SQLite WAL
 			// admits a small window between candidate selection and this
 			// per-row write during which the worker could move the row to
 			// 'processing'. A 0 affected-rows result means the row moved on
@@ -713,7 +735,7 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
 			res, err := tx.ExecContext(ctx,
 				`DELETE FROM work_queue
                  WHERE id = ?
-                   AND status IN ('pending', 'failed')`,
+                   AND status IN ('pending', 'failed', 'deferred')`,
 				c.id,
 			)
 			if err != nil {
@@ -745,7 +767,7 @@ func cancelByLibrary(ctx context.Context, tx *sql.Tx, libraryID int64, dryRun bo
 			`UPDATE work_queue
              SET output_paths = ?
              WHERE id = ?
-               AND status IN ('pending', 'failed')`,
+               AND status IN ('pending', 'failed', 'deferred')`,
 			string(newJSON), c.id,
 		)
 		if err != nil {
@@ -813,6 +835,8 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 		&item.Status,
 		&item.Priority,
 		&item.Attempts,
+		&item.MissCount,
+		&item.ProvidersVersion,
 		&nextAttemptAt,
 		&item.LastError,
 		&createdAt,

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -184,8 +184,11 @@ func TestDBQueue_NoResultRequeueIsDeferredButReprocessable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Defer: %v", err)
 	}
-	if deferred.Status != StatusFailed {
-		t.Fatalf("status = %q; want %q (deferred, not terminal)", deferred.Status, StatusFailed)
+	if deferred.Status != StatusDeferred {
+		t.Fatalf("status = %q; want %q (deferred, not terminal)", deferred.Status, StatusDeferred)
+	}
+	if deferred.MissCount != 1 {
+		t.Fatalf("miss_count = %d; want 1 (Defer must increment miss_count)", deferred.MissCount)
 	}
 
 	// The cooldown is fixed: next_attempt_at is exactly now+cooldown and attempts
@@ -248,8 +251,8 @@ func TestDBQueue_WebhookEnqueueResetsDeferredCooldown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Defer: %v", err)
 	}
-	if deferred.Status != StatusFailed {
-		t.Fatalf("status = %q; want %q", deferred.Status, StatusFailed)
+	if deferred.Status != StatusDeferred {
+		t.Fatalf("status = %q; want %q", deferred.Status, StatusDeferred)
 	}
 
 	// Control: a scan-priority Enqueue must NOT reset the cooldown.
@@ -1174,6 +1177,21 @@ func TestDBQueue_RetryRejectsNonFailedStatus(t *testing.T) {
 	if _, err := q.Retry(ctx, 9999); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("Retry missing id error = %v; want sql.ErrNoRows", err)
 	}
+
+	// Deferred rows must also be rejected; they are not reset via Retry.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "X", TrackName: "Deferred"}}, 1); err != nil {
+		t.Fatalf("Enqueue deferred candidate: %v", err)
+	}
+	ditem, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue deferred candidate: %v", err)
+	}
+	if _, err := q.Defer(ctx, ditem.ID, 7*24*time.Hour, errors.New("no results")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if _, err := q.Retry(ctx, ditem.ID); !errors.Is(err, ErrNotRetryable) {
+		t.Fatalf("Retry deferred error = %v; want ErrNotRetryable", err)
+	}
 }
 
 func TestDBQueue_ClearDoneRemovesOnlyDoneRows(t *testing.T) {
@@ -1769,5 +1787,120 @@ func TestDBQueue_CancelByLibraryTx_RunsInExternalTransaction(t *testing.T) {
 	}
 	if postCommit != 0 {
 		t.Fatalf("work_queue row %d count after commit = %d; want 0", item.ID, postCommit)
+	}
+}
+
+// TestDBQueue_DeferSetsDeferredStatus verifies that Defer transitions a
+// processing row to StatusDeferred (not StatusFailed) and increments miss_count.
+func TestDBQueue_DeferSetsDeferredStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if item.MissCount != 0 {
+		t.Fatalf("initial miss_count = %d; want 0", item.MissCount)
+	}
+
+	deferred, err := q.Defer(ctx, item.ID, 7*24*time.Hour, errors.New("no results"))
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if deferred.Status != StatusDeferred {
+		t.Fatalf("status = %q; want %q", deferred.Status, StatusDeferred)
+	}
+	if deferred.MissCount != 1 {
+		t.Fatalf("miss_count = %d; want 1 after first Defer", deferred.MissCount)
+	}
+	if deferred.Attempts != item.Attempts {
+		t.Fatalf("attempts = %d; want unchanged %d", deferred.Attempts, item.Attempts)
+	}
+
+	// Second Defer: re-enqueue and defer again; miss_count increments further.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityWebhook); err != nil {
+		t.Fatalf("Enqueue (force re-check): %v", err)
+	}
+	item2, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue 2: %v", err)
+	}
+	deferred2, err := q.Defer(ctx, item2.ID, 7*24*time.Hour, errors.New("still no results"))
+	if err != nil {
+		t.Fatalf("Defer 2: %v", err)
+	}
+	if deferred2.MissCount != 2 {
+		t.Fatalf("miss_count = %d; want 2 after second Defer", deferred2.MissCount)
+	}
+}
+
+// TestDBQueue_DeferredRowsArePickedUpByDequeue verifies that a deferred row
+// becomes eligible for Dequeue once its next_attempt_at window elapses.
+func TestDBQueue_DeferredRowsArePickedUpByDequeue(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	const cooldown = 7 * 24 * time.Hour
+	if _, err := q.Defer(ctx, item.ID, cooldown, errors.New("no results")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// Not yet eligible.
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue before cooldown = %v; want sql.ErrNoRows", err)
+	}
+
+	// Advance time past the cooldown.
+	q.now = func() time.Time { return now.Add(cooldown + time.Second) }
+	again, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue after cooldown: %v", err)
+	}
+	if again.ID != item.ID {
+		t.Fatalf("re-dequeued ID = %d; want %d", again.ID, item.ID)
+	}
+}
+
+// TestDBQueue_CountByStatusIncludesDeferred verifies that CountByStatus
+// reports a non-zero deferred bucket once a row has been deferred.
+func TestDBQueue_CountByStatusIncludesDeferred(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "B"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 7*24*time.Hour, errors.New("miss")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	counts, err := q.CountByStatus(ctx)
+	if err != nil {
+		t.Fatalf("CountByStatus: %v", err)
+	}
+	if counts[StatusDeferred] != 1 {
+		t.Fatalf("deferred count = %d; want 1. counts = %v", counts[StatusDeferred], counts)
+	}
+	if counts[StatusFailed] != 0 {
+		t.Fatalf("failed count = %d; want 0 (deferred must not appear as failed)", counts[StatusFailed])
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -340,12 +340,12 @@ func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) err
 // counter. The queue row is not retired: it stays re-dequeueable once the
 // cooldown elapses and re-enqueueable by a later scan or webhook, so it is
 // retried eventually as the catalog grows, while the worker neither slows down
-// nor re-queries upstream hourly for the same dead track. Defer leaves the row
-// in the deferred 'failed' state and does not increment attempts, so the
-// cooldown is fixed (not geometric). On a SCAN-priority re-enqueue the cooldown
-// survives: Enqueue preserves next_attempt_at for 'failed' rows. A WEBHOOK
-// re-enqueue intentionally resets it to now to force an immediate retry (see
-// DBQueue.Enqueue).
+// nor re-queries upstream hourly for the same dead track. Defer moves the row
+// to the distinct 'deferred' state and bumps miss_count without incrementing
+// attempts, so the cooldown is fixed (not geometric). On a SCAN-priority
+// re-enqueue the cooldown survives: Enqueue preserves next_attempt_at for
+// 'deferred' rows. A WEBHOOK re-enqueue intentionally resets it to now to force
+// an immediate retry (see DBQueue.Enqueue).
 //
 // A sql.ErrNoRows from Defer is benign here: it means the row is no longer
 // 'processing' because it was canceled or re-dequeued out from under us

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -72,7 +72,7 @@ func (q *fakeQueue) Defer(_ context.Context, id int64, retryAfter time.Duration,
 	q.deferred = append(q.deferred, id)
 	q.deferCauses = append(q.deferCauses, cause)
 	q.deferDurations = append(q.deferDurations, retryAfter)
-	return queue.WorkItem{ID: id, Status: queue.StatusFailed}, nil
+	return queue.WorkItem{ID: id, Status: queue.StatusDeferred}, nil
 }
 
 func (q *fakeQueue) Release(_ context.Context, id int64) error {


### PR DESCRIPTION
## Summary

Foundation slice (103a) of #103. Introduces a distinct, persisted `deferred` work-queue status so benign no-result misses (a track Musixmatch has no lyrics for *yet*) stop being overloaded onto `failed`. This makes the "benign miss counted as a failure" state unrepresentable and unpollutes the failures view, `CountByStatus`, and the `/status` endpoint.

- **Migration 012** recreates `work_queue` (SQLite can't `ALTER` a `CHECK`) to add `deferred` to the status CHECK, plus `miss_count` and `providers_version` columns (seams for 103b/103d, folded in now to avoid a second table recreation). The destructive rebuild runs inside an explicit `BEGIN/COMMIT` so a mid-migration crash rolls back cleanly; the down path reclassifies `deferred -> failed` (non-lossy) rather than dropping rows. Backfills prior benign-miss rows (`failed` + `attempts=0` + future `next_attempt_at`, a shape only `Defer` can produce).
- **queue.go**: `Defer` writes `status='deferred'` and bumps `miss_count` (attempts untouched); `Dequeue`/`Enqueue` CASE/`Cleanup`/`CancelByLibrary` include `deferred`; `Retry` refuses deferred rows (use the webhook-priority path to force a re-check).
- **CLI**: new `queue deferred` view (parity with `queue failed`) + `--status deferred`.

## Linked issue

Part of #103. (103b cadence / 103c pacer / 103d multi-source sweep follow as separate PRs before v1.1.0.)

## Test plan

- [x] `make gate` green: race tests, **96.55% patch coverage**, golangci-lint, govulncheck
- [x] Real-SQLite integration tests cover Defer status + miss_count, dequeue eligibility, CountByStatus separation, Retry rejection, Enqueue cooldown preserve/reset, and CLI routing
- [x] Migration 012 validated to apply cleanly (up) through goose + modernc
- [N/A] Manual UAT: no user-visible runtime surface beyond the CLI; behavior is fully exercised by the integration suite

## Reviewer notes

Pre-reviewed locally by the pr-review-toolkit agents (code-reviewer, silent-failure-hunter, type-design-analyzer). Their findings are addressed in this push: migration crash-safety (explicit transaction), non-lossy down-migration, and several stale doc comments. A follow-up to replace the stringly-typed status consts with a `type Status string` was flagged as pre-existing and out of scope; tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `queue deferred` subcommand to inspect deferred items separately.
  * Added `--status deferred` filter to `queue list` and `--limit` example support.

* **Behavior Changes**
  * Deferred items are treated as benign-miss cooldowns, excluded from failed counts.
  * `queue retry`/reset now refuses non-failed rows (including deferred) and points to the deferred inspection path.

* **Documentation**
  * Updated docs with examples and clarified retry/reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->