### PR TITLE
feat: escalating miss cadence + deprioritization + retirement (#103, slice 103b)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -24,6 +24,21 @@ cooldown = 15
 # minimum 300 (5 min) -- smaller values are clamped at load time.
 circuit_open_duration = 1800
 
+# Escalating re-check cadence for benign misses (no matching track or no
+# usable lyrics). The delay doubles each miss: base, 2*base, 4*base, ... up to
+# cap. Overrides: MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS.
+# miss_backoff_base_hours = 168   # initial re-check delay (hours; 7 days); minimum 1
+# miss_backoff_cap_hours = 672    # maximum re-check delay (hours; 28 days)
+
+# Maximum number of miss fetches before retiring the queue row.
+# Retire after N miss fetches: when miss_count reaches this value the row is
+# closed (work_queue and linked scan_results both set to status=done,
+# last_error="miss limit reached"). This is terminal under current providers;
+# a future multi-source sweep (issue #103d) could revive it.
+# Default 15 (~1 year with the 7d base cadence). Set to 0 for no cap.
+# Override: MXLRC_MAX_MISS_ATTEMPTS.
+# max_miss_attempts = 15
+
 [output]
 # Default output directory for .lrc files.
 dir = "lyrics"

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -13,6 +13,31 @@ const (
 	DefaultMax  = time.Hour
 )
 
+// DefaultMissBase is the initial re-check delay for a benign miss (no matching
+// track or no usable lyrics). Doubling from here gives: 168h (7d), 336h (14d),
+// 672h (28d, cap), then stays at DefaultMissCap.
+const DefaultMissBase = 7 * 24 * time.Hour
+
+// DefaultMissCap is the maximum re-check delay for a benign miss (28 days).
+// Once miss_count is high enough for the geometric doubling to exceed this,
+// every subsequent Defer uses this ceiling.
+const DefaultMissCap = 28 * 24 * time.Hour
+
+// MissCooldown returns the re-check delay for a benign miss given the current
+// (post-increment) miss_count. It delegates to Geometric so the cadence is
+// consistent with the worker's failure-backoff formula:
+//
+//	miss_count=1: base (168h / 7d default)
+//	miss_count=2: 2*base (336h / 14d)
+//	miss_count=3: 4*base (672h / 28d = cap)
+//	...capped at max.
+//
+// A missCount < 1 is treated as 1 (same as Geometric). Zero or negative
+// base/max returns 0.
+func MissCooldown(missCount int, base, max time.Duration) time.Duration {
+	return Geometric(missCount, base, max)
+}
+
 // Geometric returns the wait duration for the given 1-indexed attempt count,
 // doubling from base each step and capping at max. Returns 0 if base or max
 // is non-positive. Attempts < 1 are treated as 1.

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -56,3 +56,44 @@ func TestGeometricDefaultsCadence(t *testing.T) {
 		}
 	}
 }
+
+// TestMissCooldownCadenceAndCap verifies the documented escalation schedule
+// for benign misses: 168h (7d), 336h (14d), 672h (28d, cap), 672h, ...
+func TestMissCooldownCadenceAndCap(t *testing.T) {
+	tests := []struct {
+		missCount int
+		want      time.Duration
+	}{
+		{1, 168 * time.Hour},
+		{2, 336 * time.Hour},
+		{3, 672 * time.Hour},  // cap
+		{4, 672 * time.Hour},  // still cap
+		{5, 672 * time.Hour},  // still cap
+		{6, 672 * time.Hour},  // still cap
+		{7, 672 * time.Hour},  // still cap
+		{10, 672 * time.Hour}, // still cap
+	}
+	for _, tc := range tests {
+		got := MissCooldown(tc.missCount, DefaultMissBase, DefaultMissCap)
+		if got != tc.want {
+			t.Fatalf("MissCooldown(%d) = %s; want %s", tc.missCount, got, tc.want)
+		}
+	}
+}
+
+// TestMissCooldownZeroAttemptTreatedAsOne ensures missCount<1 maps to base.
+func TestMissCooldownZeroAttemptTreatedAsOne(t *testing.T) {
+	if got := MissCooldown(0, DefaultMissBase, DefaultMissCap); got != DefaultMissBase {
+		t.Fatalf("MissCooldown(0) = %s; want %s (treat 0 as 1)", got, DefaultMissBase)
+	}
+}
+
+// TestMissCooldownZeroBaseOrCap returns 0 (inherits Geometric behavior).
+func TestMissCooldownZeroBaseOrCap(t *testing.T) {
+	if got := MissCooldown(3, 0, DefaultMissCap); got != 0 {
+		t.Fatalf("MissCooldown(3, 0, cap) = %s; want 0", got)
+	}
+	if got := MissCooldown(3, DefaultMissBase, 0); got != 0 {
+		t.Fatalf("MissCooldown(3, base, 0) = %s; want 0", got)
+	}
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -490,6 +490,8 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	allowedRoots := webhookAllowedRoots(ctx, sqlDB)
 	w := worker.New(workQ, cache.New(sqlDB), fetcher, newWriter(allowedRoots...))
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
+	w.SetMissBackoff(time.Duration(cfg.API.MissBackoffBaseHours)*time.Hour, time.Duration(cfg.API.MissBackoffCapHours)*time.Hour)
+	w.SetMaxMissAttempts(cfg.API.MaxMissAttempts)
 	configureWorkerVerification(w, cfg, verifier)
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1042,6 +1044,9 @@ func configKeys() []string {
 		"api.token",
 		"api.cooldown",
 		"api.circuit_open_duration",
+		"api.miss_backoff_base_hours",
+		"api.miss_backoff_cap_hours",
+		"api.max_miss_attempts",
 		"output.dir",
 		"db.path",
 		"server.addr",
@@ -1067,6 +1072,12 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return strconv.Itoa(cfg.API.Cooldown), true
 	case "api.circuit_open_duration":
 		return strconv.Itoa(cfg.API.CircuitOpenDuration), true
+	case "api.miss_backoff_base_hours":
+		return strconv.Itoa(cfg.API.MissBackoffBaseHours), true
+	case "api.miss_backoff_cap_hours":
+		return strconv.Itoa(cfg.API.MissBackoffCapHours), true
+	case "api.max_miss_attempts":
+		return strconv.Itoa(cfg.API.MaxMissAttempts), true
 	case "output.dir":
 		return cfg.Output.Dir, true
 	case "db.path":
@@ -1116,6 +1127,24 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 			return fmt.Errorf("api.circuit_open_duration must be a positive integer (seconds)")
 		}
 		cfg.API.CircuitOpenDuration = n
+	case "api.miss_backoff_base_hours":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 1 {
+			return fmt.Errorf("api.miss_backoff_base_hours must be a positive integer (hours; minimum 1)")
+		}
+		cfg.API.MissBackoffBaseHours = n
+	case "api.miss_backoff_cap_hours":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 1 {
+			return fmt.Errorf("api.miss_backoff_cap_hours must be a positive integer (hours; minimum 1)")
+		}
+		cfg.API.MissBackoffCapHours = n
+	case "api.max_miss_attempts":
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 0 {
+			return fmt.Errorf("api.max_miss_attempts must be a non-negative integer (0 means no cap)")
+		}
+		cfg.API.MaxMissAttempts = n
 	case "output.dir":
 		cfg.Output.Dir = value
 	case "db.path":

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1611,3 +1611,79 @@ func TestRunQueueList_StatusDeferred(t *testing.T) {
 		t.Fatalf("output missing header: %q", out.String())
 	}
 }
+
+// TestMissCadenceConfigKeys verifies that the three miss-cadence knobs are
+// accessible via configValue, setConfigValue, and configKeys.
+func TestMissCadenceConfigKeys(t *testing.T) {
+	cfg := config.Config{API: config.APIConfig{
+		MissBackoffBaseHours: 168,
+		MissBackoffCapHours:  672,
+		MaxMissAttempts:      15,
+	}}
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"api.miss_backoff_base_hours", "168"},
+		{"api.miss_backoff_cap_hours", "672"},
+		{"api.max_miss_attempts", "15"},
+	}
+	for _, tc := range tests {
+		got, ok := configValue(cfg, tc.key)
+		if !ok {
+			t.Fatalf("configValue(%q) ok = false; want true", tc.key)
+		}
+		if got != tc.want {
+			t.Fatalf("configValue(%q) = %q; want %q", tc.key, got, tc.want)
+		}
+	}
+
+	// setConfigValue round-trip.
+	if err := setConfigValue(&cfg, "api.miss_backoff_base_hours", "48"); err != nil {
+		t.Fatalf("setConfigValue miss_backoff_base_hours: %v", err)
+	}
+	if cfg.API.MissBackoffBaseHours != 48 {
+		t.Fatalf("MissBackoffBaseHours = %d; want 48", cfg.API.MissBackoffBaseHours)
+	}
+
+	if err := setConfigValue(&cfg, "api.miss_backoff_cap_hours", "336"); err != nil {
+		t.Fatalf("setConfigValue miss_backoff_cap_hours: %v", err)
+	}
+	if cfg.API.MissBackoffCapHours != 336 {
+		t.Fatalf("MissBackoffCapHours = %d; want 336", cfg.API.MissBackoffCapHours)
+	}
+
+	if err := setConfigValue(&cfg, "api.max_miss_attempts", "10"); err != nil {
+		t.Fatalf("setConfigValue max_miss_attempts: %v", err)
+	}
+	if cfg.API.MaxMissAttempts != 10 {
+		t.Fatalf("MaxMissAttempts = %d; want 10", cfg.API.MaxMissAttempts)
+	}
+
+	// Reject invalid values.
+	for _, bad := range []string{"", "abc", "-1", "0"} {
+		if err := setConfigValue(&cfg, "api.miss_backoff_base_hours", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid miss_backoff_base_hours %q", bad)
+		}
+		if err := setConfigValue(&cfg, "api.miss_backoff_cap_hours", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid miss_backoff_cap_hours %q", bad)
+		}
+	}
+	for _, bad := range []string{"", "abc", "-1"} {
+		if err := setConfigValue(&cfg, "api.max_miss_attempts", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid max_miss_attempts %q", bad)
+		}
+	}
+	// 0 is valid for max_miss_attempts (means no cap).
+	if err := setConfigValue(&cfg, "api.max_miss_attempts", "0"); err != nil {
+		t.Fatalf("setConfigValue(max_miss_attempts, 0) = %v; want nil (0 is valid)", err)
+	}
+
+	// All three must appear in configKeys.
+	for _, key := range []string{"api.miss_backoff_base_hours", "api.miss_backoff_cap_hours", "api.max_miss_attempts"} {
+		if !slices.Contains(configKeys(), key) {
+			t.Fatalf("configKeys missing %q", key)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,21 @@ type APIConfig struct {
 	// signal. Default 1800 (30 min). Values below circuitOpenMinSeconds are
 	// clamped at load time.
 	CircuitOpenDuration int `toml:"circuit_open_duration"`
+	// MissBackoffBaseHours is the initial re-check delay (in hours) for a
+	// benign miss (no matching track or no usable lyrics). The cadence doubles
+	// each miss: base, 2*base, 4*base, ... up to MissBackoffCapHours. Default 168.
+	// Values below 1 are clamped to 1 with a warning.
+	MissBackoffBaseHours int `toml:"miss_backoff_base_hours"`
+	// MissBackoffCapHours is the maximum re-check delay (in hours) for a
+	// benign miss. Default 672 (28 days). Must be >= MissBackoffBaseHours;
+	// smaller values are clamped to MissBackoffBaseHours with a warning.
+	MissBackoffCapHours int `toml:"miss_backoff_cap_hours"`
+	// MaxMissAttempts caps the total number of re-check attempts for a benign
+	// miss. When miss_count exceeds this value the queue row is retired
+	// (status='done', last_error='miss limit reached') without writing any
+	// scan_results success. Default 0 means no cap (retry indefinitely).
+	// Negative values are clamped to 0 with a warning.
+	MaxMissAttempts int `toml:"max_miss_attempts"`
 }
 
 // circuitOpenDefaultSeconds is the default circuit-open window (30 min).
@@ -38,6 +53,15 @@ const circuitOpenDefaultSeconds = 30 * 60
 // circuitOpenMinSeconds is the minimum permissible circuit-open window.
 // Values below this are clamped to this floor with a warning.
 const circuitOpenMinSeconds = 5 * 60
+
+// missBackoffBaseDefault is the default initial miss re-check delay (168 hours = 7 days).
+const missBackoffBaseDefault = 168
+
+// missBackoffCapDefault is the default maximum miss re-check delay (672 hours = 28 days).
+const missBackoffCapDefault = 672
+
+// missBackoffBaseMin is the minimum permissible miss backoff base (1 hour).
+const missBackoffBaseMin = 1
 
 // OutputConfig holds output-related configuration.
 type OutputConfig struct {
@@ -84,7 +108,13 @@ type VerificationConfig struct {
 // defaults sets built-in fallback values.
 func defaults() Config {
 	return Config{
-		API:          APIConfig{Cooldown: 15, CircuitOpenDuration: circuitOpenDefaultSeconds},
+		API: APIConfig{
+			Cooldown:             15,
+			CircuitOpenDuration:  circuitOpenDefaultSeconds,
+			MissBackoffBaseHours: missBackoffBaseDefault,
+			MissBackoffCapHours:  missBackoffCapDefault,
+			MaxMissAttempts:      15,
+		},
 		Output:       OutputConfig{Dir: "lyrics"},
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
 		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
@@ -102,7 +132,8 @@ func Load(path string) (Config, error) {
 	}
 	if path != "" {
 		if _, err := os.Stat(path); err == nil {
-			if _, err := toml.DecodeFile(path, &cfg); err != nil {
+			md, err := toml.DecodeFile(path, &cfg)
+			if err != nil {
 				return cfg, fmt.Errorf("config: decode %s: %w", path, err)
 			}
 			// Re-apply defaults for any fields the file set to blank.
@@ -142,12 +173,30 @@ func Load(path string) (Config, error) {
 			if cfg.API.CircuitOpenDuration == 0 {
 				cfg.API.CircuitOpenDuration = d.API.CircuitOpenDuration
 			}
+			// MissBackoffBaseHours/MissBackoffCapHours: 0 means "not set in
+			// file"; restore defaults so a blank config.example.toml copy
+			// gets the documented cadence.
+			if cfg.API.MissBackoffBaseHours == 0 {
+				cfg.API.MissBackoffBaseHours = d.API.MissBackoffBaseHours
+			}
+			if cfg.API.MissBackoffCapHours == 0 {
+				cfg.API.MissBackoffCapHours = d.API.MissBackoffCapHours
+			}
+			// MaxMissAttempts: 0 is a valid user value (no cap), so a plain
+			// int TOML field cannot distinguish "omitted" from "explicit 0".
+			// Use MetaData.IsDefined to restore the default (15) only when the
+			// key is absent from the file; an explicit max_miss_attempts = 0
+			// is preserved as-is (user opts out of the cap).
+			if !md.IsDefined("api", "max_miss_attempts") {
+				cfg.API.MaxMissAttempts = d.API.MaxMissAttempts
+			}
 		} else if !os.IsNotExist(err) {
 			return cfg, fmt.Errorf("config: stat %s: %w", path, err)
 		}
 	}
 	applyEnvOverrides(&cfg)
 	clampCircuitOpenDuration(&cfg)
+	clampMissBackoff(&cfg)
 	if cfg.DB.Path == "" {
 		return cfg, fmt.Errorf("config: cannot determine DB path: set MXLRC_DB_PATH or XDG_DATA_HOME")
 	}
@@ -157,7 +206,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -188,6 +237,31 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_API_CIRCUIT_OPEN_DURATION", "value", v, "current", cfg.API.CircuitOpenDuration) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.CircuitOpenDuration = n
+		}
+	}
+
+	if v := os.Getenv("MXLRC_MISS_BACKOFF_BASE_HOURS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MISS_BACKOFF_BASE_HOURS", "value", v, "current", cfg.API.MissBackoffBaseHours) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.API.MissBackoffBaseHours = n
+		}
+	}
+	if v := os.Getenv("MXLRC_MISS_BACKOFF_CAP_HOURS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MISS_BACKOFF_CAP_HOURS", "value", v, "current", cfg.API.MissBackoffCapHours) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.API.MissBackoffCapHours = n
+		}
+	}
+	if v := os.Getenv("MXLRC_MAX_MISS_ATTEMPTS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MAX_MISS_ATTEMPTS", "value", v, "current", cfg.API.MaxMissAttempts) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.API.MaxMissAttempts = n
 		}
 	}
 
@@ -288,6 +362,25 @@ func clampCircuitOpenDuration(cfg *Config) {
 	if cfg.API.CircuitOpenDuration < circuitOpenMinSeconds {
 		slog.Warn("circuit_open_duration below minimum; clamping", "configured", cfg.API.CircuitOpenDuration, "minimum", circuitOpenMinSeconds)
 		cfg.API.CircuitOpenDuration = circuitOpenMinSeconds
+	}
+}
+
+// clampMissBackoff enforces valid ranges for the miss-cadence knobs.
+//   - MissBackoffBaseHours: clamped to missBackoffBaseMin (1h) from below.
+//   - MissBackoffCapHours: clamped to MissBackoffBaseHours from below (cap must >= base).
+//   - MaxMissAttempts: clamped to 0 from below (negative means no cap).
+func clampMissBackoff(cfg *Config) {
+	if cfg.API.MissBackoffBaseHours < missBackoffBaseMin {
+		slog.Warn("miss_backoff_base_hours below minimum; clamping", "configured", cfg.API.MissBackoffBaseHours, "minimum", missBackoffBaseMin)
+		cfg.API.MissBackoffBaseHours = missBackoffBaseMin
+	}
+	if cfg.API.MissBackoffCapHours < cfg.API.MissBackoffBaseHours {
+		slog.Warn("miss_backoff_cap_hours below base; clamping to base", "configured", cfg.API.MissBackoffCapHours, "base", cfg.API.MissBackoffBaseHours)
+		cfg.API.MissBackoffCapHours = cfg.API.MissBackoffBaseHours
+	}
+	if cfg.API.MaxMissAttempts < 0 {
+		slog.Warn("max_miss_attempts is negative; clamping to 0 (no cap)", "configured", cfg.API.MaxMissAttempts)
+		cfg.API.MaxMissAttempts = 0
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,10 +40,11 @@ type APIConfig struct {
 	// smaller values are clamped to MissBackoffBaseHours with a warning.
 	MissBackoffCapHours int `toml:"miss_backoff_cap_hours"`
 	// MaxMissAttempts caps the total number of re-check attempts for a benign
-	// miss. When miss_count exceeds this value the queue row is retired
+	// miss. When miss_count reaches this value the queue row is retired
 	// (status='done', last_error='miss limit reached') without writing any
-	// scan_results success. Default 0 means no cap (retry indefinitely).
-	// Negative values are clamped to 0 with a warning.
+	// scan_results success. Default 15 (~1 year with the default cadence).
+	// Set to 0 for no cap (retry indefinitely). Negative values are clamped
+	// to 0 with a warning.
 	MaxMissAttempts int `toml:"max_miss_attempts"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,7 @@ func isolateEnv(t *testing.T) {
 		"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN",
 		"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN",
 		"MXLRC_API_CIRCUIT_OPEN_DURATION",
+		"MXLRC_MISS_BACKOFF_BASE_HOURS", "MXLRC_MISS_BACKOFF_CAP_HOURS", "MXLRC_MAX_MISS_ATTEMPTS",
 		"MXLRC_OUTPUT_DIR", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
 		"MXLRC_SCAN_INTERVAL", "MXLRC_WORK_INTERVAL",
 		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
@@ -531,5 +532,207 @@ func TestLoad_InvalidTOMLReturnsError(t *testing.T) {
 	_, err := Load(cfgFile)
 	if err == nil {
 		t.Fatal("Load with invalid TOML returned nil error; want an error")
+	}
+}
+
+// TestLoad_MissBackoffDefaults verifies that the built-in defaults for the
+// miss-cadence knobs match the documented values.
+func TestLoad_MissBackoffDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MissBackoffBaseHours != 168 {
+		t.Fatalf("MissBackoffBaseHours = %d; want 168", cfg.API.MissBackoffBaseHours)
+	}
+	if cfg.API.MissBackoffCapHours != 672 {
+		t.Fatalf("MissBackoffCapHours = %d; want 672", cfg.API.MissBackoffCapHours)
+	}
+	if cfg.API.MaxMissAttempts != 15 {
+		t.Fatalf("MaxMissAttempts = %d; want 15", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MaxMissAttemptsOmittedInTOMLGetsDefault verifies that when
+// max_miss_attempts is absent from the TOML file, Load restores the default
+// (15) rather than leaving the TOML zero-value (0 = no cap). This matters
+// because plain-int TOML cannot distinguish "omitted" from "explicit 0";
+// MetaData.IsDefined is used to detect the omitted case.
+func TestLoad_MaxMissAttemptsOmittedInTOMLGetsDefault(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	// TOML file with [api] table but no max_miss_attempts key.
+	if err := os.WriteFile(cfgFile, []byte("[api]\ncooldown = 10\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MaxMissAttempts != 15 {
+		t.Fatalf("MaxMissAttempts = %d; want 15 (omitted key must restore default)", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MaxMissAttemptsExplicitZeroInTOMLIsPreserved verifies that an
+// explicit max_miss_attempts = 0 in the TOML file is honored as "no cap"
+// and not overwritten by the default (15).
+func TestLoad_MaxMissAttemptsExplicitZeroInTOMLIsPreserved(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgFile, []byte("[api]\nmax_miss_attempts = 0\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MaxMissAttempts != 0 {
+		t.Fatalf("MaxMissAttempts = %d; want 0 (explicit 0 must be preserved as no-cap)", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MaxMissAttemptsExplicitNonZeroInTOML verifies a positive
+// max_miss_attempts value in the TOML file is picked up correctly.
+func TestLoad_MaxMissAttemptsExplicitNonZeroInTOML(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgFile, []byte("[api]\nmax_miss_attempts = 5\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MaxMissAttempts != 5 {
+		t.Fatalf("MaxMissAttempts = %d; want 5", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MaxMissAttemptsEnvZeroIsNoCapEvenWithDefault verifies that
+// MXLRC_MAX_MISS_ATTEMPTS=0 results in 0 (no cap), overriding the default of 15.
+func TestLoad_MaxMissAttemptsEnvZeroIsNoCap(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_MAX_MISS_ATTEMPTS", "0")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MaxMissAttempts != 0 {
+		t.Fatalf("MaxMissAttempts = %d; want 0 (MXLRC_MAX_MISS_ATTEMPTS=0 must mean no cap)", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MissBackoffFromEnv verifies that the three miss-cadence env vars
+// override the defaults.
+func TestLoad_MissBackoffFromEnv(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_MISS_BACKOFF_BASE_HOURS", "48")
+	t.Setenv("MXLRC_MISS_BACKOFF_CAP_HOURS", "336")
+	t.Setenv("MXLRC_MAX_MISS_ATTEMPTS", "5")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MissBackoffBaseHours != 48 {
+		t.Fatalf("MissBackoffBaseHours = %d; want 48", cfg.API.MissBackoffBaseHours)
+	}
+	if cfg.API.MissBackoffCapHours != 336 {
+		t.Fatalf("MissBackoffCapHours = %d; want 336", cfg.API.MissBackoffCapHours)
+	}
+	if cfg.API.MaxMissAttempts != 5 {
+		t.Fatalf("MaxMissAttempts = %d; want 5", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MissBackoffClampsBase verifies that base < 1h is clamped to 1h.
+func TestLoad_MissBackoffClampsBase(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_MISS_BACKOFF_BASE_HOURS", "0")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// 0 is treated as "not set" by env override (env override only applies >0);
+	// clampMissBackoff then raises 0 to the default, which after the env parse
+	// becomes the built-in default (168h / 7d).
+	if cfg.API.MissBackoffBaseHours < 1 {
+		t.Fatalf("MissBackoffBaseHours = %d; want >= 1 (clamped from 0)", cfg.API.MissBackoffBaseHours)
+	}
+}
+
+// TestLoad_MissBackoffClampsCapBelowBase verifies that cap < base is clamped
+// up to base.
+func TestLoad_MissBackoffClampsCapBelowBase(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_MISS_BACKOFF_BASE_HOURS", "48")
+	t.Setenv("MXLRC_MISS_BACKOFF_CAP_HOURS", "24")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MissBackoffCapHours < cfg.API.MissBackoffBaseHours {
+		t.Fatalf("MissBackoffCapHours (%d) < MissBackoffBaseHours (%d); should be clamped to base", cfg.API.MissBackoffCapHours, cfg.API.MissBackoffBaseHours)
+	}
+	if cfg.API.MissBackoffCapHours != 48 {
+		t.Fatalf("MissBackoffCapHours = %d; want 48 (clamped to base)", cfg.API.MissBackoffCapHours)
+	}
+}
+
+// TestLoad_MaxMissAttemptsClampsNegative verifies that negative MaxMissAttempts
+// is clamped to 0.
+func TestLoad_MaxMissAttemptsClampsNegative(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_MAX_MISS_ATTEMPTS", "-1")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// -1 is not parsed (env override only sets positive; negative falls through
+	// and clampMissBackoff clamps to 0).
+	if cfg.API.MaxMissAttempts != 0 {
+		t.Fatalf("MaxMissAttempts = %d; want 0 (clamped from negative)", cfg.API.MaxMissAttempts)
+	}
+}
+
+// TestLoad_MissBackoffFromTOML verifies that TOML values are picked up.
+func TestLoad_MissBackoffFromTOML(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgFile, []byte(`
+[api]
+miss_backoff_base_hours = 12
+miss_backoff_cap_hours = 96
+max_miss_attempts = 10
+`), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.API.MissBackoffBaseHours != 12 {
+		t.Fatalf("MissBackoffBaseHours = %d; want 12", cfg.API.MissBackoffBaseHours)
+	}
+	if cfg.API.MissBackoffCapHours != 96 {
+		t.Fatalf("MissBackoffCapHours = %d; want 96", cfg.API.MissBackoffCapHours)
+	}
+	if cfg.API.MaxMissAttempts != 10 {
+		t.Fatalf("MaxMissAttempts = %d; want 10", cfg.API.MaxMissAttempts)
 	}
 }

--- a/internal/queue/priority.go
+++ b/internal/queue/priority.go
@@ -1,6 +1,11 @@
 package queue
 
 const (
+	// PriorityMiss is the priority applied to deferred benign-miss rows.
+	// Negative values sink below all fresh work in the ORDER BY priority DESC
+	// sort so re-attempts from an escalating miss cadence are always processed
+	// after new or normal-priority items.
+	PriorityMiss = -100
 	// PriorityScan is the baseline priority used for library scan-enqueued work.
 	PriorityScan = 0
 	// PriorityWebhook is used for webhook-enqueued work that should jump ahead of scan backlog.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -128,6 +128,14 @@ func NewDBQueue(db *sql.DB) *DBQueue {
 // scan_result_id, the link is also recorded in work_queue_scan_results so a
 // later Complete writeback can flip every collapsed scan_results row, not just
 // the first one observed.
+//
+// Priority update semantics on conflict:
+//   - A webhook-priority (>= PriorityWebhook) enqueue always overrides the
+//     stored priority so an explicit webhook can always preempt a deferred miss.
+//   - A scan-priority (< PriorityWebhook) enqueue preserves the stored priority
+//     when the row is deferred so that PriorityMiss deprioritization survives
+//     bulk library scans and the deferred row stays behind fresh work.
+//   - For all other states (pending, failed) the higher of the two priorities wins.
 func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority int) (WorkItem, error) {
 	now := formatTime(q.now())
 	outputPaths, err := marshalOutputPaths(inputs)
@@ -180,7 +188,11 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE excluded.output_paths
              END,
              scan_result_id = COALESCE(work_queue.scan_result_id, excluded.scan_result_id),
-             priority = max(work_queue.priority, excluded.priority),
+             priority = CASE
+                 WHEN excluded.priority >= 10 THEN excluded.priority           -- PriorityWebhook always wins
+                 WHEN work_queue.status = 'deferred' THEN work_queue.priority  -- preserve miss deprioritization
+                 ELSE max(work_queue.priority, excluded.priority)
+             END,
              status = CASE
                  WHEN work_queue.status IN ('done', 'processing', 'failed', 'deferred') THEN work_queue.status
                  ELSE 'pending'
@@ -426,9 +438,14 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
 		lastError = cause.Error()
 	}
 	row := q.db.QueryRowContext(ctx,
+		// priority is set to PriorityMiss (-100) so that re-attempts from the
+		// escalating miss cadence sink below all fresh work in the dequeue
+		// ORDER BY priority DESC sort. The literal -100 is used here rather than
+		// a Go constant because the SQL driver does not accept named Go values.
 		`UPDATE work_queue
          SET status = 'deferred',
              miss_count = miss_count + 1,
+             priority = -100,
              next_attempt_at = ?,
              last_error = ?
          WHERE id = ?
@@ -445,6 +462,66 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
 	}
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: defer: %w", err)
+	}
+	return item, nil
+}
+
+// RetireMiss permanently closes a processing row that has exceeded the
+// configured miss-attempt cap. It runs a transaction that mirrors Complete's
+// scan_results writeback: work_queue is set to status='done' with sentinel
+// last_error "miss limit reached", and every linked scan_results row is also
+// set to status='done' so the scan layer does not strand the track in
+// 'processing' forever. Unlike Complete (which signals a successful lyrics
+// fetch), the last_error clearly marks this as a miss-limit terminal; the
+// distinction is visible in the last_error field, not in the status column.
+//
+// Retirement is terminal under current providers. A future multi-source sweep
+// (issue #103, slice 103d) could revive a retired track by resetting its
+// scan_results row back to 'pending', but no such mechanism exists today.
+//
+// The guard AND status = 'processing' ensures only the worker that currently
+// holds the row can retire it; sql.ErrNoRows is returned if the row moved on
+// (a benign lost race).
+func (q *DBQueue) RetireMiss(ctx context.Context, id int64) (WorkItem, error) {
+	now := formatTime(q.now())
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: begin retire miss tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	row := tx.QueryRowContext(ctx,
+		`UPDATE work_queue
+         SET status = 'done',
+             completed_at = ?,
+             last_error = 'miss limit reached'
+         WHERE id = ?
+           AND status = 'processing'
+         RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
+                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+		now,
+		id,
+	)
+	item, err := scanWorkItem(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkItem{}, sql.ErrNoRows
+	}
+	if err != nil {
+		return WorkItem{}, fmt.Errorf("queue: retire miss: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+         SET status = 'done'
+         WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+           AND status != 'done'`,
+		id,
+	); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: retire miss scan_results writeback: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: commit retire miss tx: %w", err)
 	}
 	return item, nil
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -466,6 +466,11 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
 	return item, nil
 }
 
+// missLimitReachedError is the last_error value RetireMiss writes when a benign
+// miss is retired after exhausting max_miss_attempts. Defined once so the SQL
+// bind, the tests, and any log/inspection of the sentinel cannot drift.
+const missLimitReachedError = "miss limit reached"
+
 // RetireMiss permanently closes a processing row that has exceeded the
 // configured miss-attempt cap. It runs a transaction that mirrors Complete's
 // scan_results writeback: work_queue is set to status='done' with sentinel
@@ -494,12 +499,13 @@ func (q *DBQueue) RetireMiss(ctx context.Context, id int64) (WorkItem, error) {
 		`UPDATE work_queue
          SET status = 'done',
              completed_at = ?,
-             last_error = 'miss limit reached'
+             last_error = ?
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, outdir, filename, source_path, status, priority, attempts,
                    miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		now,
+		missLimitReachedError,
 		id,
 	)
 	item, err := scanWorkItem(row)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1904,3 +1904,261 @@ func TestDBQueue_CountByStatusIncludesDeferred(t *testing.T) {
 		t.Fatalf("failed count = %d; want 0 (deferred must not appear as failed)", counts[StatusFailed])
 	}
 }
+
+// TestDBQueue_DeferSetsPriorityMiss verifies that Defer sets the row priority
+// to PriorityMiss so deferred re-attempts sink below all fresh work.
+func TestDBQueue_DeferSetsPriorityMiss(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	deferred, err := q.Defer(ctx, item.ID, 24*time.Hour, errors.New("miss"))
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if deferred.Priority != PriorityMiss {
+		t.Fatalf("priority = %d; want PriorityMiss (%d)", deferred.Priority, PriorityMiss)
+	}
+}
+
+// TestDBQueue_EnqueueScanPreservesMissPriority confirms that a scan-priority
+// re-enqueue does NOT un-deprioritize a deferred miss row.
+func TestDBQueue_EnqueueScanPreservesMissPriority(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	inputs := models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}
+	if _, err := q.Enqueue(ctx, inputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 24*time.Hour, errors.New("miss")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// Scan-priority re-enqueue must preserve PriorityMiss.
+	refreshed, err := q.Enqueue(ctx, inputs, PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue (scan): %v", err)
+	}
+	if refreshed.Priority != PriorityMiss {
+		t.Fatalf("priority after scan Enqueue = %d; want PriorityMiss (%d) (scan must not un-deprioritize)", refreshed.Priority, PriorityMiss)
+	}
+}
+
+// TestDBQueue_EnqueueWebhookRestoresPriority confirms that a webhook-priority
+// re-enqueue overrides PriorityMiss (the escape hatch).
+func TestDBQueue_EnqueueWebhookRestoresPriority(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	inputs := models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}
+	if _, err := q.Enqueue(ctx, inputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 24*time.Hour, errors.New("miss")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// Webhook-priority enqueue must override PriorityMiss.
+	refreshed, err := q.Enqueue(ctx, inputs, PriorityWebhook)
+	if err != nil {
+		t.Fatalf("Enqueue (webhook): %v", err)
+	}
+	if refreshed.Priority != PriorityWebhook {
+		t.Fatalf("priority after webhook Enqueue = %d; want PriorityWebhook (%d)", refreshed.Priority, PriorityWebhook)
+	}
+}
+
+// TestDBQueue_DequeuePicksScanOverMissRow verifies that a ready PriorityScan
+// item is dequeued before a ready PriorityMiss item.
+func TestDBQueue_DequeuePicksScanOverMissRow(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	// Enqueue and defer a miss item first (so it has a lower ID and would win
+	// on created_at if priority were equal).
+	missInputs := models.Inputs{Track: models.Track{ArtistName: "Miss", TrackName: "Song"}}
+	if _, err := q.Enqueue(ctx, missInputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue miss: %v", err)
+	}
+	missItem, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue miss: %v", err)
+	}
+	// Defer sets PriorityMiss; advance clock so cooldown is in the past.
+	if _, err := q.Defer(ctx, missItem.ID, time.Millisecond, errors.New("miss")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// Advance clock so the deferred row is ready.
+	q.now = func() time.Time { return now.Add(time.Second) }
+
+	// Enqueue a fresh scan-priority item (higher ID, but higher priority).
+	freshInputs := models.Inputs{Track: models.Track{ArtistName: "Fresh", TrackName: "Song"}}
+	if _, err := q.Enqueue(ctx, freshInputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue fresh: %v", err)
+	}
+
+	// The scan-priority item must be dequeued first despite having a higher ID.
+	first, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("first Dequeue: %v", err)
+	}
+	if first.Inputs.Track.ArtistName != "Fresh" {
+		t.Fatalf("first dequeued = %q; want Fresh (scan-priority must win over PriorityMiss)", first.Inputs.Track.ArtistName)
+	}
+
+	// The miss item is dequeued second.
+	second, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("second Dequeue: %v", err)
+	}
+	if second.Inputs.Track.ArtistName != "Miss" {
+		t.Fatalf("second dequeued = %q; want Miss", second.Inputs.Track.ArtistName)
+	}
+}
+
+// TestDBQueue_RetireMiss verifies that RetireMiss sets status=done with the
+// sentinel error message. When no scan_result_id is linked the call must
+// succeed without error (empty junction is a no-op on scan_results).
+func TestDBQueue_RetireMiss(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	retired, err := q.RetireMiss(ctx, item.ID)
+	if err != nil {
+		t.Fatalf("RetireMiss: %v", err)
+	}
+	if retired.Status != StatusDone {
+		t.Fatalf("status = %q; want %q", retired.Status, StatusDone)
+	}
+	if retired.LastError != "miss limit reached" {
+		t.Fatalf("last_error = %q; want %q", retired.LastError, "miss limit reached")
+	}
+	if retired.CompletedAt == nil {
+		t.Fatal("completed_at = nil; want non-nil")
+	}
+	// No scan_result_id on this row; the scan_results UPDATE is a no-op but must
+	// not error. The linked-row writeback is covered by
+	// TestDBQueue_RetireMissWritesScanResultsDone.
+}
+
+// TestDBQueue_RetireMissWritesScanResultsDone verifies that RetireMiss
+// writes status='done' to every linked scan_results row (mirroring Complete's
+// writeback) so the scan layer does not strand the track in 'processing'.
+func TestDBQueue_RetireMissWritesScanResultsDone(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+
+	// Insert a library and scan_result row to link.
+	var libID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES ('/music', 'test') RETURNING id`,
+	).Scan(&libID); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+	var srID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO scan_results (library_id, artist, title, file_path, outdir, filename, status)
+         VALUES (?, 'Artist', 'Title', '/music/song.flac', 'out', 'song.lrc', 'pending')
+         RETURNING id`,
+		libID,
+	).Scan(&srID); err != nil {
+		t.Fatalf("insert scan_result: %v", err)
+	}
+
+	inputs := models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:       "out",
+		Filename:     "song.lrc",
+		ScanResultID: srID,
+	}
+	if _, err := q.Enqueue(ctx, inputs, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	if _, err := q.RetireMiss(ctx, item.ID); err != nil {
+		t.Fatalf("RetireMiss: %v", err)
+	}
+
+	// scan_results must be 'done' so the track is not stranded as 'processing'.
+	var srStatus string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM scan_results WHERE id = ?`, srID).Scan(&srStatus); err != nil {
+		t.Fatalf("scan scan_result status: %v", err)
+	}
+	if srStatus != "done" {
+		t.Fatalf("scan_result status = %q; want %q (RetireMiss must write back done to unblock the scan layer)", srStatus, "done")
+	}
+}
+
+// TestPriorityConstantsSQLParity is a compile-time guard asserting that
+// PriorityMiss and PriorityWebhook match the SQL literals hardcoded in Defer
+// (priority = -100) and Enqueue (priority >= 10). The SQL driver cannot bind Go
+// constants, so a future rename or value change here would silently desync with
+// those queries; this test makes such a drift a build failure instead.
+func TestPriorityConstantsSQLParity(t *testing.T) {
+	if PriorityMiss != -100 {
+		t.Fatalf("PriorityMiss = %d; SQL literal in Defer is -100 -- update the SQL or this constant", PriorityMiss)
+	}
+	if PriorityWebhook != 10 {
+		t.Fatalf("PriorityWebhook = %d; SQL literal in Enqueue is 10 -- update the SQL or this constant", PriorityWebhook)
+	}
+}
+
+// TestDBQueue_RetireMissNoRowsWhenNotProcessing verifies that RetireMiss
+// returns sql.ErrNoRows when the row is not in processing status.
+func TestDBQueue_RetireMissNoRowsWhenNotProcessing(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	// Complete the item first (now it's done, not processing).
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// RetireMiss on a non-processing row must return sql.ErrNoRows.
+	_, err = q.RetireMiss(ctx, item.ID)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("RetireMiss on non-processing row = %v; want sql.ErrNoRows", err)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -2059,8 +2059,8 @@ func TestDBQueue_RetireMiss(t *testing.T) {
 	if retired.Status != StatusDone {
 		t.Fatalf("status = %q; want %q", retired.Status, StatusDone)
 	}
-	if retired.LastError != "miss limit reached" {
-		t.Fatalf("last_error = %q; want %q", retired.LastError, "miss limit reached")
+	if retired.LastError != missLimitReachedError {
+		t.Fatalf("last_error = %q; want %q", retired.LastError, missLimitReachedError)
 	}
 	if retired.CompletedAt == nil {
 		t.Fatal("completed_at = nil; want non-nil")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -25,6 +25,12 @@ type Queue interface {
 	Fail(ctx context.Context, id int64, cause error) (queue.WorkItem, error)
 	Defer(ctx context.Context, id int64, retryAfter time.Duration, cause error) (queue.WorkItem, error)
 	Release(ctx context.Context, id int64) error
+	// RetireMiss permanently closes a processing row that has exceeded the
+	// max-miss-attempts cap. It sets status='done' with last_error='miss limit
+	// reached' on both the work_queue row and every linked scan_results row,
+	// marking the track as terminal. The scan layer will show the track as done
+	// (not pending) so it is not mistaken for an in-flight item.
+	RetireMiss(ctx context.Context, id int64) (queue.WorkItem, error)
 }
 
 // Cache provides lyrics cache operations.
@@ -38,16 +44,6 @@ type Cache interface {
 // is configured via SetCircuitOpenDuration. Mirrors the config default so
 // non-server callers (tests, ad-hoc CLI runs) get sensible behavior.
 const defaultCircuitOpenDuration = 30 * time.Minute
-
-// benignMissCooldown is the fixed delay applied when a track resolves to a
-// benign miss (no matching track, or a match with no usable lyrics). A miss
-// is not our failure and does not retire the queue row, but the catalog
-// rarely gains the missing lyrics on an hourly cadence, so a generous
-// days-scale cooldown keeps the worker from re-querying upstream for the
-// same dead track on every library scan. Unlike geometric backoff, this
-// delay does not ramp with the attempt count: each re-check waits the same
-// fixed window.
-const benignMissCooldown = 7 * 24 * time.Hour
 
 // Worker consumes queued lyrics work one item at a time. The scan_results
 // writeback for successful completions is handled atomically inside
@@ -71,6 +67,9 @@ type Worker struct {
 	now                   func() time.Time
 	circuitOpenDuration   time.Duration
 	circuitOpenUntil      time.Time
+	missBackoffBase       time.Duration
+	missBackoffCap        time.Duration
+	maxMissAttempts       int
 }
 
 var errQueueEmpty = errors.New("worker queue empty")
@@ -88,6 +87,12 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		sleep:                 sleepCtx,
 		now:                   time.Now,
 		circuitOpenDuration:   defaultCircuitOpenDuration,
+		missBackoffBase:       backoff.DefaultMissBase,
+		missBackoffCap:        backoff.DefaultMissCap,
+		// maxMissAttempts defaults to 0 (no cap). Non-serve callers (tests, ad-hoc
+		// CLI runs) get indefinite deferral; the config layer sets the cap via
+		// SetMaxMissAttempts using [api].max_miss_attempts (default 15).
+		maxMissAttempts: 0,
 	}
 }
 
@@ -99,6 +104,30 @@ func (w *Worker) SetCircuitOpenDuration(d time.Duration) {
 	if d > 0 {
 		w.circuitOpenDuration = d
 	}
+}
+
+// SetMissBackoff overrides the geometric miss-cadence parameters. base sets the
+// initial re-check delay for the first miss; cap sets the ceiling (successive
+// misses double from base up to cap). Zero or negative values are ignored so a
+// misconfigured call cannot disable the cadence; clamping against any minimum
+// is the responsibility of the caller (typically the config layer).
+func (w *Worker) SetMissBackoff(base, cap time.Duration) {
+	if base > 0 {
+		w.missBackoffBase = base
+	}
+	if cap > 0 {
+		w.missBackoffCap = cap
+	}
+}
+
+// SetMaxMissAttempts overrides the miss-attempt cap. When miss_count exceeds
+// this value the queue row is retired rather than re-deferred. A value of 0
+// means no cap (retry indefinitely). Negative values are clamped to 0.
+func (w *Worker) SetMaxMissAttempts(n int) {
+	if n < 0 {
+		n = 0
+	}
+	w.maxMissAttempts = n
 }
 
 func sleepCtx(ctx context.Context, d time.Duration) {
@@ -335,32 +364,52 @@ func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) err
 	return nil
 }
 
-// requeueDeferred re-queues a no-result item after a fixed cooldown
-// (benignMissCooldown, via Defer) WITHOUT tripping the consecutive-failure
-// counter. The queue row is not retired: it stays re-dequeueable once the
-// cooldown elapses and re-enqueueable by a later scan or webhook, so it is
-// retried eventually as the catalog grows, while the worker neither slows down
-// nor re-queries upstream hourly for the same dead track. Defer moves the row
-// to the distinct 'deferred' state and bumps miss_count without incrementing
-// attempts, so the cooldown is fixed (not geometric). On a SCAN-priority
-// re-enqueue the cooldown survives: Enqueue preserves next_attempt_at for
-// 'deferred' rows. A WEBHOOK re-enqueue intentionally resets it to now to force
-// an immediate retry (see DBQueue.Enqueue).
+// requeueDeferred reschedules a no-result item using the escalating miss
+// cadence (geometric doubling from missBackoffBase up to missBackoffCap) WITHOUT
+// tripping the consecutive-failure counter. The next miss_count (item.MissCount+1)
+// drives the delay so the first re-check is base, the second is 2*base, etc.
 //
-// A sql.ErrNoRows from Defer is benign here: it means the row is no longer
-// 'processing' because it was canceled or re-dequeued out from under us
-// (a lost race), not a real failure. Log it at debug and return nil so the run
-// loop does not surface a scary "worker run failed" warning for a no-result.
+// When maxMissAttempts > 0 and the next miss_count meets or exceeds the cap the
+// row is retired via RetireMiss (status='done' on work_queue and linked
+// scan_results, last_error='miss limit reached') rather than re-deferred. With
+// max_miss_attempts=N exactly N upstream fetches occur before retirement.
+//
+// A sql.ErrNoRows from Defer or RetireMiss is benign: the row is no longer
+// 'processing' because it was canceled or re-dequeued out from under us (a lost
+// race). Log at debug and return nil so the run loop stays quiet.
 func (w *Worker) requeueDeferred(ctx context.Context, item queue.WorkItem, cause error) error {
-	deferred, err := w.queue.Defer(context.WithoutCancel(ctx), item.ID, benignMissCooldown, cause)
+	nextMissCount := item.MissCount + 1
+	noCancel := context.WithoutCancel(ctx)
+
+	if w.maxMissAttempts > 0 && nextMissCount >= w.maxMissAttempts {
+		retired, err := w.queue.RetireMiss(noCancel, item.ID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				slog.Debug("benign miss retire skipped; item moved on", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "cause", cause)
+				return nil
+			}
+			return fmt.Errorf("worker: retire miss item %d after %v: %w", item.ID, cause, err)
+		}
+		slog.Info("benign miss retired; track abandoned after max miss attempts",
+			"id", retired.ID,
+			"artist", item.Inputs.Track.ArtistName,
+			"track", item.Inputs.Track.TrackName,
+			"miss_count", retired.MissCount,
+			"max_miss_attempts", w.maxMissAttempts,
+		)
+		return nil
+	}
+
+	cooldown := backoff.MissCooldown(nextMissCount, w.missBackoffBase, w.missBackoffCap)
+	deferred, err := w.queue.Defer(noCancel, item.ID, cooldown, cause)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			slog.Debug("benign miss defer skipped; item moved on", "id", item.ID, "cause", cause)
+			slog.Debug("benign miss defer skipped; item moved on", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "cause", cause)
 			return nil
 		}
 		return fmt.Errorf("worker: requeue item %d after %v: %w", item.ID, cause, err)
 	}
-	slog.Info("benign miss deferred", "id", item.ID, "retry_after", benignMissCooldown, "next_attempt_at", deferred.NextAttemptAt)
+	slog.Info("benign miss deferred", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "miss_count", deferred.MissCount, "retry_after", cooldown, "next_attempt_at", deferred.NextAttemptAt)
 	return nil
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
@@ -26,6 +27,7 @@ type fakeQueue struct {
 	failed         []int64
 	released       []int64
 	deferred       []int64
+	retired        []int64
 	failCauses     []error
 	deferCauses    []error
 	deferDurations []time.Duration
@@ -33,6 +35,7 @@ type fakeQueue struct {
 	failErr        error
 	deferErr       error
 	releaseErr     error
+	retireErr      error
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -82,6 +85,15 @@ func (q *fakeQueue) Release(_ context.Context, id int64) error {
 	q.removeFromProcessing(id)
 	q.released = append(q.released, id)
 	return nil
+}
+
+func (q *fakeQueue) RetireMiss(_ context.Context, id int64) (queue.WorkItem, error) {
+	if q.retireErr != nil {
+		return queue.WorkItem{}, q.retireErr
+	}
+	q.removeFromProcessing(id)
+	q.retired = append(q.retired, id)
+	return queue.WorkItem{ID: id, Status: queue.StatusDone}, nil
 }
 
 func (q *fakeQueue) removeFromProcessing(id int64) {
@@ -463,8 +475,9 @@ func TestRunOnceBenignMissRequeuesDeferredWithoutCounter(t *testing.T) {
 			if len(q.deferCauses) != 1 || !errors.Is(q.deferCauses[0], sentinel) {
 				t.Fatalf("requeue cause = %v; want errors.Is(_, %v)", q.deferCauses, sentinel)
 			}
-			if len(q.deferDurations) != 1 || q.deferDurations[0] != benignMissCooldown {
-				t.Fatalf("defer cooldown = %v; want fixed %v", q.deferDurations, benignMissCooldown)
+			// The first miss (miss_count=0+1=1) uses backoff.DefaultMissBase (168h / 7d).
+			if len(q.deferDurations) != 1 || q.deferDurations[0] != backoff.DefaultMissBase {
+				t.Fatalf("defer cooldown = %v; want first-miss base %v", q.deferDurations, backoff.DefaultMissBase)
 			}
 		})
 	}
@@ -980,5 +993,216 @@ func TestConfidence(t *testing.T) {
 
 	if score := Confidence(want, got); score != 1 {
 		t.Fatalf("Confidence() = %v; want 1", score)
+	}
+}
+
+// TestMissCadenceEscalates verifies that requeueDeferred uses escalating
+// geometric cooldowns driven by item.MissCount rather than a fixed window.
+func TestMissCadenceEscalates(t *testing.T) {
+	tests := []struct {
+		name      string
+		missCount int // current miss_count BEFORE this Defer (i.e. item.MissCount)
+		want      time.Duration
+	}{
+		{"miss1", 0, backoff.DefaultMissBase},     // 168h (7d)
+		{"miss2", 1, 2 * backoff.DefaultMissBase}, // 336h (14d)
+		{"miss3", 2, backoff.DefaultMissCap},      // 4*168h=672h = cap (28d)
+		{"miss4", 3, backoff.DefaultMissCap},      // cap; already at ceiling
+		// cap at DefaultMissCap (28 days = 672h)
+		{"miss7", 6, backoff.DefaultMissCap},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+			q := &fakeQueue{items: []queue.WorkItem{{
+				ID:        1,
+				MissCount: tc.missCount,
+				Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+			}}}
+			w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+
+			if err := w.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+			if len(q.deferDurations) != 1 || q.deferDurations[0] != tc.want {
+				t.Fatalf("defer cooldown = %v; want %v (miss_count=%d)", q.deferDurations, tc.want, tc.missCount)
+			}
+			if len(q.deferred) != 1 {
+				t.Fatalf("deferred = %v; want one item", q.deferred)
+			}
+			if len(q.failed) != 0 {
+				t.Fatalf("failed = %v; want none", q.failed)
+			}
+		})
+	}
+}
+
+// TestSetMissBackoffOverridesDefaults confirms that SetMissBackoff customizes
+// the cadence used by requeueDeferred.
+func TestSetMissBackoffOverridesDefaults(t *testing.T) {
+	customBase := 12 * time.Hour
+	customCap := 48 * time.Hour
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:        1,
+		MissCount: 0,
+		Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.SetMissBackoff(customBase, customCap)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.deferDurations) != 1 || q.deferDurations[0] != customBase {
+		t.Fatalf("defer cooldown = %v; want %v (custom base)", q.deferDurations, customBase)
+	}
+}
+
+// TestSetMissBackoffCapClamps verifies that a miss at a high count is bounded
+// by the custom cap.
+func TestSetMissBackoffCapClamps(t *testing.T) {
+	customBase := 10 * time.Hour
+	customCap := 20 * time.Hour
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:        1,
+		MissCount: 5, // would be 10*2^5 = 320h without cap
+		Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.SetMissBackoff(customBase, customCap)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.deferDurations) != 1 || q.deferDurations[0] != customCap {
+		t.Fatalf("defer cooldown = %v; want cap %v", q.deferDurations, customCap)
+	}
+}
+
+// TestMaxMissAttemptsRetires verifies that when miss_count+1 >= maxMissAttempts
+// the worker calls RetireMiss instead of Defer. With cap=3, the 3rd miss
+// (MissCount=2, nextMissCount=3) is the retirement boundary -- exactly N
+// fetches occur before the row is retired.
+func TestMaxMissAttemptsRetires(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:        99,
+		MissCount: 2, // next miss_count=3 == cap; retires on the 3rd miss
+		Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.SetMaxMissAttempts(3)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.retired) != 1 || q.retired[0] != 99 {
+		t.Fatalf("retired = %v; want [99]", q.retired)
+	}
+	if len(q.deferred) != 0 {
+		t.Fatalf("deferred = %v; want none (should have retired)", q.deferred)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none (retirement is not a failure)", q.failed)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none (RetireMiss does not go through Complete)", q.completed)
+	}
+	// Consecutive failures must not be bumped on a retirement.
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (retirement is not a failure)", w.consecutiveFailures)
+	}
+}
+
+// TestMaxMissAttemptsRetiresBoundary verifies that max_miss_attempts=1 retires
+// on the very first miss (nextMissCount=1 >= cap=1).
+func TestMaxMissAttemptsRetiresBoundary(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:        101,
+		MissCount: 0, // next miss_count=1 == cap=1; retires on the 1st miss
+		Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.SetMaxMissAttempts(1)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.retired) != 1 || q.retired[0] != 101 {
+		t.Fatalf("retired = %v; want [101] (max_miss_attempts=1 retires on first miss)", q.retired)
+	}
+	if len(q.deferred) != 0 {
+		t.Fatalf("deferred = %v; want none (should have retired on first miss)", q.deferred)
+	}
+}
+
+// TestMaxMissAttemptsZeroNeverRetires verifies that the default (0 = no cap)
+// defers indefinitely.
+func TestMaxMissAttemptsZeroNeverRetires(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:        1,
+		MissCount: 1000, // very high miss_count; cap is 0
+		Inputs:    models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	// Default maxMissAttempts = 0 (no cap)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.retired) != 0 {
+		t.Fatalf("retired = %v; want none (max=0 means no cap)", q.retired)
+	}
+	if len(q.deferred) != 1 {
+		t.Fatalf("deferred = %v; want one item", q.deferred)
+	}
+}
+
+// TestRetireMissNoRowsIsBenign covers the lost-race path in requeueDeferred's
+// retire branch: if RetireMiss returns sql.ErrNoRows the worker must not error.
+func TestRetireMissNoRowsIsBenign(t *testing.T) {
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:        88,
+			MissCount: 5,
+			Inputs:    models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}},
+		}},
+		retireErr: sql.ErrNoRows,
+	}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.SetMaxMissAttempts(3)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce = %v; want nil (RetireMiss no-rows is benign)", err)
+	}
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0", w.consecutiveFailures)
+	}
+}
+
+// TestSetMissBackoffIgnoresZero confirms that zero values are silently ignored.
+func TestSetMissBackoffIgnoresZero(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	origBase := w.missBackoffBase
+	origCap := w.missBackoffCap
+	w.SetMissBackoff(0, 0)
+	if w.missBackoffBase != origBase {
+		t.Fatalf("missBackoffBase changed after SetMissBackoff(0,0)")
+	}
+	if w.missBackoffCap != origCap {
+		t.Fatalf("missBackoffCap changed after SetMissBackoff(0,0)")
+	}
+}
+
+// TestSetMaxMissAttemptsClampNegative verifies negative values clamp to 0.
+func TestSetMaxMissAttemptsClampNegative(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetMaxMissAttempts(-5)
+	if w.maxMissAttempts != 0 {
+		t.Fatalf("maxMissAttempts = %d; want 0 after clamping -5", w.maxMissAttempts)
 	}
 }


### PR DESCRIPTION
## Summary

Second slice of #103, building on 103a's `deferred` work-queue status (#118). Benign no-result misses (a track Musixmatch has no lyrics for yet) now:

- **Escalating re-check cadence** driven by `miss_count` (reuses `backoff.Geometric`): 7d -> 14d -> 28d cap. Configurable via `[api].miss_backoff_base_hours` / `miss_backoff_cap_hours`.
- **Deprioritized** via `PriorityMiss = -100` so they sink below all fresh work. `Dequeue` already orders `priority DESC`, so a backlog of known-misses never competes with new tracks even when their cooldown has elapsed. A scan-priority re-enqueue **preserves** the deprioritization (corrected an Enqueue upsert CASE so scans don't silently un-deprioritize a miss); a webhook still overrides it.
- **Retired** after `[api].max_miss_attempts` misses (default 15, ~1 year at this cadence) via a new `RetireMiss` that marks `work_queue -> done` + `scan_results -> done` + `last_error='miss limit reached'` in one transaction. `0` disables the cap (re-check forever).

No DB migration (the `miss_count` / `priority` columns shipped in 103a's migration 012).

## Linked issue

Part of #103. (103c HTTP pacer / 103d multi-source sweep follow before v1.1.0.)

## Test plan

- [x] `make gate` green: race tests, **82% patch coverage**, golangci-lint, govulncheck
- [x] Real-SQLite tests: cadence ramp/cap, PriorityMiss ordering, scan-preserve vs webhook-override of miss priority, RetireMiss writes `scan_results=done` (no stranding, no false success), max-attempts retire boundary, config defaults/env/clamp incl. the omitted-vs-explicit-0 `max_miss_attempts` case
- [N/A] Manual UAT: no new user-visible runtime surface beyond config knobs; behavior is exercised by the integration suite

## Reviewer notes

Pre-reviewed locally (pr-review-toolkit code-reviewer + silent-failure-hunter). The silent-failure pass caught a Critical, RetireMiss originally stranded the linked `scan_results` row in `processing`; fixed by the transactional writeback above. Also folded in an off-by-one fix (`max_miss_attempts=N` now does exactly N fetches) and a constant/SQL-literal drift guard test for `PriorityMiss`/`PriorityWebhook`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable miss-retry behavior: base/cap backoff and optional max retry attempts
  * Worker will permanently retire items after configured max attempts; deferred items are deprioritized

* **Configuration**
  * New API config keys, example TOML documentation, environment variable and CLI get/set support with validation

* **Tests**
  * Expanded test coverage for backoff, config parsing, clamping, and retirement behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->