### PR TITLE
feat: client-side request pacer (#103, slice 103c)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -15,7 +15,10 @@
 # Overrides (highest to lowest): --token flag, MUSIXMATCH_TOKEN env, MXLRC_API_TOKEN env.
 # token = "your-token-here"
 
-# Cooldown between API requests in seconds.
+# Minimum gap between Musixmatch API requests in seconds. Acts as both the
+# worker's inter-item pause in serve mode and a hard per-request floor inside
+# the HTTP client -- no request is issued until at least this many seconds
+# have elapsed since the last one, even if the worker's paced pause is skipped.
 cooldown = 15
 
 # Worker circuit-breaker window in seconds. When the upstream API returns a

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -601,10 +601,17 @@ func normalizeWorkerInterval(interval time.Duration) time.Duration {
 }
 
 func selectedProvider(cfg config.Config, token string, newFetcher func(string) musixmatch.Fetcher) (providers.LyricsProvider, error) {
+	fetcher := newFetcher(token)
+	// Apply the per-request pacer floor to the concrete Musixmatch client.
+	// Test-injected fake fetchers do not satisfy *musixmatch.Client so this
+	// is a no-op for them, preserving the injection seam unchanged.
+	if mc, ok := fetcher.(*musixmatch.Client); ok {
+		mc.WithMinInterval(time.Duration(cfg.API.Cooldown) * time.Second)
+	}
 	return providers.Select(
 		cfg.Providers.Primary,
 		cfg.Providers.Disabled,
-		providers.New(providers.Musixmatch, newFetcher(token)),
+		providers.New(providers.Musixmatch, fetcher),
 	)
 }
 

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1687,3 +1687,47 @@ func TestMissCadenceConfigKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestSelectedProviderWiresMinIntervalOnRealClient(t *testing.T) {
+	cfg := config.Config{
+		API:       config.APIConfig{Cooldown: 30},
+		Providers: config.ProvidersConfig{Primary: "musixmatch"},
+	}
+	// Use the real NewClient factory so we get a *musixmatch.Client back.
+	// Capture the client before selectedProvider wraps it so we can inspect it.
+	var captured *musixmatch.Client
+	_, err := selectedProvider(cfg, "token", func(token string) musixmatch.Fetcher {
+		captured = musixmatch.NewClient(token)
+		return captured
+	})
+	if err != nil {
+		t.Fatalf("selectedProvider: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("factory was never called")
+	}
+	// selectedProvider must have called WithMinInterval(30s) on the captured client.
+	if captured.MinInterval() != 30*time.Second {
+		t.Fatalf("MinInterval = %v; want 30s (from cfg.API.Cooldown=30)", captured.MinInterval())
+	}
+}
+
+func TestSelectedProviderFakeInjectionUnaffected(t *testing.T) {
+	cfg := config.Config{
+		API:       config.APIConfig{Cooldown: 30},
+		Providers: config.ProvidersConfig{Primary: "musixmatch"},
+	}
+	// Fake fetcher: should be used unchanged; the type assertion inside
+	// selectedProvider will not match, so the fake is not paced.
+	var gotFetcher musixmatch.Fetcher
+	_, err := selectedProvider(cfg, "token", func(token string) musixmatch.Fetcher {
+		gotFetcher = fakeFetcher{}
+		return gotFetcher
+	})
+	if err != nil {
+		t.Fatalf("selectedProvider: %v", err)
+	}
+	if _, ok := gotFetcher.(fakeFetcher); !ok {
+		t.Fatal("fake fetcher was replaced; injection seam is broken")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,13 @@ type Config struct {
 
 // APIConfig holds API-related configuration.
 type APIConfig struct {
-	Token    string `toml:"token"`
-	Cooldown int    `toml:"cooldown"`
+	Token string `toml:"token"`
+	// Cooldown is the minimum gap (in seconds) between Musixmatch API requests.
+	// It serves two roles: (1) the worker's inter-item pause in serve mode, and
+	// (2) the HTTP client's hard per-request floor -- the client will not issue a
+	// new request until at least Cooldown seconds have elapsed since the last
+	// one, regardless of how the worker schedules work. Default 15.
+	Cooldown int `toml:"cooldown"`
 	// CircuitOpenDuration is the duration in seconds the worker pauses
 	// dequeuing after the upstream API returns a rate-limit or unauthorized
 	// signal. Default 1800 (30 min). Values below circuitOpenMinSeconds are

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -116,9 +116,12 @@ func (c *Client) MinInterval() time.Duration {
 
 // pace enforces the minimum request interval. It must be called at the top of
 // FindLyrics before the HTTP request is built. When minInterval is zero or
-// negative it returns immediately. Otherwise it reads the last request
-// timestamp under the mutex, waits for the remainder of the interval if
-// needed, then records the new timestamp.
+// negative it returns immediately. Otherwise it loops: under the lock it
+// checks how long remains until the next slot is free; if the slot is free it
+// reserves it (sets lastRequest = now) and returns; if not, it releases the
+// lock, sleeps for the remainder, and re-checks. Re-checking after each sleep
+// prevents concurrent callers from computing the same wait, sleeping together,
+// and then all proceeding in a burst.
 //
 // The wait is ctx-cancellable; if the context is canceled during the wait
 // pace returns ctx.Err() wrapped with context.
@@ -126,25 +129,22 @@ func (c *Client) pace(ctx context.Context) error {
 	if c.minInterval <= 0 {
 		return nil
 	}
+	for {
+		c.mu.Lock()
+		now := c.now()
+		wait := c.minInterval - now.Sub(c.lastRequest)
+		if wait <= 0 {
+			c.lastRequest = now
+			c.mu.Unlock()
+			return nil
+		}
+		c.mu.Unlock()
 
-	c.mu.Lock()
-	now := c.now()
-	elapsed := now.Sub(c.lastRequest)
-	wait := c.minInterval - elapsed
-	c.mu.Unlock()
-
-	if wait > 0 {
 		slog.Debug("musixmatch pacer: waiting before next request", "wait", wait)
 		if !c.sleep(ctx, wait) {
 			return fmt.Errorf("musixmatch: pace: %w", ctx.Err())
 		}
 	}
-
-	c.mu.Lock()
-	c.lastRequest = c.now()
-	c.mu.Unlock()
-
-	return nil
 }
 
 // Name returns the provider name.

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
@@ -63,6 +64,13 @@ func IsBenignMiss(err error) bool {
 type Client struct {
 	Token      string
 	httpClient *http.Client
+
+	// pacer fields -- zero value means no pacing (minInterval == 0).
+	mu          sync.Mutex
+	minInterval time.Duration
+	lastRequest time.Time
+	now         func() time.Time
+	sleep       func(ctx context.Context, d time.Duration) bool
 }
 
 // NewClient creates a new Musixmatch API client.
@@ -70,7 +78,73 @@ func NewClient(token string) *Client {
 	return &Client{
 		Token:      token,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
+		now:        time.Now,
+		sleep:      ctxSleep,
 	}
+}
+
+// ctxSleep sleeps for d, returning true when the sleep completes and false when
+// ctx is canceled before d elapses.
+func ctxSleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// WithMinInterval sets the minimum duration between outbound API requests.
+// It returns c so callers can chain it on construction:
+//
+//	client := musixmatch.NewClient(token).WithMinInterval(15 * time.Second)
+//
+// A zero or negative value disables pacing (the default). This method is not
+// goroutine-safe; call it before sharing the client across goroutines.
+func (c *Client) WithMinInterval(d time.Duration) *Client {
+	c.minInterval = d
+	return c
+}
+
+// MinInterval returns the configured minimum request interval. A zero value
+// means pacing is disabled.
+func (c *Client) MinInterval() time.Duration {
+	return c.minInterval
+}
+
+// pace enforces the minimum request interval. It must be called at the top of
+// FindLyrics before the HTTP request is built. When minInterval is zero or
+// negative it returns immediately. Otherwise it reads the last request
+// timestamp under the mutex, waits for the remainder of the interval if
+// needed, then records the new timestamp.
+//
+// The wait is ctx-cancellable; if the context is canceled during the wait
+// pace returns ctx.Err() wrapped with context.
+func (c *Client) pace(ctx context.Context) error {
+	if c.minInterval <= 0 {
+		return nil
+	}
+
+	c.mu.Lock()
+	now := c.now()
+	elapsed := now.Sub(c.lastRequest)
+	wait := c.minInterval - elapsed
+	c.mu.Unlock()
+
+	if wait > 0 {
+		slog.Debug("musixmatch pacer: waiting before next request", "wait", wait)
+		if !c.sleep(ctx, wait) {
+			return fmt.Errorf("musixmatch: pace: %w", ctx.Err())
+		}
+	}
+
+	c.mu.Lock()
+	c.lastRequest = c.now()
+	c.mu.Unlock()
+
+	return nil
 }
 
 // Name returns the provider name.
@@ -80,6 +154,9 @@ func (c *Client) Name() string {
 
 // FindLyrics looks up lyrics for the given track from the Musixmatch API.
 func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	if err := c.pace(ctx); err != nil {
+		return models.Song{}, err
+	}
 	song := models.Song{}
 	baseURL, err := url.Parse(apiURL)
 	if err != nil {

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -84,17 +84,24 @@ func TestPacerNoopWhenMinIntervalZero(t *testing.T) {
 
 func TestPacerEnforcesMinInterval(t *testing.T) {
 	minInterval := 10 * time.Second
-	// Start time; both calls happen at t=0 (simulated).
+	// Fake clock starts at base. The sleep function advances it by the
+	// requested duration so the re-check loop sees wait <= 0 after one sleep
+	// and terminates without spinning.
 	base := time.Unix(1000, 0)
-	callCount := 0
+	var mu sync.Mutex
+	fakeNow := base
 	nowFn := func() time.Time {
-		callCount++
-		return base // both pace() calls see the same wall clock
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
 	}
 
 	var gotSleep time.Duration
 	sleepFn := func(ctx context.Context, d time.Duration) bool {
 		gotSleep = d
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
 		return true
 	}
 
@@ -102,7 +109,8 @@ func TestPacerEnforcesMinInterval(t *testing.T) {
 	track := models.Track{TrackName: "t", ArtistName: "a"}
 	ctx := context.Background()
 
-	// First call: no prior lastRequest, so no sleep. Sets lastRequest = base.
+	// First call: no prior lastRequest (zero time), so elapsed is huge and
+	// wait <= 0 -- no sleep. Sets lastRequest = fakeNow (base).
 	if _, err := c.FindLyrics(ctx, track); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
@@ -111,6 +119,7 @@ func TestPacerEnforcesMinInterval(t *testing.T) {
 	}
 
 	// Second call at the same simulated time (elapsed=0 < minInterval=10s).
+	// sleep advances the clock by minInterval so the re-check exits cleanly.
 	if _, err := c.FindLyrics(ctx, track); err != nil {
 		t.Fatalf("second call: %v", err)
 	}
@@ -122,15 +131,16 @@ func TestPacerEnforcesMinInterval(t *testing.T) {
 func TestPacerNoSleepWhenAlreadyElapsed(t *testing.T) {
 	minInterval := 10 * time.Second
 	base := time.Unix(1000, 0)
-	call := 0
+	// Fake clock: starts at base (so first FindLyrics sets lastRequest=base),
+	// then advances to base+minInterval for the second FindLyrics so elapsed
+	// >= minInterval and no sleep is needed. A mutex guards fakeNow because
+	// pace() reads it under c.mu (different lock).
+	var mu sync.Mutex
+	fakeNow := base
 	nowFn := func() time.Time {
-		call++
-		if call <= 2 {
-			// first FindLyrics: pace() sees now=base (sets lastRequest)
-			return base
-		}
-		// second FindLyrics: pace() sees now=base+minInterval (elapsed >= minInterval)
-		return base.Add(minInterval)
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
 	}
 
 	sleepCalled := false
@@ -146,6 +156,11 @@ func TestPacerNoSleepWhenAlreadyElapsed(t *testing.T) {
 	if _, err := c.FindLyrics(ctx, track); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
+	// Advance fake clock by minInterval before second call so elapsed >= minInterval.
+	mu.Lock()
+	fakeNow = base.Add(minInterval)
+	mu.Unlock()
+
 	if _, err := c.FindLyrics(ctx, track); err != nil {
 		t.Fatalf("second call: %v", err)
 	}
@@ -184,8 +199,24 @@ func TestPacerCtxCancelDuringSleep(t *testing.T) {
 
 func TestPacerGoroutineSafe(t *testing.T) {
 	// Multiple goroutines call FindLyrics concurrently; the pacer must not race.
-	// Use a zero interval so no actual sleeping occurs (just mutex correctness).
-	c := newPacerTestClient(0, time.Now, func(ctx context.Context, d time.Duration) bool { return true })
+	// Use a tiny non-zero interval so the 10 goroutines actually exercise the
+	// locked paced path (minInterval=0 skips the mutex entirely). The fake
+	// sleep advances a shared clock by the requested duration and returns true
+	// immediately so no real time elapses and the re-check loop always terminates.
+	var mu sync.Mutex
+	fakeNow := time.Unix(2000, 0)
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+	c := newPacerTestClient(time.Nanosecond, nowFn, sleepFn)
 
 	var wg sync.WaitGroup
 	for range 10 {

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -1,0 +1,239 @@
+package musixmatch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// newPacerTestClient is a thin helper that wires up a Client with injected
+// now/sleep and the existing roundTripFunc transport.
+func newPacerTestClient(minInterval time.Duration, nowFn func() time.Time, sleepFn func(context.Context, time.Duration) bool) *Client {
+	body := minimalSyncedResponse()
+	c := newTestClient(200, body)
+	c.WithMinInterval(minInterval)
+	c.now = nowFn
+	c.sleep = sleepFn
+	return c
+}
+
+// minimalSyncedResponse returns the JSON body for a track with synced lyrics.
+func minimalSyncedResponse() string {
+	return `{
+		"message": {
+			"header": {"status_code": 200},
+			"body": {
+				"macro_calls": {
+					"matcher.track.get": {
+						"message": {
+							"header": {"status_code": 200},
+							"body": {
+								"track": {
+									"track_name": "t",
+									"artist_name": "a",
+									"has_subtitles": 1,
+									"has_lyrics": 1
+								}
+							}
+						}
+					},
+					"track.lyrics.get": {"message": {"body": {}}},
+					"track.subtitles.get": {
+						"message": {
+							"body": {
+								"subtitle_list": [
+									{
+										"subtitle": {
+											"subtitle_body": "[{\"text\":\"x\",\"time\":{\"total\":1.0,\"minutes\":0,\"seconds\":1,\"hundredths\":0}}]"
+										}
+									}
+								]
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+}
+
+func TestPacerNoopWhenMinIntervalZero(t *testing.T) {
+	sleepCalled := false
+	c := newPacerTestClient(0, time.Now, func(ctx context.Context, d time.Duration) bool {
+		sleepCalled = true
+		return true
+	})
+
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+	ctx := context.Background()
+
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if sleepCalled {
+		t.Fatal("sleep was called; pacer should be a no-op when minInterval is 0")
+	}
+}
+
+func TestPacerEnforcesMinInterval(t *testing.T) {
+	minInterval := 10 * time.Second
+	// Start time; both calls happen at t=0 (simulated).
+	base := time.Unix(1000, 0)
+	callCount := 0
+	nowFn := func() time.Time {
+		callCount++
+		return base // both pace() calls see the same wall clock
+	}
+
+	var gotSleep time.Duration
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		gotSleep = d
+		return true
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+	ctx := context.Background()
+
+	// First call: no prior lastRequest, so no sleep. Sets lastRequest = base.
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if gotSleep != 0 {
+		t.Fatalf("first call triggered sleep %v; want none", gotSleep)
+	}
+
+	// Second call at the same simulated time (elapsed=0 < minInterval=10s).
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if gotSleep != minInterval {
+		t.Fatalf("second call sleep = %v; want %v", gotSleep, minInterval)
+	}
+}
+
+func TestPacerNoSleepWhenAlreadyElapsed(t *testing.T) {
+	minInterval := 10 * time.Second
+	base := time.Unix(1000, 0)
+	call := 0
+	nowFn := func() time.Time {
+		call++
+		if call <= 2 {
+			// first FindLyrics: pace() sees now=base (sets lastRequest)
+			return base
+		}
+		// second FindLyrics: pace() sees now=base+minInterval (elapsed >= minInterval)
+		return base.Add(minInterval)
+	}
+
+	sleepCalled := false
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		sleepCalled = true
+		return true
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+	ctx := context.Background()
+
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if sleepCalled {
+		t.Fatal("sleep was called; elapsed >= minInterval, so no sleep expected")
+	}
+}
+
+func TestPacerCtxCancelDuringSleep(t *testing.T) {
+	minInterval := 10 * time.Second
+	base := time.Unix(1000, 0)
+	nowFn := func() time.Time { return base }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		cancel() // simulate context canceled during wait
+		return false
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+
+	// Prime lastRequest so second call triggers the wait.
+	if _, err := c.FindLyrics(context.Background(), track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	_, err := c.FindLyrics(ctx, track)
+	if err == nil {
+		t.Fatal("expected error on ctx cancel; got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v; want context.Canceled", err)
+	}
+}
+
+func TestPacerGoroutineSafe(t *testing.T) {
+	// Multiple goroutines call FindLyrics concurrently; the pacer must not race.
+	// Use a zero interval so no actual sleeping occurs (just mutex correctness).
+	c := newPacerTestClient(0, time.Now, func(ctx context.Context, d time.Duration) bool { return true })
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestWithMinIntervalReturnsClient(t *testing.T) {
+	c := NewClient("token")
+	got := c.WithMinInterval(5 * time.Second)
+	if got != c {
+		t.Fatal("WithMinInterval did not return the receiver")
+	}
+}
+
+func TestMinIntervalAccessor(t *testing.T) {
+	c := NewClient("token")
+	if c.MinInterval() != 0 {
+		t.Fatalf("default MinInterval = %v; want 0", c.MinInterval())
+	}
+	c.WithMinInterval(7 * time.Second)
+	if c.MinInterval() != 7*time.Second {
+		t.Fatalf("MinInterval = %v; want 7s", c.MinInterval())
+	}
+}
+
+func TestCtxSleepCompletesNormally(t *testing.T) {
+	ctx := context.Background()
+	start := time.Now()
+	got := ctxSleep(ctx, 10*time.Millisecond)
+	if !got {
+		t.Fatal("ctxSleep returned false; want true (no cancel)")
+	}
+	if elapsed := time.Since(start); elapsed < 5*time.Millisecond {
+		t.Fatalf("sleep was too short: %v", elapsed)
+	}
+}
+
+func TestCtxSleepReturnsFalseOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+	got := ctxSleep(ctx, time.Hour)
+	if got {
+		t.Fatal("ctxSleep returned true on already-canceled ctx; want false")
+	}
+}


### PR DESCRIPTION
## Summary

Third slice of #103. Adds a **minimum-interval floor on outbound Musixmatch HTTP requests** inside `musixmatch.Client`, the proactive rate guard for a source that doesn't send reliable 429/Retry-After.

- Closes the real gap the existing cooldown misses: the worker **skips** its paced pause while `consecutiveFailures > 0` (`worker.go`), so a failure run could otherwise hammer the API at backoff-loop speed. The client-level floor also covers any future direct/concurrent caller.
- **Reuses `api.cooldown`** as the interval, no new config knob. The gate is a no-op in the normal path (the worker already waits >= cooldown between items) and only fires in the gap cases.
- Mechanism: mutex + last-request timestamp + ctx-aware sleep, **no new dependency**; injectable clock/sleep for deterministic tests (no real sleeps).
- Wired via a type assertion in `selectedProvider` so the real `*Client` is paced while test-injected fake fetchers pass through untouched.

No DB migration, no new config field.

## Linked issue

Part of #103. (103d multi-source sweep is the last slice before v1.1.0.)

## Test plan

- [x] `make gate` green: race tests, **100% patch coverage**, golangci-lint, govulncheck
- [x] Pacer tests: zero-interval no-op, interval enforced (injected clock), already-elapsed skip, ctx-cancel aborts the wait, goroutine-safety, plus wiring tests proving the real client is paced and a fake fetcher is unaffected
- [N/A] Manual UAT: behavior is internal rate-limiting, exercised by the unit suite

## Reviewer notes

Pacer math handles the first request correctly (zero `lastRequest` -> negative wait -> no delay). The mutex unlocks before the sleep; concurrent callers could each schedule a sleep (bounded over-wait), but the worker is single-goroutine so this never contends in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API request throttling mechanism to prevent excessive requests to Musixmatch and improve reliability.

* **Documentation**
  * Clarified `cooldown` setting documentation, explaining its role in controlling minimum intervals between API requests.

* **Tests**
  * Added comprehensive test coverage for request pacing behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->