### PR TITLE
ci: split Codecov from Test gate, fix Build matrix name, disable CR auto-review

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -5,8 +5,10 @@ reviews:
   high_level_summary: true
   poem: false
   review_status: true
+  # Auto-review disabled to conserve CodeRabbit usage. Trigger a review on demand
+  # by commenting `@coderabbitai review` on the PR.
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
 
 chat:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
-      # Emitted here so non-code PRs get an empty matrix (zero build legs, zero
-      # checks) instead of a skipped build job whose check surfaces the literal,
-      # unexpanded "Build (${{ matrix.goos }}, ${{ matrix.goarch }})" name.
+      # Always emits at least one matrix leg so GitHub can interpolate the job
+      # name. Non-code PRs get a single placeholder leg marked skip='true' whose
+      # build steps no-op. (An empty matrix, or a job skipped via `if:`, instead
+      # surfaces the literal, unexpanded "Build (${{ matrix.goos }},
+      # ${{ matrix.goarch }})" check name.)
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -50,7 +52,7 @@ jobs:
           if [ "${{ steps.filter.outputs.code }}" = "true" ]; then
             echo 'matrix={"include":[{"goos":"linux","goarch":"amd64"},{"goos":"linux","goarch":"arm64"},{"goos":"darwin","goarch":"amd64"},{"goos":"darwin","goarch":"arm64"},{"goos":"windows","goarch":"amd64"}]}' >> "$GITHUB_OUTPUT"
           else
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"goos":"linux","goarch":"amd64","skip":"true"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   lint:
@@ -77,9 +79,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
+    # Pure correctness gate: no external-network calls, so a third-party outage
+    # (e.g. Codecov) can never fail this required check. Coverage is shipped to
+    # Codecov by the separate, non-required `coverage-upload` job.
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -92,12 +96,12 @@ jobs:
       - name: Run tests
         run: go test -v -race -count=1 -coverprofile=coverage.out ./...
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          files: coverage.out
-          fail_ci_if_error: true
-          use_oidc: true
+          name: coverage
+          path: coverage.out
+          retention-days: 1
 
   scan:
     name: Image Scan
@@ -121,27 +125,61 @@ jobs:
           severity-cutoff: high
           fail-build: true
 
-  build-matrix:
-    name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
+  coverage-upload:
+    name: Upload Coverage
     runs-on: ubuntu-latest
-    needs: [changes, lint, test]
-    # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
-    # named with the literal, unexpanded ${{ matrix.* }} template. Running unless
-    # lint or test failed keeps the matrix empty on non-code PRs (see the `changes`
-    # job), so this expands to zero legs and zero checks.
-    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' }}
-    strategy:
-      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
+    needs: [test]
+    # Consumes the artifact produced by the Test job and ships it to Codecov.
+    # Deliberately NOT a required status check: a Codecov outage may fail this
+    # job, but it can never block a merge. Only runs when Test actually passed.
+    if: needs.test.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+      - name: Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: coverage.out
+          # Upload only coverage.out; without this, Codecov's auto-search also
+          # picks up scripts/coverage-floor.json (a config file, not a report).
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: true
+
+  build-matrix:
+    name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    needs: [changes, lint, test]
+    # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
+    # named with the literal, unexpanded ${{ matrix.* }} template. Non-code PRs get
+    # a single placeholder leg (skip='true', see the `changes` job) whose steps
+    # no-op, so the check name still interpolates to a concrete goos/goarch.
+    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' }}
+    strategy:
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
+    steps:
+      - if: ${{ matrix.skip != 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - if: ${{ matrix.skip != 'true' }}
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
 
       - name: Build binary
+        if: ${{ matrix.skip != 'true' }}
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}


### PR DESCRIPTION
Bundles two CI fixes (#122, #123) plus a CodeRabbit usage change.

## #122 - Decouple Codecov from the Test gate (+ least privilege)
A Codecov-action GPG outage on 2026-06-06 failed the required `Test` check three times despite all Go tests passing (it cascaded to `Build`), blocking an approved PR (#121).

- `Test` is now a pure correctness gate: drops `id-token: write` (left `contents: read`), removes the inline Codecov step, uploads `coverage.out` as an artifact.
- New **non-required** `Upload Coverage` job consumes the artifact and uploads via OIDC. `fail_ci_if_error: true` kept (visible but cannot block).
- `disable_search: true` so only `coverage.out` is sent - local `codecovcli` dry-run revealed Codecov's auto-search was also ingesting `scripts/coverage-floor.json` (a config file).

## #123 - Interpolatable Build matrix check name
Empty `include: []` on non-code PRs produced zero legs, so GitHub showed the literal `Build (${{ matrix.goos }}, ${{ matrix.goarch }})` check name.

- Compute-matrix emits one placeholder leg (`skip: 'true'`) on non-code PRs.
- `build-matrix` steps no-op when `matrix.skip == 'true'`.

## CodeRabbit
- `reviews.auto_review.enabled: false` - reviews are now opt-in via `@coderabbitai review`. `chat.auto_reply` stays on.

## Local validation
- `actionlint` clean
- full pre-push gate green (race tests, lint, govulncheck)
- `codecovcli do-upload --dry-run --disable-search` confirms `coverage.out` parses and uploads cleanly (bypasses the action's flaky GPG bootstrap)

This PR's own required checks (Test/Build/Lint) pass even during the Codecov outage, validating the fix end-to-end. Labeled `norabbit` (CI/config change CR already planned).

Closes #122
Closes #123