### PR TITLE
ci: bump cosign to v2.6.3 to fix GoReleaser bundle verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: 'v2.4.1'
+          cosign-release: 'v2.6.3'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7


### PR DESCRIPTION
## Why
The v1.1.0 Release run [failed](https://github.com/sydlexius/mxlrcgo-svc/actions/runs/27077202924) in the goreleaser-action **setup** step (before GoReleaser runs):

\`\`\`
Verifying checksums.txt signature with cosign (... goreleaser v2.16.0)
Error: bundle does not contain cert for verification, please provide public key
\`\`\`

cosign **v2.4.1** can't read GoReleaser v2.16.0's \`checksums.txt.sigstore.json\` bundle. No release or images were published (clean failure).

## Fix
Bump \`cosign-release\` to **v2.6.3** (latest 2.x), which supports the new bundle format.

Deliberately **not** v3: cosign v3 changed \`sign-blob --output-certificate/--output-signature\` (used by our \`signs\`/\`docker_signs\` in \`.goreleaser.yml\`), so staying on 2.x fixes the verification without risking our own signing.

## Recovery after merge
A tag-triggered workflow uses the workflow file from the tag's commit, so \`v1.1.0\` (at the pre-fix commit) must be moved: after this merges, delete & re-push \`v1.1.0\` at the new \`main\` HEAD to re-trigger the release.

Non-code change (workflow only) - \`Test\`/\`Lint\` skipped by the path filter; \`Build\` reports via its sentinel.