### PR TITLE
feat(docker): pre-ship bash completion in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,12 @@ RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
 
 COPY --from=build /out/mxlrcgo-svc /usr/local/bin/mxlrcgo-svc
 COPY build/docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Make the entrypoint executable and pre-ship bash completion: generate the
+# static wrapper and source it from the system bashrc so interactive
+# `docker exec -it ... bash` sessions get tab-completion with no manual sourcing.
+RUN chmod +x /entrypoint.sh && \
+    mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
+    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' >> /etc/bash/bashrc
 
 ENV MXLRC_DOCKER=true \
     MXLRC_SERVER_ADDR=0.0.0.0:50705

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,13 @@ COPY build/docker/entrypoint.sh /entrypoint.sh
 # Make the entrypoint executable and pre-ship bash completion: generate the
 # static wrapper and source it from the system bashrc so interactive
 # `docker exec -it ... bash` sessions get tab-completion with no manual sourcing.
+# Alpine's bash compiles SYS_BASHRC=/etc/bash/bashrc (verified: that file is the
+# one an interactive non-login shell reads here). We also write the conventional
+# /etc/bash.bashrc for robustness if the base image ever changes; both are guarded.
 RUN chmod +x /entrypoint.sh && \
     mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
-    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' >> /etc/bash/bashrc
+    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' \
+      | tee -a /etc/bash/bashrc /etc/bash.bashrc > /dev/null
 
 ENV MXLRC_DOCKER=true \
     MXLRC_SERVER_ADDR=0.0.0.0:50705

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -19,7 +19,12 @@ RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/mxlrcgo-svc /usr/local/bin/mxlrcgo-svc
 COPY build/docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Make the entrypoint executable and pre-ship bash completion: generate the
+# static wrapper and source it from the system bashrc so interactive
+# `docker exec -it ... bash` sessions get tab-completion with no manual sourcing.
+RUN chmod +x /entrypoint.sh && \
+    mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
+    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' >> /etc/bash/bashrc
 
 ENV MXLRC_DOCKER=true \
     MXLRC_SERVER_ADDR=0.0.0.0:50705

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -22,9 +22,13 @@ COPY build/docker/entrypoint.sh /entrypoint.sh
 # Make the entrypoint executable and pre-ship bash completion: generate the
 # static wrapper and source it from the system bashrc so interactive
 # `docker exec -it ... bash` sessions get tab-completion with no manual sourcing.
+# Alpine's bash compiles SYS_BASHRC=/etc/bash/bashrc (verified: that file is the
+# one an interactive non-login shell reads here). We also write the conventional
+# /etc/bash.bashrc for robustness if the base image ever changes; both are guarded.
 RUN chmod +x /entrypoint.sh && \
     mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
-    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' >> /etc/bash/bashrc
+    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' \
+      | tee -a /etc/bash/bashrc /etc/bash.bashrc > /dev/null
 
 ENV MXLRC_DOCKER=true \
     MXLRC_SERVER_ADDR=0.0.0.0:50705


### PR DESCRIPTION
Closes #140.

## What

Bake the bash completion script (added in #130) into the container image so interactive `docker exec -it mxlrcgo-svc bash` sessions get tab-completion automatically, with no manual `source <(mxlrcgo-svc completion bash)`.

## How

After the binary `COPY`, fold into the existing entrypoint `chmod` RUN:

```dockerfile
RUN chmod +x /entrypoint.sh && \
    mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' >> /etc/bash/bashrc
```

- **No new apk package.** Alpine's bash reads `/etc/bash/bashrc` for interactive non-login shells (which is what `docker exec -it ... bash` is), so sourcing the generated wrapper from there is sufficient.
- Applied **identically** to `Dockerfile` and `build/docker/Dockerfile.goreleaser` to honor the byte-identical-runtime-stage convention from #116.

## Verification

Built the runtime image locally from this branch and confirmed a fresh interactive bash auto-loads it:

```
$ docker run --rm --entrypoint bash <img> -ic 'complete -p mxlrcgo-svc'
complete -F _mxlrcgo_svc_complete mxlrcgo-svc
```

No manual sourcing required.

## Notes

- **VERSION unchanged** (stays 1.2.0) - Dockerfile-only, no service behavior change.
- The goreleaser runtime stage runs the binary under buildx multi-arch emulation to emit the static wrapper; that works.
- Mechanical / Dockerfile-only - candidate for the `norabbit` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bash tab-completion for the CLI so interactive sessions offer command and option suggestions.
  * Shell initialization now auto-loads the completion script in interactive bash sessions, so completions are available automatically when opening a shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->