### PR TITLE
ci(dependabot): fix auto-merge author check and drop catch-all CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @sydlexius

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,9 +1,11 @@
 # Auto-approve Dependabot PRs for patch and minor updates.
-# Major version bumps are left for manual review.
+# Major version bumps are left for manual review. A separate workflow
+# (dependabot-merge.yml) handles merging after all checks pass.
 #
 # Prerequisites:
 #   - Branch protection rules requiring status checks on main
 #   - "Allow GitHub Actions to create and approve pull requests" enabled
+#     (Settings > Actions > General > Workflow permissions)
 
 name: Auto-approve Dependabot PRs
 
@@ -12,12 +14,13 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     concurrency:
       group: dependabot-auto-approve-${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: read
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,6 +1,11 @@
 # Merge approved Dependabot PRs after CI passes.
 #
-# Triggers on CI workflow completion for Dependabot branches.
+# Triggers on CI workflow completion for Dependabot branches. Waits for all
+# required checks to finish, then squash-merges the PR if it has been approved
+# by the auto-approve workflow.
+#
+# This avoids the repo-level "Allow auto-merge" setting, which would expose
+# the auto-merge toggle on all PRs including human-authored ones.
 
 name: Merge approved Dependabot PRs
 
@@ -10,7 +15,7 @@ on:
     types:
       - completed
 
-permissions: read-all
+permissions: {}
 
 jobs:
   merge:
@@ -18,7 +23,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      checks: read
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')
@@ -36,7 +40,7 @@ jobs:
           PR_NUMBER=$(gh pr list --repo "$REPO" \
             --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
-            echo "::warning::No open PR found for branch $BRANCH"
+            echo "::warning::No open PR found for branch $BRANCH (may have been closed or merged already)"
             exit 0
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -51,8 +55,10 @@ jobs:
         run: |
           AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json author --jq '.author.login')
-          if [ "$AUTHOR" != "dependabot[bot]" ]; then
-            echo "::warning::PR #$PR_NUMBER author is '$AUTHOR', not dependabot[bot]. Skipping."
+          # gh CLI may return "dependabot[bot]" or "app/dependabot" depending
+          # on the CLI version. Accept both formats.
+          if [ "$AUTHOR" != "dependabot[bot]" ] && [ "$AUTHOR" != "app/dependabot" ]; then
+            echo "::warning::PR #$PR_NUMBER author is '$AUTHOR', not dependabot. Skipping."
             exit 0
           fi
           echo "verified=true" >> "$GITHUB_OUTPUT"
@@ -65,23 +71,36 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Check for an APPROVED review directly via the reviews API.
+          # This works regardless of whether branch protection requires
+          # pull request reviews (which controls the reviewDecision field).
           for i in $(seq 1 10); do
-            DECISION=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-              --json reviewDecision --jq '.reviewDecision') || {
-              echo "::warning::Failed to fetch review status (attempt $i/10)"
+            # Slurp all pages into one array, sort, group by user, and take
+            # only the latest review per user to avoid stale approvals.
+            APPROVED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+              | jq -s '
+                add
+                | sort_by(.user.login, .submitted_at)
+                | group_by(.user.login)
+                | map(last)
+                | map(select(.state == "APPROVED"))
+                | length
+              ') || {
+              echo "::warning::Failed to fetch reviews for PR #$PR_NUMBER (attempt $i/10)"
               if [ "$i" -lt 10 ]; then sleep 30; fi
               continue
             }
-            if [ "$DECISION" = "APPROVED" ]; then
+            if [ "$APPROVED" -gt 0 ]; then
               echo "decision=APPROVED" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$i" -lt 10 ]; then
-              echo "Attempt $i/10: not yet approved (status: $DECISION), waiting 30s..."
+              echo "Attempt $i/10: PR #$PR_NUMBER has no approvals yet, waiting 30s..."
               sleep 30
             fi
           done
           echo "::warning::PR #$PR_NUMBER not approved after ~5 minutes, skipping merge"
+          echo "decision=NOT_APPROVED" >> "$GITHUB_OUTPUT"
 
       - name: Wait for required checks and merge
         if: steps.pr.outputs.number && steps.review.outputs.decision == 'APPROVED'
@@ -93,11 +112,11 @@ jobs:
         run: |
           echo "Waiting for required checks on PR #$PR_NUMBER..."
           if ! gh pr checks "$PR_NUMBER" --repo "$REPO" --watch --required; then
-            echo "::error::Required checks failed for PR #$PR_NUMBER"
+            echo "::error::Required checks failed for PR #$PR_NUMBER, cannot merge"
             exit 1
           fi
           if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch; then
-            echo "::error::Failed to merge PR #$PR_NUMBER"
+            echo "::error::Failed to merge PR #$PR_NUMBER. Check for merge conflicts or branch protection changes."
             exit 1
           fi
           echo "Successfully merged PR #$PR_NUMBER"


### PR DESCRIPTION
Fixes two dependabot automation problems, ported from the stillwater config.

## Auto-merge never completed
`dependabot-merge.yml` gated on `author == "dependabot[bot]"`, but the runner's `gh` CLI now returns `app/dependabot`, so every recent dependabot PR (#154-#159) was skipped at the author check and left open-but-approved. Actual run log:

> `##[warning]PR #155 author is 'app/dependabot', not dependabot[bot]. Skipping.`

Now accepts both author spellings, switches the approval check to the reviews API (works regardless of branch-protection review requirements), and tightens permissions to `{}` at workflow level (job grants `contents`+`pull-requests: write`).

## Maintainer requested as reviewer on every PR
`.github/CODEOWNERS` was a catch-all `* @sydlexius`. With `require_code_owner_reviews: false` in branch protection it gated nothing and only added a redundant reviewer request on every PR (dependabot's included). Removed.

## Also
- `dependabot-auto-approve.yml`: least-privilege permissions (`{}` workflow-level, `pull-requests: write` at job level).

After merge, dependabot rebases its open PRs onto the new base, CI re-runs, and the fixed auto-merge merges the approved patch/minor ones. #156 (`fetch-metadata` v2->v3, a major) stays manual by design.

CI/config-only change; `norabbit` candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions for enhanced security
  * Improved automated pull request approval and merge verification logic
  * Refined merge workflow error messages for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->