### PR TITLE
feat(guard): script-allowlist language guard wired into config and worker (#163)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -114,6 +114,25 @@ sample_duration_seconds = 30
 min_confidence = 0.85
 min_similarity = 0.35
 
+[guard]
+# Optional language/script guard. It rejects fetched lyrics whose body is
+# dominated by scripts outside the allowlist below, so a wrong-language match
+# (e.g. a Cyrillic or CJK body returned for a Latin-script track) is never
+# written or cached. A rejection is terminal: the track is completed without
+# output and is not retried (re-fetching yields the same wrong-language result).
+#
+# accepted_scripts is the allowlist of Unicode script buckets a lyric body may be
+# written in. Supported buckets: Latin, Han, Kana, Hangul, Other. An EMPTY list
+# (the default) DISABLES the guard. Env override: MXLRC_GUARD_ACCEPTED_SCRIPTS
+# (comma-separated). Example (Latin plus Japanese):
+# accepted_scripts = ["Latin", "Han", "Kana"]
+accepted_scripts = []
+
+# script_guard_threshold is the maximum tolerated share of foreign-script letters
+# (outside accepted_scripts) before a result is rejected. Default 0.20. Values
+# outside (0, 1] are reset to the default. Env override: MXLRC_GUARD_THRESHOLD.
+script_guard_threshold = 0.20
+
 [queue]
 # Shuffle the worker dequeue order within each priority tier so requests do not
 # go out in strict alphabetical (library insertion) order, which is a plausible

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/cache"
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/langguard"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
 	"github.com/sydlexius/mxlrcgo-svc/internal/logging"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
@@ -634,6 +635,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	w.SetMissBackoff(time.Duration(cfg.API.MissBackoffBaseHours)*time.Hour, time.Duration(cfg.API.MissBackoffCapHours)*time.Hour)
 	w.SetMaxMissAttempts(cfg.API.MaxMissAttempts)
 	configureWorkerVerification(w, cfg, verifier)
+	configureWorkerGuard(w, newGuard(cfg))
 
 	runCtx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
@@ -774,6 +776,25 @@ func configureWorkerVerification(w *worker.Worker, cfg config.Config, verifier v
 		return
 	}
 	w.EnableVerification(verifier, cfg.Verification.MinConfidence)
+}
+
+// newGuard builds the language/script guard from config. It returns an UNTYPED
+// nil interface when no allowlist is configured (guard disabled). Returning a
+// typed-nil *langguard.Guard through the interface would be non-nil and defeat
+// the nil check in configureWorkerGuard, so the disabled path must return a bare
+// nil rather than a (*langguard.Guard)(nil).
+func newGuard(cfg config.Config) worker.ScriptGuard {
+	if len(cfg.Guard.AcceptedScripts) == 0 {
+		return nil
+	}
+	return langguard.NewGuard(cfg.Guard.AcceptedScripts, cfg.Guard.Threshold)
+}
+
+func configureWorkerGuard(w *worker.Worker, g worker.ScriptGuard) {
+	if g == nil {
+		return
+	}
+	w.EnableGuard(g)
 }
 
 func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd) {
@@ -1241,6 +1262,8 @@ func configKeys() []string {
 		"verification.sample_duration_seconds",
 		"verification.min_confidence",
 		"verification.min_similarity",
+		"guard.accepted_scripts",
+		"guard.script_guard_threshold",
 	}
 }
 
@@ -1288,6 +1311,10 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return strconv.FormatFloat(cfg.Verification.MinConfidence, 'f', -1, 64), true
 	case "verification.min_similarity":
 		return strconv.FormatFloat(cfg.Verification.MinSimilarity, 'f', -1, 64), true
+	case "guard.accepted_scripts":
+		return strings.Join(cfg.Guard.AcceptedScripts, ","), true
+	case "guard.script_guard_threshold":
+		return strconv.FormatFloat(cfg.Guard.Threshold, 'f', -1, 64), true
 	default:
 		return "", false
 	}
@@ -1389,6 +1416,15 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 			return fmt.Errorf("verification.min_similarity must be a number between 0 and 1")
 		}
 		cfg.Verification.MinSimilarity = n
+	case "guard.accepted_scripts":
+		// An empty value is valid: it clears the allowlist and disables the guard.
+		cfg.Guard.AcceptedScripts = splitCSV(value)
+	case "guard.script_guard_threshold":
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil || n <= 0 || n > 1 {
+			return fmt.Errorf("guard.script_guard_threshold must be a number between 0 and 1")
+		}
+		cfg.Guard.Threshold = n
 	default:
 		return fmt.Errorf("unknown config key: %s", key)
 	}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -81,6 +81,28 @@ func TestConfigureWorkerVerificationAcceptsNilVerifier(t *testing.T) {
 	configureWorkerVerification(w, config.Config{}, nil)
 }
 
+func TestNewGuardDisabledReturnsUntypedNil(t *testing.T) {
+	g := newGuard(config.Config{Guard: config.GuardConfig{Threshold: 0.20}})
+	if g != nil {
+		t.Fatalf("newGuard with empty allowlist = %#v; want untyped nil (not a typed-nil *Guard)", g)
+	}
+}
+
+func TestNewGuardEnabledReturnsGuard(t *testing.T) {
+	g := newGuard(config.Config{Guard: config.GuardConfig{AcceptedScripts: []string{"Latin"}, Threshold: 0.20}})
+	if g == nil {
+		t.Fatal("newGuard with a non-empty allowlist = nil; want a Guard")
+	}
+	if !g.Enabled() {
+		t.Fatal("newGuard returned a disabled guard; want Enabled() == true")
+	}
+}
+
+func TestConfigureWorkerGuardAcceptsNilGuard(t *testing.T) {
+	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
+	configureWorkerGuard(w, nil)
+}
+
 func TestRunSubcommandHelpShowsSelectedCommand(t *testing.T) {
 	tests := []struct {
 		name string
@@ -403,6 +425,57 @@ func TestVerificationConfigKeys(t *testing.T) {
 	}
 	if err := setConfigValue(&cfg, "verification.ffmpeg_path", " "); err == nil {
 		t.Fatal("setConfigValue accepted blank verification.ffmpeg_path")
+	}
+}
+
+func TestConfigGuardGetSetRoundTrip(t *testing.T) {
+	cfg := config.Config{
+		Guard: config.GuardConfig{
+			AcceptedScripts: []string{"Latin", "Han"},
+			Threshold:       0.3,
+		},
+	}
+	gets := map[string]string{
+		"guard.accepted_scripts":       "Latin,Han",
+		"guard.script_guard_threshold": "0.3",
+	}
+	for key, want := range gets {
+		got, ok := configValue(cfg, key)
+		if !ok {
+			t.Fatalf("configValue(%q) ok = false; want true", key)
+		}
+		if got != want {
+			t.Fatalf("configValue(%q) = %q; want %q", key, got, want)
+		}
+		if !slices.Contains(configKeys(), key) {
+			t.Fatalf("configKeys missing %q", key)
+		}
+	}
+
+	if err := setConfigValue(&cfg, "guard.accepted_scripts", "Latin, Hangul"); err != nil {
+		t.Fatalf("setConfigValue accepted_scripts: %v", err)
+	}
+	if len(cfg.Guard.AcceptedScripts) != 2 || cfg.Guard.AcceptedScripts[0] != "Latin" || cfg.Guard.AcceptedScripts[1] != "Hangul" {
+		t.Fatalf("accepted_scripts = %v; want [Latin Hangul]", cfg.Guard.AcceptedScripts)
+	}
+	// An empty accepted_scripts is valid: it disables the guard.
+	if err := setConfigValue(&cfg, "guard.accepted_scripts", ""); err != nil {
+		t.Fatalf("setConfigValue empty accepted_scripts: %v (empty is valid, disables the guard)", err)
+	}
+	if len(cfg.Guard.AcceptedScripts) != 0 {
+		t.Fatalf("accepted_scripts = %v; want empty", cfg.Guard.AcceptedScripts)
+	}
+
+	if err := setConfigValue(&cfg, "guard.script_guard_threshold", "0.5"); err != nil {
+		t.Fatalf("setConfigValue threshold: %v", err)
+	}
+	if cfg.Guard.Threshold != 0.5 {
+		t.Fatalf("threshold = %v; want 0.5", cfg.Guard.Threshold)
+	}
+	for _, bad := range []string{"abc", "0", "2", "-1"} {
+		if err := setConfigValue(&cfg, "guard.script_guard_threshold", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid guard.script_guard_threshold %q", bad)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Server       ServerConfig       `toml:"server"`
 	Providers    ProvidersConfig    `toml:"providers"`
 	Verification VerificationConfig `toml:"verification"`
+	Guard        GuardConfig        `toml:"guard"`
 	Queue        QueueConfig        `toml:"queue"`
 	Logging      LoggingConfig      `toml:"logging"`
 }
@@ -155,6 +156,24 @@ type VerificationConfig struct {
 	MinSimilarity         float64 `toml:"min_similarity"`
 }
 
+// GuardConfig holds optional language/script guard settings. An empty
+// AcceptedScripts disables the guard.
+type GuardConfig struct {
+	// AcceptedScripts is the allowlist of Unicode script buckets a lyric body may
+	// be written in: Latin, Han, Kana, Hangul, Other. Empty disables the guard.
+	// Override: MXLRC_GUARD_ACCEPTED_SCRIPTS (comma-separated).
+	AcceptedScripts []string `toml:"accepted_scripts"`
+	// Threshold is the maximum tolerated share of foreign-script letters (outside
+	// AcceptedScripts) before a result is rejected. Default 0.20. Values outside
+	// (0,1] are reset to the default. Override: MXLRC_GUARD_THRESHOLD.
+	Threshold float64 `toml:"script_guard_threshold"`
+}
+
+// guardThresholdDefault is the default foreign-script share threshold. It
+// mirrors langguard's built-in default so an empty config and an empty
+// allowlist agree.
+const guardThresholdDefault = 0.20
+
 // QueueConfig holds work-queue behavior settings.
 type QueueConfig struct {
 	// Randomize shuffles the dequeue order within each priority tier so the
@@ -182,6 +201,7 @@ func defaults() Config {
 		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
 		Providers:    ProvidersConfig{Primary: "musixmatch"},
 		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
+		Guard:        GuardConfig{Threshold: guardThresholdDefault},
 		Queue:        QueueConfig{Randomize: true},
 		Logging: LoggingConfig{
 			Level:      "info",
@@ -269,6 +289,13 @@ func Load(path string) (Config, error) {
 			if !md.IsDefined("api", "max_miss_attempts") {
 				cfg.API.MaxMissAttempts = d.API.MaxMissAttempts
 			}
+			// Guard: an empty accepted_scripts is valid (the guard is disabled),
+			// so it is never re-defaulted. The threshold default is restored when
+			// the key is absent (a plain float field cannot tell "omitted" from
+			// "explicit 0") or set out of the valid (0,1] range.
+			if !md.IsDefined("guard", "script_guard_threshold") || cfg.Guard.Threshold <= 0 || cfg.Guard.Threshold > 1 {
+				cfg.Guard.Threshold = d.Guard.Threshold
+			}
 			// Logging: restore defaults for blank string fields and zero ints.
 			if cfg.Logging.Level == "" {
 				cfg.Logging.Level = d.Logging.Level
@@ -312,7 +339,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -473,6 +500,17 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_VERIFICATION_MIN_SIMILARITY", "value", v, "current", cfg.Verification.MinSimilarity) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.MinSimilarity = n
+		}
+	}
+	if v := os.Getenv("MXLRC_GUARD_ACCEPTED_SCRIPTS"); v != "" {
+		cfg.Guard.AcceptedScripts = splitCSV(v)
+	}
+	if v := os.Getenv("MXLRC_GUARD_THRESHOLD"); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil || n <= 0 || n > 1 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_GUARD_THRESHOLD", "value", v, "current", cfg.Guard.Threshold) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Guard.Threshold = n
 		}
 	}
 	// Logging: string env overrides.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,7 @@ func isolateEnv(t *testing.T) {
 		"MXLRC_VERIFICATION_FFMPEG_PATH",
 		"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION",
 		"MXLRC_VERIFICATION_MIN_CONFIDENCE", "MXLRC_VERIFICATION_MIN_SIMILARITY",
+		"MXLRC_GUARD_ACCEPTED_SCRIPTS", "MXLRC_GUARD_THRESHOLD",
 		"MXLRC_QUEUE_RANDOMIZE",
 		"MXLRC_LOG_LEVEL", "MXLRC_LOG_FORMAT", "MXLRC_LOG_FILE",
 		"MXLRC_LOG_MAX_SIZE_MB", "MXLRC_LOG_MAX_FILES", "MXLRC_LOG_MAX_AGE_DAYS", "MXLRC_LOG_COMPRESS",
@@ -68,6 +69,90 @@ func TestLoad_MissingConfigFileIsNotFatal(t *testing.T) {
 	}
 	if cfg.Verification.MinSimilarity != 0.35 {
 		t.Errorf("default verification min similarity = %v; want 0.35", cfg.Verification.MinSimilarity)
+	}
+	if len(cfg.Guard.AcceptedScripts) != 0 {
+		t.Errorf("default guard accepted scripts = %v; want empty (disabled)", cfg.Guard.AcceptedScripts)
+	}
+	if cfg.Guard.Threshold != 0.20 {
+		t.Errorf("default guard threshold = %v; want 0.20", cfg.Guard.Threshold)
+	}
+}
+
+func TestLoad_GuardThresholdReDefaultsWhenUndefinedOrInvalid(t *testing.T) {
+	for name, tomlBody := range map[string]string{
+		"omitted":   "[guard]\naccepted_scripts = [\"Latin\"]\n",
+		"zero":      "[guard]\nscript_guard_threshold = 0.0\n",
+		"too large": "[guard]\nscript_guard_threshold = 1.5\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			isolateEnv(t)
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tomlBody), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Guard.Threshold != 0.20 {
+				t.Errorf("guard threshold = %v; want 0.20 (re-defaulted)", cfg.Guard.Threshold)
+			}
+		})
+	}
+}
+
+func TestLoad_GuardThresholdExplicitValueHonored(t *testing.T) {
+	isolateEnv(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	body := "[guard]\naccepted_scripts = [\"Latin\", \"Han\"]\nscript_guard_threshold = 0.5\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Guard.Threshold != 0.5 {
+		t.Errorf("guard threshold = %v; want 0.5", cfg.Guard.Threshold)
+	}
+	if len(cfg.Guard.AcceptedScripts) != 2 || cfg.Guard.AcceptedScripts[0] != "Latin" || cfg.Guard.AcceptedScripts[1] != "Han" {
+		t.Errorf("guard accepted scripts = %v; want [Latin Han]", cfg.Guard.AcceptedScripts)
+	}
+}
+
+func TestLoad_EnvGuardOverrides(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_GUARD_ACCEPTED_SCRIPTS", "Latin, Hangul")
+	t.Setenv("MXLRC_GUARD_THRESHOLD", "0.4")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Guard.AcceptedScripts) != 2 || cfg.Guard.AcceptedScripts[0] != "Latin" || cfg.Guard.AcceptedScripts[1] != "Hangul" {
+		t.Errorf("guard accepted scripts = %v; want [Latin Hangul]", cfg.Guard.AcceptedScripts)
+	}
+	if cfg.Guard.Threshold != 0.4 {
+		t.Errorf("guard threshold = %v; want 0.4", cfg.Guard.Threshold)
+	}
+}
+
+func TestLoad_EnvGuardThresholdInvalidIsIgnored(t *testing.T) {
+	for name, val := range map[string]string{
+		"not a number": "abc",
+		"zero":         "0",
+		"too large":    "2",
+	} {
+		t.Run(name, func(t *testing.T) {
+			isolateEnv(t)
+			t.Setenv("MXLRC_GUARD_THRESHOLD", val)
+			cfg, err := Load("")
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Guard.Threshold != 0.20 {
+				t.Errorf("guard threshold = %v; want 0.20 (invalid env kept default)", cfg.Guard.Threshold)
+			}
+		})
 	}
 }
 

--- a/internal/langguard/credits.go
+++ b/internal/langguard/credits.go
@@ -1,0 +1,32 @@
+package langguard
+
+import (
+	"regexp"
+	"strings"
+)
+
+// creditTokens are role/attribution markers (CJK + Latin) that identify a
+// non-lyric credit line. Seed list; extend as real provider files reveal more.
+var creditTokens = []string{
+	"作词", "作曲", "编曲", "制作人", "制作", "混音", "母带", "和声", "监制",
+	"录音", "出品", "网易云音乐", "纯音乐", "演唱",
+	"lyrics", "lyricist", "composer", "arranger", "produced by", "producer",
+	"mixing", "mastering", "written by", "performed by", "arranged by",
+	"composed by",
+}
+
+// roleColon matches a short "role : value" line (CJK or ASCII colon), the
+// structural shape of a credit line not caught by the token list.
+var roleColon = regexp.MustCompile(`^\s*[^：:]{1,20}\s*[：:]\s*\S`)
+
+// IsCreditLine reports whether a single timestamp-free lyric line is a
+// credit/attribution line rather than lyric content.
+func IsCreditLine(line string) bool {
+	low := strings.ToLower(line)
+	for _, t := range creditTokens {
+		if strings.Contains(line, t) || strings.Contains(low, t) {
+			return true
+		}
+	}
+	return len([]rune(line)) < 40 && roleColon.MatchString(line)
+}

--- a/internal/langguard/credits_test.go
+++ b/internal/langguard/credits_test.go
@@ -1,0 +1,31 @@
+package langguard
+
+import "testing"
+
+func TestIsCreditLine(t *testing.T) {
+	credit := []string{
+		"作词 : Max Martin/Taylor Swift",
+		"制作人 : Steve Mac",
+		"网易云音乐",
+		"Produced by Steve Mac",
+		"Mixing : Serban Ghenea",
+	}
+	for _, s := range credit {
+		if !IsCreditLine(s) {
+			t.Errorf("IsCreditLine(%q) = false; want true", s)
+		}
+	}
+	lyric := []string{
+		"Nice to meet you, where you been?",
+		"I could show you incredible things",
+		"夜に駆ける",
+		"ла-ла-ла",
+		"歌词写得真好", // contains 词 but is a lyric line, not a credit
+		"曲折的人生路", // contains 曲 but is a lyric line, not a credit
+	}
+	for _, s := range lyric {
+		if IsCreditLine(s) {
+			t.Errorf("IsCreditLine(%q) = true; want false", s)
+		}
+	}
+}

--- a/internal/langguard/guard.go
+++ b/internal/langguard/guard.go
@@ -1,0 +1,81 @@
+package langguard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// Guard rejects lyric results whose body is dominated by scripts outside an
+// allowlist. An empty allowlist disables it (Accept always true).
+type Guard struct {
+	accepted  map[string]bool
+	threshold float64
+}
+
+// NewGuard builds a Guard from a script allowlist and a foreign-letter share
+// threshold. A threshold <= 0 or > 1 is replaced with the 0.20 default.
+func NewGuard(acceptedScripts []string, threshold float64) *Guard {
+	if threshold <= 0 || threshold > 1 {
+		threshold = 0.20
+	}
+	m := make(map[string]bool, len(acceptedScripts))
+	for _, s := range acceptedScripts {
+		if s = strings.TrimSpace(s); s != "" {
+			m[s] = true
+		}
+	}
+	return &Guard{accepted: m, threshold: threshold}
+}
+
+// Enabled reports whether any script filtering is active.
+func (g *Guard) Enabled() bool { return len(g.accepted) > 0 }
+
+// Accept reports whether the song's lyric body is within the allowlist. A
+// disabled guard, or a body with no letters, accepts. Reason is "" on accept.
+func (g *Guard) Accept(song models.Song) (bool, string) {
+	if !g.Enabled() {
+		return true, ""
+	}
+	var total, foreign int
+	for _, r := range lyricBody(song) {
+		s := ScriptOf(r)
+		if s == "" {
+			continue
+		}
+		total++
+		if !g.accepted[s] {
+			foreign++
+		}
+	}
+	if total == 0 {
+		return true, ""
+	}
+	share := float64(foreign) / float64(total)
+	if share > g.threshold {
+		return false, fmt.Sprintf("foreign-script share %.2f exceeds %.2f", share, g.threshold)
+	}
+	return true, ""
+}
+
+// lyricBody concatenates the song's lyric text (synced lines then unsynced
+// body), excluding credit/attribution lines so they do not skew script scoring.
+func lyricBody(song models.Song) string {
+	var b strings.Builder
+	for _, ln := range song.Subtitles.Lines {
+		if t := strings.TrimSpace(ln.Text); t != "" && !IsCreditLine(t) {
+			b.WriteString(t)
+			b.WriteByte('\n')
+		}
+	}
+	if song.Lyrics.LyricsBody != "" {
+		for _, raw := range strings.Split(song.Lyrics.LyricsBody, "\n") {
+			if t := strings.TrimSpace(raw); t != "" && !IsCreditLine(t) {
+				b.WriteString(t)
+				b.WriteByte('\n')
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/langguard/guard_test.go
+++ b/internal/langguard/guard_test.go
@@ -1,0 +1,64 @@
+package langguard
+
+import (
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func synced(lines ...string) models.Song {
+	var s models.Song
+	for _, l := range lines {
+		s.Subtitles.Lines = append(s.Subtitles.Lines, models.Lines{Text: l})
+	}
+	return s
+}
+
+func TestGuardDisabledAcceptsEverything(t *testing.T) {
+	g := NewGuard(nil, 0.20) // empty allowlist => disabled
+	if g.Enabled() {
+		t.Fatal("Enabled() = true for empty allowlist; want false")
+	}
+	if ok, _ := g.Accept(synced("七里香", "作词 : 方文山")); !ok {
+		t.Fatal("disabled guard rejected a song; want accept")
+	}
+}
+
+func TestGuardLatinAllowlist(t *testing.T) {
+	g := NewGuard([]string{Latin}, 0.20)
+
+	en := synced("作词 : Max Martin", "Nice to meet you, where you been?",
+		"I could show you incredible things")
+	if ok, reason := g.Accept(en); !ok {
+		t.Fatalf("English-with-CJK-credits rejected: %s", reason)
+	}
+
+	if ok, _ := g.Accept(synced("七里香", "窗外的麻雀", "在电线杆上多嘴")); ok {
+		t.Fatal("CJK body accepted; want reject")
+	}
+
+	if ok, _ := g.Accept(synced("♪ ♪ ♪")); !ok {
+		t.Fatal("no-letter body rejected; want accept")
+	}
+}
+
+func TestGuardThresholdBoundary(t *testing.T) {
+	g := NewGuard([]string{Latin}, 0.20)
+	merged := synced(
+		"Nice to meet you where you been",
+		"I could show you incredible things",
+		"很高兴认识你你去哪了我可以给你看不可思议的东西很高兴",
+	)
+	if ok, _ := g.Accept(merged); ok {
+		t.Fatal("merged ~30% Han accepted at threshold 0.20; want reject")
+	}
+}
+
+func TestNewGuardDefaultsThreshold(t *testing.T) {
+	if g := NewGuard([]string{Latin}, 0); g.threshold != 0.20 {
+		t.Fatalf("threshold = %v; want 0.20 default", g.threshold)
+	}
+	if g := NewGuard([]string{Latin}, 1.5); g.threshold != 0.20 {
+		t.Fatalf("out-of-range threshold not defaulted: %v", g.threshold)
+	}
+}

--- a/internal/langguard/script.go
+++ b/internal/langguard/script.go
@@ -1,0 +1,37 @@
+// Package langguard classifies and filters lyric text by Unicode script so a
+// configured allowlist can reject unwanted-language results (e.g. CJK lyrics for
+// an English library). It depends only on models and the standard library so it
+// can be reused by a future opt-in translation feature.
+package langguard
+
+import "unicode"
+
+// Script bucket names returned by ScriptOf.
+const (
+	Latin  = "Latin"
+	Han    = "Han"
+	Kana   = "Kana"
+	Hangul = "Hangul"
+	Other  = "Other"
+)
+
+// ScriptOf classifies a rune into a coarse Unicode script bucket. It returns ""
+// for non-letters (digits, punctuation, whitespace, symbols) so callers can
+// ignore them when scoring a lyric body.
+func ScriptOf(r rune) string {
+	if !unicode.IsLetter(r) {
+		return ""
+	}
+	switch {
+	case (r >= 0x4E00 && r <= 0x9FFF) || (r >= 0x3400 && r <= 0x4DBF):
+		return Han
+	case r >= 0x3040 && r <= 0x30FF:
+		return Kana
+	case r >= 0xAC00 && r <= 0xD7AF:
+		return Hangul
+	case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+		return Latin
+	default:
+		return Other
+	}
+}

--- a/internal/langguard/script_test.go
+++ b/internal/langguard/script_test.go
@@ -1,0 +1,24 @@
+package langguard
+
+import "testing"
+
+func TestScriptOf(t *testing.T) {
+	cases := []struct {
+		r    rune
+		want string
+	}{
+		{'a', Latin}, {'Z', Latin},
+		{'好', Han}, {'山', Han},
+		{'あ', Kana}, {'ア', Kana},
+		{'한', Hangul}, {'글', Hangul},
+		{'Я', Other}, // Cyrillic -> Other (foreign under a Latin allowlist)
+		{'5', ""}, {' ', ""}, {':', ""}, {'，', ""},
+		{'・', ""}, // U+30FB katakana middle dot (punctuation, not a letter)
+		{'゠', ""}, // U+30A0 katakana-hiragana double hyphen (punctuation)
+	}
+	for _, c := range cases {
+		if got := ScriptOf(c.r); got != c.want {
+			t.Errorf("ScriptOf(%q) = %q; want %q", c.r, got, c.want)
+		}
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -33,6 +33,14 @@ type Queue interface {
 	RetireMiss(ctx context.Context, id int64) (queue.WorkItem, error)
 }
 
+// ScriptGuard rejects lyric results whose body is dominated by scripts outside
+// a configured allowlist. A nil guard, or one whose Enabled reports false,
+// imposes no filtering. See internal/langguard for the concrete implementation.
+type ScriptGuard interface {
+	Accept(models.Song) (bool, string)
+	Enabled() bool
+}
+
 // Cache provides lyrics cache operations.
 type Cache interface {
 	LookupExact(ctx context.Context, artist, title, album string) (string, error)
@@ -71,7 +79,11 @@ type Worker struct {
 	writer                lyrics.Writer
 	verifier              verification.Verifier
 	verifyBelowConfidence float64
-	consecutiveFailures   int
+	// scriptGuard, when non-nil and Enabled, rejects fetched lyrics whose script
+	// mix falls outside the configured allowlist. Named scriptGuard (not guard)
+	// to avoid colliding with the guardReject helper. Default nil (no guard).
+	scriptGuard         ScriptGuard
+	consecutiveFailures int
 	// last* record the most recent hard failure so the backoff WARN can name the
 	// track it is throttling on (the failure cause is logged separately, but the
 	// periodic backoff line otherwise carried no identity).
@@ -201,6 +213,23 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 	if belowConfidence > 0 && belowConfidence <= 1 {
 		w.verifyBelowConfidence = belowConfidence
 	}
+}
+
+// EnableGuard configures the language/script guard used to reject lyric
+// results whose script mix falls outside the configured allowlist.
+func (w *Worker) EnableGuard(g ScriptGuard) {
+	w.scriptGuard = g
+}
+
+// guardReject reports whether the script guard rejects this song. It returns
+// (false, "") when no guard is configured or the guard is disabled, so the
+// caller can treat a nil/disabled guard as a no-op.
+func (w *Worker) guardReject(_ queue.WorkItem, song models.Song) (bool, string) {
+	if w.scriptGuard == nil || !w.scriptGuard.Enabled() {
+		return false, ""
+	}
+	ok, reason := w.scriptGuard.Accept(song)
+	return !ok, reason
 }
 
 // Run processes ready work items until the queue is empty or the context ends.
@@ -340,6 +369,19 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		if err := w.verify(ctx, item, song, confidence); err != nil {
 			slog.Warn("worker verification failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "error", err)
 			return w.fail(ctx, item, err)
+		}
+		// Language/script guard runs only on the non-cache-hit path: cache hits are
+		// our own previously-vetted data, so re-screening them is wasteful. A guard
+		// rejection is terminal POLICY, not a retriable failure: re-fetching the
+		// same track yields the same wrong-language lyrics, so we Complete the item
+		// (so it is neither cached nor written, never retried, and does not trip the
+		// circuit) rather than calling w.fail (retriable) or deferring it.
+		if reject, reason := w.guardReject(item, song); reject {
+			slog.Warn("worker guard rejected lyrics", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", reason)
+			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
+				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))
+			}
+			return nil
 		}
 		if err := w.store(ctx, resolvedTrack, song); err != nil {
 			slog.Warn("worker cache store failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -392,6 +392,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
 				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))
 			}
+			// Reset the failure backoff only after the terminal Complete durably
+			// succeeds (mirroring the benign-miss and normal-success paths): a
+			// prior transient w.fail must not keep later guard-rejected items in
+			// backoff once the provider is demonstrably healthy.
+			w.consecutiveFailures = 0
 			return nil
 		}
 		if err := w.store(ctx, resolvedTrack, song); err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -377,6 +377,17 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// (so it is neither cached nor written, never retried, and does not trip the
 		// circuit) rather than calling w.fail (retriable) or deferring it.
 		if reject, reason := w.guardReject(item, song); reject {
+			// The provider round-trip still SUCCEEDED (we fetched real lyrics and
+			// only rejected them on script policy), so recover throttle/circuit
+			// state exactly as the store-success path below does: the token is
+			// proven good and an earlier transient trip must not pin the worker in
+			// backoff after a healthy fetch.
+			w.everProviderSuccess = true
+			w.consecutiveCircuitTrips = 0
+			if w.circuitProbing {
+				slog.Info("worker circuit closed; provider recovered")
+				w.circuitProbing = false
+			}
 			slog.Warn("worker guard rejected lyrics", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", reason)
 			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
 				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -267,6 +267,120 @@ func (v *fakeVerifier) Verify(_ context.Context, path string, song models.Song) 
 	return verification.Result{Accepted: res.accepted, Similarity: 1}, nil
 }
 
+// fakeGuard is a test ScriptGuard. enabled toggles Enabled(); accept toggles
+// Accept's verdict. calls records each Accept invocation's song so tests can
+// assert the guard saw the fetched lyrics.
+type fakeGuard struct {
+	enabled bool
+	accept  bool
+	reason  string
+	calls   []models.Song
+}
+
+func (g *fakeGuard) Enabled() bool { return g.enabled }
+
+func (g *fakeGuard) Accept(song models.Song) (bool, string) {
+	g.calls = append(g.calls, song)
+	if g.accept {
+		return true, ""
+	}
+	return false, g.reason
+}
+
+func TestRunOnceGuardRejectsTerminallyWithoutCacheOrWrite(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 80,
+		Inputs: models.Inputs{
+			Track:    track,
+			Outdir:   "out",
+			Filename: "artist-title.lrc",
+		},
+	}}}
+	cache := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "wrong-language lyrics"},
+	}}
+	writer := &fakeWriter{}
+	guard := &fakeGuard{enabled: true, accept: false, reason: "foreign-script share 0.90 exceeds 0.20"}
+
+	w := New(q, cache, fetcher, writer)
+	w.EnableGuard(guard)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(guard.calls) != 1 {
+		t.Fatalf("guard calls = %d; want 1", len(guard.calls))
+	}
+	if len(writer.writes) != 0 {
+		t.Fatalf("writes = %+v; want none (guard rejection must not write)", writer.writes)
+	}
+	if len(cache.stores) != 0 {
+		t.Fatalf("cache stores = %d; want none (guard rejection must not cache)", len(cache.stores))
+	}
+	// Guard rejection is terminal/policy: Complete (not Fail, not Defer).
+	if len(q.completed) != 1 || q.completed[0] != 80 {
+		t.Fatalf("completed = %v; want [80] (terminal completion)", q.completed)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none (guard rejection is not a retriable failure)", q.failed)
+	}
+	if len(q.deferred) != 0 {
+		t.Fatalf("deferred = %v; want none (re-fetching yields the same wrong-language result)", q.deferred)
+	}
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (guard rejection must not trip backoff)", w.consecutiveFailures)
+	}
+}
+
+func TestRunOnceDisabledGuardProceedsNormally(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	for name, guard := range map[string]*fakeGuard{
+		"nil guard":      nil,
+		"disabled guard": {enabled: false, accept: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			q := &fakeQueue{items: []queue.WorkItem{{
+				ID: 81,
+				Inputs: models.Inputs{
+					Track:    track,
+					Outdir:   "out",
+					Filename: "artist-title.lrc",
+				},
+			}}}
+			cache := &fakeCache{}
+			fetcher := &fakeFetcher{song: models.Song{
+				Track:  track,
+				Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"},
+			}}
+			writer := &fakeWriter{}
+
+			w := New(q, cache, fetcher, writer)
+			if guard != nil {
+				w.EnableGuard(guard)
+			}
+
+			if err := w.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+			if len(writer.writes) != 1 {
+				t.Fatalf("writes = %+v; want one (disabled guard must not block)", writer.writes)
+			}
+			if len(cache.stores) != 1 {
+				t.Fatalf("cache stores = %d; want 1 (disabled guard must not block caching)", len(cache.stores))
+			}
+			if len(q.completed) != 1 || q.completed[0] != 81 {
+				t.Fatalf("completed = %v; want [81]", q.completed)
+			}
+			if len(q.failed) != 0 {
+				t.Fatalf("failed = %v; want none", q.failed)
+			}
+		})
+	}
+}
+
 func TestRunOnceCacheHitAvoidsFetcherAndCompletes(t *testing.T) {
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	song := models.Song{


### PR DESCRIPTION
## Summary

Adds a Unicode script guard that rejects fetched lyrics whose script mix falls outside a configured allowlist (e.g. CJK lyrics for an English library), and wires it into config and the worker pipeline. This is the prerequisite foundation for the CJK provider work in #149.

- **`internal/langguard`**: `ScriptOf` classifier (Latin/Han/Kana/Hangul/Other), credit-line stripping, and a `Guard` over `models.Song` driven by an `accepted_scripts` allowlist plus a foreign-script-share threshold (default 0.20). An empty allowlist disables it.
- **config**: `[guard]` section (`accepted_scripts`, `script_guard_threshold`) with `MXLRC_GUARD_ACCEPTED_SCRIPTS` / `MXLRC_GUARD_THRESHOLD` env overrides; `config get`/`set` support; documented in `config.example.toml`.
- **worker**: a post-fetch checkpoint on the non-cache path, after `verify` and before `store`. A guard rejection is terminal policy (re-fetching yields the same wrong-language result), so the item is `Complete`d - neither cached nor written, never retried, and it does not trip the circuit. Field named `scriptGuard` to avoid a field/method collision; `newGuard` returns an untyped-nil interface when disabled.

Patch coverage 90.98%; full gate green.

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Unicode script filtering for fetched lyrics with an allowlist and configurable threshold (default 0.20). Rejected lyrics are treated as terminal and not retried.

* **Configuration**
  * Config template and environment variables added to control accepted scripts and threshold.

* **Tests**
  * Added coverage for guard behavior, config round-trips/env overrides, script classification, and credit-line handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->