### PR TITLE
feat(petitlyrics): Petit Lyrics provider adapter (#149 Phase 1)

### DIFF
--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -70,12 +70,36 @@ type Client struct {
 // subsequent AJAX request.
 func NewClient() *Client {
 	jar, _ := cookiejar.New(nil)
-	return &Client{
-		httpClient: &http.Client{Timeout: 30 * time.Second, Jar: jar},
-		baseURL:    defaultBaseURL,
-		now:        time.Now,
-		sleep:      ctxSleep,
+	c := &Client{
+		baseURL: defaultBaseURL,
+		now:     time.Now,
+		sleep:   ctxSleep,
 	}
+	c.httpClient = &http.Client{
+		Timeout:       30 * time.Second,
+		Jar:           jar,
+		CheckRedirect: c.checkRedirect,
+	}
+	return c
+}
+
+// checkRedirect pins redirects to the configured base host. The default
+// http.Client follows up to 10 redirects without restricting the target host,
+// so a 3xx from petitlyrics.com could otherwise move a request to an arbitrary
+// host (an SSRF vector). This rejects cross-host redirects and preserves the
+// standard 10-hop cap.
+func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("petitlyrics: stopped after 10 redirects")
+	}
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return fmt.Errorf("petitlyrics: parse base URL: %w", err)
+	}
+	if req.URL.Host != base.Host {
+		return fmt.Errorf("petitlyrics: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	return nil
 }
 
 // ctxSleep sleeps for d, returning true when the sleep completes and false when
@@ -138,7 +162,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, stage string) (*http
 	if err := c.pace(ctx); err != nil {
 		return nil, err
 	}
-	res, err := c.httpClient.Do(req) //nolint:gosec // G704: the request host is c.baseURL, a fixed petitlyrics.com const overridden only by tests; track inputs go in the form body, not the URL, so there is no user-controlled SSRF vector.
+	res, err := c.httpClient.Do(req) //nolint:gosec // G704: the request host is c.baseURL (fixed petitlyrics.com const, test-only override) and the client's CheckRedirect pins redirects to that host, so a 3xx cannot move the request off-host; track inputs go in the form body, not the URL. No SSRF vector.
 	if err != nil {
 		return nil, fmt.Errorf("petitlyrics: %s: %w", stage, err)
 	}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -1,0 +1,358 @@
+// Package petitlyrics implements a lyrics provider adapter for petitlyrics.com.
+//
+// Petit Lyrics has no public API. This adapter drives a set of reverse-
+// engineered endpoints (HTML search, a CSRF token embedded in a static JS
+// file, and an AJAX lyrics endpoint), so the request and response shapes are
+// inferred and may change without notice. The maintainer has accepted the
+// access-mechanism ToS risk; Petit Lyrics content is JASRAC/NexTone-licensed.
+//
+// The client mirrors the structure and pacing of internal/musixmatch: a
+// *Client holding an *http.Client, a min pacing interval, and (here) CSRF /
+// session state, exposing FindLyrics with the shared provider signature.
+package petitlyrics
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// defaultBaseURL is the real petitlyrics.com host. Tests override baseURL to
+// point at an httptest.Server.
+const defaultBaseURL = "https://petitlyrics.com"
+
+// providerName is the canonical name of this provider.
+const providerName = "petitlyrics"
+
+// lyricsLinkRe extracts the lyrics id from a "/lyrics/<id>" href in the search
+// response HTML. The id is numeric in observed responses.
+var lyricsLinkRe = regexp.MustCompile(`/lyrics/(\d+)`)
+
+// csrfTokenRe extracts the CSRF token from the static pl-lib.js file. The token
+// is assigned to a JS variable as a quoted string in observed responses.
+var csrfTokenRe = regexp.MustCompile(`csrfToken\s*[:=]\s*["']([^"']+)["']`)
+
+// lrcLineRe matches a single LRC timestamped line: [mm:ss.xx]text. Hundredths
+// may be two or three digits in the wild; we normalize to hundredths.
+var lrcLineRe = regexp.MustCompile(`^\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?\](.*)$`)
+
+// Client communicates with petitlyrics.com over its reverse-engineered
+// endpoints.
+type Client struct {
+	httpClient *http.Client
+
+	// baseURL is the host root; injectable so tests can target httptest.
+	baseURL string
+
+	// pacer fields -- zero value means no pacing (minInterval == 0).
+	mu          sync.Mutex
+	minInterval time.Duration
+	lastRequest time.Time
+	now         func() time.Time
+	sleep       func(ctx context.Context, d time.Duration) bool
+}
+
+// NewClient creates a new Petit Lyrics client. A cookie jar is installed so the
+// PLSESSION cookie set while fetching the CSRF token is carried into the
+// subsequent AJAX request.
+func NewClient() *Client {
+	jar, _ := cookiejar.New(nil)
+	return &Client{
+		httpClient: &http.Client{Timeout: 30 * time.Second, Jar: jar},
+		baseURL:    defaultBaseURL,
+		now:        time.Now,
+		sleep:      ctxSleep,
+	}
+}
+
+// ctxSleep sleeps for d, returning true when the sleep completes and false when
+// ctx is canceled before d elapses.
+func ctxSleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// WithMinInterval sets the minimum duration between outbound requests and
+// returns the receiver for chaining. A zero or negative value disables pacing
+// (the default). Not goroutine-safe; call before sharing the client.
+func (c *Client) WithMinInterval(d time.Duration) *Client {
+	c.minInterval = d
+	return c
+}
+
+// MinInterval returns the configured minimum request interval. Zero means
+// pacing is disabled.
+func (c *Client) MinInterval() time.Duration {
+	return c.minInterval
+}
+
+// pace enforces the minimum request interval, mirroring the musixmatch pacer.
+// It must be called once at the top of FindLyrics. The wait is ctx-cancellable.
+func (c *Client) pace(ctx context.Context) error {
+	if c.minInterval <= 0 {
+		return nil
+	}
+	for {
+		c.mu.Lock()
+		now := c.now()
+		wait := c.minInterval - now.Sub(c.lastRequest)
+		if wait <= 0 {
+			c.lastRequest = now
+			c.mu.Unlock()
+			return nil
+		}
+		c.mu.Unlock()
+
+		slog.Debug("petitlyrics pacer: waiting before next request", "wait", wait)
+		if !c.sleep(ctx, wait) {
+			return fmt.Errorf("petitlyrics: pace: %w", ctx.Err())
+		}
+	}
+}
+
+// Name returns the provider name.
+func (c *Client) Name() string {
+	return providerName
+}
+
+// statusError maps a non-200 HTTP status to a sentinel error, or nil if the
+// status is 200. 403/429 -> ErrRateLimited, 401 -> ErrUnauthorized.
+func statusError(stage string, status int) error {
+	switch status {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("petitlyrics: %s: %w", stage, ErrUnauthorized)
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		return fmt.Errorf("petitlyrics: %s: HTTP %d: %w", stage, status, ErrRateLimited)
+	default:
+		return fmt.Errorf("petitlyrics: %s: unexpected HTTP status %d", stage, status)
+	}
+}
+
+const maxResponseSize = 2 << 20 // 2 MiB
+
+// readBody reads a capped response body.
+func readBody(stage string, res *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("petitlyrics: %s: read body: %w", stage, err)
+	}
+	if len(body) > maxResponseSize {
+		return nil, fmt.Errorf("petitlyrics: %s: response too large (%d bytes)", stage, len(body))
+	}
+	return body, nil
+}
+
+// FindLyrics looks up lyrics for the given track from petitlyrics.com. It runs
+// the three-stage reverse-engineered flow: search for a lyrics id, fetch the
+// CSRF token, then request the lyrics payload via the AJAX endpoint.
+func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	if err := c.pace(ctx); err != nil {
+		return models.Song{}, err
+	}
+
+	id, err := c.searchLyricsID(ctx, track)
+	if err != nil {
+		return models.Song{}, err
+	}
+
+	token, err := c.fetchCSRFToken(ctx)
+	if err != nil {
+		return models.Song{}, err
+	}
+
+	return c.fetchLyrics(ctx, id, token)
+}
+
+// searchLyricsID POSTs the search form and scrapes the first /lyrics/<id> link.
+func (c *Client) searchLyricsID(ctx context.Context, track models.Track) (string, error) {
+	form := url.Values{
+		"title":  {track.TrackName},
+		"artist": {track.ArtistName},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/search_lyrics", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: search: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: search: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if err := statusError("search", res.StatusCode); err != nil {
+		return "", err
+	}
+
+	body, err := readBody("search", res)
+	if err != nil {
+		return "", err
+	}
+
+	m := lyricsLinkRe.FindSubmatch(body)
+	if m == nil {
+		return "", fmt.Errorf("petitlyrics: search: no lyrics link found: %w", ErrNotFound)
+	}
+	return string(m[1]), nil
+}
+
+// fetchCSRFToken fetches the static pl-lib.js file, scrapes the CSRF token, and
+// (via the cookie jar) captures the PLSESSION cookie for the AJAX request.
+func (c *Client) fetchCSRFToken(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/lib/pl-lib.js", nil)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: csrf: build request: %w", err)
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: csrf: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if err := statusError("csrf", res.StatusCode); err != nil {
+		return "", err
+	}
+
+	body, err := readBody("csrf", res)
+	if err != nil {
+		return "", err
+	}
+
+	m := csrfTokenRe.FindSubmatch(body)
+	if m == nil {
+		return "", fmt.Errorf("petitlyrics: csrf: token not found in pl-lib.js")
+	}
+	return string(m[1]), nil
+}
+
+// ajaxEntry is one element of the AJAX lyrics response array. Field names are
+// inferred from observed reverse-engineered responses and may change.
+type ajaxEntry struct {
+	LyricsType int    `json:"lyrics_type"`
+	Lyrics     string `json:"lyrics"`
+}
+
+// fetchLyrics POSTs to the AJAX endpoint with the lyrics id and CSRF token,
+// then base64-decodes the payload into synced or plain lyrics.
+func (c *Client) fetchLyrics(ctx context.Context, id, token string) (models.Song, error) {
+	song := models.Song{}
+
+	form := url.Values{"lyrics_id": {id}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/com/get_lyrics.ajax", strings.NewReader(form.Encode()))
+	if err != nil {
+		return song, fmt.Errorf("petitlyrics: ajax: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-CSRF-Token", token)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return song, fmt.Errorf("petitlyrics: ajax: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if err := statusError("ajax", res.StatusCode); err != nil {
+		return song, err
+	}
+
+	body, err := readBody("ajax", res)
+	if err != nil {
+		return song, err
+	}
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return song, fmt.Errorf("petitlyrics: ajax: empty response body: %w", ErrNotFound)
+	}
+
+	var entries []ajaxEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return song, fmt.Errorf("petitlyrics: ajax: decode JSON: %w", err)
+	}
+	if len(entries) == 0 || entries[0].Lyrics == "" {
+		return song, fmt.Errorf("petitlyrics: ajax: response carried no lyrics: %w", ErrNotFound)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(entries[0].Lyrics)
+	if err != nil {
+		return song, fmt.Errorf("petitlyrics: ajax: base64 decode lyrics: %w", err)
+	}
+	text := string(decoded)
+
+	if lines, ok := parseLRC(text); ok {
+		song.Subtitles.Lines = lines
+		return song, nil
+	}
+
+	// No parseable timestamps: treat as plain lyrics.
+	song.Lyrics.LyricsBody = text
+	return song, nil
+}
+
+// parseLRC parses LRC-formatted text into synced lines. It returns ok=false
+// when no line carries a parseable [mm:ss.xx] timestamp, signaling the content
+// should be treated as plain lyrics instead.
+func parseLRC(text string) ([]models.Lines, bool) {
+	var lines []models.Lines
+	for _, raw := range strings.Split(text, "\n") {
+		raw = strings.TrimRight(raw, "\r")
+		m := lrcLineRe.FindStringSubmatch(raw)
+		if m == nil {
+			continue
+		}
+		minutes, _ := strconv.Atoi(m[1])
+		seconds, _ := strconv.Atoi(m[2])
+		hundredths := normalizeHundredths(m[3])
+		total := float64(minutes*60+seconds) + float64(hundredths)/100.0
+		lines = append(lines, models.Lines{
+			Text: strings.TrimSpace(m[4]),
+			Time: models.Time{
+				Total:      total,
+				Minutes:    minutes,
+				Seconds:    seconds,
+				Hundredths: hundredths,
+			},
+		})
+	}
+	return lines, len(lines) > 0
+}
+
+// normalizeHundredths converts a captured fractional-second string (1-3 digits)
+// to hundredths of a second. Empty means zero.
+func normalizeHundredths(frac string) int {
+	switch len(frac) {
+	case 0:
+		return 0
+	case 1:
+		n, _ := strconv.Atoi(frac)
+		return n * 10
+	case 2:
+		n, _ := strconv.Atoi(frac)
+		return n
+	default: // 3 digits: milliseconds -> hundredths
+		n, _ := strconv.Atoi(frac[:2])
+		return n
+	}
+}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -138,7 +138,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, stage string) (*http
 	if err := c.pace(ctx); err != nil {
 		return nil, err
 	}
-	res, err := c.httpClient.Do(req)
+	res, err := c.httpClient.Do(req) //nolint:gosec // G704: the request host is c.baseURL, a fixed petitlyrics.com const overridden only by tests; track inputs go in the form body, not the URL, so there is no user-controlled SSRF vector.
 	if err != nil {
 		return nil, fmt.Errorf("petitlyrics: %s: %w", stage, err)
 	}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -106,7 +106,9 @@ func (c *Client) MinInterval() time.Duration {
 }
 
 // pace enforces the minimum request interval, mirroring the musixmatch pacer.
-// It must be called once at the top of FindLyrics. The wait is ctx-cancellable.
+// It is called before each outbound request (WithMinInterval is documented as a
+// minimum between requests, not between lookups), so a single FindLyrics, which
+// makes three calls, cannot burst. The wait is ctx-cancellable.
 func (c *Client) pace(ctx context.Context) error {
 	if c.minInterval <= 0 {
 		return nil
@@ -127,6 +129,20 @@ func (c *Client) pace(ctx context.Context) error {
 			return fmt.Errorf("petitlyrics: pace: %w", ctx.Err())
 		}
 	}
+}
+
+// do enforces pacing then executes req, wrapping a transport error with the
+// stage label. Centralizing pacing here keeps WithMinInterval a per-request
+// minimum: every outbound request in a lookup passes through do.
+func (c *Client) do(ctx context.Context, req *http.Request, stage string) (*http.Response, error) {
+	if err := c.pace(ctx); err != nil {
+		return nil, err
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("petitlyrics: %s: %w", stage, err)
+	}
+	return res, nil
 }
 
 // Name returns the provider name.
@@ -167,10 +183,6 @@ func readBody(stage string, res *http.Response) ([]byte, error) {
 // the three-stage reverse-engineered flow: search for a lyrics id, fetch the
 // CSRF token, then request the lyrics payload via the AJAX endpoint.
 func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
-	if err := c.pace(ctx); err != nil {
-		return models.Song{}, err
-	}
-
 	id, err := c.searchLyricsID(ctx, track)
 	if err != nil {
 		return models.Song{}, err
@@ -196,9 +208,9 @@ func (c *Client) searchLyricsID(ctx context.Context, track models.Track) (string
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.do(ctx, req, "search")
 	if err != nil {
-		return "", fmt.Errorf("petitlyrics: search: %w", err)
+		return "", err
 	}
 	defer func() { _ = res.Body.Close() }()
 
@@ -226,9 +238,9 @@ func (c *Client) fetchCSRFToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("petitlyrics: csrf: build request: %w", err)
 	}
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.do(ctx, req, "csrf")
 	if err != nil {
-		return "", fmt.Errorf("petitlyrics: csrf: %w", err)
+		return "", err
 	}
 	defer func() { _ = res.Body.Close() }()
 
@@ -269,9 +281,9 @@ func (c *Client) fetchLyrics(ctx context.Context, id, token string) (models.Song
 	req.Header.Set("X-CSRF-Token", token)
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.do(ctx, req, "ajax")
 	if err != nil {
-		return song, fmt.Errorf("petitlyrics: ajax: %w", err)
+		return song, err
 	}
 	defer func() { _ = res.Body.Close() }()
 

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -327,6 +327,27 @@ func TestWithMinIntervalReturnsClient(t *testing.T) {
 	}
 }
 
+func TestFindLyrics_RefusesCrossHostRedirect(t *testing.T) {
+	// A second host that must never be reached: the client should refuse to
+	// follow a cross-host redirect rather than fetch from an arbitrary host.
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("client followed a cross-host redirect to %s", r.URL.Path)
+	}))
+	t.Cleanup(other.Close)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search_lyrics", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, other.URL+"/search_lyrics", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := newTestClient(srv)
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"}); err == nil {
+		t.Fatal("expected error refusing cross-host redirect; got nil")
+	}
+}
+
 func TestFindLyrics_ContextCanceled(t *testing.T) {
 	f := &fixtureServer{
 		searchBody: searchHTMLWithID("1"),

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -1,0 +1,351 @@
+package petitlyrics
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
+)
+
+// Compile-time assertions that *Client satisfies the shared provider contracts.
+var (
+	_ providers.Fetcher        = (*Client)(nil)
+	_ providers.LyricsProvider = (*Client)(nil)
+	_ Fetcher                  = (*Client)(nil)
+)
+
+func TestProviderNameConstantMatches(t *testing.T) {
+	if NewClient().Name() != providers.PetitLyrics {
+		t.Fatalf("Name() = %q; want %q", NewClient().Name(), providers.PetitLyrics)
+	}
+}
+
+// fixtureServer wires an httptest.Server that emulates the three reverse-
+// engineered petitlyrics.com endpoints. Each field lets a test override the
+// behavior of one stage. A nil handler falls back to a sane default.
+type fixtureServer struct {
+	searchStatus  int
+	searchBody    string
+	jsStatus      int
+	jsBody        string
+	ajaxStatus    int
+	ajaxBody      string
+	gotCSRFHeader string
+	gotXHRHeader  string
+}
+
+func newFixtureServer(t *testing.T, f *fixtureServer) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search_lyrics", func(w http.ResponseWriter, r *http.Request) {
+		if f.searchStatus != 0 && f.searchStatus != http.StatusOK {
+			w.WriteHeader(f.searchStatus)
+			return
+		}
+		_, _ = w.Write([]byte(f.searchBody))
+	})
+	mux.HandleFunc("/lib/pl-lib.js", func(w http.ResponseWriter, r *http.Request) {
+		if f.jsStatus != 0 && f.jsStatus != http.StatusOK {
+			w.WriteHeader(f.jsStatus)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "PLSESSION", Value: "test-session"})
+		_, _ = w.Write([]byte(f.jsBody))
+	})
+	mux.HandleFunc("/com/get_lyrics.ajax", func(w http.ResponseWriter, r *http.Request) {
+		f.gotCSRFHeader = r.Header.Get("X-CSRF-Token")
+		f.gotXHRHeader = r.Header.Get("X-Requested-With")
+		if f.ajaxStatus != 0 && f.ajaxStatus != http.StatusOK {
+			w.WriteHeader(f.ajaxStatus)
+			return
+		}
+		_, _ = w.Write([]byte(f.ajaxBody))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+const validJS = `var x = 1; var csrfToken = "tok-abc-123"; var y = 2;`
+
+func searchHTMLWithID(id string) string {
+	return `<html><body><ul class="results">` +
+		`<li><a href="/lyrics/` + id + `">Some Song</a></li>` +
+		`</ul></body></html>`
+}
+
+func ajaxJSON(lyricsB64 string, lyricsType int) string {
+	return `[{"lyrics_type":` + itoa(lyricsType) + `,"lyrics":"` + lyricsB64 + `"}]`
+}
+
+func itoa(i int) string {
+	switch i {
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	case 3:
+		return "3"
+	default:
+		return "0"
+	}
+}
+
+func newTestClient(srv *httptest.Server) *Client {
+	c := NewClient()
+	c.baseURL = srv.URL
+	c.httpClient = srv.Client()
+	return c
+}
+
+func TestName(t *testing.T) {
+	if got := NewClient().Name(); got != "petitlyrics" {
+		t.Fatalf("Name() = %q; want petitlyrics", got)
+	}
+}
+
+func TestFindLyrics_Synced(t *testing.T) {
+	lrc := "[00:01.50]hello\n[00:12.30]world\n"
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsBody:     validJS,
+		ajaxBody:   ajaxJSON(b64(lrc), 2),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) != 2 {
+		t.Fatalf("got %d synced lines; want 2", len(song.Subtitles.Lines))
+	}
+	l0 := song.Subtitles.Lines[0]
+	if l0.Text != "hello" || l0.Time.Minutes != 0 || l0.Time.Seconds != 1 || l0.Time.Hundredths != 50 {
+		t.Fatalf("line0 = %+v; want hello @ 00:01.50", l0)
+	}
+	l1 := song.Subtitles.Lines[1]
+	if l1.Text != "world" || l1.Time.Seconds != 12 || l1.Time.Hundredths != 30 {
+		t.Fatalf("line1 = %+v; want world @ 00:12.30", l1)
+	}
+	if song.Lyrics.LyricsBody != "" {
+		t.Fatalf("synced result should not set plain lyrics body; got %q", song.Lyrics.LyricsBody)
+	}
+	if f.gotCSRFHeader != "tok-abc-123" {
+		t.Fatalf("X-CSRF-Token = %q; want tok-abc-123", f.gotCSRFHeader)
+	}
+	if f.gotXHRHeader != "XMLHttpRequest" {
+		t.Fatalf("X-Requested-With = %q; want XMLHttpRequest", f.gotXHRHeader)
+	}
+}
+
+func TestFindLyrics_Plain(t *testing.T) {
+	plain := "just some words\nno timestamps here\n"
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("99"),
+		jsBody:     validJS,
+		ajaxBody:   ajaxJSON(b64(plain), 1),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) != 0 {
+		t.Fatalf("plain result should not set synced lines; got %d", len(song.Subtitles.Lines))
+	}
+	if !strings.Contains(song.Lyrics.LyricsBody, "just some words") {
+		t.Fatalf("plain body = %q; want it to contain the lyrics", song.Lyrics.LyricsBody)
+	}
+}
+
+func TestFindLyrics_NotFound_NoMatch(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: `<html><body>no results</body></html>`,
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound", err)
+	}
+}
+
+func TestFindLyrics_RateLimited429(t *testing.T) {
+	f := &fixtureServer{searchStatus: http.StatusTooManyRequests}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited", err)
+	}
+}
+
+func TestFindLyrics_Forbidden403(t *testing.T) {
+	f := &fixtureServer{searchStatus: http.StatusForbidden}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited (403 mapped to rate limited)", err)
+	}
+}
+
+func TestFindLyrics_Unauthorized401(t *testing.T) {
+	f := &fixtureServer{searchStatus: http.StatusUnauthorized}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized", err)
+	}
+}
+
+func TestFindLyrics_CSRFFetchFailure(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsStatus:   http.StatusInternalServerError,
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if err == nil {
+		t.Fatal("expected error on CSRF fetch failure; got nil")
+	}
+}
+
+func TestFindLyrics_CSRFTokenMissing(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsBody:     `var nothing = "here";`,
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if err == nil {
+		t.Fatal("expected error when CSRF token is absent; got nil")
+	}
+}
+
+func TestFindLyrics_EmptyAjaxBody(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsBody:     validJS,
+		ajaxBody:   "",
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound on empty ajax body", err)
+	}
+}
+
+func TestFindLyrics_AjaxRateLimited(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsBody:     validJS,
+		ajaxStatus: http.StatusTooManyRequests,
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited", err)
+	}
+}
+
+func TestFindLyrics_BadBase64(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("4242"),
+		jsBody:     validJS,
+		ajaxBody:   `[{"lyrics_type":2,"lyrics":"!!!not base64!!!"}]`,
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "x", ArtistName: "y"})
+	if err == nil {
+		t.Fatal("expected error on undecodable base64; got nil")
+	}
+}
+
+func TestDecodeKnownFixture(t *testing.T) {
+	// A known base64 fixture decodes to the expected LRC text.
+	const want = "[00:00.00]line\n"
+	got, err := base64.StdEncoding.DecodeString(b64(want))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("decoded %q; want %q", got, want)
+	}
+}
+
+func TestWithMinIntervalReturnsClient(t *testing.T) {
+	c := NewClient()
+	if got := c.WithMinInterval(5 * time.Second); got != c {
+		t.Fatal("WithMinInterval did not return the receiver")
+	}
+	if c.MinInterval() != 5*time.Second {
+		t.Fatalf("MinInterval = %v; want 5s", c.MinInterval())
+	}
+}
+
+func TestPacerEnforcesMinInterval(t *testing.T) {
+	lrc := "[00:01.00]x\n"
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("1"),
+		jsBody:     validJS,
+		ajaxBody:   ajaxJSON(b64(lrc), 2),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+	c.WithMinInterval(10 * time.Second)
+
+	base := time.Unix(1000, 0)
+	fakeNow := base
+	c.now = func() time.Time { return fakeNow }
+	var gotSleep time.Duration
+	c.sleep = func(ctx context.Context, d time.Duration) bool {
+		gotSleep = d
+		fakeNow = fakeNow.Add(d)
+		return true
+	}
+
+	track := models.Track{TrackName: "x", ArtistName: "y"}
+	if _, err := c.FindLyrics(context.Background(), track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if gotSleep != 0 {
+		t.Fatalf("first call slept %v; want 0", gotSleep)
+	}
+	if _, err := c.FindLyrics(context.Background(), track); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if gotSleep != 10*time.Second {
+		t.Fatalf("second call slept %v; want 10s", gotSleep)
+	}
+}

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -39,6 +39,7 @@ type fixtureServer struct {
 	ajaxBody      string
 	gotCSRFHeader string
 	gotXHRHeader  string
+	gotCookie     string
 }
 
 func newFixtureServer(t *testing.T, f *fixtureServer) *httptest.Server {
@@ -56,12 +57,15 @@ func newFixtureServer(t *testing.T, f *fixtureServer) *httptest.Server {
 			w.WriteHeader(f.jsStatus)
 			return
 		}
-		http.SetCookie(w, &http.Cookie{Name: "PLSESSION", Value: "test-session"})
+		http.SetCookie(w, &http.Cookie{Name: "PLSESSION", Value: "test-session", Path: "/"})
 		_, _ = w.Write([]byte(f.jsBody))
 	})
 	mux.HandleFunc("/com/get_lyrics.ajax", func(w http.ResponseWriter, r *http.Request) {
 		f.gotCSRFHeader = r.Header.Get("X-CSRF-Token")
 		f.gotXHRHeader = r.Header.Get("X-Requested-With")
+		if ck, err := r.Cookie("PLSESSION"); err == nil {
+			f.gotCookie = ck.Value
+		}
 		if f.ajaxStatus != 0 && f.ajaxStatus != http.StatusOK {
 			w.WriteHeader(f.ajaxStatus)
 			return
@@ -105,7 +109,11 @@ func itoa(i int) string {
 func newTestClient(srv *httptest.Server) *Client {
 	c := NewClient()
 	c.baseURL = srv.URL
-	c.httpClient = srv.Client()
+	// Adopt only the test server's transport so requests reach the httptest
+	// server, while preserving the cookie jar and timeout from NewClient so the
+	// PLSESSION jar behavior (set in the CSRF stage, replayed to the AJAX stage)
+	// is actually exercised.
+	c.httpClient.Transport = srv.Client().Transport
 	return c
 }
 
@@ -148,6 +156,11 @@ func TestFindLyrics_Synced(t *testing.T) {
 	}
 	if f.gotXHRHeader != "XMLHttpRequest" {
 		t.Fatalf("X-Requested-With = %q; want XMLHttpRequest", f.gotXHRHeader)
+	}
+	// The PLSESSION cookie set by the CSRF (pl-lib.js) stage must be replayed to
+	// the AJAX stage by the client's cookie jar.
+	if f.gotCookie != "test-session" {
+		t.Fatalf("PLSESSION cookie at AJAX stage = %q; want test-session (cookie jar should persist it)", f.gotCookie)
 	}
 }
 
@@ -314,6 +327,24 @@ func TestWithMinIntervalReturnsClient(t *testing.T) {
 	}
 }
 
+func TestFindLyrics_ContextCanceled(t *testing.T) {
+	f := &fixtureServer{
+		searchBody: searchHTMLWithID("1"),
+		jsBody:     validJS,
+		ajaxBody:   ajaxJSON(b64("[00:00.00]x\n"), 2),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.FindLyrics(ctx, models.Track{TrackName: "x", ArtistName: "y"})
+	if err == nil {
+		t.Fatal("expected error when the context is canceled; got nil")
+	}
+}
+
 func TestPacerEnforcesMinInterval(t *testing.T) {
 	lrc := "[00:01.00]x\n"
 	f := &fixtureServer{
@@ -328,24 +359,26 @@ func TestPacerEnforcesMinInterval(t *testing.T) {
 	base := time.Unix(1000, 0)
 	fakeNow := base
 	c.now = func() time.Time { return fakeNow }
-	var gotSleep time.Duration
+	var sleeps []time.Duration
 	c.sleep = func(ctx context.Context, d time.Duration) bool {
-		gotSleep = d
+		sleeps = append(sleeps, d)
 		fakeNow = fakeNow.Add(d)
 		return true
 	}
 
+	// Pacing is enforced before each outbound request, not once per lookup. A
+	// single FindLyrics makes three requests: the first does not wait (no prior
+	// request), the second and third each wait the full interval.
 	track := models.Track{TrackName: "x", ArtistName: "y"}
 	if _, err := c.FindLyrics(context.Background(), track); err != nil {
-		t.Fatalf("first call: %v", err)
+		t.Fatalf("FindLyrics: %v", err)
 	}
-	if gotSleep != 0 {
-		t.Fatalf("first call slept %v; want 0", gotSleep)
+	if len(sleeps) != 2 {
+		t.Fatalf("got %d paced waits in one lookup; want 2 (before the 2nd and 3rd requests)", len(sleeps))
 	}
-	if _, err := c.FindLyrics(context.Background(), track); err != nil {
-		t.Fatalf("second call: %v", err)
-	}
-	if gotSleep != 10*time.Second {
-		t.Fatalf("second call slept %v; want 10s", gotSleep)
+	for i, d := range sleeps {
+		if d != 10*time.Second {
+			t.Fatalf("paced wait %d = %v; want 10s", i, d)
+		}
 	}
 }

--- a/internal/petitlyrics/errors.go
+++ b/internal/petitlyrics/errors.go
@@ -1,0 +1,21 @@
+package petitlyrics
+
+import "errors"
+
+// Sentinel errors returned by the Petit Lyrics client. Callers should use
+// errors.Is to test for these classes rather than string-matching the message.
+// These mirror the classes exposed by internal/musixmatch so the two providers
+// can be handled uniformly by the worker and circuit breaker.
+var (
+	// ErrUnauthorized indicates HTTP 401 from petitlyrics.com. Treat as a
+	// circuit-breaker signal.
+	ErrUnauthorized = errors.New("petitlyrics: unauthorized")
+	// ErrRateLimited indicates HTTP 403 or 429 from petitlyrics.com. Petit
+	// Lyrics has no public API, so a 403 most commonly means the reverse-
+	// engineered access path was blocked or throttled; both are treated as a
+	// circuit-breaker signal.
+	ErrRateLimited = errors.New("petitlyrics: rate limited")
+	// ErrNotFound indicates no matching track or no lyrics id could be scraped
+	// from the search response, meaning no usable lyrics were found.
+	ErrNotFound = errors.New("petitlyrics: no results found")
+)

--- a/internal/petitlyrics/fetcher.go
+++ b/internal/petitlyrics/fetcher.go
@@ -1,0 +1,14 @@
+package petitlyrics
+
+import (
+	"context"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// Fetcher abstracts lyrics lookup from petitlyrics.com. It mirrors the shared
+// providers.Fetcher contract so the client is interchangeable with other
+// provider adapters.
+type Fetcher interface {
+	FindLyrics(ctx context.Context, track models.Track) (models.Song, error)
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -11,6 +11,10 @@ import (
 const (
 	// Musixmatch is the built-in Musixmatch provider name.
 	Musixmatch = "musixmatch"
+	// PetitLyrics is the Petit Lyrics provider name. The adapter lives in
+	// internal/petitlyrics; provider registration/selection is wired in a
+	// later phase, so this constant is currently a name reference only.
+	PetitLyrics = "petitlyrics"
 )
 
 // Fetcher is the shared lyrics lookup behavior used by provider adapters.


### PR DESCRIPTION
## Summary

Phase 1 of #149: a Petit Lyrics provider adapter (`internal/petitlyrics/`) implementing the existing `providers.LyricsProvider` interface, following the `musixmatch` client pattern.

- Reverse-engineered fetch flow: `POST /search_lyrics` (scrape lyrics id) then CSRF token + `PLSESSION` cookie then `POST /com/get_lyrics.ajax`, base64-decoding the payload into `models.Synced` or `models.Lyrics`.
- Pacing via `WithMinInterval`; sentinel errors `ErrNotFound` / `ErrRateLimited` / `ErrUnauthorized` (403/429 -> rate-limited, 401 -> unauthorized).
- Content-based synced/plain detection (does not trust the upstream `lyrics_type`); httptest-based tests with synthetic fixtures; injectable base URL.

**Scope: Phase 1 only.** Provider-selection registration, language-guard integration (depends on #163), and translation/romanization output (Phase 3) are follow-ups.

> [!NOTE]
> The endpoint shapes are reverse-engineered, so the test fixtures are synthetic and real-response parsing will need live validation in a follow-up. Access-mechanism ToS risk accepted by the maintainer per #149 Phase 0.

Part of #149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Petit Lyrics provider supporting synced (LRC) and plain lyrics, configurable request pacing, refusal of cross-host redirects, capped response reads, and standardized error signals for not-found, rate-limited, and unauthorized conditions.
  * Exposed provider name for selection.

* **Tests**
  * Added end-to-end tests covering the three-stage fetch flow, CSRF handling, base64 payload decoding, pacing enforcement, redirect behavior, and HTTP→error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->