### PR TITLE
feat(circuit): extract worker circuit breaker into internal/circuit (#173)

### DIFF
--- a/internal/circuit/breaker.go
+++ b/internal/circuit/breaker.go
@@ -1,0 +1,196 @@
+// Package circuit provides a concurrency-safe circuit breaker that models a
+// single provider lane's rate-limit / throttle response. It was extracted
+// verbatim from the worker's inline breaker (the fields and tripCircuitIfRateLimited
+// logic) so per-provider concurrency can compose one breaker per lane without
+// the data race the inline state would otherwise carry.
+//
+// The breaker is closed normally, opens for a geometrically-ramping window on a
+// throttle trip, and after the window elapses transitions to half-open (probing)
+// until a successful round-trip closes it again. All state lives behind a single
+// mutex; every method performs its full read-modify-write under the lock.
+package circuit
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
+)
+
+// BreakerState reports whether a caller may proceed through the breaker.
+type BreakerState int
+
+const (
+	// StateClosed means the breaker is healthy; the caller may proceed normally.
+	StateClosed BreakerState = iota
+	// StateOpen means the open window has not yet elapsed; the caller must not proceed.
+	StateOpen
+	// StateHalfOpen means the window has elapsed and the caller is probing the
+	// provider; it may proceed, and the next round-trip either closes the breaker
+	// (success) or reopens it (a fresh trip).
+	StateHalfOpen
+)
+
+// TripResult reports the effect of a trip so the caller can log it.
+type TripResult struct {
+	// Trips is the post-increment consecutive-trip count (0 for a renewal trip,
+	// which deliberately does not advance the throttle ramp).
+	Trips int
+	// Window is the open duration applied by this trip.
+	Window time.Duration
+	// OpenUntil is the wall-clock instant until which the breaker is open.
+	OpenUntil time.Time
+}
+
+// Breaker is a concurrency-safe circuit breaker for one provider lane.
+type Breaker struct {
+	mu sync.Mutex
+
+	backoffBase  time.Duration
+	openDuration time.Duration
+	now          func() time.Time
+
+	openUntil           time.Time
+	consecutiveTrips    int
+	probing             bool
+	everProviderSuccess bool
+}
+
+// New creates a closed breaker. backoffBase is the trip-1 window; openDuration
+// is the cap that the geometric ramp climbs to and also the flat window a
+// renewal trip applies immediately.
+func New(backoffBase, openDuration time.Duration) *Breaker {
+	return &Breaker{
+		backoffBase:  backoffBase,
+		openDuration: openDuration,
+		now:          time.Now,
+	}
+}
+
+// SetClock injects the time source. It is used by the worker (to share its
+// clock so time-based tests stay deterministic) and by unit tests.
+func (b *Breaker) SetClock(now func() time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if now != nil {
+		b.now = now
+	}
+}
+
+// SetBackoff overrides the geometric window parameters. base is the trip-1
+// window; cap is the ceiling (and the renewal window). Zero or negative values
+// are ignored so a misconfigured call cannot disable the window.
+func (b *Breaker) SetBackoff(base, cap time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if base > 0 {
+		b.backoffBase = base
+	}
+	if cap > 0 {
+		b.openDuration = cap
+	}
+}
+
+// SetOpenDuration overrides only the cap window. Values <= 0 are ignored.
+func (b *Breaker) SetOpenDuration(d time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if d > 0 {
+		b.openDuration = d
+	}
+}
+
+// Allow reports the current state, performing the window-elapsed transition to
+// half-open (setting probing and clearing openUntil) as a side effect, exactly
+// as the worker's RunOnce gate did.
+func (b *Breaker) Allow() BreakerState {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.openUntil.IsZero() {
+		if b.now().Before(b.openUntil) {
+			return StateOpen
+		}
+		// Window elapsed: enter half-open.
+		b.probing = true
+		b.openUntil = time.Time{}
+	}
+	if b.probing {
+		return StateHalfOpen
+	}
+	return StateClosed
+}
+
+// OpenUntil returns the instant until which the breaker is open (zero when not
+// open). Useful for callers that log the window.
+func (b *Breaker) OpenUntil() time.Time {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.openUntil
+}
+
+// Trip records a throttle trip: it increments the consecutive-trip counter,
+// computes the geometric window between backoffBase and openDuration, sets
+// openUntil, and clears probing (a fresh open is full-open, not a probe).
+func (b *Breaker) Trip() TripResult {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.consecutiveTrips++
+	window := backoff.Geometric(b.consecutiveTrips, b.backoffBase, b.openDuration)
+	b.openUntil = b.now().Add(window)
+	b.probing = false
+	return TripResult{Trips: b.consecutiveTrips, Window: window, OpenUntil: b.openUntil}
+}
+
+// TripRenewal records a genuine token-renewal signal: it opens for the full cap
+// (openDuration) immediately and does NOT advance the throttle ramp, so a later
+// real throttle resumes from its true position. It clears probing.
+func (b *Breaker) TripRenewal() TripResult {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.openUntil = b.now().Add(b.openDuration)
+	b.probing = false
+	return TripResult{Trips: b.consecutiveTrips, Window: b.openDuration, OpenUntil: b.openUntil}
+}
+
+// RecordSuccess records a genuine provider success: it sets everProviderSuccess,
+// resets the trip ramp, and clears probing. It returns whether the breaker
+// transitioned out of probing (so the caller can log recovery only on the real
+// transition).
+func (b *Breaker) RecordSuccess() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.everProviderSuccess = true
+	b.consecutiveTrips = 0
+	transitioned := b.probing
+	b.probing = false
+	return transitioned
+}
+
+// RecordBenignMiss records a clean miss: a successful round-trip but NOT a
+// token-proven success. It resets the trip ramp and clears probing, but does
+// NOT set everProviderSuccess. It returns whether it transitioned out of probing.
+func (b *Breaker) RecordBenignMiss() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.consecutiveTrips = 0
+	transitioned := b.probing
+	b.probing = false
+	return transitioned
+}
+
+// Trips reports the current consecutive-trip count (the throttle ramp position).
+// It is a read-only accessor for callers and tests that need to observe the ramp.
+func (b *Breaker) Trips() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.consecutiveTrips
+}
+
+// EverSucceeded reports whether any genuine provider fetch has succeeded this
+// session. It distinguishes a bare 401 that is egress-IP throttling (token
+// already proven good) from one seen before any success (token suspect).
+func (b *Breaker) EverSucceeded() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.everProviderSuccess
+}

--- a/internal/circuit/breaker_test.go
+++ b/internal/circuit/breaker_test.go
@@ -1,0 +1,260 @@
+package circuit
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testBase = 60 * time.Second
+	testCap  = 30 * time.Minute
+)
+
+// newTestBreaker builds a breaker with a frozen clock for deterministic tests.
+func newTestBreaker() (*Breaker, time.Time) {
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	b := New(testBase, testCap)
+	b.SetClock(func() time.Time { return fixed })
+	return b, fixed
+}
+
+func TestNewStartsClosed(t *testing.T) {
+	b, _ := newTestBreaker()
+	if got := b.Allow(); got != StateClosed {
+		t.Fatalf("Allow() = %v; want StateClosed on a fresh breaker", got)
+	}
+	if !b.OpenUntil().IsZero() {
+		t.Fatalf("OpenUntil() = %v; want zero on a fresh breaker", b.OpenUntil())
+	}
+	if b.EverSucceeded() {
+		t.Fatal("EverSucceeded() = true on a fresh breaker; want false")
+	}
+}
+
+func TestTripOpensAndAllowReportsOpen(t *testing.T) {
+	b, fixed := newTestBreaker()
+	res := b.Trip()
+	if res.Trips != 1 {
+		t.Fatalf("Trip().Trips = %d; want 1", res.Trips)
+	}
+	if res.Window != testBase {
+		t.Fatalf("Trip().Window = %v; want %v (trip 1 uses the geometric base)", res.Window, testBase)
+	}
+	if !res.OpenUntil.Equal(fixed.Add(testBase)) {
+		t.Fatalf("Trip().OpenUntil = %v; want %v", res.OpenUntil, fixed.Add(testBase))
+	}
+	// now == fixed, which is before openUntil, so the circuit is open.
+	if got := b.Allow(); got != StateOpen {
+		t.Fatalf("Allow() = %v; want StateOpen while the window is in the future", got)
+	}
+	if !b.OpenUntil().Equal(fixed.Add(testBase)) {
+		t.Fatalf("OpenUntil() = %v; want %v", b.OpenUntil(), fixed.Add(testBase))
+	}
+}
+
+func TestTripRampIncrementsAndCaps(t *testing.T) {
+	b, fixed := newTestBreaker()
+	// trip 6 reaches the cap: 60 -> 120 -> 240 -> 480 -> 960 -> 1800 (capped).
+	wantDeltas := []time.Duration{
+		60 * time.Second, 120 * time.Second, 240 * time.Second,
+		480 * time.Second, 960 * time.Second, 30 * time.Minute,
+	}
+	for i, want := range wantDeltas {
+		res := b.Trip()
+		if res.Trips != i+1 {
+			t.Fatalf("trip %d: Trips = %d; want %d", i+1, res.Trips, i+1)
+		}
+		if res.Window != want {
+			t.Fatalf("trip %d: Window = %v; want %v", i+1, res.Window, want)
+		}
+		if got := b.OpenUntil().Sub(fixed); got != want {
+			t.Fatalf("trip %d: OpenUntil delta = %v; want %v", i+1, got, want)
+		}
+	}
+	// The cap holds on further trips.
+	res := b.Trip()
+	if res.Window != testCap {
+		t.Fatalf("trip 7: Window = %v; want cap %v", res.Window, testCap)
+	}
+}
+
+func TestHalfOpenTransitionWhenWindowElapses(t *testing.T) {
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := fixed
+	b := New(testBase, testCap)
+	b.SetClock(func() time.Time { return now })
+
+	b.Trip() // opens until fixed+60s
+	if got := b.Allow(); got != StateOpen {
+		t.Fatalf("Allow() = %v; want StateOpen before the window elapses", got)
+	}
+	// Advance past the window.
+	now = fixed.Add(2 * time.Minute)
+	if got := b.Allow(); got != StateHalfOpen {
+		t.Fatalf("Allow() = %v; want StateHalfOpen after the window elapses", got)
+	}
+	// The transition cleared openUntil as a side effect.
+	if !b.OpenUntil().IsZero() {
+		t.Fatalf("OpenUntil() = %v; want zero after entering half-open", b.OpenUntil())
+	}
+	// Subsequent Allow stays half-open (probing), not closed, until a success.
+	if got := b.Allow(); got != StateHalfOpen {
+		t.Fatalf("Allow() = %v; want StateHalfOpen to persist until a success closes it", got)
+	}
+}
+
+func TestRecordSuccessClosesAndReportsTransition(t *testing.T) {
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := fixed
+	b := New(testBase, testCap)
+	b.SetClock(func() time.Time { return now })
+
+	b.Trip()
+	now = fixed.Add(2 * time.Minute)
+	if got := b.Allow(); got != StateHalfOpen {
+		t.Fatalf("Allow() = %v; want StateHalfOpen", got)
+	}
+	if transitioned := b.RecordSuccess(); !transitioned {
+		t.Fatal("RecordSuccess() = false; want true (probing -> closed transition)")
+	}
+	if !b.EverSucceeded() {
+		t.Fatal("EverSucceeded() = false; want true after a genuine success")
+	}
+	if got := b.Allow(); got != StateClosed {
+		t.Fatalf("Allow() = %v; want StateClosed after recovery", got)
+	}
+	// A success while already closed does not re-report a transition.
+	if transitioned := b.RecordSuccess(); transitioned {
+		t.Fatal("RecordSuccess() = true while already closed; want false")
+	}
+}
+
+func TestRecordSuccessResetsRamp(t *testing.T) {
+	b, fixed := newTestBreaker()
+	b.Trip()
+	b.Trip()
+	b.Trip()
+	b.RecordSuccess()
+	// The next trip restarts at the base, proving the ramp reset.
+	res := b.Trip()
+	if res.Trips != 1 {
+		t.Fatalf("Trips = %d; want 1 after a success reset", res.Trips)
+	}
+	if res.Window != testBase {
+		t.Fatalf("Window = %v; want base %v after a success reset", res.Window, testBase)
+	}
+	if got := b.OpenUntil().Sub(fixed); got != testBase {
+		t.Fatalf("OpenUntil delta = %v; want %v", got, testBase)
+	}
+}
+
+func TestRecordBenignMissResetsRampWithoutMarkingSuccess(t *testing.T) {
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := fixed
+	b := New(testBase, testCap)
+	b.SetClock(func() time.Time { return now })
+
+	b.Trip()
+	b.Trip()
+	b.Trip() // trip 3 opens for 240s
+	now = fixed.Add(5 * time.Minute)
+	if got := b.Allow(); got != StateHalfOpen {
+		t.Fatalf("Allow() = %v; want StateHalfOpen", got)
+	}
+	if transitioned := b.RecordBenignMiss(); !transitioned {
+		t.Fatal("RecordBenignMiss() = false; want true (probing -> closed transition)")
+	}
+	if b.EverSucceeded() {
+		t.Fatal("EverSucceeded() = true after a benign miss; a clean miss is not a provider match")
+	}
+	if got := b.Allow(); got != StateClosed {
+		t.Fatalf("Allow() = %v; want StateClosed after the benign miss closed it", got)
+	}
+	// Ramp reset: next trip restarts at the base.
+	res := b.Trip()
+	if res.Trips != 1 || res.Window != testBase {
+		t.Fatalf("after benign miss: Trips=%d Window=%v; want 1, %v", res.Trips, res.Window, testBase)
+	}
+}
+
+func TestRecordBenignMissNoTransitionWhenClosed(t *testing.T) {
+	b, _ := newTestBreaker()
+	if transitioned := b.RecordBenignMiss(); transitioned {
+		t.Fatal("RecordBenignMiss() = true while closed; want false")
+	}
+	if b.EverSucceeded() {
+		t.Fatal("EverSucceeded() = true; a benign miss must never set it")
+	}
+}
+
+func TestTripRenewalHoldsFullCapAndDoesNotAdvanceRamp(t *testing.T) {
+	b, fixed := newTestBreaker()
+	// Two throttle trips establish a ramp position.
+	b.Trip()
+	b.Trip()
+	if b.Trips() != 2 {
+		t.Fatalf("Trips() = %d; want 2 after two throttle trips", b.Trips())
+	}
+	res := b.TripRenewal()
+	if res.Window != testCap {
+		t.Fatalf("TripRenewal().Window = %v; want the full cap %v", res.Window, testCap)
+	}
+	if !res.OpenUntil.Equal(fixed.Add(testCap)) {
+		t.Fatalf("TripRenewal().OpenUntil = %v; want %v", res.OpenUntil, fixed.Add(testCap))
+	}
+	if b.Trips() != 2 {
+		t.Fatalf("Trips() = %d; want 2 (renewal must not advance the throttle ramp)", b.Trips())
+	}
+	// A subsequent throttle resumes from the preserved ramp position (trip 3).
+	next := b.Trip()
+	if next.Trips != 3 {
+		t.Fatalf("post-renewal Trip().Trips = %d; want 3 (ramp position preserved)", next.Trips)
+	}
+}
+
+func TestSetBackoffOverridesAndIgnoresNonPositive(t *testing.T) {
+	b, fixed := newTestBreaker()
+	b.SetBackoff(0, 0) // ignored
+	b.SetBackoff(10*time.Second, time.Hour)
+	res := b.Trip()
+	if res.Window != 10*time.Second {
+		t.Fatalf("Trip().Window = %v; want overridden base 10s", res.Window)
+	}
+	if !res.OpenUntil.Equal(fixed.Add(10 * time.Second)) {
+		t.Fatalf("OpenUntil = %v; want %v", res.OpenUntil, fixed.Add(10*time.Second))
+	}
+}
+
+func TestSetClockNilIsIgnored(t *testing.T) {
+	b, fixed := newTestBreaker()
+	b.SetClock(nil) // must not clear the injected clock
+	res := b.Trip()
+	if !res.OpenUntil.Equal(fixed.Add(testBase)) {
+		t.Fatalf("OpenUntil = %v; want clock unchanged at %v", res.OpenUntil, fixed.Add(testBase))
+	}
+}
+
+// TestConcurrentAccessIsRaceFree drives the breaker from many goroutines so
+// the race detector can prove every method takes the mutex.
+func TestConcurrentAccessIsRaceFree(t *testing.T) {
+	b := New(testBase, testCap)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				b.Allow()
+				b.Trip()
+				b.TripRenewal()
+				b.Trips()
+				b.OpenUntil()
+				b.RecordSuccess()
+				b.RecordBenignMiss()
+				b.EverSucceeded()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -350,6 +350,15 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	confidence := Confidence(item.Inputs.Track, song.Track)
 	slog.Debug("worker lyrics match", "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "cache_hit", cacheHit)
 	if !cacheHit {
+		// A non-cache provider fetch succeeded: the token is proven good this
+		// session (a later bare 401 is throttling, not a dead token), so record the
+		// success and recover the circuit NOW, before downstream processing. The
+		// verify/guard/store steps below are not throttle signals; their failures
+		// continue through the normal queue backoff path, but the breaker must not
+		// forget that the fetch itself worked just because a later step failed.
+		if w.circuit.RecordSuccess() {
+			slog.Info("worker circuit closed; provider recovered")
+		}
 		if err := w.verify(ctx, item, song, confidence); err != nil {
 			slog.Warn("worker verification failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "error", err)
 			return w.fail(ctx, item, err)
@@ -361,14 +370,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// (so it is neither cached nor written, never retried, and does not trip the
 		// circuit) rather than calling w.fail (retriable) or deferring it.
 		if reject, reason := w.guardReject(item, song); reject {
-			// The provider round-trip still SUCCEEDED (we fetched real lyrics and
-			// only rejected them on script policy), so recover throttle/circuit
-			// state exactly as the store-success path below does: the token is
-			// proven good and an earlier transient trip must not pin the worker in
-			// backoff after a healthy fetch.
-			if w.circuit.RecordSuccess() {
-				slog.Info("worker circuit closed; provider recovered")
-			}
+			// The provider round-trip already recorded circuit success above (the
+			// fetch worked; only the script policy rejected the result). Here we
+			// just finalize the policy rejection: neither cached nor written, and
+			// not retried.
 			slog.Warn("worker guard rejected lyrics", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", reason)
 			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
 				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))
@@ -383,14 +388,6 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		if err := w.store(ctx, resolvedTrack, song); err != nil {
 			slog.Warn("worker cache store failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
 			return w.fail(ctx, item, err)
-		}
-		// A genuine non-cache provider fetch succeeded: the token is proven good
-		// this session, so a later bare 401 is throttling rather than a dead token.
-		// Reset the throttle ramp too. Placed here (not at the shared
-		// consecutiveFailures reset below) so cache hits, which never touch the
-		// provider, do not falsely mark a provider success.
-		if w.circuit.RecordSuccess() {
-			slog.Info("worker circuit closed; provider recovered")
 		}
 	}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
@@ -70,8 +71,9 @@ const escalationThreshold = 5
 //
 // Worker is intentionally single-goroutine: per-provider concurrency is the
 // architectural model (see CLAUDE.md). RunOnce must not be invoked
-// concurrently against the same Worker; the circuit-breaker state is
-// therefore stored without a mutex.
+// concurrently against the same Worker. The circuit-breaker state lives in the
+// concurrency-safe internal/circuit.Breaker, so it is already safe for the
+// per-provider concurrency that motivated the extraction.
 type Worker struct {
 	queue                 Queue
 	cache                 Cache
@@ -87,34 +89,18 @@ type Worker struct {
 	// last* record the most recent hard failure so the backoff WARN can name the
 	// track it is throttling on (the failure cause is logged separately, but the
 	// periodic backoff line otherwise carried no identity).
-	lastFailID          int64
-	lastFailArtist      string
-	lastFailTrack       string
-	baseBackoff         time.Duration
-	maxBackoff          time.Duration
-	sleep               func(context.Context, time.Duration)
-	now                 func() time.Time
-	circuitOpenDuration time.Duration
-	circuitOpenUntil    time.Time
-	circuitBackoffBase  time.Duration
-	// everProviderSuccess records whether any non-cache provider fetch has
-	// succeeded this session. It distinguishes a bare 401 that is almost
-	// certainly egress-IP throttling (token already proven good) from one seen
-	// before any success (token genuinely suspect).
-	//
-	// NOTE: this becomes a data race the moment per-provider concurrency lands;
-	// it is safe today only because RunOnce is single-goroutine (see the Worker
-	// type doc). Revisit with a mutex or atomic when that model changes.
-	everProviderSuccess bool
-	// consecutiveCircuitTrips counts back-to-back throttle trips with no
-	// intervening provider success or benign miss. It drives both the geometric
-	// circuit window and the escalation warning, and resets on either signal.
-	consecutiveCircuitTrips int
-	// circuitProbing records that the circuit window has elapsed and the worker
-	// is in a half-open state: it has resumed dequeuing to probe the provider but
-	// has not yet confirmed recovery. A subsequent successful round-trip closes
-	// the circuit (logging recovery); a fresh trip clears the flag and reopens.
-	circuitProbing  bool
+	lastFailID     int64
+	lastFailArtist string
+	lastFailTrack  string
+	baseBackoff    time.Duration
+	maxBackoff     time.Duration
+	sleep          func(context.Context, time.Duration)
+	now            func() time.Time
+	// circuit is the concurrency-safe breaker that owns the throttle/half-open
+	// state and the geometric backoff ramp. It is driven through Allow / Trip /
+	// TripRenewal / RecordSuccess / RecordBenignMiss / EverSucceeded so the
+	// worker carries no breaker state of its own. See internal/circuit.
+	circuit         *circuit.Breaker
 	missBackoffBase time.Duration
 	missBackoffCap  time.Duration
 	maxMissAttempts int
@@ -124,6 +110,9 @@ var errQueueEmpty = errors.New("worker queue empty")
 
 // New creates a queue consumer worker.
 func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
+	now := time.Now
+	cb := circuit.New(defaultCircuitBackoffBase, defaultCircuitOpenDuration)
+	cb.SetClock(now)
 	return &Worker{
 		queue:                 q,
 		cache:                 c,
@@ -133,9 +122,8 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		baseBackoff:           backoff.DefaultBase,
 		maxBackoff:            backoff.DefaultMax,
 		sleep:                 sleepCtx,
-		now:                   time.Now,
-		circuitOpenDuration:   defaultCircuitOpenDuration,
-		circuitBackoffBase:    defaultCircuitBackoffBase,
+		now:                   now,
+		circuit:               cb,
 		missBackoffBase:       backoff.DefaultMissBase,
 		missBackoffCap:        backoff.DefaultMissCap,
 		// maxMissAttempts defaults to 0 (no cap). Non-serve callers (tests, ad-hoc
@@ -150,16 +138,14 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 // less than or equal to zero are ignored; clamping against any minimum
 // is the responsibility of the caller (typically the config layer).
 func (w *Worker) SetCircuitOpenDuration(d time.Duration) {
-	if d > 0 {
-		w.circuitOpenDuration = d
-	}
+	w.circuit.SetOpenDuration(d)
 }
 
 // SetMissBackoff overrides the geometric miss-cadence parameters. base sets the
 // initial re-check delay for the first miss; cap sets the ceiling (successive
 // misses double from base up to cap). Zero or negative values are ignored so a
-// misconfigured call cannot disable the cadence; clamping against any minimum
-// is the responsibility of the caller (typically the config layer).
+// misconfigured call cannot disable the cadence; clamping against any minimum is
+// the responsibility of the caller (typically the config layer).
 func (w *Worker) SetMissBackoff(base, cap time.Duration) {
 	if base > 0 {
 		w.missBackoffBase = base
@@ -177,12 +163,7 @@ func (w *Worker) SetMissBackoff(base, cap time.Duration) {
 // misconfigured call cannot disable the window; clamping against any minimum is
 // the responsibility of the caller (typically the config layer).
 func (w *Worker) SetCircuitBackoff(base, cap time.Duration) {
-	if base > 0 {
-		w.circuitBackoffBase = base
-	}
-	if cap > 0 {
-		w.circuitOpenDuration = cap
-	}
+	w.circuit.SetBackoff(base, cap)
 }
 
 // SetMaxMissAttempts overrides the miss-attempt cap. When miss_count exceeds
@@ -193,6 +174,14 @@ func (w *Worker) SetMaxMissAttempts(n int) {
 		n = 0
 	}
 	w.maxMissAttempts = n
+}
+
+// setClock injects the time source into both the worker and its breaker so the
+// two never drift. Used by tests to freeze the clock; production uses time.Now
+// from New.
+func (w *Worker) setClock(now func() time.Time) {
+	w.now = now
+	w.circuit.SetClock(now)
 }
 
 func sleepCtx(ctx context.Context, d time.Duration) {
@@ -300,16 +289,13 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	}
 	// Circuit breaker gate: while open, do not dequeue and do not mark any
 	// rows failed. Returning errQueueEmpty unwinds the run loop cleanly so
-	// the outer ticker idles for the configured window.
-	if !w.circuitOpenUntil.IsZero() {
-		if w.now().Before(w.circuitOpenUntil) {
-			return errQueueEmpty
-		}
-		// Circuit window elapsed: enter half-open. The probe log is emitted at the
-		// actual provider call (see song) so an empty-queue ticker tick does not
-		// log a phantom probe. Recovery is only confirmed once a round-trip succeeds.
-		w.circuitProbing = true
-		w.circuitOpenUntil = time.Time{}
+	// the outer ticker idles for the configured window. Allow performs the
+	// window-elapsed transition to half-open as a side effect; the probe log is
+	// emitted at the actual provider call (see song) so an empty-queue ticker
+	// tick does not log a phantom probe. Recovery is only confirmed once a
+	// round-trip succeeds.
+	if w.circuit.Allow() == circuit.StateOpen {
+		return errQueueEmpty
 	}
 	item, err := w.queue.Dequeue(ctx)
 	if err != nil {
@@ -350,13 +336,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// failed above we keep the failure state so backoff still applies next run.
 			w.consecutiveFailures = 0
 			// A clean benign miss proves the provider round-trip succeeded, so we
-			// are not being throttled: reset the circuit ramp too. (everProviderSuccess
-			// is deliberately NOT set here -- it tracks genuine lyric matches, and a
+			// are not being throttled: reset the circuit ramp too. (EverSucceeded is
+			// deliberately NOT set here -- it tracks genuine lyric matches, and a
 			// miss is a successful round-trip but not a match.)
-			w.consecutiveCircuitTrips = 0
-			if w.circuitProbing {
+			if w.circuit.RecordBenignMiss() {
 				slog.Info("worker circuit closed; provider recovered")
-				w.circuitProbing = false
 			}
 			return nil
 		}
@@ -382,11 +366,8 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// state exactly as the store-success path below does: the token is
 			// proven good and an earlier transient trip must not pin the worker in
 			// backoff after a healthy fetch.
-			w.everProviderSuccess = true
-			w.consecutiveCircuitTrips = 0
-			if w.circuitProbing {
+			if w.circuit.RecordSuccess() {
 				slog.Info("worker circuit closed; provider recovered")
-				w.circuitProbing = false
 			}
 			slog.Warn("worker guard rejected lyrics", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", reason)
 			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
@@ -408,11 +389,8 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// Reset the throttle ramp too. Placed here (not at the shared
 		// consecutiveFailures reset below) so cache hits, which never touch the
 		// provider, do not falsely mark a provider success.
-		w.everProviderSuccess = true
-		w.consecutiveCircuitTrips = 0
-		if w.circuitProbing {
+		if w.circuit.RecordSuccess() {
 			slog.Info("worker circuit closed; provider recovered")
-			w.circuitProbing = false
 		}
 	}
 
@@ -472,7 +450,7 @@ func (w *Worker) song(ctx context.Context, track models.Track) (models.Song, boo
 		return models.Song{}, false, fmt.Errorf("worker: lookup fallback cache: %w", err)
 	}
 
-	if w.circuitProbing {
+	if w.circuit.Allow() == circuit.StateHalfOpen {
 		// Half-open probe: the first real provider call after the circuit window
 		// elapsed. Logged here (not at the gate) so it reflects an actual attempt
 		// rather than a bare ticker tick that found an empty queue.
@@ -504,6 +482,10 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 // return value is non-nil when Release failed, in which case the item is
 // orphaned in 'processing' and RunOnce must surface the failure to the
 // outer loop rather than swallow it as errQueueEmpty.
+//
+// The breaker state mutation (window, ramp, probing) lives in the
+// internal/circuit.Breaker; this method only classifies the error, drives the
+// breaker, emits the operator-facing logs, and releases the item.
 func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkItem, err error) (bool, error) {
 	// Case 1 MUST precede the bare-401 check below: tokenRenewalError also
 	// satisfies errors.Is(_, ErrUnauthorized), so testing ErrUnauthorized first
@@ -511,12 +493,11 @@ func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkIt
 	// not throttling: hold the full window, stay loud, and do NOT advance the
 	// throttle counter (so a later real throttle resumes from its true position).
 	if errors.Is(err, musixmatch.ErrTokenRenewalRequired) {
-		w.circuitOpenUntil = w.now().Add(w.circuitOpenDuration)
-		// A fresh open clears any half-open probe state. Renewal is not a
-		// per-song failure, so consecutiveFailures/lastFail* are left untouched.
-		w.circuitProbing = false
+		res := w.circuit.TripRenewal()
+		// Renewal is not a per-song failure, so consecutiveFailures/lastFail* are
+		// left untouched.
 		slog.Warn("worker circuit opened: token renewal required; regenerate the usertoken",
-			"backoff", w.circuitOpenDuration, "next_retry", w.circuitOpenUntil, "id", item.ID, "cause", err)
+			"backoff", res.Window, "next_retry", res.OpenUntil, "id", item.ID, "cause", err)
 		if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
 			return true, fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)
 		}
@@ -529,11 +510,7 @@ func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkIt
 	}
 	// Bare 401 / 429 / truncated body: treat as throttling and ramp the window
 	// geometrically. The log level reflects what we actually know this session.
-	w.consecutiveCircuitTrips++
-	delay := backoff.Geometric(w.consecutiveCircuitTrips, w.circuitBackoffBase, w.circuitOpenDuration)
-	w.circuitOpenUntil = w.now().Add(delay)
-	// A fresh/re-open is full-open, not a probe.
-	w.circuitProbing = false
+	res := w.circuit.Trip()
 	// Reset stale failure state: a throttle is not the song's fault, and the
 	// circuit's geometric ramp is the backoff mechanism. The separate
 	// consecutive-failure WARN must not keep naming a stale victim.
@@ -544,16 +521,16 @@ func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkIt
 	switch {
 	case errors.Is(err, musixmatch.ErrTruncatedResponse):
 		slog.Warn("worker circuit opened: provider returned truncated response; likely throttling",
-			"trips", w.consecutiveCircuitTrips, "id", item.ID, "cause", err, "backoff", delay, "next_retry", w.circuitOpenUntil)
-	case w.everProviderSuccess && w.consecutiveCircuitTrips >= escalationThreshold:
+			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+	case w.circuit.EverSucceeded() && res.Trips >= escalationThreshold:
 		slog.Warn("worker circuit opened: token validated earlier this session but has failed repeatedly; it may have expired",
-			"trips", w.consecutiveCircuitTrips, "id", item.ID, "cause", err, "backoff", delay, "next_retry", w.circuitOpenUntil)
-	case w.everProviderSuccess:
+			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+	case w.circuit.EverSucceeded():
 		slog.Warn("worker circuit opened: provider throttling; token validated earlier this session",
-			"trips", w.consecutiveCircuitTrips, "id", item.ID, "cause", err, "backoff", delay, "next_retry", w.circuitOpenUntil)
+			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
 	default:
 		slog.Warn("worker circuit opened: no successful fetch yet this session; verify your token",
-			"trips", w.consecutiveCircuitTrips, "id", item.ID, "cause", err, "backoff", delay, "next_retry", w.circuitOpenUntil)
+			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
 	}
 	if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
 		return true, fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -570,6 +570,12 @@ func TestRunOnceRejectedVerificationMarksQueueFailed(t *testing.T) {
 	if len(q.completed) != 0 {
 		t.Fatalf("completed = %v; want none", q.completed)
 	}
+	// The provider fetch succeeded; only STT verification rejected the result. The
+	// circuit must still record the successful round-trip, so a later bare 401 is
+	// classified as throttling rather than a token that never worked.
+	if !w.circuit.EverSucceeded() {
+		t.Fatal("circuit EverSucceeded = false; a successful fetch must record success even when verification fails")
+	}
 }
 
 func TestRunOnceStoresCacheWithRequestedTrackKeys(t *testing.T) {
@@ -1441,8 +1447,8 @@ func TestCircuitHalfOpenThenRecovers(t *testing.T) {
 	if !hasLog(*recs, slog.LevelInfo, "circuit closed; provider recovered") {
 		t.Fatalf("logs = %+v; want Info recovery after a successful probe round-trip", *recs)
 	}
-	if w.circuit.Allow() != circuit.StateClosed {
-		t.Fatal("circuitProbing = true; want cleared (StateClosed) after recovery")
+	if got := w.circuit.Allow(); got != circuit.StateClosed {
+		t.Fatalf("circuit state = %v; want StateClosed after recovery", got)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
@@ -1040,7 +1041,7 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 			fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", sentinel)}
 			w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
 			fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-			w.now = func() time.Time { return fixed }
+			w.setClock(func() time.Time { return fixed })
 			w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
 
 			// First call dequeues, hits sentinel, opens circuit.
@@ -1058,10 +1059,10 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 			if len(q.processing) != 0 {
 				t.Fatalf("processing = %v; want empty after release", q.processing)
 			}
-			if w.circuitOpenUntil.IsZero() {
+			if w.circuit.OpenUntil().IsZero() {
 				t.Fatal("circuitOpenUntil = zero; want circuit opened")
 			}
-			if got, want := w.circuitOpenUntil, fixed.Add(60*time.Second); !got.Equal(want) {
+			if got, want := w.circuit.OpenUntil(), fixed.Add(60*time.Second); !got.Equal(want) {
 				t.Fatalf("circuitOpenUntil = %v; want %v (trip 1 uses the geometric base, not the flat cap)", got, want)
 			}
 
@@ -1084,7 +1085,7 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 
 			// Advance the clock past the window; next RunOnce closes the circuit
 			// and resumes processing (and trips again on the same fetcher).
-			w.now = func() time.Time { return fixed.Add(31 * time.Minute) }
+			w.setClock(func() time.Time { return fixed.Add(31 * time.Minute) })
 			err = w.RunOnce(context.Background())
 			if err != nil && !errors.Is(err, errQueueEmpty) {
 				t.Fatalf("RunOnce after window = %v; want nil or errQueueEmpty", err)
@@ -1102,7 +1103,7 @@ func newCircuitWorker() (*Worker, *fakeQueue, time.Time) {
 	q := &fakeQueue{}
 	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
 	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	w.now = func() time.Time { return fixed }
+	w.setClock(func() time.Time { return fixed })
 	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
 	return w, q, fixed
 }
@@ -1122,11 +1123,11 @@ func TestCircuitRampIncrementsAndCaps(t *testing.T) {
 		if !tripped || releaseErr != nil {
 			t.Fatalf("trip %d: tripped=%v releaseErr=%v; want tripped, no error", i+1, tripped, releaseErr)
 		}
-		if got := w.circuitOpenUntil.Sub(fixed); got != want {
+		if got := w.circuit.OpenUntil().Sub(fixed); got != want {
 			t.Fatalf("trip %d: window = %v; want %v", i+1, got, want)
 		}
-		if w.consecutiveCircuitTrips != i+1 {
-			t.Fatalf("trip %d: consecutiveCircuitTrips = %d; want %d", i+1, w.consecutiveCircuitTrips, i+1)
+		if w.circuit.Trips() != i+1 {
+			t.Fatalf("trip %d: consecutiveCircuitTrips = %d; want %d", i+1, w.circuit.Trips(), i+1)
 		}
 	}
 }
@@ -1134,7 +1135,7 @@ func TestCircuitRampIncrementsAndCaps(t *testing.T) {
 func TestThrottleAfterSuccessLogsWarn(t *testing.T) {
 	recs := captureLogs(t)
 	w, _, fixed := newCircuitWorker()
-	w.everProviderSuccess = true
+	w.circuit.RecordSuccess()
 
 	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
 
@@ -1171,15 +1172,15 @@ func TestThrottleBeforeAnySuccessLogsWarn(t *testing.T) {
 func TestEscalationWarnAfterThreshold(t *testing.T) {
 	recs := captureLogs(t)
 	w, _, _ := newCircuitWorker()
-	w.everProviderSuccess = true
+	w.circuit.RecordSuccess()
 	throttle := fmt.Errorf("x: %w", musixmatch.ErrRateLimited)
 
 	for i := 0; i < escalationThreshold; i++ {
 		w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, throttle)
 	}
 
-	if w.consecutiveCircuitTrips != escalationThreshold {
-		t.Fatalf("consecutiveCircuitTrips = %d; want %d", w.consecutiveCircuitTrips, escalationThreshold)
+	if w.circuit.Trips() != escalationThreshold {
+		t.Fatalf("consecutiveCircuitTrips = %d; want %d", w.circuit.Trips(), escalationThreshold)
 	}
 	if !hasLog(*recs, slog.LevelWarn, "may have expired") {
 		t.Fatalf("logs = %+v; want escalation Warn after %d trips", *recs, escalationThreshold)
@@ -1190,18 +1191,18 @@ func TestRenewalHoldsFullCapAndDoesNotIncrementTrips(t *testing.T) {
 	recs := captureLogs(t)
 	w, q, fixed := newCircuitWorker()
 	// A genuine renewal is loud even after earlier success.
-	w.everProviderSuccess = true
+	w.circuit.RecordSuccess()
 	renewal := fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired)
 
 	tripped, releaseErr := w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 7}, renewal)
 	if !tripped || releaseErr != nil {
 		t.Fatalf("tripped=%v releaseErr=%v; want tripped, no error", tripped, releaseErr)
 	}
-	if got := w.circuitOpenUntil.Sub(fixed); got != 30*time.Minute {
+	if got := w.circuit.OpenUntil().Sub(fixed); got != 30*time.Minute {
 		t.Fatalf("window = %v; want the full cap (30m), not the geometric base", got)
 	}
-	if w.consecutiveCircuitTrips != 0 {
-		t.Fatalf("consecutiveCircuitTrips = %d; want 0 (renewal must not advance the throttle ramp)", w.consecutiveCircuitTrips)
+	if w.circuit.Trips() != 0 {
+		t.Fatalf("consecutiveCircuitTrips = %d; want 0 (renewal must not advance the throttle ramp)", w.circuit.Trips())
 	}
 	if got := q.released; len(got) != 1 || got[0] != 7 {
 		t.Fatalf("released = %v; want [7]", got)
@@ -1216,7 +1217,7 @@ func TestRenewalHoldsFullCapAndDoesNotIncrementTrips(t *testing.T) {
 	// A subsequent bare-401 throttle starts the ramp at the base, proving the
 	// renewal left the ramp position untouched.
 	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 8}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
-	if got := w.circuitOpenUntil.Sub(fixed); got != 60*time.Second {
+	if got := w.circuit.OpenUntil().Sub(fixed); got != 60*time.Second {
 		t.Fatalf("post-renewal throttle window = %v; want base 60s (ramp position preserved)", got)
 	}
 }
@@ -1240,15 +1241,23 @@ func TestRunOnceResetsCircuitTripsOnNonCacheSuccess(t *testing.T) {
 	q := &fakeQueue{items: []queue.WorkItem{{ID: 5, Inputs: models.Inputs{Track: track, OutputPaths: []models.OutputPath{{Outdir: "out", Filename: "a.lrc"}}}}}}
 	fetcher := &fakeFetcher{song: models.Song{Track: track, Lyrics: models.Lyrics{LyricsBody: "fresh"}}}
 	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
-	w.consecutiveCircuitTrips = 3
+	// Prime the ramp to 3 trips, then advance past the window so the gate is
+	// half-open (not open) and RunOnce can proceed to a real provider fetch.
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return fixed })
+	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
+	w.circuit.Trip()
+	w.circuit.Trip()
+	w.circuit.Trip()
+	w.setClock(func() time.Time { return fixed.Add(time.Hour) })
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
-	if w.consecutiveCircuitTrips != 0 {
-		t.Fatalf("consecutiveCircuitTrips = %d; want 0 after a non-cache success", w.consecutiveCircuitTrips)
+	if w.circuit.Trips() != 0 {
+		t.Fatalf("consecutiveCircuitTrips = %d; want 0 after a non-cache success", w.circuit.Trips())
 	}
-	if !w.everProviderSuccess {
+	if !w.circuit.EverSucceeded() {
 		t.Fatal("everProviderSuccess = false; want true after a non-cache provider fetch")
 	}
 }
@@ -1257,15 +1266,23 @@ func TestRunOnceResetsCircuitTripsOnBenignMiss(t *testing.T) {
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	q := &fakeQueue{items: []queue.WorkItem{{ID: 6, Inputs: models.Inputs{Track: track}}}}
 	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
-	w.consecutiveCircuitTrips = 3
+	// Prime the ramp to 3 trips, then advance past the window so the gate is
+	// half-open (not open) and RunOnce can proceed to a real provider fetch.
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return fixed })
+	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
+	w.circuit.Trip()
+	w.circuit.Trip()
+	w.circuit.Trip()
+	w.setClock(func() time.Time { return fixed.Add(time.Hour) })
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
-	if w.consecutiveCircuitTrips != 0 {
-		t.Fatalf("consecutiveCircuitTrips = %d; want 0 after a benign miss (a clean 404 proves we are not throttled)", w.consecutiveCircuitTrips)
+	if w.circuit.Trips() != 0 {
+		t.Fatalf("consecutiveCircuitTrips = %d; want 0 after a benign miss (a clean 404 proves we are not throttled)", w.circuit.Trips())
 	}
-	if w.everProviderSuccess {
+	if w.circuit.EverSucceeded() {
 		t.Fatal("everProviderSuccess = true; a benign miss is not a provider match")
 	}
 }
@@ -1282,7 +1299,7 @@ func TestRunOnceCacheHitDoesNotMarkProviderSuccess(t *testing.T) {
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
-	if w.everProviderSuccess {
+	if w.circuit.EverSucceeded() {
 		t.Fatal("everProviderSuccess = true after a cache hit; a cache hit never touches the provider")
 	}
 }
@@ -1290,8 +1307,9 @@ func TestRunOnceCacheHitDoesNotMarkProviderSuccess(t *testing.T) {
 func TestRunOnceWithOpenCircuitDoesNotIncrementBackoff(t *testing.T) {
 	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
 	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	w.now = func() time.Time { return fixed }
-	w.circuitOpenUntil = fixed.Add(10 * time.Minute)
+	w.setClock(func() time.Time { return fixed })
+	w.SetCircuitBackoff(10*time.Minute, 30*time.Minute)
+	w.circuit.Trip() // opens until fixed+10m
 
 	if err := w.RunOnce(context.Background()); !errors.Is(err, errQueueEmpty) {
 		t.Fatalf("RunOnce = %v; want errQueueEmpty", err)
@@ -1326,7 +1344,7 @@ func TestRunOnceSurfacesReleaseFailureAfterCircuitTrip(t *testing.T) {
 	// Circuit must still be opened even though release failed; we want the
 	// quiet window applied to upstream while operators investigate the
 	// orphaned row.
-	if w.circuitOpenUntil.IsZero() {
+	if w.circuit.OpenUntil().IsZero() {
 		t.Fatal("circuitOpenUntil = zero; want circuit opened despite release failure")
 	}
 	if len(q.failed) != 0 {
@@ -1363,13 +1381,13 @@ func TestTruncatedResponseOpensCircuitAndReleases(t *testing.T) {
 	fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", musixmatch.ErrTruncatedResponse)}
 	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
 	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	w.now = func() time.Time { return fixed }
+	w.setClock(func() time.Time { return fixed })
 	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
 
 	if err := w.RunOnce(context.Background()); !errors.Is(err, errQueueEmpty) {
 		t.Fatalf("RunOnce = %v; want errQueueEmpty (circuit opened cleanly)", err)
 	}
-	if w.circuitOpenUntil.IsZero() {
+	if w.circuit.OpenUntil().IsZero() {
 		t.Fatal("circuitOpenUntil = zero; want circuit opened on a truncated response")
 	}
 	if got := q.released; len(got) != 1 || got[0] != 77 {
@@ -1407,9 +1425,12 @@ func TestCircuitHalfOpenThenRecovers(t *testing.T) {
 	fetcher := &fakeFetcher{song: models.Song{Track: track, Lyrics: models.Lyrics{LyricsBody: "fresh"}}}
 	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
 	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-	// The circuit window has already elapsed: now() is past circuitOpenUntil.
-	w.now = func() time.Time { return fixed }
-	w.circuitOpenUntil = fixed.Add(-time.Minute)
+	// Open the circuit two minutes in the past (base window 60s elapsed by now),
+	// so now() is past openUntil and the next RunOnce probes (half-open).
+	w.setClock(func() time.Time { return fixed.Add(-2 * time.Minute) })
+	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
+	w.circuit.Trip()
+	w.setClock(func() time.Time { return fixed })
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1420,8 +1441,8 @@ func TestCircuitHalfOpenThenRecovers(t *testing.T) {
 	if !hasLog(*recs, slog.LevelInfo, "circuit closed; provider recovered") {
 		t.Fatalf("logs = %+v; want Info recovery after a successful probe round-trip", *recs)
 	}
-	if w.circuitProbing {
-		t.Fatal("circuitProbing = true; want cleared after recovery")
+	if w.circuit.Allow() != circuit.StateClosed {
+		t.Fatal("circuitProbing = true; want cleared (StateClosed) after recovery")
 	}
 }
 


### PR DESCRIPTION
## Summary

Extracts the worker's circuit breaker into a concurrency-safe `internal/circuit` package and migrates the worker through it in one atomic change, with no behavior change. This is the foundation for the multi-provider orchestration designed in #148 (the breaker must be a per-lane component, mutex-guarded, before any second lane introduces concurrency).

- New `internal/circuit.Breaker`: all breaker state behind one `sync.Mutex`, with `Allow() BreakerState` (performs the window-elapsed -> half-open transition), `Trip()` / `TripRenewal()`, `RecordSuccess()` / `RecordBenignMiss()` (benign miss resets the ramp but does NOT set `everSucceeded`), `EverSucceeded()`, and the geometric backoff window via `backoff.Geometric`. Injectable clock for deterministic tests.
- `Worker` loses the six circuit fields and drives the single Musixmatch path through one `*circuit.Breaker`, configured by the existing `SetCircuitOpenDuration` / `SetCircuitBackoff` setters. No two-breaker intermediate state.
- The honest-401 classification is preserved byte-for-byte (reads `breaker.EverSucceeded()` to distinguish egress-IP throttling from a genuinely suspect token).

`tripCircuitIfRateLimited` is intentionally retained as a thin worker-side error classifier/logger (it inspects Musixmatch error types and drives the breaker) rather than moved into the generic breaker - keeping the breaker provider-agnostic so #174's per-lane reuse works. The state moved; the Musixmatch-specific classification stays provider-side and will relocate into the Musixmatch lane in #174.

## Verification
- `go test -race ./internal/circuit/ ./internal/worker/` and `go test -race ./...` green (incl. a 16-goroutine concurrency test exercising every breaker method).
- `make gate` green; circuit package coverage 93.2%.
- No behavior change: existing worker circuit / backoff / honest-401 tests pass (adapted to drive behavior through the public surface, assertions unchanged).

## Scope
First of four sequenced orchestration issues (#173 -> #174 -> #175 -> #176). No orchestrator or second provider here.

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit breaker implementation for more reliable provider failure detection and recovery.
  * Enhanced exponential backoff behavior with consistent window capping across failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->