### PR TITLE
feat(orchestrator): provider-lane abstraction + ordered-fallback dispatch (#174)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -116,6 +116,15 @@ primary = "musixmatch"
 # Provider names to disable explicitly.
 disabled = []
 
+# Multi-provider dispatch mode. Only "ordered" is implemented today: lanes are
+# queried in priority order and the first suitable result (passes the script
+# guard and carries synced or unsynced lyrics) wins; the next lane is consulted
+# only on a miss or an unsuitable result. The "parallel" race is reserved by
+# docs/multi-provider-orchestration.md and not yet built; any value other than
+# "ordered" is rejected at load. With a single provider this setting has no
+# observable effect. Override: MXLRC_PROVIDERS_MODE. Default "ordered".
+mode = "ordered"
+
 [verification]
 # Optional STT verification for low-confidence scanned audio.
 enabled = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -119,7 +119,9 @@ disabled = []
 # Multi-provider dispatch mode. Only "ordered" is implemented today: lanes are
 # queried in priority order and the first suitable result (passes the script
 # guard and carries synced or unsynced lyrics) wins; the next lane is consulted
-# only on a miss or an unsuitable result. The "parallel" race is reserved by
+# on a miss, an unsuitable result, or a provider error (a rate-limit/auth or
+# transport error falls through to the next lane, and the highest-precedence
+# error is returned only if every lane fails). The "parallel" race is reserved by
 # docs/multi-provider-orchestration.md and not yet built; any value other than
 # "ordered" is rejected at load. With a single provider this setting has no
 # observable effect. Override: MXLRC_PROVIDERS_MODE. Default "ordered".

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1280,6 +1280,7 @@ func configKeys() []string {
 		"server.work_interval_seconds",
 		"providers.primary",
 		"providers.disabled",
+		"providers.mode",
 		"verification.enabled",
 		"verification.whisper_url",
 		"verification.ffmpeg_path",
@@ -1325,6 +1326,8 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return cfg.Providers.Primary, true
 	case "providers.disabled":
 		return strings.Join(cfg.Providers.Disabled, ","), true
+	case "providers.mode":
+		return cfg.Providers.Mode, true
 	case "verification.enabled":
 		return strconv.FormatBool(cfg.Verification.Enabled), true
 	case "verification.whisper_url":
@@ -1417,6 +1420,11 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 		cfg.Providers.Primary = value
 	case "providers.disabled":
 		cfg.Providers.Disabled = splitCSV(value)
+	case "providers.mode":
+		if m := strings.ToLower(strings.TrimSpace(value)); m != "ordered" {
+			return fmt.Errorf("providers.mode must be \"ordered\" (only supported mode)")
+		}
+		cfg.Providers.Mode = "ordered"
 	case "verification.enabled":
 		v, err := strconv.ParseBool(value)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,7 +150,16 @@ const defaultScanIntervalSeconds = 900
 type ProvidersConfig struct {
 	Primary  string   `toml:"primary"`
 	Disabled []string `toml:"disabled"`
+	// Mode is the multi-provider dispatch strategy. Only "ordered" (query lanes
+	// in priority order, first suitable result wins) is implemented today; any
+	// other value is rejected at load time. The "parallel" race is reserved by
+	// docs/multi-provider-orchestration.md and not yet built. Default "ordered".
+	// Override: MXLRC_PROVIDERS_MODE.
+	Mode string `toml:"mode"`
 }
+
+// providersModeDefault is the only supported dispatch mode today.
+const providersModeDefault = "ordered"
 
 // VerificationConfig holds optional STT verification settings.
 type VerificationConfig struct {
@@ -205,7 +214,7 @@ func defaults() Config {
 		Output:       OutputConfig{Dir: "lyrics", EmbeddedLyrics: "off"},
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
 		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
-		Providers:    ProvidersConfig{Primary: "musixmatch"},
+		Providers:    ProvidersConfig{Primary: "musixmatch", Mode: providersModeDefault},
 		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
 		Guard:        GuardConfig{Threshold: guardThresholdDefault},
 		Queue:        QueueConfig{Randomize: true},
@@ -261,6 +270,9 @@ func Load(path string) (Config, error) {
 			}
 			if cfg.Providers.Primary == "" {
 				cfg.Providers.Primary = d.Providers.Primary
+			}
+			if cfg.Providers.Mode == "" {
+				cfg.Providers.Mode = d.Providers.Mode
 			}
 			if cfg.Verification.SampleDurationSeconds <= 0 {
 				cfg.Verification.SampleDurationSeconds = d.Verification.SampleDurationSeconds
@@ -339,6 +351,9 @@ func Load(path string) (Config, error) {
 	}
 	applyEnvOverrides(&cfg)
 	normalizeEmbeddedLyrics(&cfg)
+	if err := normalizeProvidersMode(&cfg); err != nil {
+		return cfg, err
+	}
 	clampCircuitOpenDuration(&cfg)
 	// Must run AFTER clampCircuitOpenDuration: the base is clamped against the
 	// final (clamped) cap value.
@@ -353,7 +368,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -465,6 +480,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_DISABLED"); v != "" {
 		cfg.Providers.Disabled = splitCSV(v)
+	}
+	if v := os.Getenv("MXLRC_PROVIDERS_MODE"); v != "" {
+		cfg.Providers.Mode = v
 	}
 	if v := os.Getenv("MXLRC_VERIFICATION_ENABLED"); v != "" {
 		enabled, err := strconv.ParseBool(v)
@@ -595,6 +613,23 @@ func normalizeEmbeddedLyrics(cfg *Config) {
 		slog.Warn("invalid embedded_lyrics value; using off", "value", cfg.Output.EmbeddedLyrics) //nolint:gosec // G706: tainted config value passed as a structured slog field, not a format string
 		cfg.Output.EmbeddedLyrics = "off"
 	}
+}
+
+// normalizeProvidersMode lowercases and validates the provider dispatch mode.
+// An empty value restores the default ("ordered"). Only "ordered" is supported
+// today; any other value is rejected with an error so a typo or a not-yet-built
+// mode (for example "parallel") fails loudly at load rather than silently
+// degrading. See docs/multi-provider-orchestration.md.
+func normalizeProvidersMode(cfg *Config) error {
+	v := strings.ToLower(strings.TrimSpace(cfg.Providers.Mode))
+	if v == "" {
+		v = providersModeDefault
+	}
+	if v != providersModeDefault {
+		return fmt.Errorf("config: unsupported providers.mode %q (only %q is supported)", cfg.Providers.Mode, providersModeDefault)
+	}
+	cfg.Providers.Mode = v
+	return nil
 }
 
 // clampCircuitOpenDuration enforces the minimum window for the worker

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,7 @@ func isolateEnv(t *testing.T) {
 		"MXLRC_MISS_BACKOFF_BASE_HOURS", "MXLRC_MISS_BACKOFF_CAP_HOURS", "MXLRC_MAX_MISS_ATTEMPTS",
 		"MXLRC_OUTPUT_DIR", "MXLRC_BILINGUAL_OUTPUT", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
 		"MXLRC_SCAN_INTERVAL", "MXLRC_WORK_INTERVAL",
-		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED",
+		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED", "MXLRC_PROVIDERS_MODE",
 		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
 		"MXLRC_VERIFICATION_FFMPEG_PATH",
 		"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION",
@@ -57,6 +57,9 @@ func TestLoad_MissingConfigFileIsNotFatal(t *testing.T) {
 	}
 	if cfg.Providers.Primary != "musixmatch" {
 		t.Errorf("default provider = %q; want musixmatch", cfg.Providers.Primary)
+	}
+	if cfg.Providers.Mode != "ordered" {
+		t.Errorf("default providers mode = %q; want ordered", cfg.Providers.Mode)
 	}
 	if cfg.Verification.SampleDurationSeconds != 30 {
 		t.Errorf("default verification sample duration = %d; want 30", cfg.Verification.SampleDurationSeconds)
@@ -1150,4 +1153,42 @@ func TestLoad_LoggingCompressDefaultTrueWhenKeyOmitted(t *testing.T) {
 	if !cfg.Logging.Compress {
 		t.Error("Logging.Compress = false; want default true when key is omitted from TOML")
 	}
+}
+
+func TestProvidersModeEnvOverrideAndValidation(t *testing.T) {
+	t.Run("env override accepts ordered", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_PROVIDERS_MODE", "ORDERED") // case-insensitive
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.Mode != "ordered" {
+			t.Fatalf("providers.mode = %q; want ordered", cfg.Providers.Mode)
+		}
+	})
+
+	t.Run("unsupported mode is rejected", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_PROVIDERS_MODE", "parallel")
+		_, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err == nil {
+			t.Fatal("Load with providers.mode=parallel returned nil error; want a rejection (parallel not implemented)")
+		}
+	})
+
+	t.Run("blank mode restores default", func(t *testing.T) {
+		isolateEnv(t)
+		path := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.WriteFile(path, []byte("[providers]\nmode = \"\"\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.Mode != "ordered" {
+			t.Fatalf("blank mode = %q; want ordered default", cfg.Providers.Mode)
+		}
+	})
 }

--- a/internal/orchestrator/errors.go
+++ b/internal/orchestrator/errors.go
@@ -1,0 +1,85 @@
+package orchestrator
+
+import (
+	"errors"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+)
+
+// ErrLaneUnavailable is the sentinel a lane returns when its breaker is open and
+// the provider was therefore not called. The orchestrator surfaces it as the
+// dispatch outcome only when EVERY available lane is unavailable, in which case
+// the worker releases the item back to pending with no failure increment (no
+// lane was actually consulted, so the catalog answer is unknown).
+var ErrLaneUnavailable = errors.New("orchestrator: lane unavailable (circuit open)")
+
+// OutcomeClass classifies a lane's outcome for cross-lane precedence (design
+// doc Gap 4). The precedence rule is "least-certain-negative wins": any signal
+// that we did not truly learn the track is absent (auth, rate-limit, transport,
+// open circuit) outranks the only signal that says the track is absent (a
+// benign miss).
+type OutcomeClass int
+
+const (
+	// OutcomeSuccess means the lane returned lyrics (suitable or not). It carries
+	// no error precedence.
+	OutcomeSuccess OutcomeClass = iota
+	// OutcomeBenignMiss means the lane reached the provider and the track was
+	// absent or had no usable lyrics (ErrNotFound, ErrNoLyrics). The only signal
+	// that the track is genuinely absent.
+	OutcomeBenignMiss
+	// OutcomeTransport means a retriable failure that is not a clean miss
+	// (timeout, connection failure, an unexpected error).
+	OutcomeTransport
+	// OutcomeAuthRateLimit means an auth or rate-limit / throttle signal
+	// (ErrUnauthorized, ErrTokenRenewalRequired, ErrRateLimited,
+	// ErrTruncatedResponse). The catalog answer is unknown.
+	OutcomeAuthRateLimit
+	// OutcomeUnavailable means the lane's breaker was open and the provider was
+	// not called (ErrLaneUnavailable).
+	OutcomeUnavailable
+)
+
+// ClassifyOutcome maps a lane error to its OutcomeClass. A nil error is a
+// success. The auth/rate-limit check folds in the Musixmatch throttle sentinels
+// the worker historically tripped the circuit on; classification is per-provider
+// today (only Musixmatch lanes exist) and lives here so the breaker stays
+// provider-agnostic.
+func ClassifyOutcome(err error) OutcomeClass {
+	switch {
+	case err == nil:
+		return OutcomeSuccess
+	case errors.Is(err, ErrLaneUnavailable):
+		return OutcomeUnavailable
+	case errors.Is(err, musixmatch.ErrTokenRenewalRequired),
+		errors.Is(err, musixmatch.ErrUnauthorized),
+		errors.Is(err, musixmatch.ErrRateLimited),
+		errors.Is(err, musixmatch.ErrTruncatedResponse):
+		return OutcomeAuthRateLimit
+	case musixmatch.IsBenignMiss(err):
+		return OutcomeBenignMiss
+	default:
+		return OutcomeTransport
+	}
+}
+
+// precedence returns the cross-lane ranking weight. Higher wins. Unavailable is
+// ranked at the auth/rate-limit tier for queue purposes (both release the item
+// without recording a stable miss), but it remains a distinct class so the
+// orchestrator can surface ErrLaneUnavailable when every lane was unavailable.
+func (c OutcomeClass) precedence() int {
+	switch c {
+	case OutcomeSuccess:
+		return 0
+	case OutcomeBenignMiss:
+		return 1
+	case OutcomeTransport:
+		return 2
+	case OutcomeAuthRateLimit:
+		return 3
+	case OutcomeUnavailable:
+		return 3
+	default:
+		return 0
+	}
+}

--- a/internal/orchestrator/errors_test.go
+++ b/internal/orchestrator/errors_test.go
@@ -1,0 +1,57 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+)
+
+func TestClassifyOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want OutcomeClass
+	}{
+		{"nil is success", nil, OutcomeSuccess},
+		{"lane unavailable", ErrLaneUnavailable, OutcomeUnavailable},
+		{"token renewal is auth", fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired), OutcomeAuthRateLimit},
+		{"unauthorized is auth", fmt.Errorf("x: %w", musixmatch.ErrUnauthorized), OutcomeAuthRateLimit},
+		{"rate limited is auth", fmt.Errorf("x: %w", musixmatch.ErrRateLimited), OutcomeAuthRateLimit},
+		{"truncated is auth", fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse), OutcomeAuthRateLimit},
+		{"not found is benign miss", fmt.Errorf("x: %w", musixmatch.ErrNotFound), OutcomeBenignMiss},
+		{"no lyrics is benign miss", fmt.Errorf("x: %w", musixmatch.ErrNoLyrics), OutcomeBenignMiss},
+		{"generic error is transport", errors.New("connection refused"), OutcomeTransport},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyOutcome(tt.err); got != tt.want {
+				t.Fatalf("ClassifyOutcome(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutcomePrecedence(t *testing.T) {
+	// Higher precedence wins. auth/rate-limit > transport > benign-miss.
+	// Unavailable is treated at rate-limit level for queue purposes.
+	if OutcomeAuthRateLimit.precedence() <= OutcomeTransport.precedence() {
+		t.Fatal("auth/rate-limit must outrank transport")
+	}
+	if OutcomeTransport.precedence() <= OutcomeBenignMiss.precedence() {
+		t.Fatal("transport must outrank benign miss")
+	}
+	if OutcomeUnavailable.precedence() < OutcomeAuthRateLimit.precedence() {
+		t.Fatal("all-unavailable must rank at least at rate-limit for queue purposes")
+	}
+	if OutcomeSuccess.precedence() != 0 {
+		t.Fatal("success carries no error precedence")
+	}
+}
+
+func TestErrLaneUnavailableIsSentinel(t *testing.T) {
+	if !errors.Is(fmt.Errorf("wrapped: %w", ErrLaneUnavailable), ErrLaneUnavailable) {
+		t.Fatal("ErrLaneUnavailable must be matchable through wrapping")
+	}
+}

--- a/internal/orchestrator/lane.go
+++ b/internal/orchestrator/lane.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
+)
+
+// escalationThreshold is the number of consecutive circuit trips (with zero
+// intervening provider successes, after at least one earlier success) after
+// which the throttle log escalates from a steady throttling note back to a Warn
+// that the token, valid earlier this session, may now have expired. It mirrors
+// the worker's prior constant of the same name (the classification moved here).
+const escalationThreshold = 5
+
+// Lane wraps a single lyrics provider with its own circuit breaker. It owns the
+// breaker interaction that previously lived inline in the worker: the open-gate
+// short-circuit, the half-open probe note, the throttle classification and
+// trip, the benign-miss reset, and the success/recovery recording. The breaker
+// is provider-agnostic; the rate-limit / auth / renewal classification is
+// per-provider and lives here.
+//
+// A Lane satisfies providers.Fetcher, so the orchestrator (and, with a single
+// lane, the worker) can treat it as a drop-in fetcher.
+type Lane struct {
+	provider providers.LyricsProvider
+	breaker  *circuit.Breaker
+}
+
+// NewLane builds a lane over a named provider and its dedicated breaker.
+func NewLane(provider providers.LyricsProvider, breaker *circuit.Breaker) *Lane {
+	return &Lane{provider: provider, breaker: breaker}
+}
+
+// Name reports the underlying provider's name.
+func (l *Lane) Name() string { return l.provider.Name() }
+
+// Breaker exposes the lane's breaker. It is used by construction (to share the
+// worker's configured breaker) and by tests that assert ramp/recovery state.
+func (l *Lane) Breaker() *circuit.Breaker { return l.breaker }
+
+// FindLyrics drives the lane's breaker around a provider fetch:
+//
+//   - If the breaker is open, it returns ErrLaneUnavailable WITHOUT calling the
+//     provider, so an open lane spends no calls.
+//   - On a benign miss it resets the breaker ramp (a clean miss is a successful
+//     round-trip, not a throttle) and returns the classified miss error.
+//   - On a rate-limit / auth / renewal signal it trips the breaker (or holds the
+//     full renewal window) and returns the classified error after emitting the
+//     honest four-way throttle log.
+//   - On any other (transport) error it returns the error without touching the
+//     breaker (a transport failure is not a throttle signal).
+//   - On success it records the success (recovering the breaker if it was
+//     probing) and returns the song.
+func (l *Lane) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	switch l.breaker.Allow() {
+	case circuit.StateOpen:
+		return models.Song{}, ErrLaneUnavailable
+	case circuit.StateHalfOpen:
+		// Half-open probe: the first real provider call after the window elapsed.
+		slog.Debug("lane circuit half-open; probing provider", "provider", l.Name())
+	case circuit.StateClosed:
+	}
+
+	song, err := l.provider.FindLyrics(ctx, track)
+	if err != nil {
+		return models.Song{}, l.classify(err)
+	}
+
+	if l.breaker.RecordSuccess() {
+		slog.Info("lane circuit closed; provider recovered", "provider", l.Name())
+	}
+	return song, nil
+}
+
+// classify drives the breaker for an error outcome and returns the error
+// unchanged so the orchestrator can rank it. It preserves the worker's prior
+// classification order and honest-401 logging.
+func (l *Lane) classify(err error) error {
+	// A genuine token renewal must be tested BEFORE the bare-401 check: a renewal
+	// also satisfies errors.Is(_, ErrUnauthorized), so testing ErrUnauthorized
+	// first would wrongly fold a renewal into the throttle ramp. A renewal holds
+	// the full window, stays loud, and does NOT advance the throttle counter.
+	if errors.Is(err, musixmatch.ErrTokenRenewalRequired) {
+		res := l.breaker.TripRenewal()
+		slog.Warn("lane circuit opened: token renewal required; regenerate the usertoken",
+			"provider", l.Name(), "backoff", res.Window, "next_retry", res.OpenUntil, "cause", err)
+		return err
+	}
+
+	if errors.Is(err, musixmatch.ErrRateLimited) ||
+		errors.Is(err, musixmatch.ErrUnauthorized) ||
+		errors.Is(err, musixmatch.ErrTruncatedResponse) {
+		res := l.breaker.Trip()
+		switch {
+		case errors.Is(err, musixmatch.ErrTruncatedResponse):
+			slog.Warn("lane circuit opened: provider returned truncated response; likely throttling",
+				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		case l.breaker.EverSucceeded() && res.Trips >= escalationThreshold:
+			slog.Warn("lane circuit opened: token validated earlier this session but has failed repeatedly; it may have expired",
+				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		case l.breaker.EverSucceeded():
+			slog.Warn("lane circuit opened: provider throttling; token validated earlier this session",
+				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		default:
+			slog.Warn("lane circuit opened: no successful fetch yet this session; verify your token",
+				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		}
+		return err
+	}
+
+	if musixmatch.IsBenignMiss(err) {
+		// A clean miss proves the provider round-trip succeeded, so we are not
+		// being throttled: reset the ramp. EverSucceeded is deliberately NOT set
+		// (a miss is a successful round-trip but not a genuine lyric match).
+		if l.breaker.RecordBenignMiss() {
+			slog.Info("lane circuit closed; provider recovered", "provider", l.Name())
+		}
+		return err
+	}
+
+	// Transport / unexpected error: not a throttle signal, leave the breaker
+	// untouched. Wrap for context parity with the prior worker path.
+	return fmt.Errorf("lane %s: find lyrics: %w", l.Name(), err)
+}

--- a/internal/orchestrator/lane_test.go
+++ b/internal/orchestrator/lane_test.go
@@ -1,0 +1,217 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+)
+
+type stubProvider struct {
+	name  string
+	song  models.Song
+	err   error
+	calls int
+}
+
+func (p *stubProvider) Name() string { return p.name }
+func (p *stubProvider) FindLyrics(context.Context, models.Track) (models.Song, error) {
+	p.calls++
+	if p.err != nil {
+		return models.Song{}, p.err
+	}
+	return p.song, nil
+}
+
+func newTestLane(p *stubProvider) (*Lane, *circuit.Breaker) {
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+	return l, cb
+}
+
+func TestLaneOpenBreakerSkipsProvider(t *testing.T) {
+	p := &stubProvider{name: "musixmatch"}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.Trip() // open the breaker
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, ErrLaneUnavailable) {
+		t.Fatalf("err = %v; want ErrLaneUnavailable", err)
+	}
+	if p.calls != 0 {
+		t.Fatalf("provider calls = %d; want 0 (open breaker must not call provider)", p.calls)
+	}
+}
+
+func TestLaneSuccessRecordsSuccess(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "ok"}}}
+	l, cb := newTestLane(p)
+
+	song, err := l.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.Lyrics.LyricsBody != "ok" {
+		t.Fatalf("song body = %q; want ok", song.Lyrics.LyricsBody)
+	}
+	if !cb.EverSucceeded() {
+		t.Fatal("breaker EverSucceeded = false; a genuine fetch must record success")
+	}
+}
+
+func TestLaneBenignMissRecordsBenignMiss(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.Trip()
+	cb.Trip()
+	// Advance past the window so the breaker is half-open (not open): a benign
+	// miss reaching the provider is what resets the ramp.
+	cb.SetClock(func() time.Time { return fixed.Add(2 * time.Hour) })
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound", err)
+	}
+	if cb.Trips() != 0 {
+		t.Fatalf("trips = %d; want 0 (benign miss resets the ramp)", cb.Trips())
+	}
+	if cb.EverSucceeded() {
+		t.Fatal("benign miss must NOT set EverSucceeded")
+	}
+}
+
+func TestLaneRateLimitTripsBreaker(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrRateLimited)}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited", err)
+	}
+	if cb.Trips() != 1 {
+		t.Fatalf("trips = %d; want 1 (rate limit trips the ramp)", cb.Trips())
+	}
+	if cb.OpenUntil().Sub(fixed) != 60*time.Second {
+		t.Fatalf("window = %v; want 60s", cb.OpenUntil().Sub(fixed))
+	}
+}
+
+func TestLaneRenewalHoldsFullCapNoRamp(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired)}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.RecordSuccess()
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrTokenRenewalRequired) {
+		t.Fatalf("err = %v; want ErrTokenRenewalRequired", err)
+	}
+	if cb.OpenUntil().Sub(fixed) != 30*time.Minute {
+		t.Fatalf("window = %v; want 30m (renewal holds full cap)", cb.OpenUntil().Sub(fixed))
+	}
+	if cb.Trips() != 0 {
+		t.Fatalf("trips = %d; want 0 (renewal must not advance the ramp)", cb.Trips())
+	}
+}
+
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+func TestLaneHonest401NoSuccessYet(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	l, _ := newTestLane(p)
+	logs := captureLogs(t, func() {
+		_, _ = l.FindLyrics(context.Background(), models.Track{})
+	})
+	if !strings.Contains(logs, "no successful fetch yet this session") {
+		t.Fatalf("logs = %q; want no-success-yet message", logs)
+	}
+}
+
+func TestLaneHonest401AfterSuccess(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	l, cb := newTestLane(p)
+	cb.RecordSuccess()
+	logs := captureLogs(t, func() {
+		_, _ = l.FindLyrics(context.Background(), models.Track{})
+	})
+	if !strings.Contains(logs, "token validated earlier this session") {
+		t.Fatalf("logs = %q; want throttling-after-success message", logs)
+	}
+}
+
+func TestLaneHonest401EscalatesAfterThreshold(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.RecordSuccess()
+	var logs string
+	for i := 0; i < escalationThreshold; i++ {
+		// Each trip opens the breaker; advance past the window before the next
+		// call so the lane half-opens and actually probes (and trips) again,
+		// mirroring how RunOnce reaches the escalation threshold across cycles.
+		cb.SetClock(func() time.Time { return fixed.Add(time.Duration(i) * time.Hour) })
+		logs = captureLogs(t, func() {
+			_, _ = l.FindLyrics(context.Background(), models.Track{})
+		})
+	}
+	if !strings.Contains(logs, "may have expired") {
+		t.Fatalf("logs = %q; want escalation message at threshold", logs)
+	}
+}
+
+func TestLaneHonest401Truncated(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse)}
+	l, _ := newTestLane(p)
+	logs := captureLogs(t, func() {
+		_, _ = l.FindLyrics(context.Background(), models.Track{})
+	})
+	if !strings.Contains(logs, "truncated response") {
+		t.Fatalf("logs = %q; want truncated-response message", logs)
+	}
+}
+
+func TestLaneRecoveryLogsOnHalfOpenSuccess(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "ok"}}}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.Trip()
+	// Advance past the window so Allow transitions to half-open.
+	cb.SetClock(func() time.Time { return fixed.Add(2 * time.Hour) })
+	logs := captureLogs(t, func() {
+		_, err := l.FindLyrics(context.Background(), models.Track{})
+		if err != nil {
+			t.Fatalf("FindLyrics: %v", err)
+		}
+	})
+	if !strings.Contains(logs, "recovered") {
+		t.Fatalf("logs = %q; want recovery message after half-open success", logs)
+	}
+	if cb.Allow() != circuit.StateClosed {
+		t.Fatalf("breaker state after recovery = %v; want closed", cb.Allow())
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,0 +1,127 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// Mode names the dispatch strategy. Only "ordered" is implemented; "parallel"
+// is reserved by the design (docs/multi-provider-orchestration.md) and rejected
+// by New until built.
+const (
+	// ModeOrdered queries lanes one at a time in priority order and returns the
+	// first suitable result.
+	ModeOrdered = "ordered"
+)
+
+// Orchestrator dispatches a lyrics lookup across an ordered set of provider
+// lanes. With a single Musixmatch lane it is a behavior-preserving pass-through
+// of the worker's prior single-fetch path: the one lane's breaker carries the
+// throttle state, and a suitable / best-available / classified-error result
+// flows back unchanged.
+//
+// It satisfies providers.Fetcher, so the worker can hold it in place of a bare
+// fetcher.
+type Orchestrator struct {
+	lanes []*Lane
+	guard ScriptGuard
+	mode  string
+}
+
+// New builds an ordered orchestrator over lanes in priority order. mode must be
+// "ordered" (the default for an empty string); any other value is rejected,
+// since parallel dispatch is not implemented yet.
+func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
+	if mode == "" {
+		mode = ModeOrdered
+	}
+	if mode != ModeOrdered {
+		return nil, fmt.Errorf("orchestrator: unsupported mode %q (only %q is implemented)", mode, ModeOrdered)
+	}
+	return &Orchestrator{lanes: lanes, mode: mode}, nil
+}
+
+// SetGuard installs the suitability script guard. A nil or disabled guard
+// imposes no script filtering on the suitability decision. The worker keeps its
+// own guard for the terminal policy-rejection path; this guard only governs
+// whether the orchestrator advances to the next lane.
+func (o *Orchestrator) SetGuard(g ScriptGuard) { o.guard = g }
+
+// FindLyrics runs the ordered dispatch:
+//
+//   - Iterate lanes in priority order. Return the first SUITABLE result
+//     immediately (the next lane is never consulted).
+//   - An unavailable (open breaker) or unsuitable lane is skipped; the best
+//     result seen so far (highest quality, possibly instrumental) is retained.
+//   - If no lane yields a suitable result but at least one returned some result,
+//     return that best-available result with a nil error so the worker writes
+//     the instrumental / unsynced fallback.
+//   - If every lane errored, return the highest-precedence error (Gap 4).
+//   - If every available lane's breaker was open, return ErrLaneUnavailable.
+func (o *Orchestrator) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	var (
+		bestSong    models.Song
+		haveBest    bool
+		bestQuality = QualityNone
+
+		topErr   error
+		topClass = OutcomeSuccess
+
+		consulted int
+	)
+
+	for _, lane := range o.lanes {
+		if err := ctx.Err(); err != nil {
+			return models.Song{}, err
+		}
+
+		song, err := lane.FindLyrics(ctx, track)
+		class := ClassifyOutcome(err)
+
+		if class == OutcomeUnavailable {
+			// The breaker was open and the provider was not called. An unavailable
+			// lane does not contribute to error ranking; it only matters when EVERY
+			// lane was unavailable (handled below via consulted == 0).
+			continue
+		}
+		consulted++
+
+		if err == nil {
+			if IsSuitable(song, o.guard) {
+				return song, nil
+			}
+			// Not suitable on its own, but retain it as a best-available fallback
+			// (the highest quality wins; ties keep the earliest, higher-priority lane).
+			if q := QualityOf(song); !haveBest || q > bestQuality {
+				bestSong, bestQuality, haveBest = song, q, true
+			}
+			continue
+		}
+
+		// Track the highest-precedence error across consulted lanes (Gap 4).
+		if topErr == nil || class.precedence() > topClass.precedence() {
+			topErr, topClass = err, class
+		}
+	}
+
+	// A best-available result (instrumental / unsynced / guard-rejected) is
+	// returned ahead of any error: the worker writes the best we have rather than
+	// backing off, exactly as the single-lane path does today.
+	if haveBest {
+		return bestSong, nil
+	}
+
+	// No result at all. If at least one lane was actually consulted, surface the
+	// highest-precedence error. If every lane was unavailable (breaker open),
+	// surface the unavailable sentinel so the worker releases the item.
+	if consulted == 0 && len(o.lanes) > 0 {
+		return models.Song{}, ErrLaneUnavailable
+	}
+	if topErr != nil {
+		return models.Song{}, topErr
+	}
+	// No lanes configured at all.
+	return models.Song{}, ErrLaneUnavailable
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -48,7 +48,10 @@ func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 			return nil, fmt.Errorf("orchestrator: lane %d is nil", i)
 		}
 	}
-	return &Orchestrator{lanes: lanes, mode: mode}, nil
+	// Defensively copy so a caller mutating its slice after construction cannot
+	// alter the orchestrator's dispatch order or inject a nil lane.
+	owned := append([]*Lane(nil), lanes...)
+	return &Orchestrator{lanes: owned, mode: mode}, nil
 }
 
 // SetGuard installs the suitability script guard. A nil or disabled guard

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -40,6 +40,14 @@ func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 	if mode != ModeOrdered {
 		return nil, fmt.Errorf("orchestrator: unsupported mode %q (only %q is implemented)", mode, ModeOrdered)
 	}
+	if len(lanes) == 0 {
+		return nil, fmt.Errorf("orchestrator: at least one lane is required")
+	}
+	for i, l := range lanes {
+		if l == nil {
+			return nil, fmt.Errorf("orchestrator: lane %d is nil", i)
+		}
+	}
 	return &Orchestrator{lanes: lanes, mode: mode}, nil
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,152 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
+)
+
+func laneFor(p *stubProvider) *Lane {
+	return NewLane(p, circuit.New(60*time.Second, 30*time.Minute))
+}
+
+func TestNewModeRejectsUnknown(t *testing.T) {
+	if _, err := New("parallel", nil); err == nil {
+		t.Fatal("New(parallel) should error: only ordered is supported")
+	}
+	if _, err := New("ordered"); err != nil {
+		t.Fatalf("New(ordered): %v", err)
+	}
+	if _, err := New(""); err != nil {
+		t.Fatalf("New(empty) should default to ordered: %v", err)
+	}
+}
+
+func TestOrderedReturnsFirstSuitable(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "primary"}}}
+	p2 := &stubProvider{name: "petitlyrics", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "secondary"}}}
+	o, _ := New("ordered", laneFor(p1), laneFor(p2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.Lyrics.LyricsBody != "primary" {
+		t.Fatalf("body = %q; want primary (first suitable wins)", song.Lyrics.LyricsBody)
+	}
+	if p2.calls != 0 {
+		t.Fatalf("secondary calls = %d; want 0 (primary was suitable)", p2.calls)
+	}
+}
+
+func TestOrderedFallsThroughToSuitable(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	p2 := &stubProvider{name: "petitlyrics", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "secondary"}}}
+	o, _ := New("ordered", laneFor(p1), laneFor(p2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.Lyrics.LyricsBody != "secondary" {
+		t.Fatalf("body = %q; want secondary (primary missed)", song.Lyrics.LyricsBody)
+	}
+}
+
+func TestOrderedSkipsUnsuitableInstrumentalForSyncedLater(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", song: models.Song{Track: models.Track{Instrumental: 1}}}
+	p2 := &stubProvider{name: "petitlyrics", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "hi"}}}}}
+	o, _ := New("ordered", laneFor(p1), laneFor(p2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualitySynced {
+		t.Fatalf("quality = %v; want synced (instrumental is not suitable, synced lane wins)", QualityOf(song))
+	}
+}
+
+func TestOrderedReturnsBestAvailableWhenNoSuitable(t *testing.T) {
+	// No lane is suitable; the best available (instrumental) must be returned with
+	// a nil error so the worker writes the instrumental marker.
+	p1 := &stubProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	p2 := &stubProvider{name: "petitlyrics", song: models.Song{Track: models.Track{Instrumental: 1}}}
+	o, _ := New("ordered", laneFor(p1), laneFor(p2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v (best-available instrumental should return nil err)", err)
+	}
+	if QualityOf(song) != QualityInstrumental {
+		t.Fatalf("quality = %v; want instrumental (best available)", QualityOf(song))
+	}
+}
+
+func TestOrderedReturnsBenignMissWhenAllMiss(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	o, _ := New("ordered", laneFor(p1))
+
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound (all lanes missed)", err)
+	}
+}
+
+func TestOrderedAuthOutranksBenignMiss(t *testing.T) {
+	// Primary throttles, secondary misses. The auth/rate-limit signal must win so
+	// the worker backs off rather than recording a stable miss.
+	p1 := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrRateLimited)}
+	p2 := &stubProvider{name: "petitlyrics", err: musixmatch.ErrNotFound}
+	o, _ := New("ordered", laneFor(p1), laneFor(p2))
+
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited (auth outranks benign miss)", err)
+	}
+}
+
+func TestOrderedAllUnavailableReturnsSentinel(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrRateLimited)}
+	l1 := laneFor(p1)
+	fixed := time.Now()
+	l1.Breaker().SetClock(func() time.Time { return fixed })
+	l1.Breaker().Trip() // open it
+
+	o, _ := New("ordered", l1)
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, ErrLaneUnavailable) {
+		t.Fatalf("err = %v; want ErrLaneUnavailable (all lanes' breakers open)", err)
+	}
+	if p1.calls != 0 {
+		t.Fatalf("provider calls = %d; want 0 (open breaker)", p1.calls)
+	}
+}
+
+func TestOrderedGuardRejectionIsUnsuitable(t *testing.T) {
+	// A synced result the guard rejects is not suitable. With no fallback lane the
+	// orchestrator has no suitable and no better-than-none result, so it returns
+	// the result as best-available (the worker's guard re-check then handles the
+	// terminal policy rejection, preserving current single-lane behavior).
+	p1 := &stubProvider{name: "musixmatch", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}}}}
+	o, _ := New("ordered", laneFor(p1))
+	o.SetGuard(acceptGuard{enabled: true, accept: false})
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualitySynced {
+		t.Fatalf("quality = %v; want synced returned as best-available", QualityOf(song))
+	}
+}
+
+// Ensure the orchestrator satisfies providers.Fetcher (drop-in for the worker).
+var _ providers.Fetcher = (*Orchestrator)(nil)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -43,6 +43,23 @@ func TestNewValidatesLanes(t *testing.T) {
 	}
 }
 
+func TestNewCopiesLanes(t *testing.T) {
+	p := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "primary"}}}
+	lanes := []*Lane{laneFor(p)}
+	o, err := New("ordered", lanes...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	lanes[0] = nil // mutate the caller's slice after construction
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics after caller mutated its slice: %v", err)
+	}
+	if song.Lyrics.LyricsBody != "primary" {
+		t.Fatalf("body = %q; want primary (orchestrator must use its own lane copy)", song.Lyrics.LyricsBody)
+	}
+}
+
 func TestOrderedReturnsFirstSuitable(t *testing.T) {
 	p1 := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "primary"}}}
 	p2 := &stubProvider{name: "petitlyrics", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "secondary"}}}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -18,14 +18,28 @@ func laneFor(p *stubProvider) *Lane {
 }
 
 func TestNewModeRejectsUnknown(t *testing.T) {
-	if _, err := New("parallel", nil); err == nil {
+	p := &stubProvider{name: "musixmatch"}
+	if _, err := New("parallel", laneFor(p)); err == nil {
 		t.Fatal("New(parallel) should error: only ordered is supported")
 	}
-	if _, err := New("ordered"); err != nil {
+	if _, err := New("ordered", laneFor(p)); err != nil {
 		t.Fatalf("New(ordered): %v", err)
 	}
-	if _, err := New(""); err != nil {
+	if _, err := New("", laneFor(p)); err != nil {
 		t.Fatalf("New(empty) should default to ordered: %v", err)
+	}
+}
+
+func TestNewValidatesLanes(t *testing.T) {
+	if _, err := New("ordered"); err == nil {
+		t.Fatal("New with no lanes should error (avoids a nil dispatch)")
+	}
+	if _, err := New("ordered", nil); err == nil {
+		t.Fatal("New with a nil lane should error")
+	}
+	p := &stubProvider{name: "musixmatch"}
+	if _, err := New("ordered", laneFor(p), nil); err == nil {
+		t.Fatal("New with a nil lane among valid lanes should error")
 	}
 }
 

--- a/internal/orchestrator/suitability.go
+++ b/internal/orchestrator/suitability.go
@@ -1,0 +1,65 @@
+package orchestrator
+
+import "github.com/sydlexius/mxlrcgo-svc/internal/models"
+
+// Quality ranks a lyric result by usefulness. A higher value is strictly
+// better: synced > unsynced > instrumental > none. The orchestrator uses it to
+// pick the best-available fallback when no lane yields a suitable result.
+type Quality int
+
+const (
+	// QualityNone means the result carries no usable lyrics and is not even an
+	// instrumental marker (empty body, no synced lines, not flagged instrumental).
+	QualityNone Quality = iota
+	// QualityInstrumental means the track is flagged instrumental but carries no
+	// lyric text. It is a valid best-available final output (the worker writes the
+	// instrumental marker) but is NOT suitable on its own (see IsSuitable).
+	QualityInstrumental
+	// QualityUnsynced means the result carries an unsynced lyric body.
+	QualityUnsynced
+	// QualitySynced means the result carries time-synced subtitle lines.
+	QualitySynced
+)
+
+// QualityOf classifies a song's lyric quality. The precedence mirrors the LRC
+// writer's content selection (synced lines, then an unsynced body, then an
+// instrumental marker), so the orchestrator's ranking agrees with what the
+// writer will actually emit.
+func QualityOf(song models.Song) Quality {
+	switch {
+	case len(song.Subtitles.Lines) > 0:
+		return QualitySynced
+	case song.Lyrics.LyricsBody != "":
+		return QualityUnsynced
+	case song.Track.Instrumental == 1:
+		return QualityInstrumental
+	default:
+		return QualityNone
+	}
+}
+
+// ScriptGuard rejects lyric results whose body is dominated by scripts outside
+// a configured allowlist. It matches worker.ScriptGuard so the same concrete
+// guard (internal/langguard) satisfies both. A nil guard, or one whose Enabled
+// reports false, imposes no filtering.
+type ScriptGuard interface {
+	Accept(models.Song) (bool, string)
+	Enabled() bool
+}
+
+// IsSuitable reports whether a song is good enough to commit as the dispatch's
+// result without consulting further lanes. A result is suitable iff the script
+// guard passes (a nil or disabled guard always passes) AND its quality is at
+// least unsynced. An instrumental marker or an empty body is never suitable on
+// its own: it is retained only as a best-available fallback by the orchestrator.
+func IsSuitable(song models.Song, guard ScriptGuard) bool {
+	if QualityOf(song) < QualityUnsynced {
+		return false
+	}
+	if guard != nil && guard.Enabled() {
+		if ok, _ := guard.Accept(song); !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/orchestrator/suitability_test.go
+++ b/internal/orchestrator/suitability_test.go
@@ -1,0 +1,100 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func syncedSong() models.Song {
+	return models.Song{
+		Track:     models.Track{ArtistName: "A", TrackName: "T"},
+		Subtitles: models.Synced{Lines: []models.Lines{{Text: "la la"}}},
+	}
+}
+
+func unsyncedSong() models.Song {
+	return models.Song{
+		Track:  models.Track{ArtistName: "A", TrackName: "T"},
+		Lyrics: models.Lyrics{LyricsBody: "la la"},
+	}
+}
+
+func instrumentalSong() models.Song {
+	return models.Song{Track: models.Track{ArtistName: "A", TrackName: "T", Instrumental: 1}}
+}
+
+func emptySong() models.Song {
+	return models.Song{Track: models.Track{ArtistName: "A", TrackName: "T"}}
+}
+
+func TestQualityOf(t *testing.T) {
+	tests := []struct {
+		name string
+		song models.Song
+		want Quality
+	}{
+		{"synced", syncedSong(), QualitySynced},
+		{"unsynced", unsyncedSong(), QualityUnsynced},
+		{"instrumental", instrumentalSong(), QualityInstrumental},
+		{"none", emptySong(), QualityNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := QualityOf(tt.song); got != tt.want {
+				t.Fatalf("QualityOf(%s) = %v; want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQualityOrdering(t *testing.T) {
+	if QualitySynced <= QualityUnsynced || QualityUnsynced <= QualityInstrumental || QualityInstrumental <= QualityNone {
+		t.Fatalf("quality ordering broken: synced=%d unsynced=%d instrumental=%d none=%d",
+			QualitySynced, QualityUnsynced, QualityInstrumental, QualityNone)
+	}
+}
+
+// acceptGuard accepts iff accept is true and Enabled reports true.
+type acceptGuard struct {
+	enabled bool
+	accept  bool
+}
+
+func (g acceptGuard) Enabled() bool { return g.enabled }
+func (g acceptGuard) Accept(models.Song) (bool, string) {
+	if g.accept {
+		return true, ""
+	}
+	return false, "rejected"
+}
+
+func TestIsSuitable(t *testing.T) {
+	enabledAccept := acceptGuard{enabled: true, accept: true}
+	enabledReject := acceptGuard{enabled: true, accept: false}
+	disabled := acceptGuard{enabled: false}
+
+	tests := []struct {
+		name  string
+		song  models.Song
+		guard ScriptGuard
+		want  bool
+	}{
+		{"synced passes nil guard", syncedSong(), nil, true},
+		{"unsynced passes nil guard", unsyncedSong(), nil, true},
+		{"instrumental not suitable", instrumentalSong(), nil, false},
+		{"none not suitable", emptySong(), nil, false},
+		{"synced passes disabled guard", syncedSong(), disabled, true},
+		{"synced passes enabled accepting guard", syncedSong(), enabledAccept, true},
+		{"synced rejected by guard", syncedSong(), enabledReject, false},
+		{"unsynced rejected by guard", unsyncedSong(), enabledReject, false},
+		{"instrumental rejected even if guard accepts", instrumentalSong(), enabledAccept, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSuitable(tt.song, tt.guard); got != tt.want {
+				t.Fatalf("IsSuitable(%s) = %v; want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -15,6 +15,8 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
+	"github.com/sydlexius/mxlrcgo-svc/internal/orchestrator"
+	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 )
@@ -75,9 +77,19 @@ const escalationThreshold = 5
 // concurrency-safe internal/circuit.Breaker, so it is already safe for the
 // per-provider concurrency that motivated the extraction.
 type Worker struct {
-	queue                 Queue
-	cache                 Cache
-	fetcher               musixmatch.Fetcher
+	queue Queue
+	cache Cache
+	// orch dispatches the lyrics lookup across one or more provider lanes. With a
+	// single Musixmatch lane (the only deployment today) it is a behavior-
+	// preserving pass-through of the prior single-fetch path. The lane owns the
+	// circuit interaction (open gate, half-open probe, trip, success/benign-miss
+	// reset, throttle classification and logging); the worker maps the
+	// orchestrator's outcome onto its queue side-effects.
+	orch *orchestrator.Orchestrator
+	// lane is the single Musixmatch lane held by orch. The worker keeps a direct
+	// reference so the throttle queue side-effects (release, stale-failure reset)
+	// can read the lane's breaker outcome; it shares w.circuit.
+	lane                  *orchestrator.Lane
 	writer                lyrics.Writer
 	verifier              verification.Verifier
 	verifyBelowConfidence float64
@@ -113,10 +125,18 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 	now := time.Now
 	cb := circuit.New(defaultCircuitBackoffBase, defaultCircuitOpenDuration)
 	cb.SetClock(now)
+	// Wrap the injected fetcher as the single Musixmatch lane sharing this
+	// breaker, and build an ordered orchestrator over it. With one lane this is a
+	// pass-through; the lane owns the circuit interaction the worker previously
+	// drove inline. orchestrator.New only errors on an unknown mode, and
+	// ModeOrdered is a constant, so the error is impossible here.
+	lane := orchestrator.NewLane(providers.New(providers.Musixmatch, fetcher), cb)
+	orch, _ := orchestrator.New(orchestrator.ModeOrdered, lane)
 	return &Worker{
 		queue:                 q,
 		cache:                 c,
-		fetcher:               fetcher,
+		orch:                  orch,
+		lane:                  lane,
 		writer:                writer,
 		verifyBelowConfidence: 0.85,
 		baseBackoff:           backoff.DefaultBase,
@@ -208,6 +228,13 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 // results whose script mix falls outside the configured allowlist.
 func (w *Worker) EnableGuard(g ScriptGuard) {
 	w.scriptGuard = g
+	// The orchestrator's suitability guard is deliberately left unset here. With a
+	// single lane there is no fall-through decision for it to make, and setting it
+	// would screen every result twice (once for suitability, once for the worker's
+	// terminal policy check below). The worker's own guard therefore stays the
+	// single screening point, preserving exactly-one Accept call per result.
+	// Wiring w.orch.SetGuard belongs with the change that adds a second lane, where
+	// the guard genuinely governs whether to advance to the next provider.
 }
 
 // guardReject reports whether the script guard rejects this song. It returns
@@ -314,11 +341,26 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 
 	song, cacheHit, err := w.song(ctx, resolvedTrack)
 	if err != nil {
-		if tripped, releaseErr := w.tripCircuitIfRateLimited(ctx, item, err); tripped {
-			if releaseErr != nil {
+		switch orchestrator.ClassifyOutcome(err) {
+		case orchestrator.OutcomeUnavailable:
+			// Every available lane's breaker was open, so no lane was consulted.
+			// Release the item back to pending with no failure increment (the
+			// catalog answer is unknown) and idle, exactly like the open-gate path.
+			if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
+				return fmt.Errorf("worker: release item %d after lanes unavailable: %w", item.ID, releaseErr)
+			}
+			return errQueueEmpty
+		case orchestrator.OutcomeAuthRateLimit:
+			// A throttle / auth / renewal signal. The lane already tripped its
+			// breaker and emitted the honest classification log; the worker only
+			// performs the queue side-effects: clear stale failure state (a
+			// throttle is not the song's fault) and release the item to pending.
+			if releaseErr := w.releaseAfterThrottle(ctx, item); releaseErr != nil {
 				return releaseErr
 			}
 			return errQueueEmpty
+		case orchestrator.OutcomeSuccess, orchestrator.OutcomeBenignMiss, orchestrator.OutcomeTransport:
+			// Fall through to the miss / failure handling below.
 		}
 		// A no-result (no matching track, or a match with no usable lyrics) is
 		// not our failure and does NOT retire the queue row: the catalog grows
@@ -334,14 +376,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			}
 			// Reset only after the deferral is durably recorded: if requeueDeferred
 			// failed above we keep the failure state so backoff still applies next run.
+			// The lane already reset the circuit ramp for this benign miss (a clean
+			// round-trip proves we are not throttled); the worker only owns the
+			// consecutive-failure counter here.
 			w.consecutiveFailures = 0
-			// A clean benign miss proves the provider round-trip succeeded, so we
-			// are not being throttled: reset the circuit ramp too. (EverSucceeded is
-			// deliberately NOT set here -- it tracks genuine lyric matches, and a
-			// miss is a successful round-trip but not a match.)
-			if w.circuit.RecordBenignMiss() {
-				slog.Info("worker circuit closed; provider recovered")
-			}
 			return nil
 		}
 		slog.Warn("worker song resolution failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", err)
@@ -350,15 +388,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	confidence := Confidence(item.Inputs.Track, song.Track)
 	slog.Debug("worker lyrics match", "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "cache_hit", cacheHit)
 	if !cacheHit {
-		// A non-cache provider fetch succeeded: the token is proven good this
-		// session (a later bare 401 is throttling, not a dead token), so record the
-		// success and recover the circuit NOW, before downstream processing. The
-		// verify/guard/store steps below are not throttle signals; their failures
-		// continue through the normal queue backoff path, but the breaker must not
-		// forget that the fetch itself worked just because a later step failed.
-		if w.circuit.RecordSuccess() {
-			slog.Info("worker circuit closed; provider recovered")
-		}
+		// A non-cache provider fetch succeeded: the lane already recorded the
+		// success and recovered its breaker inside FindLyrics (before any
+		// downstream step), so a later bare 401 is correctly read as throttling
+		// rather than a dead token, and a verify/guard/store failure below does not
+		// make the breaker forget the fetch itself worked.
 		if err := w.verify(ctx, item, song, confidence); err != nil {
 			slog.Warn("worker verification failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "error", err)
 			return w.fail(ctx, item, err)
@@ -447,15 +481,17 @@ func (w *Worker) song(ctx context.Context, track models.Track) (models.Song, boo
 		return models.Song{}, false, fmt.Errorf("worker: lookup fallback cache: %w", err)
 	}
 
-	if w.circuit.Allow() == circuit.StateHalfOpen {
-		// Half-open probe: the first real provider call after the circuit window
-		// elapsed. Logged here (not at the gate) so it reflects an actual attempt
-		// rather than a bare ticker tick that found an empty queue.
-		slog.Debug("worker circuit half-open; probing provider")
-	}
-	song, err := w.fetcher.FindLyrics(ctx, track)
+	// Dispatch through the orchestrator. The lane owns the circuit interaction:
+	// it short-circuits an open breaker (returning orchestrator.ErrLaneUnavailable
+	// without calling the provider), emits the half-open probe note, trips on a
+	// throttle, resets the ramp on a benign miss, and records success. The worker
+	// only maps the returned outcome onto its queue side-effects (see RunOnce).
+	// The orchestrator returns the best-available result (possibly instrumental)
+	// when no lane is suitable, so the worker still writes the instrumental marker
+	// fallback exactly as before.
+	song, err := w.orch.FindLyrics(ctx, track)
 	if err != nil {
-		return models.Song{}, false, fmt.Errorf("worker: find lyrics: %w", err)
+		return models.Song{}, false, err
 	}
 	return song, false, nil
 }
@@ -471,68 +507,25 @@ func (w *Worker) store(ctx context.Context, track models.Track, song models.Song
 	return nil
 }
 
-// tripCircuitIfRateLimited inspects the fetcher error for the upstream
-// rate-limit / unauthorized sentinels and, if matched, opens the circuit
-// breaker and releases the dequeued item back to the pending pool. The
-// first return value reports whether the error was a rate-limit signal
-// (and therefore the caller must NOT call w.fail on the item). The second
-// return value is non-nil when Release failed, in which case the item is
-// orphaned in 'processing' and RunOnce must surface the failure to the
-// outer loop rather than swallow it as errQueueEmpty.
+// releaseAfterThrottle performs the queue side-effects for a throttle / auth /
+// renewal outcome whose breaker the lane has ALREADY tripped and logged: it
+// clears the stale consecutive-failure state (a throttle is not the song's
+// fault, and the circuit's geometric ramp is the backoff mechanism) and
+// releases the dequeued item back to the pending pool. A non-nil return means
+// Release failed and the item is orphaned in 'processing', so RunOnce must
+// surface the failure to the outer loop rather than swallow it as errQueueEmpty.
 //
-// The breaker state mutation (window, ramp, probing) lives in the
-// internal/circuit.Breaker; this method only classifies the error, drives the
-// breaker, emits the operator-facing logs, and releases the item.
-func (w *Worker) tripCircuitIfRateLimited(ctx context.Context, item queue.WorkItem, err error) (bool, error) {
-	// Case 1 MUST precede the bare-401 check below: tokenRenewalError also
-	// satisfies errors.Is(_, ErrUnauthorized), so testing ErrUnauthorized first
-	// would wrongly fold a genuine renewal into the throttle ramp. A renewal is
-	// not throttling: hold the full window, stay loud, and do NOT advance the
-	// throttle counter (so a later real throttle resumes from its true position).
-	if errors.Is(err, musixmatch.ErrTokenRenewalRequired) {
-		res := w.circuit.TripRenewal()
-		// Renewal is not a per-song failure, so consecutiveFailures/lastFail* are
-		// left untouched.
-		slog.Warn("worker circuit opened: token renewal required; regenerate the usertoken",
-			"backoff", res.Window, "next_retry", res.OpenUntil, "id", item.ID, "cause", err)
-		if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
-			return true, fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)
-		}
-		return true, nil
-	}
-	if !errors.Is(err, musixmatch.ErrRateLimited) &&
-		!errors.Is(err, musixmatch.ErrUnauthorized) &&
-		!errors.Is(err, musixmatch.ErrTruncatedResponse) {
-		return false, nil
-	}
-	// Bare 401 / 429 / truncated body: treat as throttling and ramp the window
-	// geometrically. The log level reflects what we actually know this session.
-	res := w.circuit.Trip()
-	// Reset stale failure state: a throttle is not the song's fault, and the
-	// circuit's geometric ramp is the backoff mechanism. The separate
-	// consecutive-failure WARN must not keep naming a stale victim.
+// The breaker classification, ramp, and operator-facing logs now live in the
+// lane (internal/orchestrator.Lane); this method owns only the queue effects.
+func (w *Worker) releaseAfterThrottle(ctx context.Context, item queue.WorkItem) error {
 	w.consecutiveFailures = 0
 	w.lastFailID = 0
 	w.lastFailArtist = ""
 	w.lastFailTrack = ""
-	switch {
-	case errors.Is(err, musixmatch.ErrTruncatedResponse):
-		slog.Warn("worker circuit opened: provider returned truncated response; likely throttling",
-			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
-	case w.circuit.EverSucceeded() && res.Trips >= escalationThreshold:
-		slog.Warn("worker circuit opened: token validated earlier this session but has failed repeatedly; it may have expired",
-			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
-	case w.circuit.EverSucceeded():
-		slog.Warn("worker circuit opened: provider throttling; token validated earlier this session",
-			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
-	default:
-		slog.Warn("worker circuit opened: no successful fetch yet this session; verify your token",
-			"trips", res.Trips, "id", item.ID, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
-	}
 	if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
-		return true, fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)
+		return fmt.Errorf("worker: release item %d after circuit open: %w", item.ID, releaseErr)
 	}
-	return true, nil
+	return nil
 }
 
 func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) error {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/orchestrator"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 )
@@ -1104,32 +1105,52 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 }
 
 // newCircuitWorker builds a worker with a frozen clock and base=60s / cap=30m
-// for directly exercising tripCircuitIfRateLimited without driving RunOnce.
-func newCircuitWorker() (*Worker, *fakeQueue, time.Time) {
+// for directly exercising the lane's throttle classification (formerly the
+// worker's tripCircuitIfRateLimited) via tripViaLane, without driving full
+// RunOnce. The returned fakeFetcher is the lane's provider.
+func newCircuitWorker() (*Worker, *fakeQueue, *fakeFetcher, time.Time) {
 	q := &fakeQueue{}
-	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	f := &fakeFetcher{}
+	w := New(q, &fakeCache{}, f, &fakeWriter{})
 	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 	w.setClock(func() time.Time { return fixed })
 	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
-	return w, q, fixed
+	return w, q, f, fixed
+}
+
+func tripViaLane(w *Worker, f *fakeFetcher, item queue.WorkItem, err error) (bool, error) {
+	f.err = err
+	if ou := w.circuit.OpenUntil(); !ou.IsZero() {
+		w.setClock(func() time.Time { return ou.Add(time.Nanosecond) })
+	}
+	_, ferr := w.lane.FindLyrics(context.Background(), item.Inputs.Track)
+	if orchestrator.ClassifyOutcome(ferr) == orchestrator.OutcomeAuthRateLimit {
+		return true, w.releaseAfterThrottle(context.Background(), item)
+	}
+	return false, nil
 }
 
 func TestCircuitRampIncrementsAndCaps(t *testing.T) {
-	w, _, fixed := newCircuitWorker()
+	w, _, f, _ := newCircuitWorker()
 	item := queue.WorkItem{ID: 1}
 	throttle := fmt.Errorf("upstream: %w", musixmatch.ErrRateLimited)
 
 	// trip 6 reaches the cap: 60 -> 120 -> 240 -> 480 -> 960 -> 1800 (capped).
-	wantDeltas := []time.Duration{
+	// Ported from the inline tripCircuitIfRateLimited (no open gate) to drive the
+	// lane (which enforces the open gate): tripViaLane advances the clock past
+	// each window before the next probe, so the geometric ramp is asserted as the
+	// WINDOW size measured from the clock at the moment of the trip, not relative
+	// to a single frozen base. Equivalent ramp/cap assertion.
+	wantWindows := []time.Duration{
 		60 * time.Second, 120 * time.Second, 240 * time.Second,
 		480 * time.Second, 960 * time.Second, 30 * time.Minute,
 	}
-	for i, want := range wantDeltas {
-		tripped, releaseErr := w.tripCircuitIfRateLimited(context.Background(), item, throttle)
+	for i, want := range wantWindows {
+		tripped, releaseErr := tripViaLane(w, f, item, throttle)
 		if !tripped || releaseErr != nil {
 			t.Fatalf("trip %d: tripped=%v releaseErr=%v; want tripped, no error", i+1, tripped, releaseErr)
 		}
-		if got := w.circuit.OpenUntil().Sub(fixed); got != want {
+		if got := w.circuit.OpenUntil().Sub(w.now()); got != want {
 			t.Fatalf("trip %d: window = %v; want %v", i+1, got, want)
 		}
 		if w.circuit.Trips() != i+1 {
@@ -1140,10 +1161,10 @@ func TestCircuitRampIncrementsAndCaps(t *testing.T) {
 
 func TestThrottleAfterSuccessLogsWarn(t *testing.T) {
 	recs := captureLogs(t)
-	w, _, fixed := newCircuitWorker()
+	w, _, f, fixed := newCircuitWorker()
 	w.circuit.RecordSuccess()
 
-	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
+	tripViaLane(w, f, queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
 
 	if !hasLog(*recs, slog.LevelWarn, "provider throttling") {
 		t.Fatalf("logs = %+v; want Warn 'provider throttling' after a validated session", *recs)
@@ -1166,9 +1187,9 @@ func TestThrottleAfterSuccessLogsWarn(t *testing.T) {
 
 func TestThrottleBeforeAnySuccessLogsWarn(t *testing.T) {
 	recs := captureLogs(t)
-	w, _, _ := newCircuitWorker()
+	w, _, f, _ := newCircuitWorker()
 
-	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
+	tripViaLane(w, f, queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
 
 	if !hasLog(*recs, slog.LevelWarn, "no successful fetch yet") {
 		t.Fatalf("logs = %+v; want Warn advising token verification before any success", *recs)
@@ -1177,12 +1198,12 @@ func TestThrottleBeforeAnySuccessLogsWarn(t *testing.T) {
 
 func TestEscalationWarnAfterThreshold(t *testing.T) {
 	recs := captureLogs(t)
-	w, _, _ := newCircuitWorker()
+	w, _, f, _ := newCircuitWorker()
 	w.circuit.RecordSuccess()
 	throttle := fmt.Errorf("x: %w", musixmatch.ErrRateLimited)
 
 	for i := 0; i < escalationThreshold; i++ {
-		w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, throttle)
+		tripViaLane(w, f, queue.WorkItem{ID: 1}, throttle)
 	}
 
 	if w.circuit.Trips() != escalationThreshold {
@@ -1195,12 +1216,12 @@ func TestEscalationWarnAfterThreshold(t *testing.T) {
 
 func TestRenewalHoldsFullCapAndDoesNotIncrementTrips(t *testing.T) {
 	recs := captureLogs(t)
-	w, q, fixed := newCircuitWorker()
+	w, q, f, fixed := newCircuitWorker()
 	// A genuine renewal is loud even after earlier success.
 	w.circuit.RecordSuccess()
 	renewal := fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired)
 
-	tripped, releaseErr := w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 7}, renewal)
+	tripped, releaseErr := tripViaLane(w, f, queue.WorkItem{ID: 7}, renewal)
 	if !tripped || releaseErr != nil {
 		t.Fatalf("tripped=%v releaseErr=%v; want tripped, no error", tripped, releaseErr)
 	}
@@ -1221,19 +1242,20 @@ func TestRenewalHoldsFullCapAndDoesNotIncrementTrips(t *testing.T) {
 	}
 
 	// A subsequent bare-401 throttle starts the ramp at the base, proving the
-	// renewal left the ramp position untouched.
-	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 8}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
-	if got := w.circuit.OpenUntil().Sub(fixed); got != 60*time.Second {
+	// renewal left the ramp position untouched. tripViaLane advances the clock
+	// past the renewal window first, so assert the WINDOW size from the trip clock.
+	tripViaLane(w, f, queue.WorkItem{ID: 8}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
+	if got := w.circuit.OpenUntil().Sub(w.now()); got != 60*time.Second {
 		t.Fatalf("post-renewal throttle window = %v; want base 60s (ramp position preserved)", got)
 	}
 }
 
 func TestRenewalReleaseErrorIsSurfaced(t *testing.T) {
-	w, q, _ := newCircuitWorker()
+	w, q, f, _ := newCircuitWorker()
 	q.releaseErr = errors.New("release boom")
 	renewal := fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired)
 
-	tripped, releaseErr := w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 7}, renewal)
+	tripped, releaseErr := tripViaLane(w, f, queue.WorkItem{ID: 7}, renewal)
 	if !tripped {
 		t.Fatal("tripped = false; want true (renewal still opens the circuit)")
 	}
@@ -1359,7 +1381,7 @@ func TestRunOnceSurfacesReleaseFailureAfterCircuitTrip(t *testing.T) {
 }
 
 func TestThrottleResetsStaleFailureState(t *testing.T) {
-	w, _, _ := newCircuitWorker()
+	w, _, f, _ := newCircuitWorker()
 	// Simulate a prior hard failure having pinned the consecutive-failure WARN
 	// onto a now-stale victim.
 	w.consecutiveFailures = 4
@@ -1367,7 +1389,7 @@ func TestThrottleResetsStaleFailureState(t *testing.T) {
 	w.lastFailArtist = "Stale Artist"
 	w.lastFailTrack = "Stale Track"
 
-	w.tripCircuitIfRateLimited(context.Background(), queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
+	tripViaLane(w, f, queue.WorkItem{ID: 1}, fmt.Errorf("x: %w", musixmatch.ErrUnauthorized))
 
 	if w.consecutiveFailures != 0 {
 		t.Fatalf("consecutiveFailures = %d; want 0 (a throttle is not the song's fault)", w.consecutiveFailures)


### PR DESCRIPTION
## Summary

Introduces the provider-lane abstraction and an orchestrator with ordered-fallback dispatch, wrapping Musixmatch as a single lane, with no behavior change for the existing single-provider deployment. Second of four sequenced orchestration issues (#173 done -> #174 -> #175 -> #176). Implements the core of the #148 design.

New `internal/orchestrator/` package (TDD, 95.2% coverage):
- **Lane** - wraps a `providers.LyricsProvider` + its own `*circuit.Breaker` (from #173). `FindLyrics` short-circuits with `ErrLaneUnavailable` when the breaker is open, otherwise calls the provider and drives `Trip`/`TripRenewal`/`RecordBenignMiss`/`RecordSuccess`. The Musixmatch-specific error classification (formerly the worker's `tripCircuitIfRateLimited`) and the honest-401 four-way logging moved here, keeping the breaker provider-agnostic.
- **Suitability** - `Quality` rank (synced > unsynced > instrumental > none); `IsSuitable` returns true only when the guard passes AND quality is synced or unsynced (instrumental/none are NOT suitable on their own, per the design - they are retained as best-available output, not as a stop-fallback signal).
- **Error precedence** (Gap 4) - auth/rate-limit > transport > benign-miss; an all-lanes-open condition surfaces a distinct unavailable outcome.
- **Orchestrator** - ordered dispatch over lanes; returns the first suitable result, else the best-available result (so an instrumental still gets written), else the highest-precedence error; satisfies `providers.Fetcher` for drop-in worker injection.

Config: `[providers] mode` (default `ordered`, env `MXLRC_PROVIDERS_MODE`, validated). The worker now dispatches through the orchestrator (one Musixmatch lane); the circuit interaction left the worker entirely.

## Behavior preservation
- Single-Musixmatch behavior is identical: benign-miss deferral, rate-limit backoff, honest-401 classification (same message distinctions, now logged with `provider` rather than item id), half-open probe recovery, and exactly-one-write via the unchanged `queue.Complete` CAS.
- All existing `internal/worker` tests pass; circuit tests that drove the worker's old inline method were ported to drive the lane with equivalent assertions (not weakened).
- `make gate` green; `go test -race ./...` clean.

## Reviewer notes (two judgment calls)
1. The orchestrator guard is intentionally NOT wired into the single-lane worker yet - the worker's own guard remains the single screening point (avoids double-`Accept`, preserves the terminal-rejection test). `Orchestrator.SetGuard` exists and is unit-tested, to be wired in #175 when a second lane needs guard-based fallback decisions.
2. The lane/orchestrator is constructed in `worker.New` (keeping its signature and tests stable) rather than `commands.selectedProvider`.

Closes #174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added `providers.mode` configuration setting to control multi-provider query behavior
  - Implemented automatic provider health management and recovery
  - Enhanced lyric result selection with quality-based prioritization

* **Tests**
  - Added comprehensive test coverage for provider orchestration and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->