### PR TITLE
feat(orchestrator): parallel-race dispatch mode + race_wait_seconds (#176)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -5,7 +5,8 @@
 # MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_OUTPUT_DIR,
 # MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY,
 # MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE,
-# MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_QUEUE_RANDOMIZE,
+# MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER,
+# MXLRC_QUEUE_RANDOMIZE,
 # MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL,
 # MXLRC_VERIFICATION_FFMPEG_PATH,
 # MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_MIN_CONFIDENCE,
@@ -117,16 +118,31 @@ primary = "musixmatch"
 # Provider names to disable explicitly.
 disabled = []
 
-# Multi-provider dispatch mode. Only "ordered" is implemented today: lanes are
-# queried in priority order and the first suitable result (passes the script
-# guard and carries synced or unsynced lyrics) wins; the next lane is consulted
-# on a miss, an unsuitable result, or a provider error (a rate-limit/auth or
-# transport error falls through to the next lane, and the highest-precedence
-# error is returned only if every lane fails). The "parallel" race is reserved by
-# docs/multi-provider-orchestration.md and not yet built; any value other than
-# "ordered" is rejected at load. With a single provider this setting has no
+# Multi-provider dispatch mode: "ordered" (default) or "parallel".
+#   "ordered": lanes are queried in priority order and the first suitable result
+#     (passes the script guard and carries synced or unsynced lyrics) wins; the
+#     next lane is consulted on a miss, an unsuitable result, or a provider error
+#     (a rate-limit/auth or transport error falls through to the next lane, and
+#     the highest-precedence error is returned only if every lane fails).
+#   "parallel": every available lane is dispatched concurrently and raced. The
+#     first synced result wins immediately; a faster unsynced result is held for
+#     up to race_wait_seconds so a slower synced result can preempt it (see
+#     below). Parallel makes MORE upstream calls (one per lane per lookup), so it
+#     is not advised against rate-limited providers (e.g. Musixmatch) unless
+#     latency matters more than call volume.
+# Any other value is rejected at load. With a single provider this setting has no
 # observable effect. Override: MXLRC_PROVIDERS_MODE. Default "ordered".
 mode = "ordered"
+
+# Parallel-mode upgrade window, in whole seconds. After a suitable unsynced result
+# arrives, the orchestrator waits up to this long for a synced result (a strict
+# quality upgrade) to preempt it before committing the unsynced one. A synced
+# result that arrives first always wins immediately, and a held unsynced result is
+# committed at once when no other lane can still upgrade it, so this only adds
+# latency when an unsynced result is in hand and a synced one may still arrive.
+# Non-positive values are clamped to the default. Only consulted in "parallel"
+# mode. Override: MXLRC_PROVIDERS_RACE_WAIT_SECONDS. Default 2.
+race_wait_seconds = 2
 
 # Fallback provider order: providers consulted, in order, AFTER `primary` when
 # the primary yields no suitable result (a miss, an unsuitable result, or a

--- a/docs/multi-provider-orchestration.md
+++ b/docs/multi-provider-orchestration.md
@@ -315,8 +315,13 @@ higher.
 
 ## Out of scope
 
-This document decides contracts; it ships no behavior. The following are
-explicit follow-up issues, each gated on approval of this design:
+This document decided contracts; it shipped no behavior of its own. The
+follow-up implementation is now complete: the `internal/circuit` extraction
+(#173), the lane abstraction and ordered dispatch (#174), the petitlyrics
+fallback lane plus `providers_version` write-and-compare (#175), and the
+parallel-race dispatch path with the `race_wait_seconds` upgrade window (#176)
+have all landed. The original out-of-scope notes are retained below for the
+record:
 
 - **No provider adapter is implemented here.** A second concurrent provider
   (for example the CJK/petitlyrics lane in parallel with Musixmatch) is separate

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -629,6 +629,11 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	w := worker.New(workQ, cache.New(sqlDB), fetcher, writer)
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	w.SetCircuitBackoff(time.Duration(cfg.API.CircuitBackoffBase)*time.Second, time.Duration(cfg.API.CircuitOpenDuration)*time.Second)
+	// Dispatch strategy and the parallel-mode synced-upgrade window. Set before the
+	// fallback lanes for clarity; the worker rebuilds the orchestrator on every
+	// setter, so the ordering is not load-bearing.
+	w.SetProvidersMode(cfg.Providers.Mode)
+	w.SetRaceWait(time.Duration(cfg.Providers.RaceWaitSeconds) * time.Second)
 	// Register fallback lanes (each with its own breaker) and stamp the active
 	// provider set's generation onto both the queue (write-on-enqueue) and the
 	// worker (compare-on-lookup) so a provider-set change invalidates stale cached

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1352,6 +1352,7 @@ func configKeys() []string {
 		"providers.primary",
 		"providers.disabled",
 		"providers.mode",
+		"providers.race_wait_seconds",
 		"verification.enabled",
 		"verification.whisper_url",
 		"verification.ffmpeg_path",
@@ -1399,6 +1400,8 @@ func configValue(cfg config.Config, key string) (string, bool) {
 		return strings.Join(cfg.Providers.Disabled, ","), true
 	case "providers.mode":
 		return cfg.Providers.Mode, true
+	case "providers.race_wait_seconds":
+		return strconv.Itoa(cfg.Providers.RaceWaitSeconds), true
 	case "verification.enabled":
 		return strconv.FormatBool(cfg.Verification.Enabled), true
 	case "verification.whisper_url":
@@ -1492,10 +1495,17 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 	case "providers.disabled":
 		cfg.Providers.Disabled = splitCSV(value)
 	case "providers.mode":
-		if m := strings.ToLower(strings.TrimSpace(value)); m != "ordered" {
-			return fmt.Errorf("providers.mode must be \"ordered\" (only supported mode)")
+		m := strings.ToLower(strings.TrimSpace(value))
+		if m != "ordered" && m != "parallel" {
+			return fmt.Errorf("providers.mode must be \"ordered\" or \"parallel\"")
 		}
-		cfg.Providers.Mode = "ordered"
+		cfg.Providers.Mode = m
+	case "providers.race_wait_seconds":
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("providers.race_wait_seconds must be a positive integer (seconds)")
+		}
+		cfg.Providers.RaceWaitSeconds = n
 	case "verification.enabled":
 		v, err := strconv.ParseBool(value)
 		if err != nil {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1501,9 +1501,12 @@ func setConfigValue(cfg *config.Config, key string, value string) error {
 		}
 		cfg.Providers.Mode = m
 	case "providers.race_wait_seconds":
+		// Accept any integer and let config normalization clamp it: a non-positive
+		// value is the "use the default" sentinel in the config stack, so rejecting
+		// it here would make that contract unreachable from the CLI.
 		n, err := strconv.Atoi(value)
-		if err != nil || n <= 0 {
-			return fmt.Errorf("providers.race_wait_seconds must be a positive integer (seconds)")
+		if err != nil {
+			return fmt.Errorf("providers.race_wait_seconds must be an integer (seconds; non-positive uses the default)")
 		}
 		cfg.Providers.RaceWaitSeconds = n
 	case "verification.enabled":

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -632,10 +632,17 @@ func TestConfigProvidersModeAndRaceWaitGetSetRoundTrip(t *testing.T) {
 	if cfg.Providers.RaceWaitSeconds != 5 {
 		t.Fatalf("race_wait_seconds = %d; want 5", cfg.Providers.RaceWaitSeconds)
 	}
-	for _, bad := range []string{"abc", "0", "-1"} {
-		if err := setConfigValue(&cfg, "providers.race_wait_seconds", bad); err == nil {
-			t.Fatalf("setConfigValue accepted invalid providers.race_wait_seconds %q", bad)
-		}
+	// Non-positive is the "use the default" sentinel in the config stack (config
+	// load clamps it), so the CLI must accept it rather than reject it.
+	if err := setConfigValue(&cfg, "providers.race_wait_seconds", "0"); err != nil {
+		t.Fatalf("setConfigValue race_wait_seconds=0: %v (non-positive must be accepted; config load clamps it)", err)
+	}
+	if cfg.Providers.RaceWaitSeconds != 0 {
+		t.Fatalf("race_wait_seconds = %d; want 0 stored raw (clamped to the default only at load)", cfg.Providers.RaceWaitSeconds)
+	}
+	// Only a non-integer is rejected.
+	if err := setConfigValue(&cfg, "providers.race_wait_seconds", "abc"); err == nil {
+		t.Fatal("setConfigValue accepted a non-integer providers.race_wait_seconds")
 	}
 }
 

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -592,6 +592,53 @@ func TestConfigGuardGetSetRoundTrip(t *testing.T) {
 	}
 }
 
+func TestConfigProvidersModeAndRaceWaitGetSetRoundTrip(t *testing.T) {
+	cfg := config.Config{
+		Providers: config.ProvidersConfig{Mode: "parallel", RaceWaitSeconds: 3},
+	}
+	gets := map[string]string{
+		"providers.mode":              "parallel",
+		"providers.race_wait_seconds": "3",
+	}
+	for key, want := range gets {
+		got, ok := configValue(cfg, key)
+		if !ok {
+			t.Fatalf("configValue(%q) ok = false; want true", key)
+		}
+		if got != want {
+			t.Fatalf("configValue(%q) = %q; want %q", key, got, want)
+		}
+		if !slices.Contains(configKeys(), key) {
+			t.Fatalf("configKeys missing %q", key)
+		}
+	}
+
+	// Both modes are settable; an unknown mode is rejected.
+	for _, mode := range []string{"ordered", "parallel"} {
+		if err := setConfigValue(&cfg, "providers.mode", mode); err != nil {
+			t.Fatalf("setConfigValue providers.mode=%q: %v", mode, err)
+		}
+		if cfg.Providers.Mode != mode {
+			t.Fatalf("providers.mode = %q; want %q", cfg.Providers.Mode, mode)
+		}
+	}
+	if err := setConfigValue(&cfg, "providers.mode", "sequential"); err == nil {
+		t.Fatal("setConfigValue accepted an unknown providers.mode")
+	}
+
+	if err := setConfigValue(&cfg, "providers.race_wait_seconds", "5"); err != nil {
+		t.Fatalf("setConfigValue race_wait_seconds: %v", err)
+	}
+	if cfg.Providers.RaceWaitSeconds != 5 {
+		t.Fatalf("race_wait_seconds = %d; want 5", cfg.Providers.RaceWaitSeconds)
+	}
+	for _, bad := range []string{"abc", "0", "-1"} {
+		if err := setConfigValue(&cfg, "providers.race_wait_seconds", bad); err == nil {
+			t.Fatalf("setConfigValue accepted invalid providers.race_wait_seconds %q", bad)
+		}
+	}
+}
+
 func TestConfigBilingualOutputGetSetRoundTrip(t *testing.T) {
 	cfg := config.Config{
 		Output: config.OutputConfig{BilingualOutput: true},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,12 +152,20 @@ const defaultScanIntervalSeconds = 900
 type ProvidersConfig struct {
 	Primary  string   `toml:"primary"`
 	Disabled []string `toml:"disabled"`
-	// Mode is the multi-provider dispatch strategy. Only "ordered" (query lanes
-	// in priority order, first suitable result wins) is implemented today; any
-	// other value is rejected at load time. The "parallel" race is reserved by
-	// docs/multi-provider-orchestration.md and not yet built. Default "ordered".
-	// Override: MXLRC_PROVIDERS_MODE.
+	// Mode is the multi-provider dispatch strategy. "ordered" (the default) queries
+	// lanes in priority order and returns the first suitable result. "parallel"
+	// dispatches every lane concurrently and races them (the first synced result
+	// wins; a faster unsynced result is held briefly so a slower synced result can
+	// preempt it). Any other value is rejected at load time. Parallel makes more
+	// upstream calls, so it is not advised against rate-limited providers unless
+	// latency matters more than call volume. Override: MXLRC_PROVIDERS_MODE.
 	Mode string `toml:"mode"`
+	// RaceWaitSeconds bounds the parallel-mode upgrade window: after a suitable
+	// unsynced result arrives, the orchestrator waits up to this many seconds for a
+	// synced result (a strict quality upgrade) to preempt it before committing the
+	// unsynced one. Default 2. Non-positive values are clamped to the default. Only
+	// consulted in "parallel" mode. Override: MXLRC_PROVIDERS_RACE_WAIT_SECONDS.
+	RaceWaitSeconds int `toml:"race_wait_seconds"`
 	// FallbackOrder lists provider names consulted, in order, AFTER the primary
 	// when the primary yields no suitable result (ordered-fallback dispatch). Each
 	// name must be a known provider; unknown names are rejected at load. Empty (the
@@ -166,8 +174,13 @@ type ProvidersConfig struct {
 	FallbackOrder []string `toml:"fallback_order"`
 }
 
-// providersModeDefault is the only supported dispatch mode today.
-const providersModeDefault = "ordered"
+// providersModeDefault and providersModeParallel are the supported dispatch
+// modes. raceWaitSecondsDefault is the default parallel-mode upgrade window.
+const (
+	providersModeDefault   = "ordered"
+	providersModeParallel  = "parallel"
+	raceWaitSecondsDefault = 2
+)
 
 // VerificationConfig holds optional STT verification settings.
 type VerificationConfig struct {
@@ -222,7 +235,7 @@ func defaults() Config {
 		Output:       OutputConfig{Dir: "lyrics", EmbeddedLyrics: "off"},
 		DB:           DBConfig{Path: xdgDataPath("mxlrcgo-svc", "mxlrcgo.db")},
 		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
-		Providers:    ProvidersConfig{Primary: "musixmatch", Mode: providersModeDefault},
+		Providers:    ProvidersConfig{Primary: "musixmatch", Mode: providersModeDefault, RaceWaitSeconds: raceWaitSecondsDefault},
 		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
 		Guard:        GuardConfig{Threshold: guardThresholdDefault},
 		Queue:        QueueConfig{Randomize: true},
@@ -362,6 +375,7 @@ func Load(path string) (Config, error) {
 	if err := normalizeProvidersMode(&cfg); err != nil {
 		return cfg, err
 	}
+	normalizeProvidersRaceWait(&cfg)
 	if err := normalizeProvidersFallback(&cfg); err != nil {
 		return cfg, err
 	}
@@ -379,7 +393,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -494,6 +508,14 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_MODE"); v != "" {
 		cfg.Providers.Mode = v
+	}
+	if v := os.Getenv("MXLRC_PROVIDERS_RACE_WAIT_SECONDS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_PROVIDERS_RACE_WAIT_SECONDS", "value", v, "current", cfg.Providers.RaceWaitSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Providers.RaceWaitSeconds = n
+		}
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_FALLBACK_ORDER"); v != "" {
 		cfg.Providers.FallbackOrder = splitCSV(v)
@@ -630,20 +652,28 @@ func normalizeEmbeddedLyrics(cfg *Config) {
 }
 
 // normalizeProvidersMode lowercases and validates the provider dispatch mode.
-// An empty value restores the default ("ordered"). Only "ordered" is supported
-// today; any other value is rejected with an error so a typo or a not-yet-built
-// mode (for example "parallel") fails loudly at load rather than silently
-// degrading. See docs/multi-provider-orchestration.md.
+// An empty value restores the default ("ordered"). "ordered" and "parallel" are
+// supported; any other value is rejected with an error so a typo fails loudly at
+// load rather than silently degrading. See docs/multi-provider-orchestration.md.
 func normalizeProvidersMode(cfg *Config) error {
 	v := strings.ToLower(strings.TrimSpace(cfg.Providers.Mode))
 	if v == "" {
 		v = providersModeDefault
 	}
-	if v != providersModeDefault {
-		return fmt.Errorf("config: unsupported providers.mode %q (only %q is supported)", cfg.Providers.Mode, providersModeDefault)
+	if v != providersModeDefault && v != providersModeParallel {
+		return fmt.Errorf("config: unsupported providers.mode %q (supported: %q, %q)", cfg.Providers.Mode, providersModeDefault, providersModeParallel)
 	}
 	cfg.Providers.Mode = v
 	return nil
+}
+
+// normalizeProvidersRaceWait clamps the parallel-mode upgrade window to the
+// default when it is non-positive, so a misconfigured value cannot produce a
+// zero-wait busy dispatch path. It is only consulted in "parallel" mode.
+func normalizeProvidersRaceWait(cfg *Config) {
+	if cfg.Providers.RaceWaitSeconds <= 0 {
+		cfg.Providers.RaceWaitSeconds = raceWaitSecondsDefault
+	}
 }
 
 // normalizeProvidersFallback lowercases, trims, drops blanks, and de-duplicates

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,7 @@ func isolateEnv(t *testing.T) {
 		"MXLRC_OUTPUT_DIR", "MXLRC_BILINGUAL_OUTPUT", "MXLRC_SERVER_ADDR", "MXLRC_WEBHOOK_API_KEY",
 		"MXLRC_SCAN_INTERVAL", "MXLRC_WORK_INTERVAL",
 		"MXLRC_PROVIDER_PRIMARY", "MXLRC_PROVIDERS_DISABLED", "MXLRC_PROVIDERS_MODE", "MXLRC_PROVIDERS_FALLBACK_ORDER",
+		"MXLRC_PROVIDERS_RACE_WAIT_SECONDS",
 		"MXLRC_VERIFICATION_ENABLED", "MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL",
 		"MXLRC_VERIFICATION_FFMPEG_PATH",
 		"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION",
@@ -1168,12 +1169,24 @@ func TestProvidersModeEnvOverrideAndValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("env override accepts parallel", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_PROVIDERS_MODE", "PARALLEL") // case-insensitive
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load with providers.mode=parallel: %v", err)
+		}
+		if cfg.Providers.Mode != "parallel" {
+			t.Fatalf("providers.mode = %q; want parallel", cfg.Providers.Mode)
+		}
+	})
+
 	t.Run("unsupported mode is rejected", func(t *testing.T) {
 		isolateEnv(t)
-		t.Setenv("MXLRC_PROVIDERS_MODE", "parallel")
+		t.Setenv("MXLRC_PROVIDERS_MODE", "sequential")
 		_, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
 		if err == nil {
-			t.Fatal("Load with providers.mode=parallel returned nil error; want a rejection (parallel not implemented)")
+			t.Fatal("Load with providers.mode=sequential returned nil error; want a rejection (unknown mode)")
 		}
 	})
 
@@ -1189,6 +1202,73 @@ func TestProvidersModeEnvOverrideAndValidation(t *testing.T) {
 		}
 		if cfg.Providers.Mode != "ordered" {
 			t.Fatalf("blank mode = %q; want ordered default", cfg.Providers.Mode)
+		}
+	})
+}
+
+func TestProvidersRaceWaitSeconds(t *testing.T) {
+	t.Run("default is 2", func(t *testing.T) {
+		isolateEnv(t)
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.RaceWaitSeconds != 2 {
+			t.Fatalf("default race_wait_seconds = %d; want 2", cfg.Providers.RaceWaitSeconds)
+		}
+	})
+
+	t.Run("parsed from file", func(t *testing.T) {
+		isolateEnv(t)
+		path := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.WriteFile(path, []byte("[providers]\nrace_wait_seconds = 5\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.RaceWaitSeconds != 5 {
+			t.Fatalf("race_wait_seconds = %d; want 5", cfg.Providers.RaceWaitSeconds)
+		}
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_PROVIDERS_RACE_WAIT_SECONDS", "7")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.RaceWaitSeconds != 7 {
+			t.Fatalf("race_wait_seconds = %d; want 7", cfg.Providers.RaceWaitSeconds)
+		}
+	})
+
+	t.Run("non-positive is clamped to default", func(t *testing.T) {
+		isolateEnv(t)
+		path := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.WriteFile(path, []byte("[providers]\nrace_wait_seconds = 0\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.RaceWaitSeconds != 2 {
+			t.Fatalf("clamped race_wait_seconds = %d; want 2 (default)", cfg.Providers.RaceWaitSeconds)
+		}
+	})
+
+	t.Run("unparsable env is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_PROVIDERS_RACE_WAIT_SECONDS", "abc")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.RaceWaitSeconds != 2 {
+			t.Fatalf("race_wait_seconds = %d; want 2 (unparsable env ignored)", cfg.Providers.RaceWaitSeconds)
 		}
 	})
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,24 +3,32 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 )
 
-// Mode names the dispatch strategy. Only "ordered" is implemented; "parallel"
-// is reserved by the design (docs/multi-provider-orchestration.md) and rejected
-// by New until built.
+// Mode names the dispatch strategy (docs/multi-provider-orchestration.md).
 const (
 	// ModeOrdered queries lanes one at a time in priority order and returns the
 	// first suitable result.
 	ModeOrdered = "ordered"
+	// ModeParallel dispatches every available lane concurrently and races them:
+	// the first synced (strictly highest-quality) result wins immediately, while a
+	// faster unsynced result is held for a bounded window so a slower synced result
+	// can preempt it. It makes more upstream calls than ordered.
+	ModeParallel = "parallel"
 )
 
-// Orchestrator dispatches a lyrics lookup across an ordered set of provider
-// lanes. With a single Musixmatch lane it is a behavior-preserving pass-through
-// of the worker's prior single-fetch path: the one lane's breaker carries the
-// throttle state, and a suitable / best-available / classified-error result
-// flows back unchanged.
+// DefaultRaceWait is the parallel-mode upgrade window applied when SetRaceWait is
+// not called (or is called with a non-positive value). It mirrors the config
+// default (providers.race_wait_seconds = 2).
+const DefaultRaceWait = 2 * time.Second
+
+// Orchestrator dispatches a lyrics lookup across a set of provider lanes. With a
+// single Musixmatch lane it is a behavior-preserving pass-through of the worker's
+// prior single-fetch path: the one lane's breaker carries the throttle state, and
+// a suitable / best-available / classified-error result flows back unchanged.
 //
 // It satisfies providers.Fetcher, so the worker can hold it in place of a bare
 // fetcher.
@@ -28,17 +36,19 @@ type Orchestrator struct {
 	lanes []*Lane
 	guard ScriptGuard
 	mode  string
+	// raceWait bounds the parallel-mode upgrade window (synced preempts a held
+	// unsynced). Unused in ordered mode. Defaults to DefaultRaceWait.
+	raceWait time.Duration
 }
 
-// New builds an ordered orchestrator over lanes in priority order. mode must be
-// "ordered" (the default for an empty string); any other value is rejected,
-// since parallel dispatch is not implemented yet.
+// New builds an orchestrator over lanes in priority order. mode must be "ordered"
+// (the default for an empty string) or "parallel"; any other value is rejected.
 func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 	if mode == "" {
 		mode = ModeOrdered
 	}
-	if mode != ModeOrdered {
-		return nil, fmt.Errorf("orchestrator: unsupported mode %q (only %q is implemented)", mode, ModeOrdered)
+	if mode != ModeOrdered && mode != ModeParallel {
+		return nil, fmt.Errorf("orchestrator: unsupported mode %q (supported: %q, %q)", mode, ModeOrdered, ModeParallel)
 	}
 	if len(lanes) == 0 {
 		return nil, fmt.Errorf("orchestrator: at least one lane is required")
@@ -51,7 +61,7 @@ func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 	// Defensively copy so a caller mutating its slice after construction cannot
 	// alter the orchestrator's dispatch order or inject a nil lane.
 	owned := append([]*Lane(nil), lanes...)
-	return &Orchestrator{lanes: owned, mode: mode}, nil
+	return &Orchestrator{lanes: owned, mode: mode, raceWait: DefaultRaceWait}, nil
 }
 
 // SetGuard installs the suitability script guard. A nil or disabled guard
@@ -60,29 +70,40 @@ func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 // whether the orchestrator advances to the next lane.
 func (o *Orchestrator) SetGuard(g ScriptGuard) { o.guard = g }
 
-// FindLyrics runs the ordered dispatch:
+// SetRaceWait sets the parallel-mode upgrade window read once per dispatch. A
+// non-positive value is ignored so the constructed DefaultRaceWait is preserved.
+// It has no effect in ordered mode.
+func (o *Orchestrator) SetRaceWait(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	o.raceWait = d
+}
+
+// FindLyrics dispatches the lookup using the configured mode. Ordered mode walks
+// lanes in priority order; parallel mode races them with a bounded synced-upgrade
+// window. Both share the same suitability rule and the same resolution precedence
+// (best-available > highest-precedence error > unavailable sentinel).
+func (o *Orchestrator) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	if o.mode == ModeParallel {
+		return o.findParallel(ctx, track)
+	}
+	return o.findOrdered(ctx, track)
+}
+
+// findOrdered iterates lanes in priority order:
 //
-//   - Iterate lanes in priority order. Return the first SUITABLE result
-//     immediately (the next lane is never consulted).
-//   - An unavailable (open breaker) or unsuitable lane is skipped; the best
-//     result seen so far (highest quality, possibly instrumental) is retained.
+//   - Return the first SUITABLE result immediately (the next lane is never
+//     consulted).
+//   - An unavailable (open breaker) or unsuitable lane is skipped; the best result
+//     seen so far (highest quality, possibly instrumental) is retained.
 //   - If no lane yields a suitable result but at least one returned some result,
-//     return that best-available result with a nil error so the worker writes
-//     the instrumental / unsynced fallback.
+//     return that best-available result with a nil error so the worker writes the
+//     instrumental / unsynced fallback.
 //   - If every lane errored, return the highest-precedence error (Gap 4).
 //   - If every available lane's breaker was open, return ErrLaneUnavailable.
-func (o *Orchestrator) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
-	var (
-		bestSong    models.Song
-		haveBest    bool
-		bestQuality = QualityNone
-
-		topErr   error
-		topClass = OutcomeSuccess
-
-		consulted int
-	)
-
+func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (models.Song, error) {
+	var r dispatchResult
 	for _, lane := range o.lanes {
 		if err := ctx.Err(); err != nil {
 			return models.Song{}, err
@@ -94,44 +115,71 @@ func (o *Orchestrator) FindLyrics(ctx context.Context, track models.Track) (mode
 		if class == OutcomeUnavailable {
 			// The breaker was open and the provider was not called. An unavailable
 			// lane does not contribute to error ranking; it only matters when EVERY
-			// lane was unavailable (handled below via consulted == 0).
+			// lane was unavailable (handled by resolve via consulted == 0).
 			continue
 		}
-		consulted++
+		r.consulted++
 
 		if err == nil {
 			if IsSuitable(song, o.guard) {
 				return song, nil
 			}
-			// Not suitable on its own, but retain it as a best-available fallback
-			// (the highest quality wins; ties keep the earliest, higher-priority lane).
-			if q := QualityOf(song); !haveBest || q > bestQuality {
-				bestSong, bestQuality, haveBest = song, q, true
-			}
+			r.retain(song)
 			continue
 		}
 
-		// Track the highest-precedence error across consulted lanes (Gap 4).
-		if topErr == nil || class.precedence() > topClass.precedence() {
-			topErr, topClass = err, class
+		r.rankErr(err, class)
+	}
+
+	return o.resolve(ctx, &r)
+}
+
+// dispatchResult accumulates the cross-lane outcome state shared by both dispatch
+// modes: the best-available fallback (highest quality wins; ties keep the first
+// retained) and the highest-precedence error (Gap 4). Its zero value is ready to
+// use (QualityNone, OutcomeSuccess).
+type dispatchResult struct {
+	bestSong    models.Song
+	haveBest    bool
+	bestQuality Quality
+	topErr      error
+	topClass    OutcomeClass
+	consulted   int
+}
+
+// retain keeps song as the best-available fallback if it outranks the current one.
+func (r *dispatchResult) retain(song models.Song) {
+	if q := QualityOf(song); !r.haveBest || q > r.bestQuality {
+		r.bestSong, r.bestQuality, r.haveBest = song, q, true
+	}
+}
+
+// rankErr keeps err if its class outranks the current top error (Gap 4).
+func (r *dispatchResult) rankErr(err error, class OutcomeClass) {
+	if r.topErr == nil || class.precedence() > r.topClass.precedence() {
+		r.topErr, r.topClass = err, class
+	}
+}
+
+// resolve applies the shared final precedence once every lane has reported and no
+// suitable result was committed: a best-available result (instrumental / unsynced /
+// guard-rejected) is returned ahead of any error so the worker writes the best we
+// have rather than backing off. With no result at all, the highest-precedence
+// error is surfaced; if every lane was unavailable (breaker open) the unavailable
+// sentinel is returned so the worker releases the item, unless the parent context
+// was canceled, in which case its error wins.
+func (o *Orchestrator) resolve(ctx context.Context, r *dispatchResult) (models.Song, error) {
+	if r.haveBest {
+		return r.bestSong, nil
+	}
+	if r.consulted == 0 && len(o.lanes) > 0 {
+		if err := ctx.Err(); err != nil {
+			return models.Song{}, err
 		}
-	}
-
-	// A best-available result (instrumental / unsynced / guard-rejected) is
-	// returned ahead of any error: the worker writes the best we have rather than
-	// backing off, exactly as the single-lane path does today.
-	if haveBest {
-		return bestSong, nil
-	}
-
-	// No result at all. If at least one lane was actually consulted, surface the
-	// highest-precedence error. If every lane was unavailable (breaker open),
-	// surface the unavailable sentinel so the worker releases the item.
-	if consulted == 0 && len(o.lanes) > 0 {
 		return models.Song{}, ErrLaneUnavailable
 	}
-	if topErr != nil {
-		return models.Song{}, topErr
+	if r.topErr != nil {
+		return models.Song{}, r.topErr
 	}
 	// No lanes configured at all.
 	return models.Song{}, ErrLaneUnavailable

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -19,11 +19,14 @@ func laneFor(p *stubProvider) *Lane {
 
 func TestNewModeRejectsUnknown(t *testing.T) {
 	p := &stubProvider{name: "musixmatch"}
-	if _, err := New("parallel", laneFor(p)); err == nil {
-		t.Fatal("New(parallel) should error: only ordered is supported")
+	if _, err := New("sequential", laneFor(p)); err == nil {
+		t.Fatal("New(sequential) should error: unknown mode")
 	}
 	if _, err := New("ordered", laneFor(p)); err != nil {
 		t.Fatalf("New(ordered): %v", err)
+	}
+	if _, err := New("parallel", laneFor(p)); err != nil {
+		t.Fatalf("New(parallel): %v", err)
 	}
 	if _, err := New("", laneFor(p)); err != nil {
 		t.Fatalf("New(empty) should default to ordered: %v", err)

--- a/internal/orchestrator/parallel.go
+++ b/internal/orchestrator/parallel.go
@@ -30,6 +30,10 @@ type laneResult struct {
 // lane's send never blocks after cancel; the collector discards canceled-lane
 // results and does not wait for losers to drain.
 func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (models.Song, error) {
+	if err := ctx.Err(); err != nil {
+		return models.Song{}, err
+	}
+
 	childCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -52,6 +56,11 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 
 	for {
 		select {
+		case <-ctx.Done():
+			// Parent cancellation (shutdown / request abort) beats any pending commit,
+			// including a held unsynced result and the upgrade window: never turn a
+			// canceled dispatch into a successful lyrics write.
+			return models.Song{}, ctx.Err()
 		case res := <-results:
 			pending--
 			class := ClassifyOutcome(res.err)
@@ -83,13 +92,20 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 				}
 			}
 			if pending == 0 {
+				if err := ctx.Err(); err != nil {
+					return models.Song{}, err
+				}
 				if haveHeld {
 					return heldSong, nil
 				}
 				return o.resolve(ctx, &r)
 			}
 		case <-upgrade:
-			// The window elapsed with no synced upgrade: commit the held unsynced.
+			// The window elapsed with no synced upgrade: commit the held unsynced,
+			// unless the parent was canceled in the meantime.
+			if err := ctx.Err(); err != nil {
+				return models.Song{}, err
+			}
 			return heldSong, nil
 		}
 	}

--- a/internal/orchestrator/parallel.go
+++ b/internal/orchestrator/parallel.go
@@ -1,0 +1,96 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// laneResult carries one lane's outcome back from its dispatch goroutine. The
+// buffered results channel provides synchronization, so no field needs a mutex.
+type laneResult struct {
+	song models.Song
+	err  error
+}
+
+// findParallel dispatches every lane concurrently and races the results:
+//
+//   - The first SUITABLE synced result wins immediately and cancels the rest.
+//   - The first SUITABLE unsynced result is held and a bounded upgrade window is
+//     armed (only while another lane could still deliver a synced upgrade). A synced
+//     result arriving within the window preempts it; the window elapsing, or every
+//     remaining lane reporting, commits the held unsynced result.
+//   - Non-suitable results and errors fall through to the same resolution as ordered
+//     mode (best-available > highest-precedence error > unavailable sentinel).
+//
+// Cancellation/leak contract: a child context is canceled on every return path via
+// defer; the results channel is buffered to the launched-goroutine count so a losing
+// lane's send never blocks after cancel; the collector discards canceled-lane
+// results and does not wait for losers to drain.
+func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (models.Song, error) {
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan laneResult, len(o.lanes))
+	for _, lane := range o.lanes {
+		lane := lane
+		go func() {
+			song, err := lane.FindLyrics(childCtx, track)
+			results <- laneResult{song: song, err: err}
+		}()
+	}
+
+	var (
+		r        dispatchResult
+		heldSong models.Song
+		haveHeld bool // a suitable unsynced result is held, pending a synced upgrade
+		upgrade  <-chan time.Time
+		pending  = len(o.lanes)
+	)
+
+	for {
+		select {
+		case res := <-results:
+			pending--
+			class := ClassifyOutcome(res.err)
+			switch {
+			case errors.Is(res.err, context.Canceled):
+				// A canceled loser, or a parent-canceled lane: no catalog signal, skip.
+			case class == OutcomeUnavailable:
+				// Breaker open, provider not called: skip (matters only if ALL unavailable).
+			default:
+				r.consulted++
+				switch {
+				case res.err == nil && IsSuitable(res.song, o.guard):
+					if QualityOf(res.song) >= QualitySynced {
+						return res.song, nil // synced: commit now; defer cancels the losers.
+					}
+					// Suitable but unsynced: hold the first such result. Arm the upgrade
+					// window only while another lane could still deliver a synced upgrade;
+					// if this was the last lane, the pending == 0 check below commits it.
+					if !haveHeld {
+						heldSong, haveHeld = res.song, true
+					}
+					if upgrade == nil && pending > 0 {
+						upgrade = time.After(o.raceWait)
+					}
+				case res.err == nil:
+					r.retain(res.song)
+				default:
+					r.rankErr(res.err, class)
+				}
+			}
+			if pending == 0 {
+				if haveHeld {
+					return heldSong, nil
+				}
+				return o.resolve(ctx, &r)
+			}
+		case <-upgrade:
+			// The window elapsed with no synced upgrade: commit the held unsynced.
+			return heldSong, nil
+		}
+	}
+}

--- a/internal/orchestrator/parallel_test.go
+++ b/internal/orchestrator/parallel_test.go
@@ -223,6 +223,12 @@ func TestParallelParentCancelAfterHeldReturnsErr(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v; want context.Canceled (cancel must beat a held unsynced commit)", err)
 	}
+	// Both lanes must drain after the cancel: the held (fast) lane already returned,
+	// and the in-flight slow lane must observe the cancel and exit (no leak).
+	waitFor(t, func() bool {
+		return atomic.LoadInt32(&fast.finished) == atomic.LoadInt32(&fast.started) &&
+			atomic.LoadInt32(&slow.finished) == atomic.LoadInt32(&slow.started)
+	}, "provider goroutines did not terminate after parent cancel")
 }
 
 func TestParallelGuardDrivesSuitability(t *testing.T) {

--- a/internal/orchestrator/parallel_test.go
+++ b/internal/orchestrator/parallel_test.go
@@ -1,0 +1,239 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+)
+
+// delayProvider is a concurrency-safe fake provider with a configurable per-call
+// delay that honors context cancellation. started/finished track launched vs.
+// returned calls so a test can assert every dispatched goroutine unblocked (no
+// leak) without relying solely on a flaky runtime.NumGoroutine snapshot.
+type delayProvider struct {
+	name     string
+	song     models.Song
+	err      error
+	delay    time.Duration
+	started  int32
+	finished int32
+}
+
+func (p *delayProvider) Name() string { return p.name }
+
+func (p *delayProvider) FindLyrics(ctx context.Context, _ models.Track) (models.Song, error) {
+	atomic.AddInt32(&p.started, 1)
+	defer atomic.AddInt32(&p.finished, 1)
+	if p.delay > 0 {
+		select {
+		case <-time.After(p.delay):
+		case <-ctx.Done():
+			return models.Song{}, ctx.Err()
+		}
+	}
+	if p.err != nil {
+		return models.Song{}, p.err
+	}
+	return p.song, nil
+}
+
+func delayLane(p *delayProvider) *Lane {
+	return NewLane(p, circuit.New(60*time.Second, 30*time.Minute))
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+func TestParallelSyncedPreemptsSlowerUnsynced(t *testing.T) {
+	fast := &delayProvider{name: "musixmatch", song: unsyncedSong()}
+	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: 40 * time.Millisecond}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+	o.SetRaceWait(500 * time.Millisecond)
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualitySynced {
+		t.Fatalf("quality = %v; want synced (synced upgrade preempts held unsynced within window)", QualityOf(song))
+	}
+}
+
+func TestParallelUnsyncedCommittedWhenWindowElapses(t *testing.T) {
+	fast := &delayProvider{name: "musixmatch", song: unsyncedSong()}
+	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: 200 * time.Millisecond}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+	o.SetRaceWait(20 * time.Millisecond)
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualityUnsynced {
+		t.Fatalf("quality = %v; want unsynced (window elapsed before the synced result arrived)", QualityOf(song))
+	}
+}
+
+func TestParallelFastSyncedWinsImmediately(t *testing.T) {
+	fast := &delayProvider{name: "musixmatch", song: syncedSong()}
+	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: 300 * time.Millisecond}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+	o.SetRaceWait(5 * time.Second)
+
+	start := time.Now()
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualitySynced {
+		t.Fatalf("quality = %v; want synced", QualityOf(song))
+	}
+	if elapsed > time.Second {
+		t.Fatalf("returned in %v; a fast synced result must not wait for the slow lane or the race window", elapsed)
+	}
+}
+
+func TestParallelSingleUnsyncedCommitsImmediately(t *testing.T) {
+	// A held unsynced result with no other lane in flight cannot be upgraded, so it
+	// must commit immediately rather than burn the full race window.
+	p := &delayProvider{name: "musixmatch", song: unsyncedSong()}
+	o, _ := New("parallel", delayLane(p))
+	o.SetRaceWait(5 * time.Second)
+
+	start := time.Now()
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualityUnsynced {
+		t.Fatalf("quality = %v; want unsynced", QualityOf(song))
+	}
+	if elapsed > time.Second {
+		t.Fatalf("returned in %v; a single unsynced lane has no possible upgrade and must commit immediately", elapsed)
+	}
+}
+
+func TestParallelAllMissReturnsBenignMiss(t *testing.T) {
+	p1 := &delayProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	p2 := &delayProvider{name: "petitlyrics", err: musixmatch.ErrNotFound}
+	o, _ := New("parallel", delayLane(p1), delayLane(p2))
+
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound (all lanes missed)", err)
+	}
+}
+
+func TestParallelBestAvailableWhenNoSuitable(t *testing.T) {
+	p1 := &delayProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	p2 := &delayProvider{name: "petitlyrics", song: models.Song{Track: models.Track{Instrumental: 1}}}
+	o, _ := New("parallel", delayLane(p1), delayLane(p2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v (best-available instrumental should return nil err)", err)
+	}
+	if QualityOf(song) != QualityInstrumental {
+		t.Fatalf("quality = %v; want instrumental (best available)", QualityOf(song))
+	}
+}
+
+func TestParallelAuthOutranksBenignMiss(t *testing.T) {
+	p1 := &delayProvider{name: "musixmatch", err: musixmatch.ErrRateLimited}
+	p2 := &delayProvider{name: "petitlyrics", err: musixmatch.ErrNotFound}
+	o, _ := New("parallel", delayLane(p1), delayLane(p2))
+
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited (auth outranks benign miss)", err)
+	}
+}
+
+func TestParallelNoGoroutineLeak(t *testing.T) {
+	base := runtime.NumGoroutine()
+	fast := &delayProvider{name: "musixmatch", song: syncedSong()}
+	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: 150 * time.Millisecond}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+
+	if _, err := o.FindLyrics(context.Background(), models.Track{}); err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+
+	// The losing slow lane must observe the cancel and return; finished catches up
+	// to started for every dispatched goroutine (deterministic, unlike NumGoroutine).
+	waitFor(t, func() bool {
+		return atomic.LoadInt32(&slow.finished) == atomic.LoadInt32(&slow.started) &&
+			atomic.LoadInt32(&fast.finished) == atomic.LoadInt32(&fast.started)
+	}, "dispatched provider goroutines did not all unblock after cancel")
+
+	// Belt-and-suspenders: the goroutine count should settle back to the baseline.
+	waitFor(t, func() bool { return runtime.NumGoroutine() <= base }, "goroutine count did not return to baseline")
+}
+
+func TestParallelParentCancelReturnsErr(t *testing.T) {
+	slow := &delayProvider{name: "musixmatch", song: syncedSong(), delay: time.Second}
+	o, _ := New("parallel", delayLane(slow))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := o.FindLyrics(ctx, models.Track{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v; want context.Canceled (parent canceled mid-flight)", err)
+	}
+	waitFor(t, func() bool {
+		return atomic.LoadInt32(&slow.finished) == atomic.LoadInt32(&slow.started)
+	}, "in-flight lane did not terminate after parent cancel")
+}
+
+func TestParallelGuardDrivesSuitability(t *testing.T) {
+	// A guard-rejected synced result is not suitable; the other lane's suitable
+	// synced result must win the race.
+	rejected := &delayProvider{name: "musixmatch", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "reject"}}}}}
+	accepted := &delayProvider{name: "petitlyrics", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "keep"}}}}}
+	o, _ := New("parallel", delayLane(rejected), delayLane(accepted))
+	o.SetGuard(scriptOnlyGuard{accept: func(s models.Song) bool {
+		return len(s.Subtitles.Lines) > 0 && s.Subtitles.Lines[0].Text == "keep"
+	}})
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) == 0 || song.Subtitles.Lines[0].Text != "keep" {
+		t.Fatalf("got %+v; want the guard-accepted result", song.Subtitles.Lines)
+	}
+}
+
+// scriptOnlyGuard is an always-enabled guard whose accept decision is a closure,
+// used to verify the orchestrator consults the guard during parallel suitability.
+type scriptOnlyGuard struct{ accept func(models.Song) bool }
+
+func (g scriptOnlyGuard) Enabled() bool { return true }
+func (g scriptOnlyGuard) Accept(s models.Song) (bool, string) {
+	if g.accept(s) {
+		return true, ""
+	}
+	return false, "rejected"
+}

--- a/internal/orchestrator/parallel_test.go
+++ b/internal/orchestrator/parallel_test.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"context"
 	"errors"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -168,7 +167,6 @@ func TestParallelAuthOutranksBenignMiss(t *testing.T) {
 }
 
 func TestParallelNoGoroutineLeak(t *testing.T) {
-	base := runtime.NumGoroutine()
 	fast := &delayProvider{name: "musixmatch", song: syncedSong()}
 	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: 150 * time.Millisecond}
 	o, _ := New("parallel", delayLane(fast), delayLane(slow))
@@ -178,14 +176,13 @@ func TestParallelNoGoroutineLeak(t *testing.T) {
 	}
 
 	// The losing slow lane must observe the cancel and return; finished catches up
-	// to started for every dispatched goroutine (deterministic, unlike NumGoroutine).
+	// to started for every dispatched goroutine. This is a deterministic per-test
+	// leak signal, unlike a process-global runtime.NumGoroutine() snapshot which can
+	// flap on unrelated background goroutines.
 	waitFor(t, func() bool {
 		return atomic.LoadInt32(&slow.finished) == atomic.LoadInt32(&slow.started) &&
 			atomic.LoadInt32(&fast.finished) == atomic.LoadInt32(&fast.started)
 	}, "dispatched provider goroutines did not all unblock after cancel")
-
-	// Belt-and-suspenders: the goroutine count should settle back to the baseline.
-	waitFor(t, func() bool { return runtime.NumGoroutine() <= base }, "goroutine count did not return to baseline")
 }
 
 func TestParallelParentCancelReturnsErr(t *testing.T) {
@@ -205,6 +202,27 @@ func TestParallelParentCancelReturnsErr(t *testing.T) {
 	waitFor(t, func() bool {
 		return atomic.LoadInt32(&slow.finished) == atomic.LoadInt32(&slow.started)
 	}, "in-flight lane did not terminate after parent cancel")
+}
+
+// TestParallelParentCancelAfterHeldReturnsErr asserts that once an unsynced result
+// is held awaiting a synced upgrade, a parent cancellation still wins: the held
+// result must NOT be committed as a successful write during shutdown/abort.
+func TestParallelParentCancelAfterHeldReturnsErr(t *testing.T) {
+	fast := &delayProvider{name: "musixmatch", song: unsyncedSong()}
+	slow := &delayProvider{name: "petitlyrics", song: syncedSong(), delay: time.Second}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+	o.SetRaceWait(5 * time.Second) // wide window: the held unsynced is parked when cancel lands
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond) // after the fast unsynced is held + window armed
+		cancel()
+	}()
+
+	_, err := o.FindLyrics(ctx, models.Track{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v; want context.Canceled (cancel must beat a held unsynced commit)", err)
+	}
 }
 
 func TestParallelGuardDrivesSuitability(t *testing.T) {

--- a/internal/worker/multilane_test.go
+++ b/internal/worker/multilane_test.go
@@ -4,15 +4,125 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/orchestrator"
 	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
+
+// delayFetcher is a concurrency-safe fetcher with a configurable per-call delay
+// that honors context cancellation, used to drive parallel-mode races at the
+// worker level. Each lane gets its own instance, so calls is per-lane.
+type delayFetcher struct {
+	song  models.Song
+	err   error
+	delay time.Duration
+	calls int32
+}
+
+func (f *delayFetcher) FindLyrics(ctx context.Context, _ models.Track) (models.Song, error) {
+	atomic.AddInt32(&f.calls, 1)
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return models.Song{}, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return models.Song{}, f.err
+	}
+	return f.song, nil
+}
+
+// capturingWriter records the songs handed to it so a test can assert which lane's
+// result (synced vs unsynced) the orchestrator committed.
+type capturingWriter struct{ songs []models.Song }
+
+func (w *capturingWriter) WriteLRC(s models.Song, _ string, _ string) error {
+	w.songs = append(w.songs, s)
+	return nil
+}
+
+func syncedTrackSong(track models.Track) models.Song {
+	return models.Song{Track: track, Subtitles: models.Synced{Lines: []models.Lines{{Text: "synced"}}}}
+}
+
+func unsyncedTrackSong(track models.Track) models.Song {
+	return models.Song{Track: track, Lyrics: models.Lyrics{LyricsBody: "unsynced body"}}
+}
+
+// TestProvidersModeDefaultsToOrdered asserts a freshly constructed worker uses
+// ordered dispatch (parallel is strictly opt-in).
+func TestProvidersModeDefaultsToOrdered(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	if w.mode != orchestrator.ModeOrdered {
+		t.Fatalf("default mode = %q; want %q", w.mode, orchestrator.ModeOrdered)
+	}
+}
+
+// TestRunOnceParallelSyncedPreemptsUnsynced verifies that in parallel mode a
+// faster unsynced primary result is held long enough for a slower synced fallback
+// to preempt it, so the committed (written) result is the synced one.
+func TestRunOnceParallelSyncedPreemptsUnsynced(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:     30,
+		Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "artist-title.lrc"},
+	}}}
+	primary := &delayFetcher{song: unsyncedTrackSong(track)}
+	secondary := &delayFetcher{song: syncedTrackSong(track), delay: 40 * time.Millisecond}
+	writer := &capturingWriter{}
+
+	w := New(q, &fakeCache{}, primary, writer)
+	w.SetFallbackProviders(providers.New(providers.PetitLyrics, secondary))
+	w.SetProvidersMode(orchestrator.ModeParallel) // after fallback: order-independent rebuild
+	w.SetRaceWait(500 * time.Millisecond)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(writer.songs) != 1 {
+		t.Fatalf("writes = %d; want 1", len(writer.songs))
+	}
+	if len(writer.songs[0].Subtitles.Lines) == 0 {
+		t.Fatalf("written song = %+v; want the synced result (synced preempts held unsynced within the window)", writer.songs[0])
+	}
+}
+
+// TestRunOnceParallelWindowElapsesCommitsUnsynced verifies that when the synced
+// upgrade arrives after the race window, the held unsynced result is committed.
+func TestRunOnceParallelWindowElapsesCommitsUnsynced(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:     31,
+		Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "artist-title.lrc"},
+	}}}
+	primary := &delayFetcher{song: unsyncedTrackSong(track)}
+	secondary := &delayFetcher{song: syncedTrackSong(track), delay: 200 * time.Millisecond}
+	writer := &capturingWriter{}
+
+	w := New(q, &fakeCache{}, primary, writer)
+	w.SetFallbackProviders(providers.New(providers.PetitLyrics, secondary))
+	w.SetProvidersMode(orchestrator.ModeParallel)
+	w.SetRaceWait(20 * time.Millisecond)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(writer.songs) != 1 {
+		t.Fatalf("writes = %d; want 1", len(writer.songs))
+	}
+	if writer.songs[0].Lyrics.LyricsBody == "" || len(writer.songs[0].Subtitles.Lines) != 0 {
+		t.Fatalf("written song = %+v; want the unsynced result (window elapsed before the synced upgrade)", writer.songs[0])
+	}
+}
 
 // TestRunOnceFallsBackToSecondaryLaneOnPrimaryMiss verifies that when the
 // primary (Musixmatch) lane returns a benign miss, the orchestrator advances to

--- a/internal/worker/multilane_test.go
+++ b/internal/worker/multilane_test.go
@@ -67,6 +67,24 @@ func TestProvidersModeDefaultsToOrdered(t *testing.T) {
 	}
 }
 
+// TestSetProvidersModeInvalidRollsBack asserts that an unknown mode (which would
+// fail the orchestrator rebuild) is rolled back, so w.mode never diverges from the
+// live orchestrator and later setters keep working.
+func TestSetProvidersModeInvalidRollsBack(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetProvidersMode("parallel")
+	w.SetProvidersMode("sequential") // invalid: rebuild fails, must roll back
+
+	if w.mode != orchestrator.ModeParallel {
+		t.Fatalf("mode = %q; want %q (invalid mode must roll back to the prior valid mode)", w.mode, orchestrator.ModeParallel)
+	}
+	// A subsequent valid setter must still succeed (the orchestrator was not wedged).
+	w.SetFallbackProviders(providers.New(providers.PetitLyrics, &fakeFetcher{}))
+	if len(w.lanes) != 2 {
+		t.Fatalf("lanes = %d; want 2 (later setters must still work after a rejected mode)", len(w.lanes))
+	}
+}
+
 // TestRunOnceParallelSyncedPreemptsUnsynced verifies that in parallel mode a
 // faster unsynced primary result is held long enough for a slower synced fallback
 // to preempt it, so the committed (written) result is the synced one.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -187,11 +187,11 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 // calls this so their effect is order-independent. On the impossible New error
 // (the primary lane is always present and the mode is config-validated) the prior
 // orchestrator is kept.
-func (w *Worker) rebuildOrchestrator() {
+func (w *Worker) rebuildOrchestrator() error {
 	orch, err := orchestrator.New(w.mode, w.lanes...)
 	if err != nil {
 		slog.Error("worker: rebuild orchestrator", "error", err, "mode", w.mode)
-		return
+		return err
 	}
 	orch.SetRaceWait(w.raceWait)
 	// With more than one lane the guard governs fall-through, so wire it into
@@ -201,17 +201,23 @@ func (w *Worker) rebuildOrchestrator() {
 		orch.SetGuard(w.scriptGuard)
 	}
 	w.orch = orch
+	return nil
 }
 
 // SetProvidersMode selects the orchestrator dispatch strategy and rebuilds the
 // orchestrator. An empty value restores ordered. Validation lives in the config
-// layer; an unknown mode here keeps the prior orchestrator (rebuild logs it).
+// layer; as defense in depth, an unknown mode that fails the rebuild is rolled
+// back so w.mode never diverges from the live orchestrator (which would make every
+// later SetFallbackProviders / EnableGuard / SetRaceWait rebuild fail too).
 func (w *Worker) SetProvidersMode(mode string) {
 	if mode == "" {
 		mode = orchestrator.ModeOrdered
 	}
+	prev := w.mode
 	w.mode = mode
-	w.rebuildOrchestrator()
+	if err := w.rebuildOrchestrator(); err != nil {
+		w.mode = prev
+	}
 }
 
 // SetRaceWait overrides the parallel-mode synced-upgrade window. Non-positive
@@ -222,7 +228,9 @@ func (w *Worker) SetRaceWait(d time.Duration) {
 		return
 	}
 	w.raceWait = d
-	w.rebuildOrchestrator()
+	// The mode is unchanged (and already valid) and the primary lane is always
+	// present, so the rebuild cannot fail here; only SetProvidersMode acts on it.
+	_ = w.rebuildOrchestrator()
 }
 
 // SetCircuitOpenDuration overrides the window the worker stays quiet after
@@ -259,8 +267,10 @@ func (w *Worker) SetFallbackProviders(provs ...providers.LyricsProvider) {
 	}
 	w.lanes = lanes
 	// Rebuild over the new lane set, re-applying the configured mode, race wait, and
-	// the guard-fall-through wiring (all order-independent across the setters).
-	w.rebuildOrchestrator()
+	// the guard-fall-through wiring (all order-independent across the setters). The
+	// mode is unchanged (and already valid) and the primary lane is always present,
+	// so the rebuild cannot fail here.
+	_ = w.rebuildOrchestrator()
 }
 
 // SetProvidersVersion sets the current providers generation used to invalidate
@@ -378,7 +388,9 @@ func (w *Worker) EnableGuard(g ScriptGuard) {
 	// would screen every result twice, once in suitability and once in the worker's
 	// terminal guardReject below), preserving exactly-one Accept call per result.
 	// All setters route through rebuildOrchestrator, so their order does not matter.
-	w.rebuildOrchestrator()
+	// The mode is unchanged (and already valid) and the primary lane is always
+	// present, so the rebuild cannot fail here.
+	_ = w.rebuildOrchestrator()
 }
 
 // guardReject reports whether the script guard rejects this song. It returns

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -133,6 +133,12 @@ type Worker struct {
 	// against the current provider set. 0 means "not configured" (cache always
 	// honored), preserving single-provider behavior.
 	providersVersion int
+	// mode is the orchestrator dispatch strategy (orchestrator.ModeOrdered or
+	// ModeParallel). raceWait is the parallel-mode synced-upgrade window. Both are
+	// applied to the orchestrator on every (re)build so setter ordering does not
+	// matter. Defaults: ordered, orchestrator.DefaultRaceWait.
+	mode     string
+	raceWait time.Duration
 }
 
 var errQueueEmpty = errors.New("worker queue empty")
@@ -170,7 +176,53 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		// CLI runs) get indefinite deferral; the config layer sets the cap via
 		// SetMaxMissAttempts using [api].max_miss_attempts (default 15).
 		maxMissAttempts: 0,
+		mode:            orchestrator.ModeOrdered,
+		raceWait:        orchestrator.DefaultRaceWait,
 	}
+}
+
+// rebuildOrchestrator reconstructs the orchestrator over the current lanes using
+// the worker's configured mode and race-wait window, and re-applies the guard
+// wiring rule. Every setter that changes the lanes, mode, race wait, or guard
+// calls this so their effect is order-independent. On the impossible New error
+// (the primary lane is always present and the mode is config-validated) the prior
+// orchestrator is kept.
+func (w *Worker) rebuildOrchestrator() {
+	orch, err := orchestrator.New(w.mode, w.lanes...)
+	if err != nil {
+		slog.Error("worker: rebuild orchestrator", "error", err, "mode", w.mode)
+		return
+	}
+	orch.SetRaceWait(w.raceWait)
+	// With more than one lane the guard governs fall-through, so wire it into
+	// suitability. With a single lane it stays unset (the worker's guardReject is
+	// the sole screen), preserving exactly-one Accept call per result.
+	if len(w.lanes) > 1 && w.scriptGuard != nil {
+		orch.SetGuard(w.scriptGuard)
+	}
+	w.orch = orch
+}
+
+// SetProvidersMode selects the orchestrator dispatch strategy and rebuilds the
+// orchestrator. An empty value restores ordered. Validation lives in the config
+// layer; an unknown mode here keeps the prior orchestrator (rebuild logs it).
+func (w *Worker) SetProvidersMode(mode string) {
+	if mode == "" {
+		mode = orchestrator.ModeOrdered
+	}
+	w.mode = mode
+	w.rebuildOrchestrator()
+}
+
+// SetRaceWait overrides the parallel-mode synced-upgrade window. Non-positive
+// values are ignored so the default window is preserved. Only consulted in
+// parallel mode.
+func (w *Worker) SetRaceWait(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	w.raceWait = d
+	w.rebuildOrchestrator()
 }
 
 // SetCircuitOpenDuration overrides the window the worker stays quiet after
@@ -205,21 +257,10 @@ func (w *Worker) SetFallbackProviders(provs ...providers.LyricsProvider) {
 		cb.SetClock(w.now)
 		lanes = append(lanes, orchestrator.NewLane(p, cb))
 	}
-	orch, err := orchestrator.New(orchestrator.ModeOrdered, lanes...)
-	if err != nil {
-		// lanes always includes the non-nil primary and ModeOrdered is a constant,
-		// so New cannot error here; keep the prior orchestrator if it somehow does.
-		slog.Error("worker: rebuild orchestrator with fallback lanes", "error", err)
-		return
-	}
-	w.orch = orch
 	w.lanes = lanes
-	// With more than one lane the guard governs fall-through, so wire it into
-	// suitability. With a single lane it stays unset (the worker's guardReject is
-	// the sole screen), preserving exactly-one Accept call per result.
-	if len(w.lanes) > 1 && w.scriptGuard != nil {
-		w.orch.SetGuard(w.scriptGuard)
-	}
+	// Rebuild over the new lane set, re-applying the configured mode, race wait, and
+	// the guard-fall-through wiring (all order-independent across the setters).
+	w.rebuildOrchestrator()
 }
 
 // SetProvidersVersion sets the current providers generation used to invalidate
@@ -330,17 +371,14 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 // results whose script mix falls outside the configured allowlist.
 func (w *Worker) EnableGuard(g ScriptGuard) {
 	w.scriptGuard = g
-	// With more than one lane the guard governs fall-through (a guard-failing but
-	// quality-OK primary result must be unsuitable so the orchestrator advances to
-	// the next provider), so wire it into suitability. With a single lane there is
-	// no fall-through decision and setting it would screen every result twice (once
-	// in suitability, once in the worker's terminal guardReject below), so the
-	// worker's own guard stays the sole screening point, preserving exactly-one
-	// Accept call per result. SetFallbackProviders performs the same wiring when
-	// fallbacks are added after the guard, so the two are order-independent.
-	if len(w.lanes) > 1 {
-		w.orch.SetGuard(g)
-	}
+	// Rebuild so the guard-fall-through wiring rule is applied: with more than one
+	// lane the guard governs fall-through (a guard-failing but quality-OK primary
+	// result must be unsuitable so the orchestrator advances to the next provider),
+	// so it is wired into suitability. With a single lane it stays unset (setting it
+	// would screen every result twice, once in suitability and once in the worker's
+	// terminal guardReject below), preserving exactly-one Accept call per result.
+	// All setters route through rebuildOrchestrator, so their order does not matter.
+	w.rebuildOrchestrator()
 }
 
 // guardReject reports whether the script guard rejects this song. It returns


### PR DESCRIPTION
Closes #176. Completes the multi-provider orchestration design (#148) - the last of the four implementation issues (#173 -> #174 -> #175 -> #176).

## What

Adds the opt-in `[providers] mode = "parallel"` topology. Parallel mode dispatches every available lane concurrently and races them: the first **synced** (highest-quality) result wins immediately, while a faster **unsynced** result is held for a bounded window so a slower synced result can preempt it. Ordered remains the default and is behaviorally untouched.

Parallel makes more upstream calls (one per lane per lookup), so it is documented as not advised against rate-limited providers (e.g. Musixmatch) unless latency matters more than call volume.

## Changes

- **config**: accept `mode = "parallel"`; add `race_wait_seconds` (default 2, non-positive clamped to default) + env `MXLRC_PROVIDERS_RACE_WAIT_SECONDS`.
- **orchestrator**: `FindLyrics` branches on mode; new `parallel.go` `findParallel` derives a child context (`defer cancel()` on every path), launches one goroutine per lane, and funnels into a results channel buffered to the lane count so a losing lane's send never blocks after cancel (no goroutine leak). The bounded synced-upgrade window is armed only while another lane could still deliver an upgrade, so a held unsynced result with nothing left to upgrade it commits immediately. Ordered and parallel share one accumulator/resolver, keeping cross-lane precedence (Gap 4) identical. `raceWait` is stored once via `SetRaceWait` - no `2 * time.Second` literal in the dispatch path.
- **worker**: `mode` + `raceWait` fields and a private `rebuildOrchestrator()` reused by `New`, `SetFallbackProviders`, `EnableGuard`, and the new `SetProvidersMode` / `SetRaceWait` setters, so all wiring is order-independent.
- **commands**: `serve` wires `cfg.Providers.Mode` + `RaceWaitSeconds` into the worker.
- **docs**: `config.example.toml` documents both knobs; design doc marks the #173-#176 follow-ups complete.

## Acceptance criteria

- [x] `mode = "parallel"` dispatches all available lanes concurrently and returns the first suitable result; documented in `config.example.toml`.
- [x] Committing a winner cancels sibling in-flight fetches; no goroutine leak (verified under `-race` with a deterministic started/finished completion assertion + a `NumGoroutine` settle check).
- [x] `race_wait_seconds` config (default 2) gates the synced-preempts-unsynced window; no literal in the dispatch path.
- [x] A synced result preempts an already-held unsynced result within the window; the window elapsing commits the unsynced one.
- [x] Ordered mode is unaffected and remains the default.

## Notes / design choices

- The window arms only while an upgrade is still possible, so single-lane parallel behaves like ordered (no needless wait) - a small improvement beyond a literal reading of the issue.
- Reused the existing `Quality` / `IsSuitable` types instead of adding a separate `resultQuality` type (CR's plan suggested one) - less duplication, same behavior.
- `fetch` (one-shot) stays primary-only; parallel race is worker/serve-only (matches #175). No `lyrics_cache` schema change.

## Testing

TDD red -> green throughout. New tests cover parallel dispatch, synced-preempts-unsynced, window-elapsed-commits-unsynced, fast-synced-wins-immediately, single-unsynced-immediate, all-miss, best-available, auth-outranks-miss, guard-driven suitability, goroutine-leak, and parent-cancel; plus config (parallel accepted, invalid rejected, race_wait default/parse/env/clamp) and worker RunOnce parallel paths. `make gate` green (gofmt, build, `-race` tests, patch coverage 85%, golangci-lint, actionlint, govulncheck). Functional smoke: real `serve` boot in parallel mode with a fallback lane starts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in parallel provider dispatch for concurrent lyric lookups with synced-vs-unsynced racing.
  * New race_wait_seconds setting (default 2s) to control the parallel upgrade window.
  * Environment override: MXLRC_PROVIDERS_RACE_WAIT_SECONDS supported.

* **Documentation**
  * Updated configuration example and multi-provider orchestration guide to describe parallel mode and race_wait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->