### PR TITLE
feat(petitlyrics): select search candidate by album, prefer synced (#191)

### DIFF
--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -49,6 +49,17 @@ var csrfTokenRe = regexp.MustCompile(`csrfToken\s*[:=]\s*["']([^"']+)["']`)
 // may be two or three digits in the wild; we normalize to hundredths.
 var lrcLineRe = regexp.MustCompile(`^\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?\](.*)$`)
 
+// candidateBlockRe matches the inner content of a single <li> result block
+// (dot-all so the block can span multiple lines).
+var candidateBlockRe = regexp.MustCompile(`(?s)<li[^>]*>(.*?)</li>`)
+
+// candidateAlbumRe extracts the text from a lyrics-list-album element.
+// The class token may appear alongside other classes (e.g. "lyrics-list-album active").
+var candidateAlbumRe = regexp.MustCompile(`(?i)class=["'][^"']*\blyrics-list-album\b[^"']*["'][^>]*>([^<]+)<`)
+
+// candidateSyncedRe detects a text_sync marker anywhere in a candidate block.
+var candidateSyncedRe = regexp.MustCompile(`(?i)text_sync`)
+
 // Client communicates with petitlyrics.com over its reverse-engineered
 // endpoints.
 type Client struct {
@@ -247,11 +258,7 @@ func (c *Client) searchLyricsID(ctx context.Context, track models.Track) (string
 		return "", err
 	}
 
-	m := lyricsLinkRe.FindSubmatch(body)
-	if m == nil {
-		return "", fmt.Errorf("petitlyrics: search: no lyrics link found: %w", ErrNotFound)
-	}
-	return string(m[1]), nil
+	return selectCandidate(parseSearchCandidates(body), track.AlbumName)
 }
 
 // fetchCSRFToken fetches the static pl-lib.js file, scrapes the CSRF token, and
@@ -305,6 +312,91 @@ const (
 	lyricsTypeTranslation  = 4
 	lyricsTypeRomanization = 5
 )
+
+// searchCandidate holds one result from the /search_lyrics HTML response.
+type searchCandidate struct {
+	id     string // numeric id from /lyrics/<id>
+	album  string // text of lyrics-list-album element; empty if absent
+	synced bool   // true when text_sync marker is present in the item block
+}
+
+// normalizeAlbum lowercases, trims, and collapses internal whitespace so that
+// "(Deluxe Edition)" suffixes and minor spacing differences do not prevent a
+// prefix match.
+func normalizeAlbum(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+// albumMatches reports whether candidate matches query using a normalized
+// prefix comparison. Exact match and edition-suffix variants (e.g. "Album
+// Name (Deluxe Edition)" vs "Album Name") both return true. Substring-only
+// matches (e.g. "Hits" inside "Greatest Hits") do not. An empty candidate
+// or query never matches so that blank-album candidates fall through to the
+// fallback-to-all path rather than polluting an album-narrowed working set.
+func albumMatches(candidate, query string) bool {
+	nc := normalizeAlbum(candidate)
+	nq := normalizeAlbum(query)
+	if nc == "" || nq == "" {
+		return false
+	}
+	return strings.HasPrefix(nc, nq) || strings.HasPrefix(nq, nc)
+}
+
+// parseSearchCandidates extracts all lyrics candidates from the /search_lyrics
+// HTML response. Each <li> block is inspected for a /lyrics/<id> link; blocks
+// without one are skipped. Album and sync-type are extracted from the
+// lyrics-list-album class element and text_sync marker respectively.
+func parseSearchCandidates(body []byte) []searchCandidate {
+	blocks := candidateBlockRe.FindAllSubmatch(body, -1)
+	var candidates []searchCandidate
+	for _, block := range blocks {
+		inner := block[1]
+		m := lyricsLinkRe.FindSubmatch(inner)
+		if m == nil {
+			continue
+		}
+		album := ""
+		if am := candidateAlbumRe.FindSubmatch(inner); am != nil {
+			album = strings.TrimSpace(string(am[1]))
+		}
+		candidates = append(candidates, searchCandidate{
+			id:     string(m[1]),
+			album:  album,
+			synced: candidateSyncedRe.Match(inner),
+		})
+	}
+	return candidates
+}
+
+// selectCandidate picks the best candidate id from the search results.
+// When album is non-empty, candidates whose album field matches (via
+// albumMatches) form a preferred working set; if no candidates match the
+// album, all candidates are used (best-effort fallback). Within the working
+// set, the first synced candidate wins; otherwise the first candidate is
+// returned. An empty candidates slice returns ErrNotFound.
+func selectCandidate(candidates []searchCandidate, album string) (string, error) {
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("petitlyrics: search: no lyrics link found: %w", ErrNotFound)
+	}
+	working := candidates
+	if album != "" {
+		var matched []searchCandidate
+		for _, c := range candidates {
+			if albumMatches(c.album, album) {
+				matched = append(matched, c)
+			}
+		}
+		if len(matched) > 0 {
+			working = matched
+		}
+	}
+	for _, c := range working {
+		if c.synced {
+			return c.id, nil
+		}
+	}
+	return working[0].id, nil
+}
 
 // trackFromEntry decodes one ajaxEntry's base64 payload into synced lines via
 // parseLRC. It returns ok=false when the payload is empty, undecodable, or

--- a/internal/petitlyrics/selection_test.go
+++ b/internal/petitlyrics/selection_test.go
@@ -1,0 +1,312 @@
+package petitlyrics
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// liBlock builds one <li> block for a multi-candidate search HTML fixture.
+func liBlock(id, album string, synced bool) string {
+	var sb strings.Builder
+	sb.WriteString(`<li class="lyrics-list-item">`)
+	sb.WriteString(`<a href="/lyrics/` + id + `">Song Title</a>`)
+	if album != "" {
+		sb.WriteString(`<p class="lyrics-list-album">` + album + `</p>`)
+	}
+	if synced {
+		sb.WriteString(`<span class="text_sync"></span>`)
+	}
+	sb.WriteString(`</li>`)
+	return sb.String()
+}
+
+// searchHTMLMulti wraps a set of liBlock strings in a minimal search result page.
+func searchHTMLMulti(blocks ...string) string {
+	return `<html><body><ul class="lyrics-list">` +
+		strings.Join(blocks, "\n") +
+		`</ul></body></html>`
+}
+
+func TestParseSearchCandidates(t *testing.T) {
+	html := searchHTMLMulti(
+		liBlock("100", "Album One", true),
+		liBlock("200", "Album Two", false),
+		liBlock("300", "", false),
+		// spurious <li> with no lyrics link must be skipped
+		`<li class="nav-item"><a href="/about">About</a></li>`,
+	)
+	got := parseSearchCandidates([]byte(html))
+	if len(got) != 3 {
+		t.Fatalf("want 3 candidates, got %d", len(got))
+	}
+	if got[0].id != "100" || got[0].album != "Album One" || !got[0].synced {
+		t.Errorf("candidate 0 = %+v; want {id:100 album:Album One synced:true}", got[0])
+	}
+	if got[1].id != "200" || got[1].album != "Album Two" || got[1].synced {
+		t.Errorf("candidate 1 = %+v; want {id:200 album:Album Two synced:false}", got[1])
+	}
+	if got[2].id != "300" || got[2].album != "" || got[2].synced {
+		t.Errorf("candidate 2 = %+v; want {id:300 album: synced:false}", got[2])
+	}
+}
+
+func TestParseSearchCandidates_Empty(t *testing.T) {
+	if got := parseSearchCandidates([]byte(`<html><body>no results</body></html>`)); len(got) != 0 {
+		t.Fatalf("want 0 candidates for no-results page, got %d", len(got))
+	}
+}
+
+// TestParseSearchCandidates_MultiClassAlbum verifies that the album class token
+// is matched even when additional classes appear on the same element.
+func TestParseSearchCandidates_MultiClassAlbum(t *testing.T) {
+	html := `<ul><li class="lyrics-list-item">` +
+		`<a href="/lyrics/42">Song</a>` +
+		`<p class="lyrics-list-album active">Multi Class Album</p>` +
+		`</li></ul>`
+	got := parseSearchCandidates([]byte(html))
+	if len(got) != 1 {
+		t.Fatalf("want 1 candidate, got %d", len(got))
+	}
+	if got[0].album != "Multi Class Album" {
+		t.Errorf("album = %q; want %q", got[0].album, "Multi Class Album")
+	}
+}
+
+func TestNormalizeAlbum(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Greatest Hits", "greatest hits"},
+		{"  Greatest  Hits  ", "greatest hits"},
+		{"Greatest Hits (Deluxe Edition)", "greatest hits (deluxe edition)"},
+	}
+	for _, tc := range cases {
+		if got := normalizeAlbum(tc.in); got != tc.want {
+			t.Errorf("normalizeAlbum(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAlbumMatches(t *testing.T) {
+	cases := []struct {
+		candidate, query string
+		want             bool
+	}{
+		// exact match
+		{"Greatest Hits", "Greatest Hits", true},
+		// edition suffix on candidate, base in query
+		{"Greatest Hits (Deluxe Edition)", "Greatest Hits", true},
+		// edition suffix on query, base on candidate
+		{"Greatest Hits", "Greatest Hits (Deluxe Edition)", true},
+		// remaster variant
+		{"Greatest Hits (Remastered 2011)", "Greatest Hits", true},
+		// "Hits" must NOT match "Greatest Hits" (no prefix in either direction)
+		{"Greatest Hits", "Hits", false},
+		{"Hits", "Greatest Hits", false},
+		// empty candidate album must not match any non-empty query
+		{"", "Greatest Hits", false},
+		// empty query must not match any candidate
+		{"Greatest Hits", "", false},
+		// completely unrelated
+		{"Album One", "Album Two", false},
+	}
+	for _, tc := range cases {
+		got := albumMatches(tc.candidate, tc.query)
+		if got != tc.want {
+			t.Errorf("albumMatches(%q, %q) = %v; want %v", tc.candidate, tc.query, got, tc.want)
+		}
+	}
+}
+
+func TestSelectCandidate(t *testing.T) {
+	cases := []struct {
+		name       string
+		candidates []searchCandidate
+		album      string
+		wantID     string
+		wantErr    error
+	}{
+		{
+			name:    "zero candidates",
+			wantErr: ErrNotFound,
+		},
+		{
+			name:       "single candidate, no album arg",
+			candidates: []searchCandidate{{id: "1", synced: false}},
+			wantID:     "1",
+		},
+		{
+			name: "multi, no album arg, no synced - return first",
+			candidates: []searchCandidate{
+				{id: "1", synced: false},
+				{id: "2", synced: false},
+			},
+			wantID: "1",
+		},
+		{
+			name: "multi, no album arg, synced available - prefer synced",
+			candidates: []searchCandidate{
+				{id: "1", synced: false},
+				{id: "2", synced: true},
+			},
+			wantID: "2",
+		},
+		{
+			name: "album match with no synced in matched set - return album match",
+			candidates: []searchCandidate{
+				{id: "1", album: "A", synced: false},
+				{id: "2", album: "B", synced: true},
+			},
+			album:  "A",
+			wantID: "1",
+		},
+		{
+			name: "album match with synced in matched set - prefer synced album match",
+			candidates: []searchCandidate{
+				{id: "1", album: "A", synced: false},
+				{id: "2", album: "A", synced: true},
+				{id: "3", album: "B", synced: true},
+			},
+			album:  "A",
+			wantID: "2",
+		},
+		{
+			name: "no album match - fall back to all, prefer synced",
+			candidates: []searchCandidate{
+				{id: "1", album: "A", synced: false},
+				{id: "2", album: "B", synced: true},
+			},
+			album:  "Z",
+			wantID: "2",
+		},
+		{
+			name: "no album match - fall back to all, no synced - return first",
+			candidates: []searchCandidate{
+				{id: "1", album: "A", synced: false},
+				{id: "2", album: "B", synced: false},
+			},
+			album:  "Z",
+			wantID: "1",
+		},
+		{
+			name: "edition suffix in candidate album - matches base query",
+			candidates: []searchCandidate{
+				{id: "1", album: "Greatest Hits (Deluxe Edition)", synced: false},
+				{id: "2", album: "Other Album", synced: true},
+			},
+			album:  "Greatest Hits",
+			wantID: "1",
+		},
+		{
+			name: "substring non-match: Hits should not match Greatest Hits",
+			candidates: []searchCandidate{
+				{id: "1", album: "Greatest Hits", synced: false},
+				{id: "2", album: "Hits", synced: true},
+			},
+			album: "Hits",
+			// only id=2 matches "Hits" exactly; id=1 "Greatest Hits" does not
+			wantID: "2",
+		},
+		{
+			name: "empty album arg - ignore album, prefer synced",
+			candidates: []searchCandidate{
+				{id: "1", album: "A", synced: false},
+				{id: "2", album: "B", synced: true},
+			},
+			album:  "",
+			wantID: "2",
+		},
+		{
+			// Regression: a blank-album candidate must NOT enter the matched set
+			// when a non-empty query album is given. HasPrefix(nq, "") is always
+			// true without the empty-string guard, so id:1 would wrongly win.
+			name: "blank-album candidate must not match non-empty query (empty-string guard)",
+			candidates: []searchCandidate{
+				{id: "1", album: "", synced: false},
+				{id: "2", album: "Target Album", synced: false},
+			},
+			album:  "Target Album",
+			wantID: "2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := selectCandidate(tc.candidates, tc.album)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v; want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID {
+				t.Fatalf("id = %q; want %q", id, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestFindLyrics_MultiCandidate_AlbumSelection verifies end-to-end that
+// FindLyrics picks the album-matched candidate and uses its id for the AJAX
+// lyrics fetch.
+func TestFindLyrics_MultiCandidate_AlbumSelection(t *testing.T) {
+	lrc := "[00:01.00]picked\n"
+	// Two candidates: id=100 (Album A, not synced) and id=200 (Album B, synced).
+	// With album="Album B" the selector should pick id=200 (album match + synced).
+	f := &fixtureServer{
+		searchBody: searchHTMLMulti(
+			liBlock("100", "Album A", false),
+			liBlock("200", "Album B", true),
+		),
+		jsBody:   validJS,
+		ajaxBody: ajaxJSON(b64(lrc), 2),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	song, err := c.FindLyrics(context.Background(), models.Track{
+		TrackName:  "x",
+		ArtistName: "y",
+		AlbumName:  "Album B",
+	})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) != 1 || song.Subtitles.Lines[0].Text != "picked" {
+		t.Fatalf("song = %+v; want one synced line 'picked'", song.Subtitles)
+	}
+}
+
+// TestFindLyrics_MultiCandidate_NoAlbumMatch_FallsBack verifies that when no
+// candidate matches the requested album, FindLyrics does not return an error
+// and instead falls back to the global synced-preference logic.
+func TestFindLyrics_MultiCandidate_NoAlbumMatch_FallsBack(t *testing.T) {
+	lrc := "[00:01.00]fallback\n"
+	f := &fixtureServer{
+		searchBody: searchHTMLMulti(
+			liBlock("100", "Album A", false),
+			liBlock("200", "Album B", true),
+		),
+		jsBody:   validJS,
+		ajaxBody: ajaxJSON(b64(lrc), 2),
+	}
+	srv := newFixtureServer(t, f)
+	c := newTestClient(srv)
+
+	// AlbumName="Z" matches nothing; should fall back and pick id=200 (synced).
+	song, err := c.FindLyrics(context.Background(), models.Track{
+		TrackName:  "x",
+		ArtistName: "y",
+		AlbumName:  "Z",
+	})
+	if err != nil {
+		t.Fatalf("FindLyrics with no album match should not error; got: %v", err)
+	}
+	if len(song.Subtitles.Lines) == 0 {
+		t.Fatal("expected lyrics from fallback candidate, got none")
+	}
+}


### PR DESCRIPTION
## Summary

petitlyrics' search returns multiple candidates (each tagged with album + sync type), but the client discarded them and took the first `/lyrics/<id>`. This reworks `searchLyricsID` to parse ALL candidates and select intentionally:

- Narrow to candidates whose album matches the queued song's album, using a normalized (lowercase / trim / whitespace-collapsed), edition-suffix-tolerant prefix match (so "(Deluxe Edition)" / "(Remastered)" still match, but "Hits" does not match "Greatest Hits").
- Within the working set, prefer synced (`text_sync`) lyrics over plain text.
- Fall back to ALL candidates when no album matches, so it never fails where the old first-match code succeeded.

petitlyrics exposes album (its only disambiguation lever) but no duration/ISRC, so album-narrowing is how this provider distinguishes recordings.

## Linked issue

Part of #191 (petitlyrics album-selection lane). #191 stays open for the ISRC/duration (C1) and MusicBrainz (C2) lanes.

## Test plan

- [x] `make gate` green: build, race tests, golangci-lint 0 issues, govulncheck clean
- [x] Patch coverage 100% (47/47) on `internal/petitlyrics/client.go`
- [x] Table-driven tests: parseSearchCandidates (multi / single / empty / multi-class), albumMatches (edition-suffix match, "Hits"/"Greatest Hits" non-match, empty-string guard), selectCandidate (album match, no-match fallback, synced preference, blank-album regression)
- [x] Adversarial review pass: found + fixed an empty-string `albumMatches` bug, now locked by a regression test
