### PR TITLE
feat(scanner): recording enrichment (ISRC/MBID/duration) + relicense to GPL-3.0 (#191)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 # The two differ only in how the binary arrives (built here vs copied by goreleaser).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="GPL-3.0"
 
 RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2022 fahmi
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,36 @@
+mxlrcgo-svc
+
+This program is free software licensed under the GNU General Public License,
+version 3.0 (GPL-3.0). See the LICENSE file for the full license text.
+
+Copyright (C) 2026 sydlexius and contributors.
+
+--------------------------------------------------------------------------------
+
+This work is a derivative of the original "mxlrcgo" project by fahmi, which is
+distributed under the MIT License. In accordance with the MIT License, the
+original copyright and permission notice is retained below. The MIT-licensed
+portions remain available under the MIT License; the combined work as a whole is
+distributed under the GPL-3.0.
+
+    MIT License
+
+    Copyright (c) 2022 fahmi
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `M
 
 ## License
 
-[MIT](LICENSE).
+[GPL-3.0](LICENSE). This project is a fork of [fashni/mxlrc-go](https://github.com/fashni/mxlrc-go), which is MIT-licensed; the original MIT copyright and permission notice are retained in [NOTICE](NOTICE).

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -5,7 +5,7 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 # The two differ only in how the binary arrives (copied here vs built in the root Dockerfile).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="GPL-3.0"
 
 RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/lizc2003/audioduration v0.8.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/lizc2003/audioduration v0.8.0 h1:EWOR9jsSOcg1OpriKVCBAkcHce7zPX1pwTEv1Y0EgVs=
+github.com/lizc2003/audioduration v0.8.0/go.mod h1:83wTmbasMJdlL2y7YYqlpLeSoVo5CoIXdJwuqeZ3TnY=
 github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
 github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -10,11 +10,13 @@ type Track struct {
 	Instrumental int    `json:"instrumental,omitempty"`
 	HasLyrics    int    `json:"has_lyrics,omitempty"`
 	HasSubtitles int    `json:"has_subtitles,omitempty"`
-	// ISRC and SpotifyID are recording-level identifiers fed to the matcher when
-	// present (see internal/musixmatch). Currently populated only by the
-	// fetch --probe diagnostic flags; the normal scan path leaves them empty.
-	ISRC      string `json:"isrc,omitempty"`
-	SpotifyID string `json:"spotify_id,omitempty"`
+	// ISRC, SpotifyID, and RecordingMBID are recording-level identifiers fed to
+	// the matcher when present (see internal/musixmatch). ISRC and RecordingMBID
+	// are populated from audio tags during library scans; SpotifyID is populated
+	// only by the fetch --probe diagnostic flags.
+	ISRC          string `json:"isrc,omitempty"`
+	SpotifyID     string `json:"spotify_id,omitempty"`
+	RecordingMBID string `json:"recording_mbid,omitempty"`
 }
 
 // Lyrics holds unsynced lyrics text.

--- a/internal/scanner/recording_test.go
+++ b/internal/scanner/recording_test.go
@@ -1,0 +1,208 @@
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/testutil"
+)
+
+const (
+	testISRC = "GBRC12345678"
+	testMBID = "550e8400-e29b-41d4-a716-446655440000"
+)
+
+// skipDurationScanner returns a Scanner whose probeFunc always returns 0,
+// for tests that only care about tag extraction, not duration.
+func skipDurationScanner() *Scanner {
+	return &Scanner{probeFunc: func(string) (int, error) { return 0, nil }}
+}
+
+func TestExtractISRC_Present(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFileExtended(dir, "track.mp3", "Artist", "Title", "Album", "",
+		map[string]string{"TSRC": testISRC}, nil); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if got := results[0].Track.ISRC; got != testISRC {
+		t.Errorf("Track.ISRC = %q; want %q", got, testISRC)
+	}
+}
+
+func TestExtractISRC_Absent(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "Artist", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if got := results[0].Track.ISRC; got != "" {
+		t.Errorf("Track.ISRC = %q; want empty", got)
+	}
+}
+
+func TestExtractRecordingMBID_Present(t *testing.T) {
+	dir := t.TempDir()
+	// mbz.Extract reads TXXX frames; "MusicBrainz Track Id" is the alias for
+	// the Recording constant in the mbz package (mbz.tags[Recording]).
+	if err := testutil.WriteAudioFileExtended(dir, "track.mp3", "Artist", "Title", "Album", "",
+		nil, map[string]string{"MusicBrainz Track Id": testMBID}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if got := results[0].Track.RecordingMBID; got != testMBID {
+		t.Errorf("Track.RecordingMBID = %q; want %q", got, testMBID)
+	}
+}
+
+func TestExtractRecordingMBID_Absent(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "Artist", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if got := results[0].Track.RecordingMBID; got != "" {
+		t.Errorf("Track.RecordingMBID = %q; want empty", got)
+	}
+}
+
+// TestProbeDuration_ProberCalled verifies that probeFunc is called and its return
+// value populates Track.TrackLength.
+func TestProbeDuration_ProberCalled(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "Artist", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	sc := &Scanner{probeFunc: func(path string) (int, error) {
+		if filepath.Base(path) != "track.mp3" {
+			t.Errorf("probeFunc called with unexpected path %q", path)
+		}
+		return 180, nil
+	}}
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if got := results[0].Track.TrackLength; got != 180 {
+		t.Errorf("Track.TrackLength = %d; want 180", got)
+	}
+}
+
+// TestProbeDuration_ProberError_GracefulDegrade verifies that a per-file probe
+// error degrades TrackLength to 0 without failing the scan.
+func TestProbeDuration_ProberError_GracefulDegrade(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "Artist", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	sc := &Scanner{probeFunc: func(string) (int, error) { return 0, errors.New("corrupt file") }}
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("ScanLibrary must not fail on per-file probe error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1 (track must still be scanned)", len(results))
+	}
+	if got := results[0].Track.TrackLength; got != 0 {
+		t.Errorf("Track.TrackLength = %d; want 0 (graceful degrade)", got)
+	}
+	wantPath := filepath.Join(dir, "track.mp3")
+	if got := results[0].FilePath; got != wantPath {
+		t.Errorf("FilePath = %q; want %q", got, wantPath)
+	}
+}
+
+// TestAudioDuration_FLAC verifies that audioDuration correctly parses a STREAMINFO
+// block to compute duration. The fixture encodes exactly 44100 samples at 44100 Hz
+// (1 second), so int(secs) must equal 1.
+func TestAudioDuration_FLAC(t *testing.T) {
+	const sampleRate = 44100
+	const totalSamples = 44100 // exactly 1 second
+
+	data := testutil.GenerateFLAC(sampleRate, totalSamples)
+	got, err := audioDuration(bytes.NewReader(data), ".flac")
+	if err != nil {
+		t.Fatalf("audioDuration: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("duration = %d; want 1", got)
+	}
+}
+
+// TestAudioDuration_FLAC_MultiSecond exercises a longer duration.
+func TestAudioDuration_FLAC_MultiSecond(t *testing.T) {
+	const sampleRate = 44100
+	const totalSamples = 44100 * 179 // 179 seconds exactly
+
+	data := testutil.GenerateFLAC(sampleRate, totalSamples)
+	got, err := audioDuration(bytes.NewReader(data), ".flac")
+	if err != nil {
+		t.Fatalf("audioDuration: %v", err)
+	}
+	if got != 179 {
+		t.Errorf("duration = %d; want 179", got)
+	}
+}
+
+// TestAudioDuration_UnknownExt verifies that an unrecognized extension returns
+// an error and duration 0 (not a panic).
+func TestAudioDuration_UnknownExt(t *testing.T) {
+	got, err := audioDuration(bytes.NewReader([]byte("junk")), ".xyz")
+	if err == nil {
+		t.Error("expected error for unknown extension; got nil")
+	}
+	if got != 0 {
+		t.Errorf("duration = %d; want 0 for error case", got)
+	}
+}
+
+// TestWriteAudioFileExtended_CreatesFile verifies the testutil helper itself.
+func TestWriteAudioFileExtended_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	err := testutil.WriteAudioFileExtended(dir, "track.mp3", "A", "T", "Al", "",
+		map[string]string{"TSRC": "US-12345678"},
+		map[string]string{"MusicBrainz Track Id": "some-uuid"})
+	if err != nil {
+		t.Fatalf("WriteAudioFileExtended: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "track.mp3")); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -24,18 +24,24 @@ import (
 // supportedFileTypes lists audio file extensions that can have metadata read.
 var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".flac", ".ogg", ".dsf"}
 
-// audioFileType maps a lower-case audio file extension to the audioduration type
-// constant used for header-only duration parsing. Extensions absent from this map
-// are not probed and get TrackLength=0.
-var audioFileType = map[string]int{
-	".flac": audioduration.TypeFlac,
-	".mp3":  audioduration.TypeMp3,
-	".m4a":  audioduration.TypeMp4,
-	".m4b":  audioduration.TypeMp4,
-	".m4p":  audioduration.TypeMp4,
-	".alac": audioduration.TypeMp4,
-	".ogg":  audioduration.TypeOgg,
-	".dsf":  audioduration.TypeDsd,
+// audioFileTypeForExt returns the audioduration type constant for a lower-case
+// audio file extension. Extensions not recognized return (0, false); callers
+// degrade to TrackLength=0 (the "unknown duration" sentinel).
+func audioFileTypeForExt(ext string) (int, bool) {
+	switch ext {
+	case ".flac":
+		return audioduration.TypeFlac, true
+	case ".mp3":
+		return audioduration.TypeMp3, true
+	case ".m4a", ".m4b", ".m4p", ".alac":
+		return audioduration.TypeMp4, true
+	case ".ogg":
+		return audioduration.TypeOgg, true
+	case ".dsf":
+		return audioduration.TypeDsd, true
+	default:
+		return 0, false
+	}
 }
 
 // Scanner handles parsing input sources and populating the work queue.
@@ -68,7 +74,7 @@ func NewScanner() *Scanner {
 // Returns 0 and a wrapped error for unknown extension or parse failure;
 // callers treat 0 as the "unknown duration" sentinel (duration_bucket=0).
 func audioDuration(r io.ReadSeeker, ext string) (int, error) {
-	ft, ok := audioFileType[ext]
+	ft, ok := audioFileTypeForExt(ext)
 	if !ok {
 		return 0, fmt.Errorf("no duration parser for %s", ext)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -14,6 +15,8 @@ import (
 	"strings"
 
 	"github.com/dhowden/tag"
+	"github.com/dhowden/tag/mbz"
+	"github.com/lizc2003/audioduration"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
@@ -21,8 +24,26 @@ import (
 // supportedFileTypes lists audio file extensions that can have metadata read.
 var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".flac", ".ogg", ".dsf"}
 
+// audioFileType maps a lower-case audio file extension to the audioduration type
+// constant used for header-only duration parsing. Extensions absent from this map
+// are not probed and get TrackLength=0.
+var audioFileType = map[string]int{
+	".flac": audioduration.TypeFlac,
+	".mp3":  audioduration.TypeMp3,
+	".m4a":  audioduration.TypeMp4,
+	".m4b":  audioduration.TypeMp4,
+	".m4p":  audioduration.TypeMp4,
+	".alac": audioduration.TypeMp4,
+	".ogg":  audioduration.TypeOgg,
+	".dsf":  audioduration.TypeDsd,
+}
+
 // Scanner handles parsing input sources and populating the work queue.
-type Scanner struct{}
+type Scanner struct {
+	// probeFunc, when set, is used as the duration probe instead of audioduration
+	// (tests only -- lets tests inject a known duration without real audio fixtures).
+	probeFunc func(string) (int, error)
+}
 
 // ScanOptions controls library directory traversal and queue eligibility.
 type ScanOptions struct {
@@ -33,13 +54,59 @@ type ScanOptions struct {
 	// EmbeddedLyrics controls handling of unsynced lyrics embedded in tags:
 	// "off" (default) ignores them; "respect" skips fetching a file that already
 	// carries embedded lyrics; "extract" writes them to a .txt sidecar (and then
-	// skips fetching). Synced (SYLT) tags are intentionally out of scope.
+	// skips fetching). Synced (SYLT) tags are intentionally not handled. "off"
+	// (default) is a no-op.
 	EmbeddedLyrics string
 }
 
 // NewScanner creates a new Scanner.
 func NewScanner() *Scanner {
 	return &Scanner{}
+}
+
+// audioDuration reads the header of r to determine duration in seconds.
+// Returns 0 and a wrapped error for unknown extension or parse failure;
+// callers treat 0 as the "unknown duration" sentinel (duration_bucket=0).
+func audioDuration(r io.ReadSeeker, ext string) (int, error) {
+	ft, ok := audioFileType[ext]
+	if !ok {
+		return 0, fmt.Errorf("no duration parser for %s", ext)
+	}
+	secs, err := audioduration.Duration(r, ft)
+	if err != nil {
+		return 0, fmt.Errorf("duration %s: %w", ext, err)
+	}
+	return int(secs), nil
+}
+
+// probeDuration returns the duration in seconds for the file at f.
+// Uses probeFunc when set (tests), otherwise calls audioDuration.
+func (sc *Scanner) probeDuration(f *os.File, ext string) (int, error) {
+	if sc.probeFunc != nil {
+		return sc.probeFunc(f.Name())
+	}
+	return audioDuration(f, ext)
+}
+
+// extractISRC returns the ISRC from audio tag metadata, or "" if absent.
+// Checks format-specific raw keys in priority order: TSRC (ID3v2.3/v2.4),
+// TRC (ID3v2.2), isrc/ISRC (Vorbis/FLAC), iTunes freeform atom (MP4).
+func extractISRC(m tag.Metadata) string {
+	raw := m.Raw()
+	for _, k := range []string{"TSRC", "TRC", "isrc", "ISRC", "----:com.apple.iTunes:ISRC"} {
+		if v, ok := raw[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// extractRecordingMBID returns the MusicBrainz recording ID from audio tag metadata,
+// or "" if absent.
+func extractRecordingMBID(m tag.Metadata) string {
+	return mbz.Extract(m).Get(mbz.Recording)
 }
 
 // AssertInput validates a "artist,title" string and returns a Track, or nil if invalid.
@@ -175,8 +242,8 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		}
 
 		m, err := tag.ReadFrom(f)
-		_ = f.Close()
 		if err != nil {
+			_ = f.Close()
 			slog.Warn("error reading metadata", "file", file.Name(), "error", err)
 			continue
 		}
@@ -196,24 +263,41 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 						// (rather than silently dropping it from the pipeline).
 						slog.Warn("failed to extract embedded lyrics; enqueuing for fetch instead", "file", file.Name(), "error", err)
 					} else {
+						_ = f.Close()
 						slog.Debug("extracted embedded lyrics to sidecar; skipping fetch", "file", file.Name())
 						continue
 					}
 				default: // "respect"
+					_ = f.Close()
 					slog.Debug("respecting embedded lyrics; skipping fetch", "file", file.Name())
 					continue
 				}
 			}
 		}
 
+		// Duration: audioduration reads only the file header (no audio decode).
+		// The library seeks to 0 internally, so f may be at any position from
+		// tag.ReadFrom above. Parse errors degrade gracefully to TrackLength=0
+		// (duration_bucket sentinel for "unknown").
+		filePath := filepath.Join(dir, file.Name())
+		dur, durErr := sc.probeDuration(f, ext)
+		_ = f.Close()
+		if durErr != nil {
+			slog.Debug("duration parse failed; using 0", "file", file.Name(), "error", durErr)
+			dur = 0
+		}
+
 		slog.Debug("adding file", "file", file.Name())
 		*results = append(*results, models.ScanResult{
-			FilePath: filepath.Join(dir, file.Name()),
+			FilePath: filePath,
 			Track: models.Track{
-				ArtistName:  m.Artist(),
-				TrackName:   m.Title(),
-				AlbumName:   m.Album(),
-				AlbumArtist: m.AlbumArtist(),
+				ArtistName:    m.Artist(),
+				TrackName:     m.Title(),
+				AlbumName:     m.Album(),
+				AlbumArtist:   m.AlbumArtist(),
+				TrackLength:   dur,
+				ISRC:          extractISRC(m),
+				RecordingMBID: extractRecordingMBID(m),
 			},
 			Outdir:   dir,
 			Filename: stem + ".lrc",

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -177,3 +177,32 @@ func TestScanLibrary_RespectsCanceledContext(t *testing.T) {
 		t.Fatalf("ScanLibrary error = %v; want context.Canceled", err)
 	}
 }
+
+// TestAudioFileTypeForExt covers every branch of the audioFileTypeForExt
+// switch including the default (unknown extension) path.
+func TestAudioFileTypeForExt(t *testing.T) {
+	cases := []struct {
+		ext    string
+		wantOK bool
+	}{
+		{".flac", true},
+		{".mp3", true},
+		{".m4a", true},
+		{".m4b", true},
+		{".m4p", true},
+		{".alac", true},
+		{".ogg", true},
+		{".dsf", true},
+		{".wav", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		ft, ok := audioFileTypeForExt(tc.ext)
+		if ok != tc.wantOK {
+			t.Errorf("audioFileTypeForExt(%q) ok=%v, want %v", tc.ext, ok, tc.wantOK)
+		}
+		if !ok && ft != 0 {
+			t.Errorf("audioFileTypeForExt(%q) returned non-zero type on miss: %d", tc.ext, ft)
+		}
+	}
+}

--- a/internal/testutil/id3.go
+++ b/internal/testutil/id3.go
@@ -6,6 +6,7 @@ package testutil
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -174,15 +175,9 @@ func GenerateFLAC(sampleRate, totalSamples uint32) []byte {
 	//
 	// Pack into bytes 10-17 (8 bytes).
 	pack := (sr << 44) | (0 << 41) | (uint64(15) << 36) | (ts & 0xFFFFFFFFF)
-	//nolint:gosec // G115: shifts reduce pack to <=8 bits before truncation; no real overflow
-	si[10] = byte(pack >> 56)
-	si[11] = byte(pack >> 48) //nolint:gosec // G115: same
-	si[12] = byte(pack >> 40) //nolint:gosec // G115: same
-	si[13] = byte(pack >> 32) //nolint:gosec // G115: same
-	si[14] = byte(pack >> 24) //nolint:gosec // G115: same
-	si[15] = byte(pack >> 16) //nolint:gosec // G115: same
-	si[16] = byte(pack >> 8)  //nolint:gosec // G115: same
-	si[17] = byte(pack)       //nolint:gosec // G115: same
+	var packed [8]byte
+	binary.BigEndian.PutUint64(packed[:], pack)
+	copy(si[10:18], packed[:])
 	// si[18..33] = MD5, zeroed.
 
 	b.Write(si[:])

--- a/internal/testutil/id3.go
+++ b/internal/testutil/id3.go
@@ -49,12 +49,31 @@ func usltFrame(lyrics string) []byte {
 	return frame("USLT", p.Bytes())
 }
 
+// txxxFrame builds a UTF-8 TXXX (user-defined text information) frame.
+// desc is the null-terminated description field; text is the value.
+func txxxFrame(desc, text string) []byte {
+	var p bytes.Buffer
+	p.WriteByte(0x03) // UTF-8
+	p.WriteString(desc)
+	p.WriteByte(0x00) // null-terminate description
+	p.WriteString(text)
+	return frame("TXXX", p.Bytes())
+}
+
 // GenerateID3v2 builds an ID3v2.4 (UTF-8) tag with TIT2 (title), TPE1 (artist),
 // and TALB (album) frames. When lyrics is non-empty a USLT frame is appended.
 // The returned bytes are a complete, parseable tag suitable to write as a .mp3
 // file for github.com/dhowden/tag to read. Unicode artist/title/album are
 // supported via the UTF-8 text encoding byte.
 func GenerateID3v2(artist, title, album, lyrics string) []byte {
+	return GenerateID3v2Extended(artist, title, album, lyrics, nil, nil)
+}
+
+// GenerateID3v2Extended builds an ID3v2.4 tag like GenerateID3v2 but also
+// accepts extra text frames and TXXX frames.
+// textExtras maps frame ID to value (e.g. "TSRC" -> "US-ABC-12-34567").
+// txxxExtras maps TXXX description to value (e.g. "MusicBrainz Track Id" -> "uuid").
+func GenerateID3v2Extended(artist, title, album, lyrics string, textExtras, txxxExtras map[string]string) []byte {
 	var frames bytes.Buffer
 	if title != "" {
 		frames.Write(textFrame("TIT2", title))
@@ -68,6 +87,12 @@ func GenerateID3v2(artist, title, album, lyrics string) []byte {
 	if lyrics != "" {
 		frames.Write(usltFrame(lyrics))
 	}
+	for id, val := range textExtras {
+		frames.Write(textFrame(id, val))
+	}
+	for desc, val := range txxxExtras {
+		frames.Write(txxxFrame(desc, val))
+	}
 	var b bytes.Buffer
 	b.WriteString("ID3")
 	b.Write([]byte{0x04, 0x00}) // version 2.4.0
@@ -77,12 +102,99 @@ func GenerateID3v2(artist, title, album, lyrics string) []byte {
 	return b.Bytes()
 }
 
+// WriteAudioFileExtended writes a synthetic tagged .mp3 using GenerateID3v2Extended.
+func WriteAudioFileExtended(dir, filename, artist, title, album, lyrics string, textExtras, txxxExtras map[string]string) error {
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, GenerateID3v2Extended(artist, title, album, lyrics, textExtras, txxxExtras), 0o644); err != nil { //nolint:gosec // test fixture file
+		return fmt.Errorf("testutil: write audio file %s: %w", path, err)
+	}
+	return nil
+}
+
 // WriteAudioFile writes a synthetic tagged .mp3 (ID3v2.4) into dir. lyrics is
 // optional; when empty, no USLT frame is embedded.
 func WriteAudioFile(dir, filename, artist, title, album, lyrics string) error {
 	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, GenerateID3v2(artist, title, album, lyrics), 0o644); err != nil { //nolint:gosec // test fixture file
 		return fmt.Errorf("testutil: write audio file %s: %w", path, err)
+	}
+	return nil
+}
+
+// GenerateFLAC builds a minimal valid FLAC file containing only a STREAMINFO
+// metadata block. The STREAMINFO encodes sampleRate and totalSamples so that
+// audioduration.FLAC can calculate the exact duration (totalSamples/sampleRate
+// seconds). No audio frames are present -- this is header-only, which is all
+// that audioduration reads.
+//
+// STREAMINFO bit layout (34 bytes after the block header):
+//
+//	bits  0-15  : min block size (16-bit)
+//	bits 16-31  : max block size (16-bit)
+//	bits 32-55  : min frame size (24-bit)
+//	bits 56-79  : max frame size (24-bit)
+//	bits 80-99  : sample rate (20-bit)
+//	bits 100-102: channels minus one (3-bit)
+//	bits 103-107: bits per sample minus one (5-bit)
+//	bits 108-143: total samples (36-bit)
+//	bits 144-271: MD5 signature (128-bit, zeroed)
+func GenerateFLAC(sampleRate, totalSamples uint32) []byte {
+	var b bytes.Buffer
+
+	// "fLaC" stream marker.
+	b.WriteString("fLaC")
+
+	// STREAMINFO block header: last-metadata-block flag (0x80) | type 0.
+	b.WriteByte(0x80) // last metadata block, type = STREAMINFO (0)
+	// 24-bit block length = 34 bytes.
+	b.Write([]byte{0x00, 0x00, 0x22})
+
+	// 34-byte STREAMINFO payload -- build via bit-packing.
+	var si [34]byte
+
+	// min/max block size: 4096 (2 bytes each, big-endian).
+	si[0] = 0x10
+	si[1] = 0x00
+	si[2] = 0x10
+	si[3] = 0x00
+
+	// min/max frame size: 0 (3 bytes each, meaning unknown).
+	// si[4..9] already zero.
+
+	// Pack sample_rate (20 bits), channels-1 (3 bits), bps-1 (5 bits),
+	// total_samples (36 bits) into si[10..17].
+	// channels=1 (stored as 0), bps=16 (stored as 15=0x0F).
+	sr := uint64(sampleRate)
+	ts := uint64(totalSamples)
+
+	// Bits 80-99 = sample_rate (20 bits) at byte offset 10.
+	// Bits 100-102 = channels-1 (3 bits).
+	// Bits 103-107 = bps-1 (5 bits).
+	// Bits 108-143 = total_samples (36 bits).
+	//
+	// Pack into bytes 10-17 (8 bytes).
+	pack := (sr << 44) | (0 << 41) | (uint64(15) << 36) | (ts & 0xFFFFFFFFF)
+	//nolint:gosec // G115: shifts reduce pack to <=8 bits before truncation; no real overflow
+	si[10] = byte(pack >> 56)
+	si[11] = byte(pack >> 48) //nolint:gosec // G115: same
+	si[12] = byte(pack >> 40) //nolint:gosec // G115: same
+	si[13] = byte(pack >> 32) //nolint:gosec // G115: same
+	si[14] = byte(pack >> 24) //nolint:gosec // G115: same
+	si[15] = byte(pack >> 16) //nolint:gosec // G115: same
+	si[16] = byte(pack >> 8)  //nolint:gosec // G115: same
+	si[17] = byte(pack)       //nolint:gosec // G115: same
+	// si[18..33] = MD5, zeroed.
+
+	b.Write(si[:])
+	return b.Bytes()
+}
+
+// WriteFLACFile writes a minimal FLAC fixture (header-only, no audio frames)
+// into dir with the given sampleRate and totalSamples.
+func WriteFLACFile(dir, filename string, sampleRate, totalSamples uint32) error {
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, GenerateFLAC(sampleRate, totalSamples), 0o644); err != nil { //nolint:gosec // test fixture file
+		return fmt.Errorf("testutil: write flac file %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/testutil/id3_extended_test.go
+++ b/internal/testutil/id3_extended_test.go
@@ -1,0 +1,85 @@
+package testutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dhowden/tag"
+)
+
+// TestGenerateID3v2Extended exercises the extended generator with both extra
+// text frames (e.g. TSRC) and TXXX frames (e.g. MusicBrainz Track Id).
+func TestGenerateID3v2Extended(t *testing.T) {
+	data := GenerateID3v2Extended("Artøst", "Tîtle", "Albüm", "la la la",
+		map[string]string{"TSRC": "USRC17607839"},
+		map[string]string{"MusicBrainz Track Id": "11111111-2222-3333-4444-555555555555"})
+
+	m, err := tag.ReadFrom(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if m.Artist() != "Artøst" || m.Title() != "Tîtle" || m.Album() != "Albüm" {
+		t.Errorf("tags = %q / %q / %q, want Artøst / Tîtle / Albüm",
+			m.Artist(), m.Title(), m.Album())
+	}
+}
+
+// TestGenerateID3v2Extended_NilExtras covers the nil-extras path (what
+// GenerateID3v2 delegates to).
+func TestGenerateID3v2Extended_NilExtras(t *testing.T) {
+	data := GenerateID3v2Extended("A", "T", "Al", "", nil, nil)
+	m, err := tag.ReadFrom(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if m.Artist() != "A" || m.Title() != "T" {
+		t.Errorf("tags = %q / %q, want A / T", m.Artist(), m.Title())
+	}
+}
+
+// TestGenerateFLAC verifies the synthetic FLAC generator emits a FLAC stream.
+func TestGenerateFLAC(t *testing.T) {
+	data := GenerateFLAC(44100, 441000) // ~10 seconds
+	if len(data) < 4 || string(data[:4]) != "fLaC" {
+		t.Fatalf("GenerateFLAC did not produce a FLAC stream (len=%d)", len(data))
+	}
+}
+
+// TestWriteAudioFileExtended writes a tagged file and reads it back.
+func TestWriteAudioFileExtended(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteAudioFileExtended(dir, "song.mp3", "Artist", "Title", "Album", "",
+		map[string]string{"TSRC": "USRC17607839"}, nil); err != nil {
+		t.Fatalf("WriteAudioFileExtended: %v", err)
+	}
+	f, err := os.Open(filepath.Join(dir, "song.mp3"))
+	if err != nil {
+		t.Fatalf("open written file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	m, err := tag.ReadFrom(f)
+	if err != nil {
+		t.Fatalf("ReadFrom written file: %v", err)
+	}
+	if m.Artist() != "Artist" {
+		t.Errorf("Artist = %q, want Artist", m.Artist())
+	}
+}
+
+// TestWriteFLACFile writes a synthetic FLAC and confirms a non-empty file.
+func TestWriteFLACFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteFLACFile(dir, "track.flac", 48000, 96000); err != nil {
+		t.Fatalf("WriteFLACFile: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "track.flac"))
+	if err != nil {
+		t.Fatalf("stat written FLAC: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("written FLAC is empty")
+	}
+}


### PR DESCRIPTION
## Summary

C1 of #191 — recording-precise enrichment in the scanner:
- Extract recording **ISRC** (`TSRC` and per-format equivalents) and **RecordingMBID** (via `dhowden/tag` `mbz`) from audio tags into `models.Track`.
- Populate **track duration** via pure-Go header parsing (`github.com/lizc2003/audioduration`), behind a DI seam; graceful degrade to `0` when a file is unparseable. No ffmpeg, no CGO.

## License change (important)

This PR **relicenses the project from MIT to GPL-3.0**, because the new `audioduration` dependency is GPLv3. This project is a fork of the MIT-licensed [fashni/mxlrc-go](https://github.com/fashni/mxlrc-go); per MIT's notice-retention requirement, the original MIT copyright (© 2022 fahmi) is preserved in the new `NOTICE` file. The combined work as a whole is now distributed under GPL-3.0.

## Linked issue

Part of #191 (C1 lane). #191 stays open for the C2 MusicBrainz lookup lane.

## Test plan

- [x] `make gate` green: build, race tests, golangci-lint, govulncheck, actionlint
- [x] Patch coverage **94.12%** (scanner 97.7%, testutil 92.1%)
- [x] Scanner tests: ISRC/MBID present+absent, duration probe (FLAC fixture), graceful degrade
- [x] In-package testutil tests for the new id3 / FLAC generators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project license changed from MIT to GPL-3.0; NOTICE and README updated with licensing and attribution.
  * Container image license metadata updated; module dependency added.

* **New Features**
  * Metadata extraction enhanced to capture Recording MBID and ISRC during library scans.
  * Added duration probing with graceful handling of probe failures.

* **Tests**
  * Added comprehensive tests for metadata extraction, duration probing, and audio fixture generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->