### PR TITLE
fix(lyrics): instrumental tracks always write .txt, never upgrade to .lrc (#199)

### DIFF
--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -12,6 +12,12 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
 )
 
+// InstrumentalMarker is the human-readable marker embedded in an instrumental .txt
+// sidecar (without trailing newline). Exported so consumers can detect the marker
+// via substring search -- e.g. files renamed from .lrc may carry LRC tag headers
+// before the marker line. The writer appends "\n" when writing the bare .txt form.
+const InstrumentalMarker = "♪ Instrumental ♪"
+
 // Writer abstracts LRC file output.
 type Writer interface {
 	WriteLRC(song models.Song, filename string, outdir string) error
@@ -90,6 +96,11 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	// writes are visible at the default Info level, not just under Debug.
 	var kind string
 	switch {
+	case song.Track.Instrumental == 1:
+		// Instrumental is authoritative: MM delivers a synced subtitle line alongside
+		// the flag, so this case must precede the subtitles check.
+		kind = "instrumental"
+		writeContent = writeInstrumental
 	case len(song.Subtitles.Lines) > 0:
 		kind = "synced"
 		writeContent = func(buf *bufio.Writer) error { return writeSyncedLRC(song, buf, w.bilingual) }
@@ -98,10 +109,6 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	case song.Lyrics.LyricsBody != "":
 		kind = "unsynced"
 		writeContent = func(buf *bufio.Writer) error { return writeUnsyncedLRC(song, buf) }
-	case song.Track.Instrumental == 1:
-		kind = "instrumental"
-		writeContent = writeInstrumental
-		// Instrumentals are a plain .txt marker: no timestamp, no tag headers.
 	default:
 		return fmt.Errorf("nothing to save for %s - %s", song.Track.ArtistName, song.Track.TrackName)
 	}
@@ -304,8 +311,7 @@ func writeUnsyncedLRC(song models.Song, buff *bufio.Writer) error {
 // writeInstrumental emits a plain instrumental marker (no [00:00.00] timestamp,
 // no tag headers) so the .txt output carries only the single marker line.
 func writeInstrumental(buff *bufio.Writer) error {
-	line := "\u266a Instrumental \u266a"
-	if _, err := buff.WriteString(line + "\n"); err != nil {
+	if _, err := buff.WriteString(InstrumentalMarker + "\n"); err != nil {
 		return fmt.Errorf("writing instrumental line: %w", err)
 	}
 	if err := buff.Flush(); err != nil {

--- a/internal/lyrics/writer_test.go
+++ b/internal/lyrics/writer_test.go
@@ -325,6 +325,46 @@ func TestWriteLRC_StaleSidecarCleanup(t *testing.T) {
 	})
 }
 
+// TestWriteLRC_InstrumentalWithSubtitles covers the real Musixmatch response: an
+// instrumental track carries both Track.Instrumental==1 AND a synced subtitle line.
+// The instrumental flag must win -- output must be .txt, not .lrc.
+func TestWriteLRC_InstrumentalWithSubtitles(t *testing.T) {
+	w := NewLRCWriter()
+	tmpDir := t.TempDir()
+
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:   "Test Artist",
+			TrackName:    "Instrumental Track",
+			Instrumental: 1,
+		},
+		Subtitles: models.Synced{Lines: []models.Lines{
+			// Musixmatch delivers this synced line for instrumentals.
+			{Text: "♪ Instrumental ♪", Time: models.Time{Minutes: 0, Seconds: 0, Hundredths: 0}},
+		}},
+	}
+
+	if err := w.WriteLRC(song, "song.lrc", tmpDir); err != nil {
+		t.Fatalf("expected nil error for instrumental with subtitles, got: %v", err)
+	}
+
+	txtPath := filepath.Join(tmpDir, "song.txt")
+	data, err := os.ReadFile(txtPath) //nolint:gosec // test path constructed from known test data
+	if err != nil {
+		t.Fatalf("expected song.txt to exist: %v", err)
+	}
+	const want = "♪ Instrumental ♪\n"
+	if got := string(data); got != want {
+		t.Fatalf("content = %q; want %q", got, want)
+	}
+	if strings.Contains(string(data), "[00:00.00]") {
+		t.Fatalf("instrumental must not contain LRC timestamp, got: %q", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "song.lrc")); err == nil {
+		t.Fatal("expected no .lrc file for instrumental with subtitles, but one was created")
+	}
+}
+
 func TestWriteLRC_Synced(t *testing.T) {
 	w := NewLRCWriter()
 	tmpDir := t.TempDir()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dhowden/tag"
 	"github.com/dhowden/tag/mbz"
 	"github.com/lizc2003/audioduration"
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
@@ -113,6 +114,18 @@ func extractISRC(m tag.Metadata) string {
 // or "" if absent.
 func extractRecordingMBID(m tag.Metadata) string {
 	return mbz.Extract(m).Get(mbz.Recording)
+}
+
+// isInstrumentalTxt reports whether the file at path contains the instrumental
+// marker. Uses substring match rather than exact equality because files renamed
+// from .lrc carry LRC tag headers before the marker line. Returns false on any
+// read error so a scan failure never silently drops a track.
+func isInstrumentalTxt(path string) bool {
+	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from directory scan within a validated root
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), lyrics.InstrumentalMarker)
 }
 
 // AssertInput validates a "artist,title" string and returns a Track, or nil if invalid.
@@ -229,6 +242,11 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		case lrcExists && !opts.Update:
 			// Synced lyrics already present and not asked to update -- skip.
 			slog.Debug("skipping file, lyrics exist", "file", file.Name())
+			continue
+		case txtExists && !lrcExists && !opts.Update && isInstrumentalTxt(filepath.Join(dir, txtFile)):
+			// Instrumental markers are terminal -- re-fetching would produce the same result.
+			// Skip regardless of --upgrade; only --update (explicit full re-fetch) overrides.
+			slog.Debug("skipping file, instrumental marker", "file", file.Name())
 			continue
 		case txtExists && !opts.Upgrade && !opts.Update && !lrcExists:
 			// Unsynced .txt present and not asked to upgrade or update -- skip.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
 
@@ -39,6 +40,28 @@ func touchFile(t *testing.T, dir, name string) {
 	}
 }
 
+// writeInstrumentalTxt creates a .txt sidecar in dir with the plain instrumental
+// marker (matching what lyrics.writeInstrumental emits: marker + newline).
+func writeInstrumentalTxt(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
+		t.Fatalf("writeInstrumentalTxt %s: %v", path, err)
+	}
+}
+
+// writeRenamedLRCInstrumentalTxt creates a .txt sidecar in dir that looks like a
+// .lrc file renamed to .txt (LRC tag headers followed by the marker line).
+// This is the format produced by the #199 cleanup of the ~2 k incorrectly-written .lrc files.
+func writeRenamedLRCInstrumentalTxt(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	content := "[by:fashni]\n[ar:X]\n[ti:Y]\n[al:Z]\n[length:00:01]\n[00:00.00]" + lyrics.InstrumentalMarker + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeRenamedLRCInstrumentalTxt %s: %v", path, err)
+	}
+}
+
 // TestGetSongDir_SkipLogic covers the 12-case skip-logic matrix:
 // flags: (update, upgrade) × file states: (none, lrcOnly, txtOnly, both).
 //
@@ -66,12 +89,14 @@ func touchFile(t *testing.T, dir, name string) {
 //	  (same as update=true, upgrade=false — all four cases enqueue)
 func TestGetSongDir_SkipLogic(t *testing.T) {
 	tests := []struct {
-		name      string
-		update    bool
-		upgrade   bool
-		lrcExists bool
-		txtExists bool
-		wantQueue bool
+		name              string
+		update            bool
+		upgrade           bool
+		lrcExists         bool
+		txtExists         bool
+		txtIsInstrumental bool
+		txtIsRenamedLRC   bool
+		wantQueue         bool
 	}{
 		// update=false, upgrade=false
 		{name: "no_flags_no_files", update: false, upgrade: false, lrcExists: false, txtExists: false, wantQueue: true},
@@ -84,12 +109,19 @@ func TestGetSongDir_SkipLogic(t *testing.T) {
 		{name: "upgrade_lrc_only", update: false, upgrade: true, lrcExists: true, txtExists: false, wantQueue: false},
 		{name: "upgrade_txt_only", update: false, upgrade: true, lrcExists: false, txtExists: true, wantQueue: true},
 		{name: "upgrade_both", update: false, upgrade: true, lrcExists: true, txtExists: true, wantQueue: false},
+		// Instrumental .txt markers are terminal -- must not be re-queued even with --upgrade.
+		{name: "upgrade_txt_only_instrumental", update: false, upgrade: true, lrcExists: false, txtExists: true, txtIsInstrumental: true, wantQueue: false},
+		// Files renamed from .lrc carry LRC tag headers before the marker line --
+		// substring match must still detect them as instrumental and skip.
+		{name: "upgrade_txt_renamed_lrc_instrumental", update: false, upgrade: true, lrcExists: false, txtExists: true, txtIsRenamedLRC: true, wantQueue: false},
 
 		// update=true, upgrade=false
 		{name: "update_no_files", update: true, upgrade: false, lrcExists: false, txtExists: false, wantQueue: true},
 		{name: "update_lrc_only", update: true, upgrade: false, lrcExists: true, txtExists: false, wantQueue: true},
 		{name: "update_txt_only", update: true, upgrade: false, lrcExists: false, txtExists: true, wantQueue: true},
 		{name: "update_both", update: true, upgrade: false, lrcExists: true, txtExists: true, wantQueue: true},
+		// --update is an explicit full re-fetch; instrumental markers do not block it.
+		{name: "update_txt_only_instrumental", update: true, upgrade: false, lrcExists: false, txtExists: true, txtIsInstrumental: true, wantQueue: true},
 	}
 
 	for _, tc := range tests {
@@ -100,7 +132,14 @@ func TestGetSongDir_SkipLogic(t *testing.T) {
 				touchFile(t, dir, "track.lrc")
 			}
 			if tc.txtExists {
-				touchFile(t, dir, "track.txt")
+				switch {
+				case tc.txtIsRenamedLRC:
+					writeRenamedLRCInstrumentalTxt(t, dir, "track.txt")
+				case tc.txtIsInstrumental:
+					writeInstrumentalTxt(t, dir, "track.txt")
+				default:
+					touchFile(t, dir, "track.txt")
+				}
 			}
 
 			q := queue.NewInputsQueue()


### PR DESCRIPTION
## Summary

Fixes the instrumental-`.lrc` bug (#199): instrumental tracks were sometimes written as `.lrc`, and existing instrumental `.txt` files were being "upgraded" to `.lrc`.

- **writer**: `song.Track.Instrumental == 1` is now authoritative and evaluated FIRST in the write-type switch, so instrumental tracks always write `.txt` (previously the synced-first precedence could mis-write them as `.lrc`).
- **scanner**: instrumental `.txt` is excluded from `--upgrade` via a substring match on the exported `lyrics.InstrumentalMarker` (no trailing newline). The substring match also catches the ~2,018 artifacts already renamed from `.lrc`.

## Linked issue

Closes #199.

## Test plan

- [x] `make gate` PASS, patch coverage 76.47% (writer.go 83.3%, scanner.go 72.7%; threshold 70%)
- [x] writer test: instrumental track writes `.txt`
- [x] scanner test `upgrade_txt_renamed_lrc_instrumental` (wantQueue=false) - renamed-from-.lrc instrumental not re-upgraded
