### PR TITLE
docs(legal): privacy policy + code signing policy (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `M
 - [Spicetify Lyrics Plus](https://github.com/spicetify/spicetify-cli/tree/master/CustomApps/lyrics-plus)
 - Forked from [fashni/mxlrc-go](https://github.com/fashni/mxlrc-go).
 
+## Legal
+
+- [Privacy Policy](https://sydlexius.github.io/mxlrcgo-svc/privacy-policy/) - what data leaves your machine during a lyrics lookup and what does not.
+- [Code Signing Policy](https://sydlexius.github.io/mxlrcgo-svc/code-signing-policy/) - SignPath attribution, team roles, and release approval process.
+
 ## License
 
 [GPL-3.0](LICENSE). This project is a fork of [fashni/mxlrc-go](https://github.com/fashni/mxlrc-go), which is MIT-licensed; the original MIT copyright and permission notice are retained in [NOTICE](NOTICE).

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -1,0 +1,47 @@
+# Code Signing Policy
+
+Free code signing is provided by [SignPath.io](https://signpath.io/), certificate
+by [SignPath Foundation](https://signpath.org/).
+
+## Scope
+
+All `mxlrcgo-svc` release binaries published to GitHub Releases are signed
+using the SignPath free open-source program. Signing applies to the final
+binaries produced by the GoReleaser release pipeline.
+
+## Release approval
+
+Every release is manually reviewed and approved before signing. No automated
+process can approve a signing request on its own. A human approver verifies
+that the release tag corresponds to a reviewed, merged commit on `main` before
+authorizing the signing step.
+
+## Team member roles
+
+**Authors** hold commit access to the repository and may push branches and open
+pull requests without requiring an additional gating review:
+
+- `sydlexius`
+
+**Reviewers** inspect changes and provide feedback before merge. Automated
+review bots (CodeRabbit, Codoki) assist human review by surfacing findings on
+each pull request. All automated review output is assessed by a human before
+merge.
+
+**Approvers** authorize each signing request. A signing request is approved
+only after the release has been reviewed and the approver confirms the binary
+corresponds to the intended commit:
+
+- `sydlexius`
+
+## Privacy
+
+Lookup data handling is described in the [Privacy Policy](privacy-policy.md).
+No personal data is transmitted to SignPath beyond what is required for the
+signing workflow.
+
+## Cross-references
+
+- [SignPath.io](https://signpath.io/) - code signing provider
+- [SignPath Foundation](https://signpath.org/) - certificate authority for the free open-source program
+- [Privacy Policy](privacy-policy.md) - data handling policy for `mxlrcgo-svc`

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -38,7 +38,8 @@ corresponds to the intended commit:
 
 Lookup data handling is described in the [Privacy Policy](privacy-policy.md).
 No personal data is transmitted to SignPath beyond what is required for the
-signing workflow.
+signing workflow. For details on what SignPath processes during signing, see the
+[SignPath Foundation Privacy Policy](https://signpath.org/privacy).
 
 ## Cross-references
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,3 +20,8 @@ New here? Start with the [Getting Started](GETTING_STARTED.md) guide - it picks 
 - [CLI Reference](CLI_REFERENCE.md) - the full usage text, every subcommand and flag, `--version` output, and the library/key-management commands.
 - [Configuration](CONFIGURATION.md) - the complete environment-variable table, the TOML config keys, token precedence, and XDG path defaults.
 - [Developer Guide](DEVELOPER.md) - development setup, make targets, the quality gate, contributing notes, and design decisions.
+
+## Legal
+
+- [Privacy Policy](privacy-policy.md) - what data leaves your machine during a lyrics lookup and what does not.
+- [Code Signing Policy](code-signing-policy.md) - SignPath attribution, team roles, and release approval process.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -6,9 +6,22 @@ and what does not.
 ## Musixmatch (default provider)
 
 **What is sent.** Each lyrics lookup sends an HTTPS request to the Musixmatch
-API. The request includes the track name, artist name, and (where available)
-album name as query parameters. Your API token (`usertoken`) is also transmitted
-as a query parameter in the URL.
+API. The request includes the following as URL query parameters:
+
+- Track name, artist name, and album name (always present; may be empty strings
+  if the audio file lacks those tags).
+- Your API token (`usertoken`).
+- Fixed application parameters (`app_id`, `format`, `namespace`,
+  `subtitle_format`) that identify the client type; these contain no personal
+  data.
+- Recording-level identifiers, sent only when available from the audio file's
+  tags, to help Musixmatch match the exact recording rather than a cover or
+  alternate version:
+  - Track duration in seconds (`q_duration`) - sent when the file's tag
+    reports a non-zero duration.
+  - Recording ISRC (`track_isrc`) - sent when the file carries an ISRC tag.
+  - Spotify track ID (`track_spotify_id`) - sent when the file carries a
+    Spotify ID tag.
 
 **Credentials scope.** The Musixmatch token is read from the CLI flag, the
 `MUSIXMATCH_TOKEN` environment variable, or the TOML config file, in that order
@@ -36,13 +49,16 @@ other than the lyrics providers listed above.
 
 ## Summary
 
-| Data                         | Destination          |
-|------------------------------|----------------------|
-| Track name, artist name      | Active lyrics provider API |
-| Album name (when available)  | Musixmatch API only  |
-| Musixmatch token             | Musixmatch API only  |
-| Lookup results               | Local SQLite cache   |
-| Telemetry / analytics        | Not collected        |
+| Data                                      | Destination                |
+|-------------------------------------------|----------------------------|
+| Track name, artist name                   | Active lyrics provider API |
+| Album name                                | Musixmatch API only        |
+| Track duration (when tag present)         | Musixmatch API only        |
+| Recording ISRC (when tag present)         | Musixmatch API only        |
+| Spotify track ID (when tag present)       | Musixmatch API only        |
+| Musixmatch token                          | Musixmatch API only        |
+| Lookup results                            | Local SQLite cache         |
+| Telemetry / analytics                     | Not collected              |
 
 ## Cross-references
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,51 @@
+# Privacy Policy
+
+This page documents what data leaves your machine when you run `mxlrcgo-svc`,
+and what does not.
+
+## Musixmatch (default provider)
+
+**What is sent.** Each lyrics lookup sends an HTTPS request to the Musixmatch
+API. The request includes the track name, artist name, and (where available)
+album name as query parameters. Your API token (`usertoken`) is also transmitted
+as a query parameter in the URL.
+
+**Credentials scope.** The Musixmatch token is read from the CLI flag, the
+`MUSIXMATCH_TOKEN` environment variable, or the TOML config file, in that order
+of precedence. It is transmitted only to `apic.musixmatch.com`; it is never
+sent anywhere else.
+
+## PetitLyrics (optional provider)
+
+**What is sent.** When PetitLyrics is enabled, each lookup sends track name and
+artist name to the PetitLyrics API. No credentials are required or transmitted
+for this provider.
+
+## Local cache
+
+**What stays local.** Lookup results are stored in a local SQLite database
+(path resolved via XDG conventions). Nothing in the cache is transmitted
+anywhere. Subsequent lookups for the same track are served from this local cache
+without contacting any external API.
+
+## Telemetry, analytics, and crash reporting
+
+**None.** `mxlrcgo-svc` does not collect telemetry, analytics, or crash
+reports. No data is ever sent to the project maintainers or any third party
+other than the lyrics providers listed above.
+
+## Summary
+
+| Data                         | Destination          |
+|------------------------------|----------------------|
+| Track name, artist name      | Active lyrics provider API |
+| Album name (when available)  | Musixmatch API only  |
+| Musixmatch token             | Musixmatch API only  |
+| Lookup results               | Local SQLite cache   |
+| Telemetry / analytics        | Not collected        |
+
+## Cross-references
+
+- `internal/musixmatch/client.go` - Musixmatch HTTP client (query parameters and token handling)
+- `internal/petitlyrics/client.go` - PetitLyrics HTTP client (no credentials transmitted)
+- `internal/cache/` - local SQLite cache repository

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -34,6 +34,15 @@ sent anywhere else.
 artist name to the PetitLyrics API. No credentials are required or transmitted
 for this provider.
 
+## Network metadata
+
+Like any application that makes internet requests, `mxlrcgo-svc` does not
+control what standard network metadata a remote server or intermediary receives.
+When the app contacts a lyrics provider, that provider - and any network
+intermediary on the path - inherently receives the request's source IP address
+alongside the query content. This is true of any internet request; it is not
+additional data the app chooses to send.
+
 ## Local cache
 
 **What stays local.** Lookup results are stored in a local SQLite database

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -83,3 +83,6 @@ nav:
       - Overview: DEVELOPER.md
       - Multilingual Output Policy: multilingual-output-policy.md
       - Multi-Provider Orchestration: multi-provider-orchestration.md
+  - Legal:
+      - Privacy Policy: privacy-policy.md
+      - Code Signing Policy: code-signing-policy.md


### PR DESCRIPTION
## Summary

Publishes the two documents SignPath Foundation requires before approving the project for free Windows code signing (#183): a **privacy policy** and a **code signing policy**, both reachable from the docs homepage and README.

- **`docs/privacy-policy.md`** - discloses exactly what leaves the user's machine: on a lookup, artist/title (and album where used) go to the active lyrics provider (Musixmatch by default; Petit Lyrics only if enabled); results are cached locally in SQLite; no telemetry, analytics, or crash reporting; the API token is sent only to the provider it authenticates.
- **`docs/code-signing-policy.md`** - SignPath.io attribution, Authors/Reviewers/Approvers role listing (CodeRabbit/Codoki assist review; a human approves each signing request), a link to the privacy policy, and a manual-approval-before-signing statement.

Wired into the `properdocs.yml` "Legal" nav group, `docs/index.md`, and `README.md`.

## Linked issue

Closes #185. Unblocks #183 (SignPath Windows signing).

## Test plan

- [x] Docs-only change (5 files, no Go touched)
- [x] All `properdocs.yml` nav entries and internal markdown links resolve (manual link-check; `git-revision-date-localized` plugin absent locally so `mkdocs build --strict` was not run)
