### PR TITLE
feat(release): produce .deb/.rpm/.apk via goreleaser nfpms (#181)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,58 @@ archives:
           - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+nfpms:
+  - id: mxlrcgo-svc
+    package_name: mxlrcgo-svc
+    ids:
+      - mxlrcgo-svc
+    vendor: sydlexius
+    homepage: https://sydlexius.github.io/mxlrcgo-svc/
+    maintainer: sydlexius <maintainer@placeholder.example>
+    description: Fetch synced lyrics from Musixmatch and save them as .lrc files
+    license: GPL-3.0
+    bindir: /usr/local/bin
+    formats:
+      - deb
+      - rpm
+      - apk
+    # Default contents and scripts apply to rpm (and as a fallback base).
+    # deb and apk use overrides below to adjust service unit path and init system.
+    contents:
+      - src: config.example.toml
+        dst: /etc/mxlrcgo-svc/config.example.toml
+        type: config|noreplace
+      - src: build/package/mxlrcgo-svc.service
+        dst: /usr/lib/systemd/system/mxlrcgo-svc.service
+    scripts:
+      postinstall: build/package/postinstall.sh
+      preremove: build/package/preremove.sh
+    overrides:
+      # Debian places systemd units under /lib/systemd/system/.
+      deb:
+        contents:
+          - src: config.example.toml
+            dst: /etc/mxlrcgo-svc/config.example.toml
+            type: config|noreplace
+          - src: build/package/mxlrcgo-svc.service
+            dst: /lib/systemd/system/mxlrcgo-svc.service
+        scripts:
+          postinstall: build/package/postinstall.sh
+          preremove: build/package/preremove.sh
+      # Alpine uses OpenRC; no systemd unit, no systemctl in lifecycle scripts.
+      apk:
+        contents:
+          - src: config.example.toml
+            dst: /etc/mxlrcgo-svc/config.example.toml
+            type: config|noreplace
+          - src: build/package/mxlrcgo-svc.openrc
+            dst: /etc/init.d/mxlrcgo-svc
+            file_info:
+              mode: 0755
+        scripts:
+          postinstall: build/package/postinstall-apk.sh
+          preremove: build/package/preremove-apk.sh
+
 dockers_v2:
   - id: mxlrcgo-svc
     images:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,31 @@ Full documentation is published at **<https://sydlexius.github.io/mxlrcgo-svc/>*
 
 ## Install
 
-Versioned binaries for Linux, macOS, and Windows (amd64/arm64 where supported) are published on the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases) page.
+**Linux (.deb / .rpm / .apk):** Download the appropriate package for your distro
+from the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)
+page and install it with your package manager:
 
-Build from source (requires Go 1.26.4+):
+```sh
+# Debian / Ubuntu
+sudo dpkg -i mxlrcgo-svc_*.deb
+
+# RHEL / Fedora / Rocky
+sudo rpm -i mxlrcgo-svc_*.rpm
+
+# Alpine
+sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
+```
+
+The package installs the binary to `/usr/local/bin/mxlrcgo-svc`, a systemd unit
+(or OpenRC script on Alpine), and an example config at
+`/etc/mxlrcgo-svc/config.example.toml`. Copy the example to
+`/etc/mxlrcgo-svc/config.toml` and edit it before starting the service.
+
+**Tarballs / macOS / Windows:** Versioned archives for all platforms are also
+available on the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)
+page.
+
+**Build from source** (requires Go 1.26.4+):
 
 ```sh
 go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest

--- a/build/package/mxlrcgo-svc.openrc
+++ b/build/package/mxlrcgo-svc.openrc
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+
+description="mxlrcgo-svc lyrics fetcher daemon"
+
+command=/usr/local/bin/mxlrcgo-svc
+command_args="serve"
+command_user=mxlrcgo-svc:mxlrcgo-svc
+command_background=yes
+pidfile=/run/mxlrcgo-svc/mxlrcgo-svc.pid
+
+export MXLRC_DB_PATH=/var/lib/mxlrcgo-svc/mxlrcgo.db
+export MXLRC_LOG_FORMAT=json
+
+depend() {
+    need net
+}
+
+start_pre() {
+    checkpath --directory --owner mxlrcgo-svc:mxlrcgo-svc --mode 0750 \
+        /run/mxlrcgo-svc \
+        /var/lib/mxlrcgo-svc
+}

--- a/build/package/mxlrcgo-svc.service
+++ b/build/package/mxlrcgo-svc.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=mxlrcgo-svc lyrics fetcher daemon
+Documentation=https://sydlexius.github.io/mxlrcgo-svc/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=mxlrcgo-svc
+Group=mxlrcgo-svc
+ExecStart=/usr/local/bin/mxlrcgo-svc serve
+Restart=on-failure
+RestartSec=5s
+
+Environment=MXLRC_DB_PATH=/var/lib/mxlrcgo-svc/mxlrcgo.db
+Environment=MXLRC_LOG_FORMAT=json
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ReadWritePaths=/var/lib/mxlrcgo-svc
+
+[Install]
+WantedBy=multi-user.target

--- a/build/package/postinstall-apk.sh
+++ b/build/package/postinstall-apk.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Create system group if it does not exist.
+if ! getent group mxlrcgo-svc > /dev/null 2>&1; then
+    addgroup -S mxlrcgo-svc
+fi
+
+# Create system user if it does not exist.
+if ! getent passwd mxlrcgo-svc > /dev/null 2>&1; then
+    adduser \
+        -S \
+        -G mxlrcgo-svc \
+        -h /var/lib/mxlrcgo-svc \
+        -H \
+        -s /sbin/nologin \
+        mxlrcgo-svc
+fi
+
+# Create state, runtime, and config directories.
+mkdir -p /var/lib/mxlrcgo-svc /run/mxlrcgo-svc /etc/mxlrcgo-svc
+chown mxlrcgo-svc:mxlrcgo-svc /var/lib/mxlrcgo-svc /run/mxlrcgo-svc
+chmod 0750 /var/lib/mxlrcgo-svc /run/mxlrcgo-svc
+
+# Do NOT add to default runlevel or start the service.

--- a/build/package/postinstall.sh
+++ b/build/package/postinstall.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# Create system group if it does not exist.
+if ! getent group mxlrcgo-svc > /dev/null 2>&1; then
+    groupadd --system mxlrcgo-svc
+fi
+
+# Create system user if it does not exist.
+if ! getent passwd mxlrcgo-svc > /dev/null 2>&1; then
+    useradd \
+        --system \
+        --gid mxlrcgo-svc \
+        --home-dir /var/lib/mxlrcgo-svc \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        mxlrcgo-svc
+fi
+
+# Create state directory.
+mkdir -p /var/lib/mxlrcgo-svc
+chown mxlrcgo-svc:mxlrcgo-svc /var/lib/mxlrcgo-svc
+chmod 0750 /var/lib/mxlrcgo-svc
+
+# Create config directory.
+mkdir -p /etc/mxlrcgo-svc
+
+# Reload unit files so the new unit is available.
+# Do NOT enable or start the service.
+systemctl daemon-reload || true

--- a/build/package/preremove-apk.sh
+++ b/build/package/preremove-apk.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Stop the service if it is running. Failure is non-fatal.
+rc-service mxlrcgo-svc stop || true
+
+# State directory (/var/lib/mxlrcgo-svc) and system user are intentionally
+# preserved so the SQLite database survives an upgrade or reinstall.

--- a/build/package/preremove.sh
+++ b/build/package/preremove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Stop the service if it is running. Failure is non-fatal.
+systemctl stop mxlrcgo-svc || true
+
+# State directory (/var/lib/mxlrcgo-svc) and system user are intentionally
+# preserved so the SQLite database survives an upgrade or reinstall.


### PR DESCRIPTION
## Summary

Adds an `nfpms:` block to `.goreleaser.yml` so the release pipeline produces `.deb`, `.rpm`, and `.apk` packages alongside the existing tarballs, each with a service definition that runs `mxlrcgo-svc serve`. Purely additive - reuses the existing `builds:` output.

## What's included

- **`build/package/`** assets: a hardened systemd unit (`ProtectSystem=strict`, `NoNewPrivileges`, etc.; `ExecStart=... serve`, dedicated `mxlrcgo-svc` user, `MXLRC_DB_PATH`/`MXLRC_LOG_FORMAT` env), an Alpine OpenRC script, and postinstall/preremove lifecycle scripts for both systemd and Alpine.
- Lifecycle scripts create the `mxlrcgo-svc` system user + `/var/lib/mxlrcgo-svc`, run `daemon-reload` only (never auto-start), and **preserve `/var/lib/mxlrcgo-svc` on removal** (the SQLite cache/queue is data).
- `nfpms:` block with `formats: [deb, rpm, apk]`, GPL-3.0 license, format overrides for the systemd-vs-OpenRC path split.
- README install section now leads with the native-package install before the tarball steps.

## Linked issue

Closes #181.

## Test plan

- [x] `goreleaser check` passes (migrated the deprecated `nfpms.builds` to `nfpms.ids` for GoReleaser v2)
- [x] `goreleaser release --snapshot --clean` produces all 6 artifacts: `.deb`/`.rpm`/`.apk` for amd64 and arm64
- [ ] Live `dpkg -i`/`rpm -i`/`apk add` install+uninstall on Debian/Fedora/Alpine (needs distro VMs; package contents verified by inspection)

## Notes

- License set to **GPL-3.0** (the issue body predated the MIT->GPL-3.0 relicense in #200).
- Sigstore/cosign checksum signing covers the new artifacts automatically (it signs the checksums of all release artifacts).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Linux package installation support for Debian, RPM, and Alpine distributions with automatic service configuration and management.

* **Documentation**
  * Updated installation guide with distribution-specific package installation instructions, service management details, and installed file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->