### PR TITLE
feat(release): publish Homebrew cask via goreleaser to the shared tap (#182)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,32 @@ archives:
           - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+homebrew_casks:
+  - name: mxlrcgo-svc
+    ids:
+      - default
+    # ffmpeg is only needed for the optional audio verification/instrumental
+    # sidecar; it is NOT a required runtime dependency and is not listed here.
+    binaries:
+      - mxlrcgo-svc
+    repository:
+      owner: sydlexius
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: https://sydlexius.github.io/mxlrcgo-svc/
+    description: Fetch synced lyrics from Musixmatch and save them as .lrc files
+    caveats: |
+      Set your Musixmatch token via MUSIXMATCH_TOKEN or in the config file:
+        ~/.config/mxlrcgo-svc/config.toml (XDG path)
+        See config.example.toml for all available options.
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "feat: update mxlrcgo-svc cask to {{ .Tag }}"
+    skip_upload: auto
+
 nfpms:
   - id: mxlrcgo-svc
     package_name: mxlrcgo-svc

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Full documentation is published at **<https://sydlexius.github.io/mxlrcgo-svc/>*
 
 ## Install
 
+**macOS / Linuxbrew (Homebrew):**
+
+```sh
+brew install sydlexius/tap/mxlrcgo-svc
+```
+
 **Linux (.deb / .rpm / .apk):** Download the appropriate package for your distro
 from the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)
 page and install it with your package manager:


### PR DESCRIPTION
## Summary

Publishes a Homebrew **cask** to the shared `sydlexius/homebrew-tap` on each release, so macOS/Linux users can `brew install sydlexius/tap/mxlrcgo-svc`.

## What's included

- **`.goreleaser.yml`** - a `homebrew_casks:` block (GoReleaser v2 deprecated `brews:` for pre-built binaries; casks are the current path for distributing compiled binaries via Homebrew). Targets `sydlexius/homebrew-tap` (branch `main`, `Casks/` dir), reuses the existing build, token from `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}`, GPL-3.0 project, caveats pointing at `MUSIXMATCH_TOKEN` + the XDG config path. No ffmpeg dependency (optional sidecar only).
- **`.github/workflows/release.yml`** - passes `HOMEBREW_TAP_GITHUB_TOKEN` (an Actions secret, a fine-grained PAT with Contents:write on the tap) to the GoReleaser step.
- **`README.md`** - a Homebrew install line at the top of Install.

## Linked issue

Closes #182.

## Test plan

- [x] `goreleaser check` clean (goreleaser 2.16.0)
- [x] `actionlint` clean on the modified workflow
- [ ] Actual tap push happens only on a real `git tag` release (config validated; the `HOMEBREW_TAP_GITHUB_TOKEN` secret is set)

## Notes

- The tap is shared across sydlexius tools (mxlrcgo-svc, stillwater, …); one `Formula`/`Casks` repo, many entries.
- Corrected the caveats env var to `MUSIXMATCH_TOKEN` (the actual token variable; `MXLRC_TOKEN` does not exist).
