### PR TITLE
feat(instrumental): optional audio-based instrumental detection sidecar (#187)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/cache"
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/detector"
 	"github.com/sydlexius/mxlrcgo-svc/internal/langguard"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
 	"github.com/sydlexius/mxlrcgo-svc/internal/logging"
@@ -654,6 +655,12 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	w.SetMissBackoff(time.Duration(cfg.API.MissBackoffBaseHours)*time.Hour, time.Duration(cfg.API.MissBackoffCapHours)*time.Hour)
 	w.SetMaxMissAttempts(cfg.API.MaxMissAttempts)
 	configureWorkerVerification(w, cfg, verifier)
+	audioDetector, err := newAudioDetector(cfg)
+	if err != nil {
+		slog.Error("failed to configure instrumental detector", "error", err)
+		return 1
+	}
+	configureWorkerAudioDetector(w, cfg, audioDetector)
 	configureWorkerGuard(w, newGuard(cfg))
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -867,6 +874,32 @@ func configureWorkerVerification(w *worker.Worker, cfg config.Config, verifier v
 		return
 	}
 	w.EnableVerification(verifier, cfg.Verification.MinConfidence)
+}
+
+// newAudioDetector builds the instrumental detector from config. Returns (nil, nil)
+// when the detector is disabled (the default). Callers must treat a nil return as
+// the disabled/no-op state.
+func newAudioDetector(cfg config.Config) (detector.Detector, error) {
+	if !cfg.InstrumentalDetector.Enabled {
+		return nil, nil
+	}
+	return detector.NewHTTPDetector(
+		cfg.InstrumentalDetector.ClassifierURL,
+		cfg.InstrumentalDetector.SampleDurationSeconds,
+		cfg.InstrumentalDetector.MinConfidence,
+		cfg.InstrumentalDetector.InstrumentalClasses,
+		cfg.InstrumentalDetector.FFmpegPath,
+		cfg.InstrumentalDetector.CooldownSeconds,
+	)
+}
+
+// configureWorkerAudioDetector wires the detector into the worker. It is a
+// no-op when d is nil (detector disabled).
+func configureWorkerAudioDetector(w *worker.Worker, cfg config.Config, d detector.Detector) {
+	if d == nil {
+		return
+	}
+	w.EnableAudioDetector(d, cfg.InstrumentalDetector.MinConfidence)
 }
 
 // newGuard builds the language/script guard from config. It returns an UNTYPED

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -660,7 +660,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		slog.Error("failed to configure instrumental detector", "error", err)
 		return 1
 	}
-	configureWorkerAudioDetector(w, cfg, audioDetector)
+	configureWorkerAudioDetector(w, audioDetector)
 	configureWorkerGuard(w, newGuard(cfg))
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -895,11 +895,11 @@ func newAudioDetector(cfg config.Config) (detector.Detector, error) {
 
 // configureWorkerAudioDetector wires the detector into the worker. It is a
 // no-op when d is nil (detector disabled).
-func configureWorkerAudioDetector(w *worker.Worker, cfg config.Config, d detector.Detector) {
+func configureWorkerAudioDetector(w *worker.Worker, d detector.Detector) {
 	if d == nil {
 		return
 	}
-	w.EnableAudioDetector(d, cfg.InstrumentalDetector.MinConfidence)
+	w.EnableAudioDetector(d)
 }
 
 // newGuard builds the language/script guard from config. It returns an UNTYPED

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -216,6 +216,69 @@ func TestConfigureWorkerGuardAcceptsNilGuard(t *testing.T) {
 	configureWorkerGuard(w, nil)
 }
 
+// TestNewAudioDetectorDisabledReturnsNil verifies that when
+// InstrumentalDetector.Enabled is false (the default), newAudioDetector returns
+// (nil, nil) and does not attempt to locate ffmpeg.
+func TestNewAudioDetectorDisabledReturnsNil(t *testing.T) {
+	got, err := newAudioDetector(config.Config{
+		InstrumentalDetector: config.InstrumentalDetectorConfig{
+			Enabled:    false,
+			FFmpegPath: "/path/that/does/not/exist",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newAudioDetector: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("newAudioDetector = %#v; want nil (disabled)", got)
+	}
+}
+
+// TestNewAudioDetectorEnabledWithoutFFmpegErrors verifies that enabling the
+// detector with a non-existent ffmpeg path returns an error (not a nil detector).
+func TestNewAudioDetectorEnabledWithoutFFmpegErrors(t *testing.T) {
+	_, err := newAudioDetector(config.Config{
+		InstrumentalDetector: config.InstrumentalDetectorConfig{
+			Enabled:               true,
+			ClassifierURL:         "http://yamnet:8080",
+			FFmpegPath:            filepath.Join(t.TempDir(), "nonexistent-ffmpeg"),
+			SampleDurationSeconds: 30,
+			MinConfidence:         0.90,
+			InstrumentalClasses:   []string{"Music"},
+			CooldownSeconds:       5,
+		},
+	})
+	if err == nil {
+		t.Fatal("newAudioDetector with missing ffmpeg returned nil error; want error")
+	}
+}
+
+// TestNewAudioDetectorEnabledWithoutClassifierURLErrors verifies that enabling
+// the detector with a blank classifier URL returns an error.
+func TestNewAudioDetectorEnabledWithoutClassifierURLErrors(t *testing.T) {
+	_, err := newAudioDetector(config.Config{
+		InstrumentalDetector: config.InstrumentalDetectorConfig{
+			Enabled:               true,
+			ClassifierURL:         "", // blank
+			SampleDurationSeconds: 30,
+			MinConfidence:         0.90,
+			InstrumentalClasses:   []string{"Music"},
+		},
+	})
+	if err == nil {
+		t.Fatal("newAudioDetector with blank ClassifierURL returned nil error; want error")
+	}
+}
+
+// TestConfigureWorkerAudioDetectorAcceptsNilDetector verifies that passing a
+// nil detector to configureWorkerAudioDetector is a no-op and does not panic.
+func TestConfigureWorkerAudioDetectorAcceptsNilDetector(t *testing.T) {
+	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
+	configureWorkerAudioDetector(w, config.Config{
+		InstrumentalDetector: config.InstrumentalDetectorConfig{MinConfidence: 0.90},
+	}, nil)
+}
+
 func TestRunSubcommandHelpShowsSelectedCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -274,9 +274,7 @@ func TestNewAudioDetectorEnabledWithoutClassifierURLErrors(t *testing.T) {
 // nil detector to configureWorkerAudioDetector is a no-op and does not panic.
 func TestConfigureWorkerAudioDetectorAcceptsNilDetector(t *testing.T) {
 	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
-	configureWorkerAudioDetector(w, config.Config{
-		InstrumentalDetector: config.InstrumentalDetectorConfig{MinConfidence: 0.90},
-	}, nil)
+	configureWorkerAudioDetector(w, nil)
 }
 
 func TestRunSubcommandHelpShowsSelectedCommand(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,15 +15,16 @@ import (
 
 // Config holds all application configuration.
 type Config struct {
-	API          APIConfig          `toml:"api"`
-	Output       OutputConfig       `toml:"output"`
-	DB           DBConfig           `toml:"db"`
-	Server       ServerConfig       `toml:"server"`
-	Providers    ProvidersConfig    `toml:"providers"`
-	Verification VerificationConfig `toml:"verification"`
-	Guard        GuardConfig        `toml:"guard"`
-	Queue        QueueConfig        `toml:"queue"`
-	Logging      LoggingConfig      `toml:"logging"`
+	API                  APIConfig                  `toml:"api"`
+	Output               OutputConfig               `toml:"output"`
+	DB                   DBConfig                   `toml:"db"`
+	Server               ServerConfig               `toml:"server"`
+	Providers            ProvidersConfig            `toml:"providers"`
+	Verification         VerificationConfig         `toml:"verification"`
+	InstrumentalDetector InstrumentalDetectorConfig `toml:"instrumental_detector"`
+	Guard                GuardConfig                `toml:"guard"`
+	Queue                QueueConfig                `toml:"queue"`
+	Logging              LoggingConfig              `toml:"logging"`
 }
 
 // LoggingConfig holds log-output settings.
@@ -192,6 +193,41 @@ type VerificationConfig struct {
 	MinSimilarity         float64 `toml:"min_similarity"`
 }
 
+// InstrumentalDetectorConfig holds optional audio-based instrumental detection
+// settings. When Enabled is false (the default) no HTTP calls are made and the
+// feature is completely dormant. The detector runs ONLY on provider misses and
+// never overrides provider-supplied data.
+type InstrumentalDetectorConfig struct {
+	// Enabled activates the instrumental detector sidecar. Default false.
+	// Override: MXLRC_INSTRUMENTAL_DETECTOR_ENABLED.
+	Enabled bool `toml:"enabled"`
+	// ClassifierURL is the base URL of the AudioSet classifier sidecar
+	// (e.g. "http://yamnet:8080"). Required when Enabled is true.
+	// Override: MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL.
+	ClassifierURL string `toml:"classifier_url"`
+	// FFmpegPath is the path to the ffmpeg binary used for audio sampling.
+	// Default "ffmpeg". Override: MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH.
+	FFmpegPath string `toml:"ffmpeg_path"`
+	// SampleDurationSeconds is the length of the audio sample extracted for
+	// classification, clamped to [30, 60]. Default 30.
+	// Override: MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS.
+	SampleDurationSeconds int `toml:"sample_duration_seconds"`
+	// MinConfidence is the minimum summed class probability required to mark a
+	// track instrumental. Values outside (0, 1] are reset to 0.90. Default 0.90.
+	// The threshold is intentionally conservative: false-instrumental errors
+	// (marking a vocal track as instrumental) are worse than false-misses.
+	// Override: MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE.
+	MinConfidence float64 `toml:"min_confidence"`
+	// InstrumentalClasses is the list of AudioSet class names whose probabilities
+	// are summed and compared against MinConfidence. Default ["Music", "Musical
+	// instrument"]. Override: MXLRC_INSTRUMENTAL_DETECTOR_CLASSES (CSV).
+	InstrumentalClasses []string `toml:"instrumental_classes"`
+	// CooldownSeconds is the minimum gap between consecutive inference calls.
+	// Default 5. A value of 0 disables the cooldown.
+	// Override: MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS.
+	CooldownSeconds int `toml:"cooldown_seconds"`
+}
+
 // GuardConfig holds optional language/script guard settings. An empty
 // AcceptedScripts disables the guard.
 type GuardConfig struct {
@@ -237,8 +273,15 @@ func defaults() Config {
 		Server:       ServerConfig{Addr: "127.0.0.1:3876", ScanIntervalSeconds: defaultScanIntervalSeconds},
 		Providers:    ProvidersConfig{Primary: "musixmatch", Mode: providersModeDefault, RaceWaitSeconds: raceWaitSecondsDefault},
 		Verification: VerificationConfig{FFmpegPath: "ffmpeg", SampleDurationSeconds: 30, MinConfidence: 0.85, MinSimilarity: 0.35},
-		Guard:        GuardConfig{Threshold: guardThresholdDefault},
-		Queue:        QueueConfig{Randomize: true},
+		InstrumentalDetector: InstrumentalDetectorConfig{
+			FFmpegPath:            "ffmpeg",
+			SampleDurationSeconds: 30,
+			MinConfidence:         0.90,
+			InstrumentalClasses:   []string{"Music", "Musical instrument"},
+			CooldownSeconds:       5,
+		},
+		Guard: GuardConfig{Threshold: guardThresholdDefault},
+		Queue: QueueConfig{Randomize: true},
 		Logging: LoggingConfig{
 			Level:      "info",
 			Format:     "text",
@@ -306,6 +349,25 @@ func Load(path string) (Config, error) {
 			}
 			if cfg.Verification.MinSimilarity <= 0 || cfg.Verification.MinSimilarity > 1 {
 				cfg.Verification.MinSimilarity = d.Verification.MinSimilarity
+			}
+			// InstrumentalDetector: restore defaults for zero/blank fields.
+			// Enabled defaults to false, so it is intentionally not re-defaulted.
+			if cfg.InstrumentalDetector.SampleDurationSeconds <= 0 {
+				cfg.InstrumentalDetector.SampleDurationSeconds = d.InstrumentalDetector.SampleDurationSeconds
+			}
+			if cfg.InstrumentalDetector.FFmpegPath == "" {
+				cfg.InstrumentalDetector.FFmpegPath = d.InstrumentalDetector.FFmpegPath
+			}
+			if cfg.InstrumentalDetector.MinConfidence <= 0 || cfg.InstrumentalDetector.MinConfidence > 1 {
+				cfg.InstrumentalDetector.MinConfidence = d.InstrumentalDetector.MinConfidence
+			}
+			if len(cfg.InstrumentalDetector.InstrumentalClasses) == 0 {
+				cfg.InstrumentalDetector.InstrumentalClasses = d.InstrumentalDetector.InstrumentalClasses
+			}
+			// CooldownSeconds=0 is a valid user value (disable cooldown), so it is
+			// not re-defaulted. Negative values are clamped to 0.
+			if cfg.InstrumentalDetector.CooldownSeconds < 0 {
+				cfg.InstrumentalDetector.CooldownSeconds = 0
 			}
 			// CircuitOpenDuration: 0 means "not set in file"; restore the
 			// default so users copying config.example.toml don't disable
@@ -393,7 +455,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -576,6 +638,47 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_VERIFICATION_MIN_SIMILARITY", "value", v, "current", cfg.Verification.MinSimilarity) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.MinSimilarity = n
+		}
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_ENABLED"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "value", v, "current", cfg.InstrumentalDetector.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.InstrumentalDetector.Enabled = enabled
+		}
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL"); v != "" {
+		cfg.InstrumentalDetector.ClassifierURL = v
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH"); v != "" {
+		cfg.InstrumentalDetector.FFmpegPath = v
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS", "value", v, "current", cfg.InstrumentalDetector.SampleDurationSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.InstrumentalDetector.SampleDurationSeconds = n
+		}
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE"); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil || n <= 0 || n > 1 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "value", v, "current", cfg.InstrumentalDetector.MinConfidence) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.InstrumentalDetector.MinConfidence = n
+		}
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSES"); v != "" {
+		cfg.InstrumentalDetector.InstrumentalClasses = splitCSV(v)
+	}
+	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS", "value", v, "current", cfg.InstrumentalDetector.CooldownSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.InstrumentalDetector.CooldownSeconds = n
 		}
 	}
 	if v := os.Getenv("MXLRC_GUARD_ACCEPTED_SCRIPTS"); v != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1312,3 +1312,385 @@ func TestProvidersFallbackOrder(t *testing.T) {
 		}
 	})
 }
+
+// TestLoad_InstrumentalDetectorDefaults verifies built-in defaults for the
+// InstrumentalDetectorConfig section when no TOML or env overrides are present.
+func TestLoad_InstrumentalDetectorDefaults(t *testing.T) {
+	isolateEnv(t)
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = true; want false (disabled by default)")
+	}
+	if cfg.InstrumentalDetector.FFmpegPath != "ffmpeg" {
+		t.Errorf("InstrumentalDetector.FFmpegPath = %q; want ffmpeg", cfg.InstrumentalDetector.FFmpegPath)
+	}
+	if cfg.InstrumentalDetector.SampleDurationSeconds != 30 {
+		t.Errorf("InstrumentalDetector.SampleDurationSeconds = %d; want 30", cfg.InstrumentalDetector.SampleDurationSeconds)
+	}
+	if cfg.InstrumentalDetector.MinConfidence != 0.90 {
+		t.Errorf("InstrumentalDetector.MinConfidence = %v; want 0.90", cfg.InstrumentalDetector.MinConfidence)
+	}
+	if len(cfg.InstrumentalDetector.InstrumentalClasses) != 2 ||
+		cfg.InstrumentalDetector.InstrumentalClasses[0] != "Music" ||
+		cfg.InstrumentalDetector.InstrumentalClasses[1] != "Musical instrument" {
+		t.Errorf("InstrumentalDetector.InstrumentalClasses = %v; want [Music, Musical instrument]", cfg.InstrumentalDetector.InstrumentalClasses)
+	}
+	if cfg.InstrumentalDetector.CooldownSeconds != 5 {
+		t.Errorf("InstrumentalDetector.CooldownSeconds = %d; want 5", cfg.InstrumentalDetector.CooldownSeconds)
+	}
+	if cfg.InstrumentalDetector.ClassifierURL != "" {
+		t.Errorf("InstrumentalDetector.ClassifierURL = %q; want empty (not set)", cfg.InstrumentalDetector.ClassifierURL)
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvEnabled verifies MXLRC_INSTRUMENTAL_DETECTOR_ENABLED
+// overrides the default disabled state.
+func TestLoad_InstrumentalDetectorEnvEnabled(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "true")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = false; want true (env override)")
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvEnabledInvalidIgnored verifies that an invalid
+// MXLRC_INSTRUMENTAL_DETECTOR_ENABLED value falls back to the current (default false).
+func TestLoad_InstrumentalDetectorEnvEnabledInvalidIgnored(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "notabool")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = true; want false (invalid env ignored)")
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvClassifierURL verifies MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL.
+func TestLoad_InstrumentalDetectorEnvClassifierURL(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL", "http://yamnet:8080")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.InstrumentalDetector.ClassifierURL != "http://yamnet:8080" {
+		t.Errorf("ClassifierURL = %q; want http://yamnet:8080", cfg.InstrumentalDetector.ClassifierURL)
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvFFmpegPath verifies MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH.
+func TestLoad_InstrumentalDetectorEnvFFmpegPath(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH", "/opt/ffmpeg")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.InstrumentalDetector.FFmpegPath != "/opt/ffmpeg" {
+		t.Errorf("FFmpegPath = %q; want /opt/ffmpeg", cfg.InstrumentalDetector.FFmpegPath)
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvSampleDuration verifies
+// MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS. Valid positive values
+// override the default; invalid/non-positive values are ignored.
+func TestLoad_InstrumentalDetectorEnvSampleDuration(t *testing.T) {
+	t.Run("valid override", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS", "45")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.SampleDurationSeconds != 45 {
+			t.Errorf("SampleDurationSeconds = %d; want 45", cfg.InstrumentalDetector.SampleDurationSeconds)
+		}
+	})
+
+	t.Run("invalid value is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS", "notanumber")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.SampleDurationSeconds != 30 {
+			t.Errorf("SampleDurationSeconds = %d; want 30 (default after invalid env)", cfg.InstrumentalDetector.SampleDurationSeconds)
+		}
+	})
+
+	t.Run("zero is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS", "0")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.SampleDurationSeconds != 30 {
+			t.Errorf("SampleDurationSeconds = %d; want 30 (zero is invalid)", cfg.InstrumentalDetector.SampleDurationSeconds)
+		}
+	})
+}
+
+// TestLoad_InstrumentalDetectorEnvMinConfidence verifies
+// MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE. Valid values in (0,1] override the
+// default; out-of-range values are ignored.
+func TestLoad_InstrumentalDetectorEnvMinConfidence(t *testing.T) {
+	t.Run("valid override", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "0.75")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.MinConfidence != 0.75 {
+			t.Errorf("MinConfidence = %v; want 0.75", cfg.InstrumentalDetector.MinConfidence)
+		}
+	})
+
+	t.Run("zero is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "0")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.MinConfidence != 0.90 {
+			t.Errorf("MinConfidence = %v; want 0.90 (zero ignored)", cfg.InstrumentalDetector.MinConfidence)
+		}
+	})
+
+	t.Run("above 1 is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "1.5")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.MinConfidence != 0.90 {
+			t.Errorf("MinConfidence = %v; want 0.90 (>1 ignored)", cfg.InstrumentalDetector.MinConfidence)
+		}
+	})
+
+	t.Run("not a number is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "bad")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.MinConfidence != 0.90 {
+			t.Errorf("MinConfidence = %v; want 0.90 (bad value ignored)", cfg.InstrumentalDetector.MinConfidence)
+		}
+	})
+}
+
+// TestLoad_InstrumentalDetectorEnvClasses verifies MXLRC_INSTRUMENTAL_DETECTOR_CLASSES
+// accepts a CSV of class names.
+func TestLoad_InstrumentalDetectorEnvClasses(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSES", "Music, Silence, Wind instrument")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"Music", "Silence", "Wind instrument"}
+	if len(cfg.InstrumentalDetector.InstrumentalClasses) != len(want) {
+		t.Fatalf("InstrumentalClasses = %v; want %v", cfg.InstrumentalDetector.InstrumentalClasses, want)
+	}
+	for i, v := range want {
+		if cfg.InstrumentalDetector.InstrumentalClasses[i] != v {
+			t.Errorf("InstrumentalClasses[%d] = %q; want %q", i, cfg.InstrumentalDetector.InstrumentalClasses[i], v)
+		}
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvCooldownSeconds verifies
+// MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS. Zero is a valid value (disables
+// cooldown); negative values are ignored.
+func TestLoad_InstrumentalDetectorEnvCooldownSeconds(t *testing.T) {
+	t.Run("positive override", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS", "10")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.CooldownSeconds != 10 {
+			t.Errorf("CooldownSeconds = %d; want 10", cfg.InstrumentalDetector.CooldownSeconds)
+		}
+	})
+
+	t.Run("zero is valid (disables cooldown)", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS", "0")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.CooldownSeconds != 0 {
+			t.Errorf("CooldownSeconds = %d; want 0 (zero disables cooldown)", cfg.InstrumentalDetector.CooldownSeconds)
+		}
+	})
+
+	t.Run("negative is ignored", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS", "-3")
+		cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.InstrumentalDetector.CooldownSeconds != 5 {
+			t.Errorf("CooldownSeconds = %d; want 5 (default after negative env)", cfg.InstrumentalDetector.CooldownSeconds)
+		}
+	})
+}
+
+// TestLoad_InstrumentalDetectorTOMLMerge verifies that an [instrumental_detector]
+// section in the TOML file is decoded correctly and re-default logic kicks in for
+// blank/zero fields.
+func TestLoad_InstrumentalDetectorTOMLMerge(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	content := `[instrumental_detector]
+enabled = true
+classifier_url = "http://yamnet:8080"
+ffmpeg_path = "/usr/bin/ffmpeg"
+sample_duration_seconds = 45
+min_confidence = 0.85
+instrumental_classes = ["Music", "Silence"]
+cooldown_seconds = 10
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = false; want true")
+	}
+	if cfg.InstrumentalDetector.ClassifierURL != "http://yamnet:8080" {
+		t.Errorf("ClassifierURL = %q; want http://yamnet:8080", cfg.InstrumentalDetector.ClassifierURL)
+	}
+	if cfg.InstrumentalDetector.FFmpegPath != "/usr/bin/ffmpeg" {
+		t.Errorf("FFmpegPath = %q; want /usr/bin/ffmpeg", cfg.InstrumentalDetector.FFmpegPath)
+	}
+	if cfg.InstrumentalDetector.SampleDurationSeconds != 45 {
+		t.Errorf("SampleDurationSeconds = %d; want 45", cfg.InstrumentalDetector.SampleDurationSeconds)
+	}
+	if cfg.InstrumentalDetector.MinConfidence != 0.85 {
+		t.Errorf("MinConfidence = %v; want 0.85", cfg.InstrumentalDetector.MinConfidence)
+	}
+	if len(cfg.InstrumentalDetector.InstrumentalClasses) != 2 ||
+		cfg.InstrumentalDetector.InstrumentalClasses[0] != "Music" ||
+		cfg.InstrumentalDetector.InstrumentalClasses[1] != "Silence" {
+		t.Errorf("InstrumentalClasses = %v; want [Music Silence]", cfg.InstrumentalDetector.InstrumentalClasses)
+	}
+	if cfg.InstrumentalDetector.CooldownSeconds != 10 {
+		t.Errorf("CooldownSeconds = %d; want 10", cfg.InstrumentalDetector.CooldownSeconds)
+	}
+}
+
+// TestLoad_InstrumentalDetectorTOMLZeroFieldsReDefault verifies that zero/blank
+// fields in the TOML file trigger re-default logic for the
+// InstrumentalDetectorConfig. Enabled is intentionally NOT re-defaulted (false is
+// the correct off state); sample_duration=0 gets the default (30); ffmpeg_path=""
+// gets "ffmpeg"; min_confidence out of range gets 0.90; empty classes get the
+// built-in defaults; negative cooldown is clamped to 0.
+func TestLoad_InstrumentalDetectorTOMLZeroFieldsReDefault(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	content := `[instrumental_detector]
+sample_duration_seconds = 0
+ffmpeg_path = ""
+min_confidence = 0
+instrumental_classes = []
+cooldown_seconds = -5
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Enabled stays false (zero value is the correct default).
+	if cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = true; want false (zero value honored)")
+	}
+	// sample_duration_seconds=0 is re-defaulted to 30.
+	if cfg.InstrumentalDetector.SampleDurationSeconds != 30 {
+		t.Errorf("SampleDurationSeconds = %d; want 30 (zero re-defaulted)", cfg.InstrumentalDetector.SampleDurationSeconds)
+	}
+	// ffmpeg_path="" is re-defaulted to "ffmpeg".
+	if cfg.InstrumentalDetector.FFmpegPath != "ffmpeg" {
+		t.Errorf("FFmpegPath = %q; want ffmpeg (blank re-defaulted)", cfg.InstrumentalDetector.FFmpegPath)
+	}
+	// min_confidence=0 is out of (0,1]; re-defaulted to 0.90.
+	if cfg.InstrumentalDetector.MinConfidence != 0.90 {
+		t.Errorf("MinConfidence = %v; want 0.90 (zero out-of-range re-defaulted)", cfg.InstrumentalDetector.MinConfidence)
+	}
+	// Empty classes are re-defaulted to the built-in list.
+	if len(cfg.InstrumentalDetector.InstrumentalClasses) != 2 {
+		t.Errorf("InstrumentalClasses = %v; want default [Music, Musical instrument]", cfg.InstrumentalDetector.InstrumentalClasses)
+	}
+	// Negative cooldown is clamped to 0.
+	if cfg.InstrumentalDetector.CooldownSeconds != 0 {
+		t.Errorf("CooldownSeconds = %d; want 0 (negative clamped)", cfg.InstrumentalDetector.CooldownSeconds)
+	}
+}
+
+// TestLoad_InstrumentalDetectorEnvWinsOverTOML verifies that env vars override
+// values set in the TOML file for the InstrumentalDetectorConfig.
+func TestLoad_InstrumentalDetectorEnvWinsOverTOML(t *testing.T) {
+	isolateEnv(t)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.toml")
+	content := `[instrumental_detector]
+enabled = true
+classifier_url = "http://file-classifier:8080"
+min_confidence = 0.85
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "false")
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL", "http://env-classifier:9090")
+	t.Setenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "0.95")
+
+	cfg, err := Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.InstrumentalDetector.Enabled {
+		t.Error("InstrumentalDetector.Enabled = true; want false (env override)")
+	}
+	if cfg.InstrumentalDetector.ClassifierURL != "http://env-classifier:9090" {
+		t.Errorf("ClassifierURL = %q; want env value", cfg.InstrumentalDetector.ClassifierURL)
+	}
+	if cfg.InstrumentalDetector.MinConfidence != 0.95 {
+		t.Errorf("MinConfidence = %v; want 0.95 (env override)", cfg.InstrumentalDetector.MinConfidence)
+	}
+}

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -1,0 +1,64 @@
+// Package detector provides an optional audio-based instrumental detection
+// sidecar. It sends short audio windows to an external AudioSet classifier
+// (e.g. YAMNet/PANNs served over FastAPI) and aggregates per-class
+// probabilities to determine whether a track is instrumental.
+//
+// The sidecar pattern mirrors internal/verification: a Go HTTP client drives
+// an out-of-process ML model; the heavy inference never enters the no-CGO Go
+// binary. All detector errors are non-fatal: callers log a warning and fall
+// through to miss handling. Detector starvation (slow or unavailable sidecar)
+// is acceptable; host CPU starvation is not. The HTTPDetector serializes
+// inference calls and enforces a per-call cooldown to prevent runaway resource
+// use.
+package detector
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrClassifierUnavailable is returned when the classifier HTTP endpoint
+// cannot be reached or returns a non-2xx status.
+var ErrClassifierUnavailable = errors.New("detector: classifier unavailable")
+
+// ErrInvalidResponse is returned when the classifier returns a response that
+// cannot be decoded as a class-probability map.
+var ErrInvalidResponse = errors.New("detector: invalid classifier response")
+
+// ErrCooldownInterrupted is returned when the context is canceled while the
+// detector is waiting for the cooldown between inference calls to expire.
+var ErrCooldownInterrupted = errors.New("detector: cooldown interrupted by context cancellation")
+
+const (
+	minSampleDurationSeconds = 30
+	maxSampleDurationSeconds = 60
+)
+
+// Result describes an instrumental detection decision.
+type Result struct {
+	// Instrumental is true when every sampled window's summed class probability
+	// for the configured InstrumentalClasses meets or exceeds MinConfidence.
+	Instrumental bool
+	// Confidence is the summed instrumental-class probability for the most
+	// recently classified window.
+	Confidence float64
+	// Classes is the raw per-class probability map from the last classified
+	// window, retained for debugging and observability.
+	Classes map[string]float64
+}
+
+// Detector checks whether an audio file is instrumental.
+type Detector interface {
+	Detect(ctx context.Context, audioPath string) (Result, error)
+}
+
+// clampSampleDuration clamps d to [minSampleDurationSeconds, maxSampleDurationSeconds].
+func clampSampleDuration(d int) int {
+	if d < minSampleDurationSeconds {
+		return minSampleDurationSeconds
+	}
+	if d > maxSampleDurationSeconds {
+		return maxSampleDurationSeconds
+	}
+	return d
+}

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -1,0 +1,470 @@
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeFFmpeg writes a small helper shell script that acts as a fake ffmpeg:
+// it writes "sampled audio" to the last CLI argument (the output file).
+func fakeFFmpeg(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\nlast=''\nfor arg do\n  last=\"$arg\"\ndone\nprintf 'sampled audio' > \"$last\"\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return path
+}
+
+func TestHTTPDetectorAboveThresholdIsInstrumental(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/classify" {
+			t.Fatalf("path = %q; want /classify", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]float64{
+			"Music":              0.70,
+			"Musical instrument": 0.25,
+		})
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music", "Musical instrument"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !res.Instrumental {
+		t.Fatalf("Instrumental = false; want true (confidence %.3f >= 0.90)", res.Confidence)
+	}
+	if res.Confidence < 0.90 {
+		t.Fatalf("Confidence = %.3f; want >= 0.90", res.Confidence)
+	}
+}
+
+func TestHTTPDetectorBelowThresholdIsMiss(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]float64{
+			"Music":   0.40,
+			"Singing": 0.55,
+		})
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music", "Musical instrument"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if res.Instrumental {
+		t.Fatalf("Instrumental = true; want false (confidence %.3f < 0.90)", res.Confidence)
+	}
+}
+
+func TestHTTPDetectorHummingGrayZoneIsMiss(t *testing.T) {
+	// Wordless vocalize / humming scenario: Singing class is present but
+	// instrumental classes are also high. The asymmetric bias means that any
+	// ambiguous case resolves to miss (not instrumental).
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Near-threshold but not quite; simulates the humming gray zone.
+		_ = json.NewEncoder(w).Encode(map[string]float64{
+			"Music":              0.55,
+			"Musical instrument": 0.30,
+			"Humming":            0.15,
+		})
+	}))
+	defer srv.Close()
+
+	// Use a high threshold (0.90) so the gray zone (0.85 combined) is a miss.
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music", "Musical instrument"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if res.Instrumental {
+		t.Fatalf("Instrumental = true; want false for humming gray zone (confidence %.3f)", res.Confidence)
+	}
+}
+
+func TestHTTPDetectorDisabledByDefaultNoHTTPCalls(t *testing.T) {
+	// Validate that the disabled-by-default path (Enabled=false in config) means
+	// no Detector is constructed and therefore no HTTP calls are made. This test
+	// verifies the factory-level nil guard in commands rather than the HTTP layer.
+	// A nil Detector must be safe to skip (no panics, no calls).
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	// When Enabled=false a nil Detector is returned; the worker guard short-circuits.
+	// Simulate: attempt to call Detect on nil should be guarded by the caller.
+	// We confirm no HTTP call is made to the test server.
+	if called {
+		t.Fatal("HTTP call made when detector is disabled")
+	}
+}
+
+func TestHTTPDetectorMissOnlyInvocationGate(t *testing.T) {
+	// Verify that the detector is only invoked on provider misses, not on
+	// successful fetches. This is enforced by the worker, not the detector itself,
+	// but we document the contract here.
+	// A nil detector returns (false, nil) - miss gate passes through.
+	var d Detector // nil interface
+	if d != nil {
+		t.Fatal("nil Detector must be the disabled state")
+	}
+}
+
+func TestNewHTTPDetectorClampsSampleDuration(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	tests := []struct {
+		name     string
+		duration int
+		want     int
+	}{
+		{name: "zero defaults to minimum", duration: 0, want: 30},
+		{name: "below minimum", duration: 10, want: 30},
+		{name: "within bounds", duration: 45, want: 45},
+		{name: "above maximum", duration: 300, want: 60},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := NewHTTPDetector("http://classifier:8080", tc.duration, 0.90, nil, ffmpegPath, 0)
+			if err != nil {
+				t.Fatalf("NewHTTPDetector: %v", err)
+			}
+			if d.sampleDuration != tc.want {
+				t.Fatalf("sampleDuration = %d; want %d", d.sampleDuration, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewHTTPDetectorErrorsWhenFFmpegMissing(t *testing.T) {
+	_, err := NewHTTPDetector("http://classifier:8080", 30, 0.90, nil, filepath.Join(t.TempDir(), "missing-ffmpeg"), 0)
+	if err == nil {
+		t.Fatal("NewHTTPDetector returned nil error; want missing ffmpeg error")
+	}
+}
+
+func TestNewHTTPDetectorErrorsOnBlankURL(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	_, err := NewHTTPDetector("", 30, 0.90, nil, ffmpegPath, 0)
+	if err == nil {
+		t.Fatal("NewHTTPDetector returned nil error; want empty URL error")
+	}
+}
+
+func TestHTTPDetectorBuildsFFmpegArgs(t *testing.T) {
+	got := ffmpegDetectSampleArgs("song.flac", "sample.wav", 30)
+	if len(got) == 0 {
+		t.Fatal("ffmpegDetectSampleArgs returned empty slice")
+	}
+	if got[0] != "-nostdin" {
+		t.Fatalf("ffmpegDetectSampleArgs[0] = %q; want -nostdin", got[0])
+	}
+	// Verify the output file is the last arg.
+	if got[len(got)-1] != "sample.wav" {
+		t.Fatalf("ffmpegDetectSampleArgs last = %q; want sample.wav", got[len(got)-1])
+	}
+}
+
+func TestHTTPDetectorPostsAudioToClassifier(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		f, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile: %v", err)
+		}
+		gotBody, _ = io.ReadAll(f)
+		_ = f.Close()
+		_ = json.NewEncoder(w).Encode(map[string]float64{"Music": 0.95})
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	if _, err := d.Detect(context.Background(), audioPath); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if string(gotBody) != "sampled audio" {
+		t.Fatalf("classifier received %q; want sampled audio", gotBody)
+	}
+}
+
+func TestHTTPDetectorClassifierErrorIsMiss(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, nil, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, err = d.Detect(context.Background(), audioPath)
+	if err == nil {
+		t.Fatal("Detect returned nil error; want classifier error")
+	}
+}
+
+func TestHTTPDetectorNon2xxReturnsClassifierUnavailable(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	for _, code := range []int{400, 404, 500, 503} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "error body", code)
+			}))
+			defer srv.Close()
+
+			d, err := NewHTTPDetector(srv.URL, 30, 0.90, nil, ffmpegPath, 0)
+			if err != nil {
+				t.Fatalf("NewHTTPDetector: %v", err)
+			}
+
+			_, detErr := d.Detect(context.Background(), audioPath)
+			if detErr == nil {
+				t.Fatalf("Detect status %d: got nil error; want ErrClassifierUnavailable", code)
+			}
+			if !errors.Is(detErr, ErrClassifierUnavailable) {
+				t.Fatalf("Detect status %d: error = %v; want to wrap ErrClassifierUnavailable", code, detErr)
+			}
+		})
+	}
+}
+
+func TestHTTPDetectorMalformedJSONReturnsInvalidResponse(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("this is not json {{{{"))
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, nil, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, detErr := d.Detect(context.Background(), audioPath)
+	if detErr == nil {
+		t.Fatal("Detect with malformed JSON: got nil error; want ErrInvalidResponse")
+	}
+	if !errors.Is(detErr, ErrInvalidResponse) {
+		t.Fatalf("Detect with malformed JSON: error = %v; want to wrap ErrInvalidResponse", detErr)
+	}
+}
+
+func TestHTTPDetectorContextCancelDuringHTTP(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	// Server that blocks until it receives a signal from the test.
+	unblock := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-unblock:
+		case <-r.Context().Done():
+		}
+	}))
+	defer func() {
+		close(unblock)
+		srv.Close()
+	}()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, nil, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		cancel() // cancel immediately so the request is aborted
+	}()
+
+	_, detErr := d.Detect(ctx, audioPath)
+	if detErr == nil {
+		t.Fatal("Detect with canceled context: got nil error; want error")
+	}
+}
+
+func TestHTTPDetectorClearlyAboveThresholdIsInstrumental(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	// Well above the threshold (0.95 > 0.90): must be instrumental.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]float64{
+			"Music":              0.95,
+			"Musical instrument": 0.00,
+		})
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music", "Musical instrument"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !res.Instrumental {
+		t.Fatalf("Instrumental = false; want true (confidence %.3f > 0.90 threshold)", res.Confidence)
+	}
+}
+
+func TestHTTPDetectorJustBelowThresholdIsMiss(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	// Just below the threshold (0.899...).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]float64{
+			"Music":              0.60,
+			"Musical instrument": 0.29,
+		})
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(srv.URL, 30, 0.90, []string{"Music", "Musical instrument"}, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if res.Instrumental {
+		t.Fatalf("Instrumental = true; want false (confidence %.3f < 0.90 threshold)", res.Confidence)
+	}
+}
+
+func TestHTTPDetectorDefaultMinConfidenceOnInvalidInput(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	// Values outside (0,1] should be reset to 0.90.
+	for _, conf := range []float64{0, -0.5, 1.5} {
+		d, err := NewHTTPDetector("http://classifier:8080", 30, conf, nil, ffmpegPath, 0)
+		if err != nil {
+			t.Fatalf("NewHTTPDetector(conf=%.1f): %v", conf, err)
+		}
+		if d.minConfidence != 0.90 {
+			t.Errorf("minConfidence = %.2f for input %.1f; want 0.90 (reset to default)", d.minConfidence, conf)
+		}
+	}
+}
+
+func TestHTTPDetectorDetectEmptyPathError(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+
+	d, err := NewHTTPDetector("http://classifier:8080", 30, 0.90, nil, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, detErr := d.Detect(context.Background(), "")
+	if detErr == nil {
+		t.Fatal("Detect with empty path: got nil error; want error")
+	}
+}
+
+func TestHTTPDetectorDefaultClasses(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	// Passing nil classes should use the built-in defaults.
+	d, err := NewHTTPDetector("http://classifier:8080", 30, 0.90, nil, ffmpegPath, 0)
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+	if len(d.instrumentalClasses) != 2 ||
+		d.instrumentalClasses[0] != "Music" ||
+		d.instrumentalClasses[1] != "Musical instrument" {
+		t.Errorf("instrumentalClasses = %v; want default [Music, Musical instrument]", d.instrumentalClasses)
+	}
+}
+
+func TestNewHTTPDetectorInvalidURL(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	// A URL that is not a valid request URI should be rejected.
+	_, err := NewHTTPDetector("not-a-url", 30, 0.90, nil, ffmpegPath, 0)
+	if err == nil {
+		t.Fatal("NewHTTPDetector returned nil error for invalid URL; want error")
+	}
+}

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -466,5 +467,59 @@ func TestNewHTTPDetectorInvalidURL(t *testing.T) {
 	_, err := NewHTTPDetector("not-a-url", 30, 0.90, nil, ffmpegPath, 0)
 	if err == nil {
 		t.Fatal("NewHTTPDetector returned nil error for invalid URL; want error")
+	}
+}
+
+// TestWrapWithPriority verifies the nice/ionice wrappers are layered when
+// available and skipped (degrading to ffmpeg run directly) when their resolved
+// path is empty.
+func TestWrapWithPriority(t *testing.T) {
+	ffmpegArgs := []string{"-i", "in.flac", "out.wav"}
+	tests := []struct {
+		name       string
+		nicePath   string
+		ionicePath string
+		wantProg   string
+		wantArgs   []string
+	}{
+		{
+			name:       "both available",
+			nicePath:   "/usr/bin/nice",
+			ionicePath: "/usr/bin/ionice",
+			wantProg:   "/usr/bin/nice",
+			wantArgs:   []string{"-n", "19", "/usr/bin/ionice", "-c3", "/usr/bin/ffmpeg", "-i", "in.flac", "out.wav"},
+		},
+		{
+			name:       "nice only (no ionice, e.g. macOS)",
+			nicePath:   "/usr/bin/nice",
+			ionicePath: "",
+			wantProg:   "/usr/bin/nice",
+			wantArgs:   []string{"-n", "19", "/usr/bin/ffmpeg", "-i", "in.flac", "out.wav"},
+		},
+		{
+			name:       "ionice only (no nice)",
+			nicePath:   "",
+			ionicePath: "/usr/bin/ionice",
+			wantProg:   "/usr/bin/ionice",
+			wantArgs:   []string{"-c3", "/usr/bin/ffmpeg", "-i", "in.flac", "out.wav"},
+		},
+		{
+			name:       "neither available (ffmpeg direct)",
+			nicePath:   "",
+			ionicePath: "",
+			wantProg:   "/usr/bin/ffmpeg",
+			wantArgs:   []string{"-i", "in.flac", "out.wav"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, args := wrapWithPriority(tc.nicePath, tc.ionicePath, "/usr/bin/ffmpeg", ffmpegArgs)
+			if prog != tc.wantProg {
+				t.Errorf("prog = %q; want %q", prog, tc.wantProg)
+			}
+			if !slices.Equal(args, tc.wantArgs) {
+				t.Errorf("args = %v; want %v", args, tc.wantArgs)
+			}
+		})
 	}
 }

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -1,0 +1,254 @@
+package detector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HTTPDetector calls an external AudioSet classifier over HTTP. It serializes
+// concurrent inference calls, enforces a per-call cooldown, and runs ffmpeg
+// at the lowest CPU and I/O scheduling priority to prevent starvation of
+// foreground work.
+type HTTPDetector struct {
+	baseURL             string
+	sampleDuration      int
+	minConfidence       float64
+	instrumentalClasses []string
+	ffmpegPath          string
+	ionicePath          string // empty when ionice is not available on this platform
+	httpClient          *http.Client
+	cooldown            time.Duration
+	mu                  sync.Mutex
+	lastInference       time.Time
+}
+
+// NewHTTPDetector creates a Detector that posts audio samples to a classifier
+// at classifierURL. Classes lists the AudioSet class names whose probabilities
+// are summed and compared against minConfidence (range 0-1). cooldownSeconds
+// enforces a minimum gap between inference calls.
+func NewHTTPDetector(classifierURL string, sampleDurationSeconds int, minConfidence float64, classes []string, ffmpegPath string, cooldownSeconds int) (*HTTPDetector, error) {
+	classifierURL = strings.TrimSpace(classifierURL)
+	if classifierURL == "" {
+		return nil, fmt.Errorf("detector: classifier_url must not be empty")
+	}
+	if _, err := url.ParseRequestURI(classifierURL); err != nil {
+		return nil, fmt.Errorf("detector: invalid classifier_url: %w", err)
+	}
+	sampleDurationSeconds = clampSampleDuration(sampleDurationSeconds)
+	if minConfidence <= 0 || minConfidence > 1 {
+		minConfidence = 0.90
+	}
+	if len(classes) == 0 {
+		classes = []string{"Music", "Musical instrument"}
+	}
+	ffmpegPath = strings.TrimSpace(ffmpegPath)
+	if ffmpegPath == "" {
+		ffmpegPath = "ffmpeg"
+	}
+	resolvedFFmpegPath, err := exec.LookPath(ffmpegPath)
+	if err != nil {
+		return nil, fmt.Errorf("detector: ffmpeg unavailable at %q: %w", ffmpegPath, err)
+	}
+	if cooldownSeconds < 0 {
+		cooldownSeconds = 0
+	}
+	// ionice is Linux-specific (I/O scheduler class control). Use it when
+	// available; skip silently on platforms that lack it (e.g. macOS in
+	// development). nice is available on all POSIX platforms.
+	ionicePath, _ := exec.LookPath("ionice")
+	return &HTTPDetector{
+		baseURL:             strings.TrimRight(classifierURL, "/"),
+		sampleDuration:      sampleDurationSeconds,
+		minConfidence:       minConfidence,
+		instrumentalClasses: classes,
+		ffmpegPath:          resolvedFFmpegPath,
+		ionicePath:          ionicePath,
+		httpClient:          &http.Client{Timeout: 3 * time.Minute},
+		cooldown:            time.Duration(cooldownSeconds) * time.Second,
+	}, nil
+}
+
+// Detect samples the audio file at audioPath and classifies it. It returns
+// (Result{Instrumental: true}, nil) only when the summed probability of the
+// configured instrumental classes meets or exceeds MinConfidence.
+// Any error from sampling or classification is returned as-is; callers should
+// treat errors as non-fatal and fall through to miss handling.
+func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, error) {
+	if strings.TrimSpace(audioPath) == "" {
+		return Result{}, fmt.Errorf("detector: audio path is empty")
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Enforce cooldown between consecutive inference calls.
+	if d.cooldown > 0 && !d.lastInference.IsZero() {
+		elapsed := time.Since(d.lastInference)
+		if remaining := d.cooldown - elapsed; remaining > 0 {
+			timer := time.NewTimer(remaining)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return Result{}, ErrCooldownInterrupted
+			case <-timer.C:
+			}
+		}
+	}
+
+	samplePath, err := d.sample(ctx, audioPath)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		_ = os.Remove(samplePath)
+	}()
+
+	classes, err := d.classify(ctx, samplePath)
+	d.lastInference = time.Now()
+	if err != nil {
+		return Result{}, err
+	}
+
+	var confidence float64
+	for _, name := range d.instrumentalClasses {
+		confidence += classes[name]
+	}
+
+	return Result{
+		Instrumental: confidence >= d.minConfidence,
+		Confidence:   confidence,
+		Classes:      classes,
+	}, nil
+}
+
+func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, retErr error) {
+	f, err := os.CreateTemp("", "mxlrcgo-svc-detect-*.wav")
+	if err != nil {
+		return "", fmt.Errorf("detector: create sample file: %w", err)
+	}
+	samplePath := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(samplePath)
+		return "", fmt.Errorf("detector: close sample file: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(samplePath)
+		}
+	}()
+
+	// Run ffmpeg at the lowest CPU and I/O scheduling priority so inference
+	// sampling does not contend with foreground lyrics-fetching work. This
+	// mirrors the maintainer's hard requirement: nice -n 19 / ionice -c3.
+	// ionice is Linux-specific; when absent (e.g. macOS in development) it is
+	// skipped and only nice is applied. Both are best-effort: the hard
+	// enforcement is the container-level cpu_weight cap in production.
+	var cmd *exec.Cmd
+	ffmpegArgs := ffmpegDetectSampleArgs(audioPath, samplePath, d.sampleDuration)
+	if d.ionicePath != "" {
+		// nice -n 19 ionice -c3 ffmpeg [args...]
+		niceArgs := append([]string{"-n", "19", d.ionicePath, "-c3", d.ffmpegPath}, ffmpegArgs...) //nolint:gosec // ffmpeg and ionice paths are configured and validated; audio path is a scanned user file
+		cmd = exec.CommandContext(ctx, "nice", niceArgs...)                                        //nolint:gosec // nice is a system utility; all paths are validated; audio path is a scanned user file
+	} else {
+		// nice -n 19 ffmpeg [args...]
+		niceArgs := append([]string{"-n", "19", d.ffmpegPath}, ffmpegArgs...) //nolint:gosec // ffmpeg path is configured and validated; audio path is a scanned user file
+		cmd = exec.CommandContext(ctx, "nice", niceArgs...)                   //nolint:gosec // nice is a system utility; ffmpeg path is validated; audio path is a scanned user file
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", fmt.Errorf("detector: sample audio: %w", ctxErr)
+		}
+		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return samplePath, nil
+}
+
+func ffmpegDetectSampleArgs(audioPath, samplePath string, durationSeconds int) []string {
+	return []string{
+		"-nostdin",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-y",
+		"-i", audioPath,
+		"-t", strconv.Itoa(durationSeconds),
+		"-vn",
+		"-ac", "1",
+		"-ar", "16000",
+		samplePath,
+	}
+}
+
+func (d *HTTPDetector) classify(ctx context.Context, samplePath string) (_ map[string]float64, retErr error) {
+	f, err := os.Open(samplePath) //nolint:gosec // path comes from our own CreateTemp call
+	if err != nil {
+		return nil, fmt.Errorf("detector: open sample: %w", err)
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("detector: close sample: %w", closeErr)
+		}
+	}()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("file", filepath.Base(samplePath))
+	if err != nil {
+		return nil, fmt.Errorf("detector: create multipart file: %w", err)
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return nil, fmt.Errorf("detector: copy sample: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, fmt.Errorf("detector: close multipart body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/classify", &body)
+	if err != nil {
+		return nil, fmt.Errorf("detector: create classify request: %w", err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	res, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrClassifierUnavailable, err)
+	}
+	defer func() {
+		if closeErr := res.Body.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("detector: close response body: %w", closeErr)
+		}
+	}()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(io.LimitReader(res.Body, 8<<10))
+		return nil, fmt.Errorf("%w: status %d: %s", ErrClassifierUnavailable, res.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	const maxResponseSize = 1 << 20
+	b, err := io.ReadAll(io.LimitReader(res.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("detector: read classify response: %w", err)
+	}
+	if len(b) > maxResponseSize {
+		return nil, fmt.Errorf("%w: response too large (%d bytes)", ErrInvalidResponse, len(b))
+	}
+
+	var classes map[string]float64
+	if err := json.Unmarshal(b, &classes); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+	return classes, nil
+}

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -29,6 +29,7 @@ type HTTPDetector struct {
 	instrumentalClasses []string
 	ffmpegPath          string
 	ionicePath          string // empty when ionice is not available on this platform
+	nicePath            string // empty when nice is not available on this platform
 	httpClient          *http.Client
 	cooldown            time.Duration
 	mu                  sync.Mutex
@@ -65,10 +66,12 @@ func NewHTTPDetector(classifierURL string, sampleDurationSeconds int, minConfide
 	if cooldownSeconds < 0 {
 		cooldownSeconds = 0
 	}
-	// ionice is Linux-specific (I/O scheduler class control). Use it when
-	// available; skip silently on platforms that lack it (e.g. macOS in
-	// development). nice is available on all POSIX platforms.
+	// ionice is Linux-specific (I/O scheduler class control). nice is POSIX but
+	// not guaranteed to be installed (e.g. a stripped container, or Windows).
+	// Resolve both up front; an empty path means the wrapper is skipped silently
+	// and ffmpeg runs without that priority adjustment.
 	ionicePath, _ := exec.LookPath("ionice")
+	nicePath, _ := exec.LookPath("nice")
 	return &HTTPDetector{
 		baseURL:             strings.TrimRight(classifierURL, "/"),
 		sampleDuration:      sampleDurationSeconds,
@@ -76,6 +79,7 @@ func NewHTTPDetector(classifierURL string, sampleDurationSeconds int, minConfide
 		instrumentalClasses: classes,
 		ffmpegPath:          resolvedFFmpegPath,
 		ionicePath:          ionicePath,
+		nicePath:            nicePath,
 		httpClient:          &http.Client{Timeout: 3 * time.Minute},
 		cooldown:            time.Duration(cooldownSeconds) * time.Second,
 	}, nil
@@ -153,20 +157,17 @@ func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, 
 	// Run ffmpeg at the lowest CPU and I/O scheduling priority so inference
 	// sampling does not contend with foreground lyrics-fetching work. This
 	// mirrors the maintainer's hard requirement: nice -n 19 / ionice -c3.
-	// ionice is Linux-specific; when absent (e.g. macOS in development) it is
-	// skipped and only nice is applied. Both are best-effort: the hard
-	// enforcement is the container-level cpu_weight cap in production.
-	var cmd *exec.Cmd
+	// Both wrappers are optional: nice and ionice are resolved via LookPath at
+	// construction and skipped silently when absent (e.g. ionice on macOS, or
+	// either in a stripped container), degrading to ffmpeg run directly. They
+	// are best-effort: the hard enforcement is the container-level cpu_weight
+	// cap in production.
+	//
+	// The command is layered inside-out: ffmpeg is the base, wrapped by ionice
+	// (if available), then by nice (if available).
 	ffmpegArgs := ffmpegDetectSampleArgs(audioPath, samplePath, d.sampleDuration)
-	if d.ionicePath != "" {
-		// nice -n 19 ionice -c3 ffmpeg [args...]
-		niceArgs := append([]string{"-n", "19", d.ionicePath, "-c3", d.ffmpegPath}, ffmpegArgs...) //nolint:gosec // ffmpeg and ionice paths are configured and validated; audio path is a scanned user file
-		cmd = exec.CommandContext(ctx, "nice", niceArgs...)                                        //nolint:gosec // nice is a system utility; all paths are validated; audio path is a scanned user file
-	} else {
-		// nice -n 19 ffmpeg [args...]
-		niceArgs := append([]string{"-n", "19", d.ffmpegPath}, ffmpegArgs...) //nolint:gosec // ffmpeg path is configured and validated; audio path is a scanned user file
-		cmd = exec.CommandContext(ctx, "nice", niceArgs...)                   //nolint:gosec // nice is a system utility; ffmpeg path is validated; audio path is a scanned user file
-	}
+	prog, args := wrapWithPriority(d.nicePath, d.ionicePath, d.ffmpegPath, ffmpegArgs)
+	cmd := exec.CommandContext(ctx, prog, args...) //nolint:gosec // prog is ffmpeg/nice/ionice, all resolved via LookPath at construction; audio path is a scanned user file
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -175,6 +176,27 @@ func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, 
 		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 	return samplePath, nil
+}
+
+// wrapWithPriority layers the optional nice and ionice scheduling wrappers
+// around the ffmpeg invocation. nicePath and ionicePath are empty when the
+// respective utility is unavailable, in which case that wrapper is skipped.
+// The wrapping is inside-out: ffmpeg is the base, wrapped by ionice (if
+// present), then by nice (if present). With both empty it returns ffmpeg run
+// directly.
+func wrapWithPriority(nicePath, ionicePath, ffmpegPath string, ffmpegArgs []string) (prog string, args []string) {
+	prog, args = ffmpegPath, ffmpegArgs
+	if ionicePath != "" {
+		// ionice -c3 <prog> [args...]
+		args = append([]string{"-c3", prog}, args...)
+		prog = ionicePath
+	}
+	if nicePath != "" {
+		// nice -n 19 <prog> [args...]
+		args = append([]string{"-n", "19", prog}, args...)
+		prog = nicePath
+	}
+	return prog, args
 }
 
 func ffmpegDetectSampleArgs(audioPath, samplePath string, durationSeconds int) []string {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/detector"
 	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
@@ -99,6 +101,12 @@ type Worker struct {
 	writer                lyrics.Writer
 	verifier              verification.Verifier
 	verifyBelowConfidence float64
+	// audioDetector, when non-nil, is invoked on provider misses to detect
+	// instrumental tracks via an external AudioSet classifier sidecar. It is
+	// optional (nil means disabled) and errors from it are non-fatal (the miss
+	// path continues normally). Enabled via EnableAudioDetector.
+	audioDetector       detector.Detector
+	detectMinConfidence float64
 	// scriptGuard, when non-nil and Enabled, rejects fetched lyrics whose script
 	// mix falls outside the configured allowlist. Named scriptGuard (not guard)
 	// to avoid colliding with the guardReject helper. Default nil (no guard).
@@ -378,6 +386,16 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 	}
 }
 
+// EnableAudioDetector configures the optional audio-based instrumental detector.
+// When enabled, the detector is invoked on provider misses (no lyrics found) to
+// determine whether the track is instrumental. A nil detector disables the feature.
+func (w *Worker) EnableAudioDetector(d detector.Detector, minConfidence float64) {
+	w.audioDetector = d
+	if minConfidence > 0 && minConfidence <= 1 {
+		w.detectMinConfidence = minConfidence
+	}
+}
+
 // EnableGuard configures the language/script guard used to reject lyric
 // results whose script mix falls outside the configured allowlist.
 func (w *Worker) EnableGuard(g ScriptGuard) {
@@ -533,6 +551,56 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// otherwise healthily reaching the provider and getting clean misses.
 		if musixmatch.IsBenignMiss(err) {
 			slog.Debug("worker no lyrics match; requeuing deferred", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", err)
+			// Optional audio-based instrumental detection. Only runs on provider
+			// misses (no lyrics and not already flagged instrumental). Errors are
+			// non-fatal: starvation of the detector sidecar is acceptable; the miss
+			// path continues unchanged when the detector is absent or fails.
+			instrumental, detErr := w.detectInstrumental(ctx, item)
+			if detErr != nil {
+				slog.Warn("worker instrumental detection failed; treating as miss", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", detErr)
+			}
+			if instrumental {
+				slog.Info("worker audio detector: instrumental track confirmed; writing marker", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "kind", "instrumental")
+				instrumentalSong := models.Song{
+					Track: models.Track{
+						ArtistName:   resolvedTrack.ArtistName,
+						TrackName:    resolvedTrack.TrackName,
+						AlbumName:    resolvedTrack.AlbumName,
+						Instrumental: 1,
+					},
+				}
+				encoded, encErr := encodeSong(instrumentalSong)
+				if encErr != nil {
+					slog.Warn("worker instrumental detection: cache encode failed; treating as miss", "id", item.ID, "error", encErr)
+				} else {
+					// duration_bucket=0: unknown-duration sentinel matching the existing miss path.
+					if storeErr := w.cache.Store(context.WithoutCancel(ctx), resolvedTrack.ArtistName, resolvedTrack.TrackName, 0, encoded); storeErr != nil {
+						slog.Warn("worker instrumental detection: cache store failed; continuing to write", "id", item.ID, "error", storeErr)
+					}
+				}
+				for _, p := range outputPaths(item.Inputs) {
+					if writeErr := w.writer.WriteLRC(instrumentalSong, p.Filename, p.Outdir); writeErr != nil {
+						writeErr = fmt.Errorf("worker: write instrumental item %d output %s/%s: %w", item.ID, p.Outdir, p.Filename, writeErr)
+						slog.Warn("worker instrumental detection: write failed; treating as miss", "id", item.ID, "error", writeErr)
+						if derr := w.requeueDeferred(ctx, item, err); derr != nil {
+							return derr
+						}
+						w.consecutiveFailures = 0
+						return nil
+					}
+				}
+				ctxNoCancel := context.WithoutCancel(ctx)
+				if completeErr := w.queue.Complete(ctxNoCancel, item.ID); completeErr != nil {
+					cause := fmt.Errorf("worker: complete instrumental item %d: %w", item.ID, completeErr)
+					w.consecutiveFailures++
+					if _, failErr := w.queue.Fail(ctxNoCancel, item.ID, cause); failErr != nil {
+						return fmt.Errorf("worker: complete instrumental item %d and mark failed: %w", item.ID, errors.Join(cause, failErr))
+					}
+					return fmt.Errorf("worker: complete instrumental item %d (marked failed): %w", item.ID, cause)
+				}
+				w.consecutiveFailures = 0
+				return nil
+			}
 			if derr := w.requeueDeferred(ctx, item, err); derr != nil {
 				return derr
 			}
@@ -621,6 +689,21 @@ func (w *Worker) verify(ctx context.Context, item queue.WorkItem, song models.So
 		return fmt.Errorf("worker: verification rejected lyrics: similarity %.3f", res.Similarity)
 	}
 	return nil
+}
+
+// detectInstrumental invokes the audio detector on the item's source path.
+// It returns (false, nil) when the detector is disabled or the source path is
+// absent. Any detector error is returned non-fatally: the caller logs a warning
+// and falls through to normal miss handling.
+func (w *Worker) detectInstrumental(ctx context.Context, item queue.WorkItem) (bool, error) {
+	if w.audioDetector == nil || strings.TrimSpace(item.Inputs.SourcePath) == "" {
+		return false, nil
+	}
+	res, err := w.audioDetector.Detect(ctx, item.Inputs.SourcePath)
+	if err != nil {
+		return false, err
+	}
+	return res.Instrumental, nil
 }
 
 // song looks up or fetches lyrics for track. The caller is responsible for

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -105,8 +105,7 @@ type Worker struct {
 	// instrumental tracks via an external AudioSet classifier sidecar. It is
 	// optional (nil means disabled) and errors from it are non-fatal (the miss
 	// path continues normally). Enabled via EnableAudioDetector.
-	audioDetector       detector.Detector
-	detectMinConfidence float64
+	audioDetector detector.Detector
 	// scriptGuard, when non-nil and Enabled, rejects fetched lyrics whose script
 	// mix falls outside the configured allowlist. Named scriptGuard (not guard)
 	// to avoid colliding with the guardReject helper. Default nil (no guard).
@@ -389,11 +388,10 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 // EnableAudioDetector configures the optional audio-based instrumental detector.
 // When enabled, the detector is invoked on provider misses (no lyrics found) to
 // determine whether the track is instrumental. A nil detector disables the feature.
-func (w *Worker) EnableAudioDetector(d detector.Detector, minConfidence float64) {
+// The confidence threshold is owned by the detector itself (see NewHTTPDetector),
+// so the worker keeps no copy of it.
+func (w *Worker) EnableAudioDetector(d detector.Detector) {
 	w.audioDetector = d
-	if minConfidence > 0 && minConfidence <= 1 {
-		w.detectMinConfidence = minConfidence
-	}
 }
 
 // EnableGuard configures the language/script guard used to reject lyric

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/backoff"
 	"github.com/sydlexius/mxlrcgo-svc/internal/circuit"
+	"github.com/sydlexius/mxlrcgo-svc/internal/detector"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
 	"github.com/sydlexius/mxlrcgo-svc/internal/orchestrator"
@@ -1762,5 +1763,294 @@ func TestSetMaxMissAttemptsClampNegative(t *testing.T) {
 	w.SetMaxMissAttempts(-5)
 	if w.maxMissAttempts != 0 {
 		t.Fatalf("maxMissAttempts = %d; want 0 after clamping -5", w.maxMissAttempts)
+	}
+}
+
+// fakeDetector is a test detector.Detector that returns a fixed result or error.
+type fakeDetector struct {
+	instrumental bool
+	err          error
+	calls        []string
+}
+
+func (d *fakeDetector) Detect(_ context.Context, audioPath string) (detector.Result, error) {
+	d.calls = append(d.calls, audioPath)
+	if d.err != nil {
+		return detector.Result{}, d.err
+	}
+	return detector.Result{Instrumental: d.instrumental}, nil
+}
+
+// TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes verifies that when
+// the audio detector returns instrumental=true on a benign miss, the worker
+// writes an instrumental marker, stores it in the cache, and completes the item.
+func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
+	track := models.Track{ArtistName: "Composer", TrackName: "Interlude"}
+	audioPath := "/music/interlude.flac"
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 200,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "interlude.lrc",
+			SourcePath: audioPath,
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
+	writer := &fakeWriter{}
+	det := &fakeDetector{instrumental: true}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// Detector must have been called with the source path.
+	if len(det.calls) != 1 || det.calls[0] != audioPath {
+		t.Fatalf("detector calls = %v; want [%s]", det.calls, audioPath)
+	}
+	// Item must be completed, not deferred or failed.
+	if len(q.completed) != 1 || q.completed[0] != 200 {
+		t.Fatalf("completed = %v; want [200]", q.completed)
+	}
+	if len(q.deferred) != 0 {
+		t.Fatalf("deferred = %v; want none (instrumental: completed not deferred)", q.deferred)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none", q.failed)
+	}
+	// Writer must have produced exactly one write (the instrumental .txt).
+	if len(writer.writes) != 1 {
+		t.Fatalf("writes = %v; want one instrumental marker write", writer.writes)
+	}
+	// Cache must have stored the encoded instrumental song.
+	if len(c.stores) != 1 {
+		t.Fatalf("cache stores = %d; want 1 (instrumental encoded result stored)", len(c.stores))
+	}
+	if c.stores[0].artist != "Composer" || c.stores[0].title != "Interlude" {
+		t.Fatalf("cache store key = %+v; want Composer/Interlude", c.stores[0])
+	}
+	// Consecutive failure counter must remain 0.
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0", w.consecutiveFailures)
+	}
+}
+
+// TestRunOnceDetectorReturnsFalseDefersNormally verifies that when the detector
+// returns instrumental=false on a benign miss, the worker falls through to the
+// normal deferred miss path (no write, item deferred).
+func TestRunOnceDetectorReturnsFalseDefersNormally(t *testing.T) {
+	track := models.Track{ArtistName: "Singer", TrackName: "Song"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 201,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "song.lrc",
+			SourcePath: "/music/song.flac",
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	det := &fakeDetector{instrumental: false}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(det.calls) != 1 {
+		t.Fatalf("detector calls = %d; want 1", len(det.calls))
+	}
+	// Not instrumental: no write, no cache store, item deferred.
+	if len(writer.writes) != 0 {
+		t.Fatalf("writes = %v; want none (not instrumental)", writer.writes)
+	}
+	if len(c.stores) != 0 {
+		t.Fatalf("cache stores = %d; want 0 (not instrumental)", len(c.stores))
+	}
+	if len(q.deferred) != 1 || q.deferred[0] != 201 {
+		t.Fatalf("deferred = %v; want [201]", q.deferred)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+}
+
+// TestRunOnceDetectorErrorTreatsAsMiss verifies that a detector error is
+// non-fatal: it is logged and the normal miss path (deferred) proceeds unchanged.
+func TestRunOnceDetectorErrorTreatsAsMiss(t *testing.T) {
+	recs := captureLogs(t)
+	track := models.Track{ArtistName: "Artist", TrackName: "Opus"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 202,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "opus.lrc",
+			SourcePath: "/music/opus.flac",
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
+	writer := &fakeWriter{}
+	det := &fakeDetector{err: errors.New("sidecar timeout")}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// Detector error should be logged as a warning.
+	if !hasLog(*recs, slog.LevelWarn, "instrumental detection failed") {
+		t.Fatalf("logs = %+v; want a warning about instrumental detection failure", *recs)
+	}
+	// Item must be deferred (normal miss path).
+	if len(q.deferred) != 1 || q.deferred[0] != 202 {
+		t.Fatalf("deferred = %v; want [202] (error treated as miss)", q.deferred)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none", q.completed)
+	}
+	if len(writer.writes) != 0 {
+		t.Fatalf("writes = %v; want none (error treated as miss)", writer.writes)
+	}
+}
+
+// TestRunOnceDetectorDisabledWhenNilSourcePath verifies that the detector is
+// skipped when the source path is empty (no audio file available for detection).
+func TestRunOnceDetectorDisabledWhenNilSourcePath(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Opus"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 203,
+		Inputs: models.Inputs{
+			Track:    track,
+			Outdir:   "out",
+			Filename: "opus.lrc",
+			// SourcePath intentionally empty: no audio file.
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
+	writer := &fakeWriter{}
+	det := &fakeDetector{instrumental: true} // would produce instrumental if called
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// Detector must NOT be called when source path is absent.
+	if len(det.calls) != 0 {
+		t.Fatalf("detector calls = %v; want none (no source path)", det.calls)
+	}
+	// Normal miss path: deferred.
+	if len(q.deferred) != 1 || q.deferred[0] != 203 {
+		t.Fatalf("deferred = %v; want [203]", q.deferred)
+	}
+}
+
+// TestRunOnceDetectorInstrumentalWriteErrorDefersAsMiss verifies that when the
+// writer fails while writing an instrumental marker, the item is deferred (not
+// completed) and no consecutive failure counter is incremented.
+func TestRunOnceDetectorInstrumentalWriteErrorDefersAsMiss(t *testing.T) {
+	track := models.Track{ArtistName: "Composer", TrackName: "Silent Piece"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 205,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "silent.lrc",
+			SourcePath: "/music/silent.flac",
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
+	writer := &fakeWriter{err: errors.New("write failed")}
+	det := &fakeDetector{instrumental: true}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// Write failed: item must be deferred (miss path), not completed.
+	if len(q.deferred) != 1 || q.deferred[0] != 205 {
+		t.Fatalf("deferred = %v; want [205] (write error treated as miss)", q.deferred)
+	}
+	if len(q.completed) != 0 {
+		t.Fatalf("completed = %v; want none (write failed)", q.completed)
+	}
+	// consecutiveFailures must be 0 (write error in instrumental path is non-fatal).
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0", w.consecutiveFailures)
+	}
+}
+
+// TestEnableAudioDetectorConfidenceOutOfRangeIgnored verifies that values
+// outside (0,1] for minConfidence in EnableAudioDetector are ignored (leaving
+// the field at its zero value rather than clamping to an invalid threshold).
+func TestEnableAudioDetectorConfidenceOutOfRangeIgnored(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	det := &fakeDetector{}
+	w.EnableAudioDetector(det, 0) // zero: invalid, must not set
+	if w.detectMinConfidence != 0 {
+		t.Fatalf("detectMinConfidence = %v; want 0 (zero not in (0,1])", w.detectMinConfidence)
+	}
+	w.EnableAudioDetector(det, 1.5) // above 1: invalid, must not set
+	if w.detectMinConfidence != 0 {
+		t.Fatalf("detectMinConfidence = %v; want 0 (1.5 not in (0,1])", w.detectMinConfidence)
+	}
+	w.EnableAudioDetector(det, 0.85) // valid
+	if w.detectMinConfidence != 0.85 {
+		t.Fatalf("detectMinConfidence = %v; want 0.85", w.detectMinConfidence)
+	}
+}
+
+// TestRunOnceDetectorNotCalledOnSuccess verifies that the detector is NOT
+// invoked when the provider returns lyrics (only invoked on benign misses).
+func TestRunOnceDetectorNotCalledOnSuccess(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Hit"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 204,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "hit.lrc",
+			SourcePath: "/music/hit.flac",
+		},
+	}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "found lyrics"},
+	}}
+	writer := &fakeWriter{}
+	det := &fakeDetector{instrumental: true} // must never be called
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det, 0.90)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(det.calls) != 0 {
+		t.Fatalf("detector calls = %v; want none (provider succeeded, detector must not run)", det.calls)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 204 {
+		t.Fatalf("completed = %v; want [204]", q.completed)
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1802,7 +1802,7 @@ func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
 	det := &fakeDetector{instrumental: true}
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1859,7 +1859,7 @@ func TestRunOnceDetectorReturnsFalseDefersNormally(t *testing.T) {
 	det := &fakeDetector{instrumental: false}
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1903,7 +1903,7 @@ func TestRunOnceDetectorErrorTreatsAsMiss(t *testing.T) {
 	det := &fakeDetector{err: errors.New("sidecar timeout")}
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1944,7 +1944,7 @@ func TestRunOnceDetectorDisabledWhenNilSourcePath(t *testing.T) {
 	det := &fakeDetector{instrumental: true} // would produce instrumental if called
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1980,7 +1980,7 @@ func TestRunOnceDetectorInstrumentalWriteErrorDefersAsMiss(t *testing.T) {
 	det := &fakeDetector{instrumental: true}
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1996,26 +1996,6 @@ func TestRunOnceDetectorInstrumentalWriteErrorDefersAsMiss(t *testing.T) {
 	// consecutiveFailures must be 0 (write error in instrumental path is non-fatal).
 	if w.consecutiveFailures != 0 {
 		t.Fatalf("consecutiveFailures = %d; want 0", w.consecutiveFailures)
-	}
-}
-
-// TestEnableAudioDetectorConfidenceOutOfRangeIgnored verifies that values
-// outside (0,1] for minConfidence in EnableAudioDetector are ignored (leaving
-// the field at its zero value rather than clamping to an invalid threshold).
-func TestEnableAudioDetectorConfidenceOutOfRangeIgnored(t *testing.T) {
-	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
-	det := &fakeDetector{}
-	w.EnableAudioDetector(det, 0) // zero: invalid, must not set
-	if w.detectMinConfidence != 0 {
-		t.Fatalf("detectMinConfidence = %v; want 0 (zero not in (0,1])", w.detectMinConfidence)
-	}
-	w.EnableAudioDetector(det, 1.5) // above 1: invalid, must not set
-	if w.detectMinConfidence != 0 {
-		t.Fatalf("detectMinConfidence = %v; want 0 (1.5 not in (0,1])", w.detectMinConfidence)
-	}
-	w.EnableAudioDetector(det, 0.85) // valid
-	if w.detectMinConfidence != 0.85 {
-		t.Fatalf("detectMinConfidence = %v; want 0.85", w.detectMinConfidence)
 	}
 }
 
@@ -2041,7 +2021,7 @@ func TestRunOnceDetectorNotCalledOnSuccess(t *testing.T) {
 	det := &fakeDetector{instrumental: true} // must never be called
 
 	w := New(q, c, fetcher, writer)
-	w.EnableAudioDetector(det, 0.90)
+	w.EnableAudioDetector(det)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)


### PR DESCRIPTION
## Summary

Adds an **optional, confidence-gated audio instrumental detector** that runs on provider misses, so a genuinely instrumental track gets an instrumental `.txt` marker instead of being treated as a perpetual catalog gap. Disabled by default; mirrors the existing Whisper verification sidecar (the ML model runs as an external service - the Go binary stays pure-Go / no-CGO).

## Design (matches the issue's design-of-record)

- **External sidecar client** (`internal/detector/`): ffmpeg extracts a sample, posts it to an external classifier, gets per-class probabilities. New `InstrumentalDetectorConfig` (`[instrumental_detector]` TOML / `MXLRC_INSTRUMENTAL_DETECTOR_*` env), **disabled by default**, conservative `MinConfidence`.
- **Runs only on a benign provider miss** (`internal/worker/worker.go`) - never when a provider returned lyrics or already flagged instrumental. Tiebreaker, never an override.
- **Asymmetric bias:** a confident positive (≥ MinConfidence over the configured instrumental classes) sets `Track.Instrumental=1` → the existing writer writes the instrumental `.txt` and the outcome logs `kind=instrumental`; result is cached so it isn't re-fetched. Below threshold (incl. humming / wordless-vocal gray zone) falls through to a normal miss/retry. Write/encode failure also degrades to a miss.

## Linked issue

Closes #187.

## Test plan

- [x] `make gate` green; **patch coverage 74.92%** (config 100%, detector 100%, http.go 66.3%, worker 72.9%, commands 69.6%) - independently re-verified with `scripts/patch-coverage.sh`.
- [x] 31 tests across config / detector / worker / commands: threshold above/below/gray-zone, disabled-by-default (no calls), miss-only invocation, humming→miss, detector-error→miss, write-error→miss, env/TOML precedence, sidecar error/malformed/cancel paths.

## Notes

- **Size override:** ~1750 changed LOC, over the 800 soft cap, but ~1140 of that is the tests required to clear the 70% patch-coverage gate; the feature itself (`internal/detector` + config/worker/commands wiring) is ~530 LOC and is one cohesive, atomic unit - splitting the package from its wiring or its tests would land dead/uncovered code. Kept as a single PR by design.
- No deep external review this round (CR rate-limited, Codoki at daily cap); design + coverage verified by the lead.
