### PR TITLE
docs(design): reports-workspace design of record for serve-mode observability (#186)

### DIFF
--- a/docs/design/2026-06-10-186-reports-workspace.md
+++ b/docs/design/2026-06-10-186-reports-workspace.md
@@ -1,0 +1,93 @@
+# Design: serve-mode Reports workspace (issue #186)
+
+Status: approved 2026-06-10 (maintainer-reviewed high-level design)
+Scope: design of record for the web observability surface in serve mode.
+Implementation is tracked in separate issues (see "Decomposition").
+
+## Problem
+
+Serve mode runs as a long-lived daemon (Docker or native service) processing a
+lyrics queue against rate-limited providers. Today its only observability is
+four JSON endpoints and container logs. Operators need to answer questions like
+"what is the queue doing", "which provider lanes are earning their keep", and
+"what failed and why" without shelling into the box.
+
+## Shape
+
+A read-only web UI served by the existing serve-mode listener:
+
+- Sidebar shell (ported from the stillwater M55 layout) with two nav items:
+  **Reports** and **Config**.
+- **Reports** is a two-pane workspace, adapted from stillwater's next-UI
+  reports prototype (stillwater #1337): a left rail (~260px) lists canned
+  reports with last-run timestamps; the right pane renders the selected
+  report's results with a "Run now" action.
+- **Config** shows the effective TOML configuration with secrets redacted.
+
+Deliberate exclusions, per #186's guardrails and this design pass:
+
+- No live tiles, no polling, no SSE. Every report runs on demand against
+  SQLite and is stamped with its run time. The system moves on provider
+  cooldowns; the UI is honest about that.
+- No search or fetch affordances (no instant-result UX; Musixmatch is bursty).
+- No prefs drawer or per-user preference machinery.
+- No write operations of any kind.
+
+## v1 report rail
+
+Five canned reports, all queries over data the DB already holds. A report that
+turns out to need a migration is a red flag to re-scope, not a reason to add
+one.
+
+1. **Queue summary** - counts by status (pending / processing / done /
+   failed / deferred).
+2. **Recent outcomes** - last N processed tracks: result (synced / unsynced /
+   instrumental / miss), provider lane, timestamp.
+3. **Provider effectiveness** - hits and misses per provider lane.
+4. **Instrumental inventory** - tracks flagged instrumental, attributed to
+   the flag source (provider data vs the optional audio detector, #187).
+5. **Failure analysis** - failed and deferred tracks grouped by reason.
+
+(A cache-performance report was considered and cut from v1.)
+
+## Stack and brand
+
+A direct port of the stillwater M55 system so both projects share one design
+language:
+
+- Templ + HTMX + Tailwind; all assets shipped via `go:embed` so the single
+  binary remains the deliverable. No CGO. No node runtime dependency at run
+  time (Tailwind builds at dev time).
+- stillwater's `web/static/css/design-tokens.css` as the token source: dark
+  default, blue-600 (`#2563eb`) primary / blue-500 (`#3b82f6`) accent.
+- Two font families, under the three-family cap: Inter (UI text) and
+  JetBrains Mono (code, IDs, timestamps), self-hosted.
+- Reference implementation paths (stillwater repo): layout shell
+  `web/templates/next/layout.templ`, sidebar `web/templates/next/sidebar.templ`,
+  reports prototype per issue #1337, proto screenshot
+  `m55-sidebar-dashboard-proto.png`.
+
+## Exposure and auth
+
+As locked in #186: served on the existing serve listener, localhost by
+default; the webhook API-key gate covers remote exposure. The dashboard does
+not grow its own auth - authenticated web access, onboarding, and TLS arrive
+with #204 and supersede this section.
+
+## Decomposition
+
+Three implementation issues, each referencing this document:
+
+1. **UI foundation** - templ/tailwind toolchain + Make targets, design-token
+   port, sidebar shell, Config view, `go:embed` wiring. Lands first.
+2. **Reports workspace** - two-pane layout, the five canned reports, and
+   their read-only queries. Builds on the foundation.
+3. **`/metrics` Prometheus endpoint** - counters/gauges over the same
+   queue/provider queries; independent of the UI lanes.
+
+## Testing
+
+Each lane carries its own tests: token/shell templates get golden-render
+tests, report queries get in-package tests against real SQLite (repo
+convention: no mocks for storage), and `/metrics` gets a scrape-shape test.
+Patch coverage follows the repo's 70% gate.

--- a/docs/design/references/m55/README.md
+++ b/docs/design/references/m55/README.md
@@ -1,0 +1,19 @@
+# M55 reference artifacts (stillwater)
+
+Design references copied from the stillwater milestone-55 (UX refresh)
+planning artifacts. They are the source material the mxlrcgo-svc Reports
+workspace design (`../../2026-06-10-186-reports-workspace.md`) ports from:
+
+- `reports-workspace-spec.md` - the two-pane reports workspace prototype
+  spec (stillwater #1337) that the #211 Reports workspace adapts.
+- `dashboard-spec.md` - the sidebar + dashboard layout the shell derives
+  from.
+- `sidebar-spec.md` - sidebar structure, nav behavior, and type-token
+  bindings (one machine-specific UAT note removed).
+- `aesthetic-guidance.md` - the M55 design-language guidance (palette,
+  typography, density).
+
+These are stillwater documents: class names (`sw-`), routes (`/next/*`),
+and feature references are stillwater's and do not map 1:1. Treat them as
+the visual and structural reference, not as requirements; the mxlrcgo-svc
+requirements live in the design doc and issues #210/#211/#212.

--- a/docs/design/references/m55/aesthetic-guidance.md
+++ b/docs/design/references/m55/aesthetic-guidance.md
@@ -1,0 +1,96 @@
+# #1339 next/ Settings -- aesthetic / layout guidance (user, 2026-06-02)
+
+STATUS: PARTIAL -- user has MORE aesthetic/layout guidance to give before #1339
+is built; this captures what was shared so far. Revisit/finish this conversation
+(brainstorming) BEFORE starting the #1339 N1/N2 chrome. The frozen spec
+`06-settings.md` + the prototype remain the baseline; this guidance SUPPLEMENTS
+the prototype where the prototype "doesn't fully capture" the intended look
+(charter: spec wins for functional/structural; user guidance + prototype drive
+chrome aesthetics).
+
+## Inspiration: Firefox `about:preferences`
+
+User's stated inspiration for the searchable Settings screen. "I really like how
+FF is laid out." Chrome's searchable settings noted too, but FF is the model.
+Cross-referenceable from knowledge; published Mozilla screenshots can be fetched
+for exact fidelity (Playwright drives Chromium, so it can NOT open live FF
+`about:` pages).
+
+### FF traits to emulate
+1. Search input pinned ABOVE the category rail (top-left), magnifier glyph --
+   first thing the eye lands on, not buried in the content pane.
+2. Search filters across ALL categories at once: highlights matches in place
+   (soft highlight bar) AND surfaces a synthetic "Search Results" entry; flags
+   the rail category that contains a hit. (Richer than plain show/hide.)
+3. ONE long scrollable content column; clicking a rail category JUMP-SCROLLS to
+   that section's anchor -- not separate pages, not accordion panels that hide
+   the rest.
+4. Calm row rhythm: label + muted secondary description + control, grouped under
+   bold subsection headings with thin dividers and generous whitespace.
+
+## Decision gaps vs the current plan (resolve before/with the user)
+
+The D-migration plan already specs a 260px sticky rail (4 groups: Essentials /
+Data / Integrations / System) + keyword filter over labels+help with
+`localStorage` persistence -- bones match FF. Open deltas the prototype does not
+settle:
+
+- **Rail behavior:** FF jump-scroll-to-anchor within ONE page vs the prototype's
+  collapsible groups that show one group at a time. (User leans FF.)
+- **Search behavior:** FF highlight-in-place + a "Results" view vs a plain
+  show/hide keyword filter.
+- **Search placement:** above the rail (FF) vs wherever the prototype parks it.
+
+## Converging decisions (dialogue 2026-06-02 -- not yet a locked spec)
+
+Direction both the user and the agent lean toward for the `next/` chrome:
+
+- **Single long scrollable settings page**, FF-style, with the sticky rail acting
+  as **anchors + scroll-spy** (jump-scroll to `#section-id`, rail highlights the
+  current section) -- NOT discrete panel swaps. It is a document you scroll, not
+  an app with modes.
+- **`/`-triggered in-app search box is the PRIMARY search** (the global `/`
+  keyboard-registry trigger). It reads the STATIC index
+  (`window.swSettingsSearchIndex` / `BuildSettingsSearchIndex`), so it finds
+  matches in every section regardless of render state. This deliberately makes
+  native `Ctrl+F` a non-goal -- which is what unblocks lazy-loading below.
+- **Lazy-load the heavy CRUD bodies** (provider keys, connections, libraries,
+  webhooks, API tokens, users, rule config forms) via declarative
+  `hx-trigger="revealed"` (or on expand), so the long page stays lean. Render
+  every section SHELL (header + light World-2 KV controls) eagerly for instant
+  anchor/scroll/search; hydrate the expensive bodies on reveal. `hx-trigger=
+  "revealed"` is declarative HTMX, not hand-written JS, so it should clear the
+  minimal-JS bar -- confirm at build time.
+- Two seams that must hold for the above to work (add tests):
+  1. The static search index must stay COMPREHENSIVE -- every section's controls
+     represented. It is a hand-list today, so "search finds everything" is a
+     maintenance contract. A test should fail if a section has zero index entries.
+  2. Selecting a `/`-search result must REVEAL + scroll the (possibly lazy)
+     target section, not scroll to an empty shell.
+
+### DECIDED (user, 2026-06-02)
+
+- **Layout: the long single-page model with the left rail tracking the user's
+  position in the UI (scroll-spy).** This is the chosen `next/` Settings
+  direction -- not discrete panel swaps.
+- **A/B is PoC-only, not long-term.** The user wants the stable-vs-next
+  comparison only as a proof-of-concept before this new version ships, NOT an
+  ongoing A/B feature. So: do NOT build two next/ variants; build the long-page
+  variant as next/ and compare it to stable for the pre-ship PoC via the existing
+  `SW_UX` flag. No sub-flag, no second next/ shell.
+
+STATUS: user signalled they may have MORE aesthetic/layout guidance later;
+the core layout decision (long-page + scroll-spy rail + `/`-search + lazy CRUD
+bodies) is now settled. Promote to a 06-settings.md addendum when #1339 N1/N2
+work begins.
+
+## Bearing on #1809 (confirmed: none)
+
+The anchor-vs-panel + lazy-load decisions are ALL `next/` chrome (#1339)
+concerns. #1809 extracts each `.sw-card` into a chrome-agnostic `Section*(data)`
+func that renders identical markup however a chrome arranges it; tab-`hidden`
+toggling and panel wrapping stay in the STABLE chrome wrapper, not in the section
+funcs. So S1-S4 proceed byte-identical-to-stable and are unaffected. One thing to
+NOT do during extraction: do not bake tab-panel-only assumptions or conflicting
+DOM ids into the shared funcs (the `next/` chrome supplies its own section-anchor
+wrapper + `hx-trigger="revealed"` hooks).

--- a/docs/design/references/m55/dashboard-spec.md
+++ b/docs/design/references/m55/dashboard-spec.md
@@ -1,0 +1,142 @@
+# 01 — Dashboard
+
+> Part of [Milestone 55 — v1.6.0 UX Refresh](../milestone-55.md). Read [`migration-plan.md`](migration-plan.md) §2.2 first — it lists the v1 dashboard behaviour that must survive the redesign.
+>
+> **Prototypes (standalone, open offline):**
+> · [Proposed](prototypes/standalone/dashboard.html)
+> · [Current](prototypes/standalone/dashboard-current.html)
+
+## Today / Proposed / Why
+
+**Today.** The v1 dashboard is `dashboard.templ` with `ActionQueueData`. It is **already polished**: a header strip with three compact metrics (`artist count` · `health %` · `last evaluated`), then the action queue — a search bar, a filter flyout, active-filter chips, severity badges, a category-color left-border per card, and per-card `Fix` / `Dismiss` / `View` buttons with a `Load more` at the bottom. Fixes drop an `UndoToast` (~30 s window) and dispatch the `dashboard:action-resolved` body event when the timer expires; the violations-tab badge listens for it. When `GetHealthStats` fails the page carries `HealthStatsError=true` and the metrics render `---` instead of a confident zero.
+
+**Proposed.** A v2 redesign that is **restraint-first**. Same `ActionQueueData`, same `/api/v1/notifications/{id}/fix`, `/api/v1/fix-undo/{id}`, and dashboard-action endpoints. Visual changes only:
+
+- Compress the three header metrics into a single bar that sits above the queue (instead of three stacked tiles), keeping the `---` health-error fallback.
+- Tighten the action-card row so two-line cards fit in the viewport at 1100 px (severity dot + category accent + artist + reason + age + actions, all on one row when copy fits, otherwise stacking the action row beneath).
+- Put the search input + filter flyout + active-filter chips on a single sticky toolbar that follows the queue scroll.
+- Replace the v1 right-side empty whitespace at ≥1440 px with a sticky **Recent activity** rail (SSE-driven, capped at 50, drops on overflow — Logs is for the rest).
+
+Everything else — the undo flow, filter-preserving reload after revert, the `dashboard:action-resolved` event, the load-more affordance, the `Fix` / `Dismiss` / `View` button set per card, the severity colour tokens — is unchanged.
+
+**Why.** The v1 dashboard is the most-loved screen in the app; users complained about it taking a tall column and leaving the right half of the viewport blank, not about how it works. The redesign reclaims horizontal space (activity rail) and density (single-row cards) without reaching for any of the buttons that already work.
+
+## UX requirements
+
+### Layout
+
+- Two-column grid, `minmax(0, 1fr) 320px`. Right rail collapses below 1100 px to a stacked card under the queue.
+- Page chrome from the new `LayoutV2` wrapper (sidebar + page header). No screen-specific chrome.
+
+### Header strip (compact)
+
+A single row, `height: 56px`, `--sw-paper` background, `--sw-divider` bottom border. Three groups, separated by a vertical divider.
+
+| Group | Label | Value | Notes |
+|---|---|---|---|
+| 1 | `Artists` | `2,847` | Click → `/v2/artists` |
+| 2 | `Library health` | `87%` (with a 28 px inline donut to the left of the number) | Clicking does not filter — there is no per-tile filter affordance in v2; filtering happens in the queue toolbar |
+| 3 | `Last evaluated` | `4h ago` (relative; tooltip with absolute) | Click → opens the run-rules confirm modal |
+
+When `HealthStatsError=true`, group 2 reads `Library health · ---` with a tooltip `Health stats unavailable — check Logs`. Do not render a `0%` donut in this case; render the donut as a faint dashed circle.
+
+### Action queue (left column)
+
+- Sticky toolbar:
+  - Search input (`placeholder="Search violations…"`, `/` focus shortcut, debounce 200 ms, hits the existing endpoint with `q=`)
+  - Filter flyout button (preserves the v1 flyout markup; tri-state per filter family — see Artists list, the same component is reused)
+  - Active-filter chips (close-icon per chip, `Clear all` when ≥ 2)
+  - Right-aligned: `Re-run rules` button (opens the existing confirm modal) and a count meta `7 of 64`.
+- Cards: severity dot · category-color left border (4 px, `--sw-cat-{category}`) · artist name (link → artist detail) · short reason · age (relative) · action row (`Fix`, `Dismiss`, `View`).
+- Card states match v1: a card in the middle of a fix shows a spinner inside `Fix`; a fixed card collapses to a 28 px-tall undo strip (`Fixed · undo` + countdown) for the duration of the undo window; on undo timer expiry the strip animates out and `dashboard:action-resolved` is dispatched.
+- Empty state: `No action needed — your library is compliant against the current rules.` with a `Re-run rules` button.
+- Loading state: 7 skeleton rows (preserve v1 skeleton).
+- Error state: a single banner row `Couldn't load violations — retry` with retry button.
+- `Load more` button at the bottom — same contract as v1 (HTMX swap appends without losing scroll position).
+
+### Recent activity (right column, ≥1100 px only)
+
+- Header: `Recent activity` + meta `SSE live` (a small green dot animating).
+- Row schema: timestamp (relative) · icon · short text · optional artist link.
+- Capped at 50 in-memory; older items are dropped with no "load more" — Logs is for that.
+- When the SSE stream disconnects, the meta switches to `Reconnecting…` (yellow dot, 2 s pulse) and items keep accruing locally; they backfill on reconnect.
+- Below 1100 px the rail is hidden entirely. (It is a "nice to have" sidebar, not a primary surface — Logs is the primary.)
+
+### Filter persistence (must not regress)
+
+The v1 filter flyout writes filters to the URL (`?severity=high&category=artwork&…`). On undo, the queue reloads via HTMX **with the current query string preserved** so the user does not lose context. v2 must replicate this byte-for-byte; this is one of the easy regressions to introduce when reskinning.
+
+### Edge cases
+
+- **`HealthStatsError=true`** — group 2 shows `---`, donut is faint dashed, tooltip explains. Do not show `0%`.
+- **No violations at all** — header group 3 still shows last-evaluated; queue body shows the empty state.
+- **More than 99 violations** — meta reads `7 of 412`; no abbreviation in the meta.
+- **Recent activity empty on first boot** — `Stillwater is idle — kick off a scan from Artists ▸ Run rules now.` with a link.
+- **Undo timer expires while the queue is mid-load-more** — the load-more append must not duplicate the resolved row; rely on the existing server-side cursor (don't dedupe client-side).
+- **Two cards from the same artist** — both render; v1 already supports this; v2 must not collapse them.
+
+### Copy strings
+
+- Page title: `Dashboard`
+- Donut label: `Library health`
+- Health-error tooltip: `Health stats unavailable — check Logs`
+- Time-ago copy: `12s ago`, `4m ago`, `2h ago`, `yesterday`, `Mar 14`. No "just now".
+- Undo strip: `Fixed · undo · 28s`
+
+## Keyboard / interaction surface
+
+| Key | Action |
+|---|---|
+| `/` | Focus the action-queue search input |
+| `r` (when queue focused, no input focused) | Open `Re-run rules` confirm |
+| `j` / `k` | Move card focus down / up in the queue |
+| `Enter` | Open the focused card's artist detail |
+| `f` | Toggle the filter flyout |
+| `u` (while undo strip is visible on focused card) | Trigger undo |
+
+Roving-focus `j` / `k` / `Enter` / `u` is DEFERRED to the shared roving-focus helper (issue #1789) and its dashboard adoption (issue #1790); the light shortcuts `/`, `f`, `r` shipped per-screen in #1334.
+
+Global shortcuts (`g d`, `g a`, etc.) are listed in [`milestone-55.md`](../milestone-55.md#global-keyboard-shortcuts).
+
+## Backend dependencies
+
+The dashboard's existing endpoints are unchanged. v2 reuses:
+
+- `GET /dashboard` (templ-rendered HTML) — same handler renders v2 template under `/v2/dashboard`.
+- `GET /dashboard/actions?q=&severity=&category=&cursor=` — same HTMX fragment endpoint.
+- `POST /api/v1/notifications/{id}/fix` — unchanged.
+- `POST /api/v1/fix-undo/{id}` — unchanged.
+- `POST /api/v1/rules/run` — unchanged.
+- `GET /api/v1/health/stats` — unchanged; v2 must respect the existing `HealthStatsError=true` carrier.
+
+New SSE channel (see [`07-backend.md`](07-backend.md)):
+
+- `activity.recent` — for the right-rail. Payload `{ ts, kind, text, artistId? }`. The channel exists in v1 but is not currently consumed; v2 wires it up to the rail.
+
+DB touchpoints: **none.**
+
+## Acceptance
+
+### UI
+- [ ] Compact header strip matches `screens/dashboard.html` proposal at ≥ 1100 px and falls back gracefully under it.
+- [ ] `HealthStatsError=true` renders `---` and the dashed donut.
+- [ ] Action queue cards keep all v1 affordances (`Fix` / `Dismiss` / `View`, severity dot, category accent, undo strip, load-more).
+- [ ] Filter flyout is the **same** templ component used on the Artists list (no fork).
+- [ ] On undo, the queue reloads preserving the current query string.
+- [ ] `dashboard:action-resolved` body event fires on undo-timer expiry; the violations-tab badge updates.
+- [ ] Recent activity rail reflects live `activity.recent` SSE events within 1 s of dispatch.
+- [ ] All states implemented: loading, empty, error, disconnected-SSE.
+
+### API
+- [ ] No backend changes required for v1 parity. Smoke test confirms v2 calls only the v1 endpoints listed above.
+- [ ] `activity.recent` SSE stream survives a backend restart on the client side (auto-reconnect with backoff capped at 30 s).
+
+### Tests
+- [ ] Cypress: load `/v2/dashboard`, fix a violation, assert `UndoToast`, click undo, assert the row reappears in the same filter context.
+- [ ] Cypress: simulate `HealthStatsError=true` (test fixture), assert `---` and dashed donut.
+- [ ] Cypress: dispatch a synthetic `activity.recent` SSE event, assert it lands in the rail.
+- [ ] Cypress: filter by `severity=high`, fix a card, undo, assert the URL still carries `severity=high`.
+
+### Docs
+- [ ] `docs/dashboard.md` updated with the new layout + screenshots; explicitly notes that endpoints are unchanged.
+- [ ] `CHANGELOG.md` line under `## [1.6.0]`.

--- a/docs/design/references/m55/reports-workspace-spec.md
+++ b/docs/design/references/m55/reports-workspace-spec.md
@@ -1,0 +1,127 @@
+# 04 — Reports
+
+> Part of [Milestone 55 — v1.6.0 UX Refresh](../milestone-55.md).
+>
+> **Prototype (standalone, open offline):** [Proposed](prototypes/standalone/reports.html)
+
+## Today / Proposed / Why
+
+**Today.** Reports is a single page with a fixed list of canned reports as cards (`Missing artwork`, `Stale biographies`, `Empty albums`, etc.). Clicking a card runs the report and shows results in a table below the cards, replacing whatever was there. There is no concept of saving, scheduling, or comparing reports, and no compliance-matrix view.
+
+**Proposed.** Reports becomes a two-pane workspace, but the **only behavioural addition this milestone is the compliance-matrix view**. Saved/named reports and scheduling are mentioned as a follow-up but are **out of scope for v1.6.0** to keep the milestone tight. Specifically:
+
+- **Left pane (260 px):** the existing canned-report list, restyled. Each row shows name + last-run timestamp.
+- **Right pane:** the active report — header (name, last run, run-now button) → filters bar (the same tri-state flyout used on Artists / Dashboard) → results table with row selection. Below the table, a **Compliance matrix** tab: artists × rules grid, cells coloured by status.
+- The "Save as report" / "Schedule" / "Pin" affordances seen in earlier prototypes are **deferred**; the rail shows only built-in reports for v1.6.0.
+
+**Why.** The compliance question — "which artists violate which rules" — is what the canned reports approximate badly. A real matrix view answers it directly and is cheap to add (the data already exists via `compliance.templ`). Saved reports + scheduling are a real feature but they introduce migrations and a runner that this milestone explicitly is **not** doing (see `migration-plan.md` §1: no DB migrations for v1.6.0). Punt them.
+
+## UX requirements
+
+### Reports rail (left)
+
+- The list of built-in canned reports, in v1 order.
+- Per item: name (truncated to 1 line), `last run · 4h ago`.
+- Active item gets a 3 px left-edge accent (`--sw-blue`); no background swap.
+- Empty state: not applicable — built-ins always exist.
+
+### Report header (right pane top)
+
+- Title (h1, 22 px) + last-run pill (`Last run · 4h ago`, click → opens an inline run-history disclosure listing the last 10 runs from server logs — no DB change required since runs are already log-line events).
+- `Run now` primary button (calls existing `POST /api/v1/reports/{name}/run`).
+- `…` overflow with `Export current results as CSV`.
+
+### Filters bar
+
+- Reuse the **same tri-state filter flyout** used on Artists and Dashboard. Filter families exposed for reports: severity, rule, tag, library, last-seen.
+- Filter state syncs to the URL: `/v2/reports/missing-artwork?include[severity]=high&exclude[tag]=demo`.
+- The flyout is a single component instance; **do not fork**.
+
+### Results table
+
+- Columns: severity dot · rule · artist (link to artist detail) · detail · last seen · `…`.
+- Header is sticky.
+- Row click opens artist detail (full page; not a drawer — drawer was an earlier prototype invention).
+- **Severity `err` rows surface a `View logs` link** in the row's `…` overflow that deep-links to Logs with the filter pre-applied (`/v2/logs?rule={rule}&level=error&since=...`). Warn/info rows do not get this link. URL shape and rationale: see [`07-backend.md` § Error-only Logs deep-links](07-backend.md#error-only-logs-deep-links).
+- Multi-select: shift-click range, `Cmd/Ctrl-click` toggle. Bulk actions appear in a context bar at the bottom: `Acknowledge`, `Mark resolved`, `Open in Artists`. The bar dispatches via the existing artist-list bulk endpoints (issue 02), filtered to the selected artist ids.
+- Pagination is the existing `Pagination` component (no virtualization). 50 rows / page is the v1 default; keep it.
+
+### Compliance matrix tab
+
+A second tab at the top of the right pane: `Results | Matrix`. The matrix is the existing `compliance.templ` rendering, restyled.
+
+- Artists down the rows, rules across the columns.
+- Cells: `●` (fail, severity-tinted) / `○` (pass) / `–` (n/a).
+- Hover cell → tooltip with the rule name and the most recent evidence excerpt.
+- Click cell → opens the violations tab on that artist's detail page, scoped to the rule (using existing `?rule=` URL param on the detail page).
+- Header-row controls: `Group rows by …` (folder, label, library), `Sort by …` (most failing first, alphabetical), `Hide passing rows` toggle.
+- Sticky first column for artist names; horizontal scroll for the rule columns when more than ~30 fit.
+- Performance: the existing endpoint already paginates artists; the matrix is a different presentation of the same data, not a different query.
+
+### Edge cases
+
+- **Run in progress** — header shows a determinate progress bar; SSE-driven via the existing `report.run.progress` channel (no new event names this milestone).
+- **No violations at all** — Results tab shows the empty state; Matrix tab shows: `Everything passes the current rules.`
+- **User on `viewer` role** — same access as v1; this issue does not change roles.
+
+### Copy strings
+
+- Page title: `Reports`
+- Empty results: `Everything passes for "{report}".`
+- Empty matrix: `Everything passes the current rules.`
+- Last-run pill: `Last run · 4h ago` (relative; tooltip with absolute)
+- Bulk-action bar reuses the same copy as Artists list.
+
+## Keyboard / interaction surface
+
+| Key | Action |
+|---|---|
+| `/` | Focus the filters input |
+| `r` | Run the current report |
+| `m` | Toggle between **R**esults and **M**atrix |
+| `j` / `k` | Move row focus in results table |
+| `x` | Toggle row selection |
+| `Shift+x` | Range-select up to focused row |
+| `Esc` | Cancel range select |
+
+Roving focus over the results table (`j` / `k` to move row focus, `Enter` to open the focused finding) comes from the shared roving-focus helper (issue #1789) once adopted here; that helper also carries the single per-screen contextual key. The light shortcuts `/`, `f`, `r` are the per-screen baseline that ships independently of the helper.
+
+## Backend dependencies
+
+The reports page's existing endpoints are unchanged. v2 reuses:
+
+- `GET /reports` (templ-rendered page).
+- `GET /reports/{name}` — HTMX fragment for the active report's results.
+- `POST /api/v1/reports/{name}/run` — runs the report; SSE events follow.
+- `GET /api/v1/reports/{name}/export.csv` — CSV export (already exists for built-ins).
+- `GET /api/v1/compliance/matrix?groupBy=&hidePassing=` — same endpoint that powers `compliance.templ` today.
+
+New SSE channels (see [`07-backend.md`](07-backend.md)):
+
+- `report.run.progress` — already emitted; now formally documented.
+
+DB touchpoints: **none.** Saved reports / scheduling / snapshot tables are **out of scope**.
+
+## Acceptance
+
+### UI
+- [ ] Two-pane layout matches the prototype; rail lists the v1 built-in reports in v1 order.
+- [ ] Filters bar is the same tri-state flyout used by Artists and Dashboard (no fork).
+- [ ] Results / Matrix tab toggle preserves filter state across the swap.
+- [ ] Matrix renders artists × rules from the existing endpoint; sticky first column, horizontal scroll for rule columns.
+- [ ] Bulk actions on selected results dispatch via the existing artist bulk endpoints.
+- [ ] Empty states render for: zero results, zero failures in matrix, run-in-progress.
+
+### API
+- [ ] No backend changes required. Smoke test confirms v2 calls only the v1 endpoints listed above.
+- [ ] `report.run.progress` SSE delivered within 250 ms of state change.
+
+### Tests
+- [ ] Cypress: open Missing artwork, apply `severity=high` include filter, assert row count drops appropriately.
+- [ ] Cypress: switch to Matrix tab, click a failing cell, assert artist detail opens with the right rule scope.
+- [ ] Cypress: select 5 results, mark resolved, assert the bulk action dispatches via the artist bulk endpoint.
+- [ ] Existing compliance tests continue to pass.
+
+### Docs
+- [ ] `docs/reports.md` updated with the matrix tab and the explicit note that saved reports / scheduling are out of scope for v1.6.0.
+- [ ] `CHANGELOG.md` line.

--- a/docs/design/references/m55/sidebar-spec.md
+++ b/docs/design/references/m55/sidebar-spec.md
@@ -1,0 +1,60 @@
+# #1778 + #1715 -- next/ Sidebar Redesign: LOCKED SPEC (2026-06-04)
+
+Authoritative design for the `sidebar` teammate to bring to completion. The lead (UX) iterated this live with the maintainer; this doc + the existing spike are the source of truth. Anchors #1778 (semantic glyphs / chrome), folds in #1715 (Reports children nesting).
+
+## Current state: a working SPIKE (commit it first)
+- Worktree `../stillwater-m55-1778-sidebar-spike`, branch `m55-1778-sidebar-spike` (off main `6520e522`). **UNCOMMITTED.** It BUILDS and runs on :1973 (SW_UX=dual).
+- FIRST STEP: commit the existing spike as a checkpoint (`feat(next/chrome): sidebar redesign spike (Part of #1778)`), then continue. Rename the branch to `m55-1778-sidebar` before the PR.
+- Files already changed in the spike (read them for exact current code):
+  - `web/templates/next/sidebar.templ` -- full rewrite; no longer delegates to stable. Reuses the stable `.sw-sidebar-*` classes for behavior.
+  - `web/templates/next/sidebar_helpers.go` -- new `sidebarName` / `sidebarInitial`.
+  - `web/static/css/input.css` -- `.sw-sidebar-subnav-link` indent, `.sw-sidebar-actions`, brand/version, light-theme tree-line override, resize easing + motion/lite snap gating.
+  - `web/static/js/sidebar.js` -- `/next`-aware `highlightActiveLink` (strips `/next` so `data-path` matches on `/next/*`).
+
+## Locked design (top -> bottom)
+- **Brand header:** favicon mark + "Stillwater" on line 1; **version on its own muted line below** in JetBrains Mono (`var(--sw-font-mono)`, ~0.625rem, ellipsis) so nightly/dirty strings fit. **Collapse chevron top-right**, reuses `swSidebar.cycle()` (full -> icon-only -> hidden).
+- **Primary nav** (semantic glyphs from `design/shell.jsx`; the **active-highlight is the screen indicator** since per-page H1s are dropped):
+  - Dashboard (home) -> `/next/` + action/notif count pill
+  - Artists (people) -> `/next/artists` + artist-count pill
+- **REPORTS** = a **section header** (uppercase muted label, NOT a link -- this kills the old Reports/Compliance duplication). Children:
+  - Compliance (bar-chart glyph) -> `/next/reports/compliance` -- ALWAYS shown
+  - Duplicates (copy/overlap glyph) -> `/next/reports/duplicates` -- CONDITIONAL (only when count>0; hydrated via `/api/v1/reports/duplicates/count`), count shown as a count pill
+  - Foreign Files (file-question glyph, SVG below) -> `/next/foreign` -- CONDITIONAL (only when count>0), count pill
+- **Activity** (pulse) -> `/next/activity`
+- spacer (`flex-1`)
+- **Low-frequency destinations** (no label): Logs (doc) -> `/next/logs` (stub until #1338); Settings (gear, admin-only) -> `/next/settings` + update-dot; Preferences (sliders) -> `/next/preferences`
+- **Bottom bar:** glyph-only quick **actions row ABOVE the user identity**:
+  - actions: Theme (sun/moon, `swSidebar.cycleTheme()`), Help (`?`, `toggleHelpOverlay()`), Log out (hx-post logout). **Even spacing (`space-evenly`) at full width; centered vertical STACK in icon-only/narrow.**
+  - user identity: avatar + name/role (name/role hidden in icon-only)
+
+**All nav links -> `/next/<screen>`; keep `data-path` = the STABLE path** (e.g. `/artists`, `/reports/compliance`) so the `/next`-aware `highlightActiveLink` matches. No channel leak.
+
+## Foreign Files glyph -- LOCKED (2026-06-05): plain dog-eared document
+Maintainer chose the PLAIN dog-eared `document` glyph (Heroicons style) -- NO `?` overlay. Add as a Heroicons-style `Icon*` component (e.g. `IconDocument`). Keep Logs as `document-text` (dog-eared doc WITH text lines) so the two stay visually distinct; they sit in different sections (Foreign Files under REPORTS, Logs in low-freq) which further disambiguates. Discard the interim file-question SVG.
+
+## Icon library (IMPORTANT -- the spike is off-standard here)
+The project uses **Heroicons (v2)** vendored as inline-SVG `Icon*` templ components in `web/components/icon.templ` (e.g. `IconCrop`, `IconScissors`, `IconPhoto`, `IconMagnifyingGlass`). NO runtime icon dependency (minimal-JS rule).
+- The spike currently inlines raw SVG paths (mix of `design/shell.jsx` hand-drawn glyphs + ad-hoc Heroicons). CONVERT the sidebar to use `Icon*` components, and ADD the missing semantic glyphs to `icon.templ` as new Heroicons-style components: home (Dashboard), user-group (Artists), chart-bar (Compliance), signal/activity (Activity), document-duplicate (Duplicates), document-question (Foreign Files -- dog-eared doc + `?` overlay; maintainer to supply an example), document-text (Logs), cog (Settings). Reuse existing `Icon*` where present.
+- Foreign Files glyph: dog-eared `document` base + a `?` overlay in Heroicons stroke style. Interim SVG below; swap for the maintainer's example when relayed.
+
+## Final tweaks to implement (this round)
+1. **Duplicates count = consistent count pill.** Align the sidebar count pills (Artists, Dashboard, Duplicates, Foreign Files) to ONE canonical pill style. (The dashboard-vs-artists in-content pill inconsistency is a separate tracked follow-up; here just keep the sidebar's pills internally consistent.)
+2. **Foreign Files conditional sub-item under Reports** (glyph above), shown only when count>0. Needs a foreign-files **count source** -- mirror `/api/v1/reports/duplicates/count`; if none exists, add a tiny count endpoint OR show unconditionally until #1773. Link `/next/foreign` (stub until #1773 ports the page; mirror the Logs stub approach).
+3. **Bottom actions evenly spaced** (`space-evenly`) at full width; centered vertical stack in icon-only (already partly wired -- finish it).
+
+## Hardening (bring-to-completion)
+- **Typography pref:** bind sidebar fonts/sizes to the type tokens (`--sw-font-sans`/`--sw-font-mono` + the rem type-scale); mirror `.sw-next-artist-detail`. Replace hardcoded px. (Spike already uses `--sw-font-mono` for the version line.)
+- **Background-opacity pref:** bind the sidebar surface to the bg_opacity pref; mirror `.sw-next-artist-detail`'s correct opacity impl (maintainer-cited reference). Verify BOTH themes at 85% AND ~50%.
+- **i18n:** replace the spike's hardcoded English labels with i18n keys (some `nav.*` exist; add `nav.activity`, `nav.logs`, `nav.reports`, `nav.reports.foreign`, etc.). `en.json` is a hot-spot -- this PR owns its keys.
+- **a11y (hard gate):** axe-core; contrast in BOTH themes; nav landmark + `aria-current` on the active item; proper labels/roles on the glyph-only buttons (theme/help/logout already have aria-label); keyboard focus order; verify icon-only too.
+- **Count fragments:** the hydrated `/api/v1/reports/duplicates/count` fragment must emit the copy glyph + `sw-sidebar-subnav-link` + point `/next/reports/duplicates` (the spike renders Duplicates statically). Same pattern for the foreign-files count.
+- **Motion/lite:** resize easing + snap under `prefers-reduced-motion` / `[data-motion=on]` / `[data-lite=on]` is done in the spike -- verify it holds after the actions-row + foreign-files changes.
+- **icon-only edge cases:** version line, actions stack, count pills, section-label hide -- all collapse cleanly.
+- **Tests:** templ render tests (structure, glyphs, conditional children present/absent), the `highlightActiveLink` `/next` fix, a11y.
+- Keyboard g-leader nav is OUT OF SCOPE (owned by #1775); the sidebar only exposes nav targets. Logs is a stub (#1338).
+
+## Constraints (teammate)
+- NO push / PR / merge / gh mutations without an explicit HUMAN go. Commit locally freely.
+- After `.templ` edits: `go tool templ generate` (never bare templ). Capture `go test -race` to a log. No emoji, no em-dashes.
+- **Merge seams** (lead reconciles at merge): `input.css`/`styles.css`, `en.json`, and `layout.templ`/`handlers.go` (AssetPaths) overlap with the 4B + dashboard branches. Keep sidebar edits scoped to `.sw-sidebar-*`.
+- Then `/prep-pr` + `pr-review-toolkit:review-pr`; report to the lead for the human PR go.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -12,8 +12,10 @@ docs_dir: docs
 site_dir: site
 
 # docs/superpowers/ holds internal planning docs that should not be published.
+# docs/design/ holds design-of-record documents and reference artifacts.
 exclude_docs: |
   superpowers/
+  design/
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

Design of record for the serve-mode web observability surface (#186), as approved in the 2026-06-10 design pass.

Adds `docs/design/2026-06-10-186-reports-workspace.md`:

- Sidebar shell (stillwater M55 port) with Reports + Config nav
- Reports = two-pane run-on-demand workspace (no polling/SSE, read-only, async-first), adapted from stillwater's next-UI reports prototype
- v1 rail: queue summary, recent outcomes, provider effectiveness, instrumental inventory, failure analysis
- Stack: Templ + HTMX + Tailwind + M55 design tokens, go:embed, no CGO
- Decomposition into three implementation issues (filed separately, referencing this doc)

Part of #186 (the implementation issues close it; this PR lands the design artifact the issue bodies and prototype work reference).

Docs-only: no Go code touched.
