### PR TITLE
feat(library): per-library settings foundation (#216)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -198,9 +198,11 @@ type LibraryCmd struct {
 
 // LibraryAddCmd adds a library root.
 type LibraryAddCmd struct {
-	Path       string `arg:"positional,required" help:"library root path"`
-	Name       string `arg:"--name" help:"display name (default: directory base)" default:""`
-	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+	Path               string `arg:"positional,required" help:"library root path"`
+	Name               string `arg:"--name" help:"display name (default: directory base)" default:""`
+	Enrich             *bool  `arg:"--enrich" help:"recording enrichment for this library; omit to inherit the global default, --enrich / --enrich=false to set"`
+	DetectInstrumental *bool  `arg:"--detect-instrumental" help:"instrumental detection for this library; omit to inherit the global default, --detect-instrumental / --detect-instrumental=false to set"`
+	ConfigPath         string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // LibraryListCmd lists library roots.
@@ -216,10 +218,12 @@ type LibraryRemoveCmd struct {
 
 // LibraryUpdateCmd updates a library root.
 type LibraryUpdateCmd struct {
-	ID         int64  `arg:"positional,required" help:"library id"`
-	Path       string `arg:"--path" help:"new library root path" default:""`
-	Name       string `arg:"--name" help:"new display name" default:""`
-	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+	ID                 int64  `arg:"positional,required" help:"library id"`
+	Path               string `arg:"--path" help:"new library root path" default:""`
+	Name               string `arg:"--name" help:"new display name" default:""`
+	Enrich             *bool  `arg:"--enrich" help:"set recording enrichment for this library (--enrich / --enrich=false); omit to leave unchanged"`
+	DetectInstrumental *bool  `arg:"--detect-instrumental" help:"set instrumental detection for this library (--detect-instrumental / --detect-instrumental=false); omit to leave unchanged"`
+	ConfigPath         string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // KeysCmd contains nested key subcommands.
@@ -1125,7 +1129,10 @@ func runLibrary(ctx context.Context, out io.Writer, args LibraryCmd) int {
 		if name == "" {
 			name = filepath.Base(filepath.Clean(args.Add.Path))
 		}
-		lib, err := repo.Add(ctx, args.Add.Path, name)
+		lib, err := repo.Add(ctx, args.Add.Path, name, models.LibrarySettings{
+			EnrichRecording:    args.Add.Enrich,
+			DetectInstrumental: args.Add.DetectInstrumental,
+		})
 		if err != nil {
 			slog.Error("failed to add library", "error", err)
 			return 1
@@ -1147,8 +1154,9 @@ func runLibrary(ctx context.Context, out io.Writer, args LibraryCmd) int {
 		}
 		_, _ = fmt.Fprintf(out, "removed library %d\n", args.Remove.ID)
 	case args.Update != nil:
-		if args.Update.Path == "" && args.Update.Name == "" {
-			_, _ = fmt.Fprintln(out, "library update requires --path, --name, or both")
+		if args.Update.Path == "" && args.Update.Name == "" &&
+			args.Update.Enrich == nil && args.Update.DetectInstrumental == nil {
+			_, _ = fmt.Fprintln(out, "library update requires --path, --name, --enrich, or --detect-instrumental")
 			return 2
 		}
 		lib, err := repo.Get(ctx, args.Update.ID)
@@ -1169,7 +1177,10 @@ func runLibrary(ctx context.Context, out io.Writer, args LibraryCmd) int {
 		if args.Update.Name != "" {
 			name = args.Update.Name
 		}
-		lib, err = repo.Update(ctx, args.Update.ID, path, name)
+		lib, err = repo.Update(ctx, args.Update.ID, path, name, models.LibrarySettings{
+			EnrichRecording:    args.Update.Enrich,
+			DetectInstrumental: args.Update.DetectInstrumental,
+		})
 		if err != nil {
 			slog.Error("failed to update library", "error", err)
 			return 1

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -422,7 +422,7 @@ func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(context.Background(), "/music", "Music")
+	lib, err := libRepo.Add(context.Background(), "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1035,7 +1035,7 @@ func TestRunScanResults_ResolvesLibraryByNameAndID(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1074,7 +1074,7 @@ func TestRunScanClear_DryRunAndConfirm(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1141,7 +1141,7 @@ func TestRunScanClear_CancelsLinkedWorkQueueRow(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "MusicLib")
+	lib, err := libRepo.Add(ctx, "/music", "MusicLib", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1215,11 +1215,11 @@ func TestRunScan_LibrarySelectorScansOnlyTheNamedLibrary(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	libA, err := libRepo.Add(ctx, dirA, "Alpha")
+	libA, err := libRepo.Add(ctx, dirA, "Alpha", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add Alpha: %v", err)
 	}
-	libB, err := libRepo.Add(ctx, dirB, "Beta")
+	libB, err := libRepo.Add(ctx, dirB, "Beta", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add Beta: %v", err)
 	}
@@ -1290,7 +1290,7 @@ func TestRunScan_LibrarySelectorReportsScanFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	if _, err := library.New(sqlDB).Add(ctx, dir, "Alpha"); err != nil {
+	if _, err := library.New(sqlDB).Add(ctx, dir, "Alpha", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add Alpha: %v", err)
 	}
 	_ = sqlDB.Close()
@@ -1333,11 +1333,11 @@ func TestRunScan_LibrarySelectorRejectsAmbiguousName(t *testing.T) {
 	// Two libraries where the second one is literally named after the first
 	// one's numeric id. Looking up "1" resolves to both: ID match (lib1) and
 	// name match (lib2). resolveLibrary must reject that as ambiguous.
-	lib1, err := libRepo.Add(ctx, t.TempDir(), "music")
+	lib1, err := libRepo.Add(ctx, t.TempDir(), "music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add lib1: %v", err)
 	}
-	if _, err := libRepo.Add(ctx, t.TempDir(), strconvFormatInt(lib1.ID)); err != nil {
+	if _, err := libRepo.Add(ctx, t.TempDir(), strconvFormatInt(lib1.ID), models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add lib2: %v", err)
 	}
 	_ = sqlDB.Close()
@@ -1575,7 +1575,7 @@ func TestRunScanClear_DryRunOnEmpty(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	if _, err := libRepo.Add(ctx, "/music", "Music"); err != nil {
+	if _, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
 	_ = sqlDB.Close()
@@ -1607,7 +1607,7 @@ func TestRunScanResults_FilterByLibraryByID(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1642,7 +1642,7 @@ func TestResolveLibrary_NumericNameLooksUpByName(t *testing.T) {
 	}
 	defer func() { _ = sqlDB.Close() }()
 	repo := library.New(sqlDB)
-	added, err := repo.Add(ctx, "/music/numeric", "9999")
+	added, err := repo.Add(ctx, "/music/numeric", "9999", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -1666,11 +1666,11 @@ func TestResolveLibrary_NumericRefAmbiguousIDvsName(t *testing.T) {
 	defer func() { _ = sqlDB.Close() }()
 	repo := library.New(sqlDB)
 	// Library #1 (Music)
-	if _, err := repo.Add(ctx, "/music/a", "Music"); err != nil {
+	if _, err := repo.Add(ctx, "/music/a", "Music", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add a: %v", err)
 	}
 	// Library #2 named "1" — ref "1" now matches BOTH id=1 and name="1".
-	if _, err := repo.Add(ctx, "/music/b", "1"); err != nil {
+	if _, err := repo.Add(ctx, "/music/b", "1", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add b: %v", err)
 	}
 
@@ -1692,7 +1692,7 @@ func TestRunScanResults_FilterByStatus(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1731,7 +1731,7 @@ func TestRunScanResults_LimitTrimsResults(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -1770,7 +1770,7 @@ func TestRunQueueRetry_ResetsLinkedScanResults(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	libRepo := library.New(sqlDB)
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}

--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 )
 
 func TestRunComplete_TopLevelPrefix(t *testing.T) {
@@ -44,7 +45,7 @@ func TestRunComplete_LibraryNamesFromDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	if _, err := library.New(sqlDB).Add(ctx, "/music", "MyMusic"); err != nil {
+	if _, err := library.New(sqlDB).Add(ctx, "/music", "MyMusic", models.LibrarySettings{}); err != nil {
 		t.Fatalf("add library: %v", err)
 	}
 	_ = sqlDB.Close()

--- a/internal/commands/library_settings_test.go
+++ b/internal/commands/library_settings_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/library"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func getLibraryForTest(t *testing.T, ctx context.Context, dbPath string, id int64) models.Library {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	lib, err := library.New(sqlDB).Get(ctx, id)
+	if err != nil {
+		t.Fatalf("get library: %v", err)
+	}
+	return lib
+}
+
+func TestRunLibrarySettingsFlags(t *testing.T) {
+	bp := func(v bool) *bool { return &v }
+	isolateCommandsEnv(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state", "test.db")
+	cfg := writeCommandsConfig(t, dbPath)
+	libPath := filepath.Join(dir, "music")
+	if err := os.Mkdir(libPath, 0o750); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runLibrary(ctx, &out, LibraryCmd{Add: &LibraryAddCmd{
+		Path:               libPath,
+		Name:               "Music",
+		Enrich:             bp(false),
+		DetectInstrumental: bp(true),
+		ConfigPath:         cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library add exit code = %d; want 0", code)
+	}
+
+	lib := getLibraryForTest(t, ctx, dbPath, 1)
+	if lib.EnrichRecording == nil || *lib.EnrichRecording {
+		t.Fatalf("EnrichRecording = %v; want false", lib.EnrichRecording)
+	}
+	if lib.DetectInstrumental == nil || !*lib.DetectInstrumental {
+		t.Fatalf("DetectInstrumental = %v; want true", lib.DetectInstrumental)
+	}
+
+	// Update with only --enrich (no --path/--name) is allowed and changes only
+	// the enrich column; detect stays unchanged.
+	out.Reset()
+	code = runLibrary(ctx, &out, LibraryCmd{Update: &LibraryUpdateCmd{
+		ID:         1,
+		Enrich:     bp(true),
+		ConfigPath: cfg,
+	}})
+	if code != 0 {
+		t.Fatalf("library update --enrich exit code = %d; want 0", code)
+	}
+	lib = getLibraryForTest(t, ctx, dbPath, 1)
+	if lib.EnrichRecording == nil || !*lib.EnrichRecording {
+		t.Fatalf("after update EnrichRecording = %v; want true", lib.EnrichRecording)
+	}
+	if lib.DetectInstrumental == nil || !*lib.DetectInstrumental {
+		t.Fatalf("after update DetectInstrumental = %v; want true (unchanged)", lib.DetectInstrumental)
+	}
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,15 @@
+package config
+
+// ResolveBool resolves a tri-state setting using the precedence
+// CLI > per-library > global default. The first non-nil of cli then lib wins;
+// otherwise globalDefault is returned. The built-in default folds into
+// globalDefault at the call site.
+func ResolveBool(cli, lib *bool, globalDefault bool) bool {
+	if cli != nil {
+		return *cli
+	}
+	if lib != nil {
+		return *lib
+	}
+	return globalDefault
+}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,0 +1,30 @@
+package config
+
+import "testing"
+
+func TestResolveBool(t *testing.T) {
+	bp := func(v bool) *bool { return &v }
+
+	cases := []struct {
+		name          string
+		cli           *bool
+		lib           *bool
+		globalDefault bool
+		want          bool
+	}{
+		{"cli wins over lib and global", bp(true), bp(false), false, true},
+		{"cli false wins over lib and global true", bp(false), bp(true), true, false},
+		{"lib wins over global when cli nil", nil, bp(true), false, true},
+		{"lib false wins over global true when cli nil", nil, bp(false), true, false},
+		{"global used when cli and lib nil (true)", nil, nil, true, true},
+		{"global used when cli and lib nil (false)", nil, nil, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveBool(tc.cli, tc.lib, tc.globalDefault); got != tc.want {
+				t.Fatalf("ResolveBool(%v, %v, %v) = %v; want %v", tc.cli, tc.lib, tc.globalDefault, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/db/migrations/015_library_settings.sql
+++ b/internal/db/migrations/015_library_settings.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-library tri-state toggles for recording enrichment and instrumental
+-- detection. NULL = inherit the global default, 0 = off, 1 = on. Nullable so
+-- "unset/inherit" is distinct from an explicit "off". Plain ADD COLUMN needs no
+-- table rebuild here (no CHECK/constraint change); existing rows default to
+-- NULL (inherit), preserving current behavior.
+ALTER TABLE libraries ADD COLUMN enrich_recording INTEGER;
+ALTER TABLE libraries ADD COLUMN detect_instrumental INTEGER;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE libraries DROP COLUMN detect_instrumental;
+ALTER TABLE libraries DROP COLUMN enrich_recording;
+-- +goose StatementEnd

--- a/internal/library/repository.go
+++ b/internal/library/repository.go
@@ -20,16 +20,19 @@ func New(db *sql.DB) *Repo {
 	return &Repo{db: db}
 }
 
-// Add creates a new library root. Path must be unique.
-func (r *Repo) Add(ctx context.Context, path, name string) (models.Library, error) {
+// Add creates a new library root. Path must be unique. A nil settings field is
+// stored as NULL (inherit the global default).
+func (r *Repo) Add(ctx context.Context, path, name string, settings models.LibrarySettings) (models.Library, error) {
 	path, name, err := validate(path, name)
 	if err != nil {
 		return models.Library{}, err
 	}
 	res, err := r.db.ExecContext(ctx,
-		`INSERT INTO libraries (path, name) VALUES (?, ?)`,
+		`INSERT INTO libraries (path, name, enrich_recording, detect_instrumental) VALUES (?, ?, ?, ?)`,
 		path,
 		name,
+		boolToNullableInt(settings.EnrichRecording),
+		boolToNullableInt(settings.DetectInstrumental),
 	)
 	if err != nil {
 		return models.Library{}, fmt.Errorf("library: add: %w", err)
@@ -44,7 +47,7 @@ func (r *Repo) Add(ctx context.Context, path, name string) (models.Library, erro
 // List returns all configured library roots in stable ID order.
 func (r *Repo) List(ctx context.Context) (libs []models.Library, retErr error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, path, name, created_at, updated_at FROM libraries ORDER BY id ASC`,
+		`SELECT id, path, name, created_at, updated_at, enrich_recording, detect_instrumental FROM libraries ORDER BY id ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("library: list: %w", err)
@@ -57,9 +60,12 @@ func (r *Repo) List(ctx context.Context) (libs []models.Library, retErr error) {
 
 	for rows.Next() {
 		var lib models.Library
-		if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt); err != nil {
+		var enrich, detect sql.NullInt64
+		if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt, &enrich, &detect); err != nil {
 			return nil, fmt.Errorf("library: list scan: %w", err)
 		}
+		lib.EnrichRecording = nullableIntToBool(enrich)
+		lib.DetectInstrumental = nullableIntToBool(detect)
 		libs = append(libs, lib)
 	}
 	if err := rows.Err(); err != nil {
@@ -71,13 +77,16 @@ func (r *Repo) List(ctx context.Context) (libs []models.Library, retErr error) {
 // Get returns the library root with id. It returns sql.ErrNoRows when not found.
 func (r *Repo) Get(ctx context.Context, id int64) (models.Library, error) {
 	var lib models.Library
+	var enrich, detect sql.NullInt64
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE id = ?`,
+		`SELECT id, path, name, created_at, updated_at, enrich_recording, detect_instrumental FROM libraries WHERE id = ?`,
 		id,
-	).Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt)
+	).Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt, &enrich, &detect)
 	if err != nil {
 		return models.Library{}, fmt.Errorf("library: get: %w", err)
 	}
+	lib.EnrichRecording = nullableIntToBool(enrich)
+	lib.DetectInstrumental = nullableIntToBool(detect)
 	return lib, nil
 }
 
@@ -96,7 +105,7 @@ func (r *Repo) GetByName(ctx context.Context, name string) (models.Library, erro
 		return models.Library{}, fmt.Errorf("library: name must not be empty")
 	}
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, path, name, created_at, updated_at FROM libraries WHERE name = ? LIMIT 2`,
+		`SELECT id, path, name, created_at, updated_at, enrich_recording, detect_instrumental FROM libraries WHERE name = ? LIMIT 2`,
 		name,
 	)
 	if err != nil {
@@ -111,9 +120,12 @@ func (r *Repo) GetByName(ctx context.Context, name string) (models.Library, erro
 		return models.Library{}, fmt.Errorf("library: get by name: %w", sql.ErrNoRows)
 	}
 	var lib models.Library
-	if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt); err != nil {
+	var enrich, detect sql.NullInt64
+	if err := rows.Scan(&lib.ID, &lib.Path, &lib.Name, &lib.CreatedAt, &lib.UpdatedAt, &enrich, &detect); err != nil {
 		return models.Library{}, fmt.Errorf("library: get by name: %w", err)
 	}
+	lib.EnrichRecording = nullableIntToBool(enrich)
+	lib.DetectInstrumental = nullableIntToBool(detect)
 	if rows.Next() {
 		return models.Library{}, fmt.Errorf("library: get by name %q: %w", name, ErrAmbiguousLibraryName)
 	}
@@ -123,16 +135,25 @@ func (r *Repo) GetByName(ctx context.Context, name string) (models.Library, erro
 	return lib, nil
 }
 
-// Update changes the path and name for an existing library root.
-func (r *Repo) Update(ctx context.Context, id int64, path, name string) (models.Library, error) {
+// Update changes the path and name for an existing library root. A nil settings
+// field leaves that column unchanged; a non-nil field writes the explicit value
+// (COALESCE keeps the existing value when the parameter is NULL).
+func (r *Repo) Update(ctx context.Context, id int64, path, name string, settings models.LibrarySettings) (models.Library, error) {
 	path, name, err := validate(path, name)
 	if err != nil {
 		return models.Library{}, err
 	}
 	res, err := r.db.ExecContext(ctx,
-		`UPDATE libraries SET path = ?, name = ? WHERE id = ?`,
+		`UPDATE libraries
+		   SET path = ?,
+		       name = ?,
+		       enrich_recording = COALESCE(?, enrich_recording),
+		       detect_instrumental = COALESCE(?, detect_instrumental)
+		 WHERE id = ?`,
 		path,
 		name,
+		boolToNullableInt(settings.EnrichRecording),
+		boolToNullableInt(settings.DetectInstrumental),
 		id,
 	)
 	if err != nil {
@@ -162,6 +183,28 @@ func (r *Repo) Remove(ctx context.Context, id int64) error {
 		return fmt.Errorf("library: remove missing: %w", sql.ErrNoRows)
 	}
 	return nil
+}
+
+// boolToNullableInt maps a tri-state *bool to a nullable SQL INTEGER parameter:
+// nil -> NULL, false -> 0, true -> 1.
+func boolToNullableInt(v *bool) any {
+	if v == nil {
+		return nil
+	}
+	if *v {
+		return 1
+	}
+	return 0
+}
+
+// nullableIntToBool maps a scanned nullable INTEGER back to a tri-state *bool:
+// NULL -> nil, 0 -> false, non-zero -> true.
+func nullableIntToBool(v sql.NullInt64) *bool {
+	if !v.Valid {
+		return nil
+	}
+	b := v.Int64 != 0
+	return &b
 }
 
 func validate(path, name string) (string, string, error) {

--- a/internal/library/repository_test.go
+++ b/internal/library/repository_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -25,7 +26,7 @@ func TestAddGetListUpdateRemove(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))
 
-	added, err := repo.Add(ctx, "/music/rock", "Rock")
+	added, err := repo.Add(ctx, "/music/rock", "Rock", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -52,7 +53,7 @@ func TestAddGetListUpdateRemove(t *testing.T) {
 		t.Fatalf("List got %+v; want [%+v]", list, added)
 	}
 
-	updated, err := repo.Update(ctx, added.ID, "/music/jazz", "Jazz")
+	updated, err := repo.Update(ctx, added.ID, "/music/jazz", "Jazz", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -73,10 +74,10 @@ func TestAdd_RejectsDuplicatePath(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))
 
-	if _, err := repo.Add(ctx, "/music", "Music"); err != nil {
+	if _, err := repo.Add(ctx, "/music", "Music", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add initial: %v", err)
 	}
-	if _, err := repo.Add(ctx, "/music", "Duplicate"); err == nil {
+	if _, err := repo.Add(ctx, "/music", "Duplicate", models.LibrarySettings{}); err == nil {
 		t.Fatal("Add duplicate returned nil error; want constraint error")
 	}
 }
@@ -97,7 +98,7 @@ func TestAdd_ValidatesRequiredFields(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := repo.Add(ctx, tc.path, tc.lib); err == nil {
+			if _, err := repo.Add(ctx, tc.path, tc.lib, models.LibrarySettings{}); err == nil {
 				t.Fatal("Add returned nil error; want validation error")
 			}
 		})
@@ -108,7 +109,7 @@ func TestGetByName(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))
 
-	added, err := repo.Add(ctx, "/music/rock", "Rock")
+	added, err := repo.Add(ctx, "/music/rock", "Rock", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestUpdateRemove_NotFound(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))
 
-	_, err := repo.Update(ctx, 123, "/music", "Music")
+	_, err := repo.Update(ctx, 123, "/music", "Music", models.LibrarySettings{})
 	if !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("Update missing got %v; want sql.ErrNoRows", err)
 	}
@@ -155,10 +156,10 @@ func TestGetByName_AmbiguousReturnsError(t *testing.T) {
 	ctx := context.Background()
 	repo := library.New(openTestDB(t))
 
-	if _, err := repo.Add(ctx, "/music/a", "Music"); err != nil {
+	if _, err := repo.Add(ctx, "/music/a", "Music", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add a: %v", err)
 	}
-	if _, err := repo.Add(ctx, "/music/b", "Music"); err != nil {
+	if _, err := repo.Add(ctx, "/music/b", "Music", models.LibrarySettings{}); err != nil {
 		t.Fatalf("Add b: %v", err)
 	}
 

--- a/internal/library/settings_test.go
+++ b/internal/library/settings_test.go
@@ -1,0 +1,86 @@
+package library_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/library"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func bp(v bool) *bool { return &v }
+
+func wantBoolPtr(t *testing.T, label string, got *bool, want *bool) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Fatalf("%s = %v; want nil", label, *got)
+	case want != nil && got == nil:
+		t.Fatalf("%s = nil; want %v", label, *want)
+	case want != nil && got != nil && *got != *want:
+		t.Fatalf("%s = %v; want %v", label, *got, *want)
+	}
+}
+
+func TestAddPersistsSettings(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	// Unset settings round-trip as NULL -> nil (inherit global default).
+	inherit, err := repo.Add(ctx, "/music/inherit", "Inherit", models.LibrarySettings{})
+	if err != nil {
+		t.Fatalf("Add inherit: %v", err)
+	}
+	wantBoolPtr(t, "inherit.EnrichRecording", inherit.EnrichRecording, nil)
+	wantBoolPtr(t, "inherit.DetectInstrumental", inherit.DetectInstrumental, nil)
+
+	// Explicit values round-trip as 0/1 -> *bool.
+	explicit, err := repo.Add(ctx, "/music/explicit", "Explicit", models.LibrarySettings{
+		EnrichRecording:    bp(true),
+		DetectInstrumental: bp(false),
+	})
+	if err != nil {
+		t.Fatalf("Add explicit: %v", err)
+	}
+	wantBoolPtr(t, "explicit.EnrichRecording", explicit.EnrichRecording, bp(true))
+	wantBoolPtr(t, "explicit.DetectInstrumental", explicit.DetectInstrumental, bp(false))
+
+	// Values survive a fresh Get and appear in List.
+	got, err := repo.Get(ctx, explicit.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	wantBoolPtr(t, "get.EnrichRecording", got.EnrichRecording, bp(true))
+	wantBoolPtr(t, "get.DetectInstrumental", got.DetectInstrumental, bp(false))
+}
+
+func TestUpdatePreservesAndSetsSettings(t *testing.T) {
+	ctx := context.Background()
+	repo := library.New(openTestDB(t))
+
+	base, err := repo.Add(ctx, "/music/base", "Base", models.LibrarySettings{
+		EnrichRecording:    bp(true),
+		DetectInstrumental: bp(true),
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Nil settings leave both columns unchanged.
+	preserved, err := repo.Update(ctx, base.ID, "/music/base2", "Base2", models.LibrarySettings{})
+	if err != nil {
+		t.Fatalf("Update preserve: %v", err)
+	}
+	wantBoolPtr(t, "preserved.EnrichRecording", preserved.EnrichRecording, bp(true))
+	wantBoolPtr(t, "preserved.DetectInstrumental", preserved.DetectInstrumental, bp(true))
+
+	// A non-nil field is written; the absent field stays unchanged.
+	updated, err := repo.Update(ctx, base.ID, "/music/base2", "Base2", models.LibrarySettings{
+		EnrichRecording: bp(false),
+	})
+	if err != nil {
+		t.Fatalf("Update set: %v", err)
+	}
+	wantBoolPtr(t, "updated.EnrichRecording", updated.EnrichRecording, bp(false))
+	wantBoolPtr(t, "updated.DetectInstrumental", updated.DetectInstrumental, bp(true))
+}

--- a/internal/library/settings_test.go
+++ b/internal/library/settings_test.go
@@ -45,13 +45,31 @@ func TestAddPersistsSettings(t *testing.T) {
 	wantBoolPtr(t, "explicit.EnrichRecording", explicit.EnrichRecording, bp(true))
 	wantBoolPtr(t, "explicit.DetectInstrumental", explicit.DetectInstrumental, bp(false))
 
-	// Values survive a fresh Get and appear in List.
+	// Values survive a fresh Get.
 	got, err := repo.Get(ctx, explicit.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	wantBoolPtr(t, "get.EnrichRecording", got.EnrichRecording, bp(true))
 	wantBoolPtr(t, "get.DetectInstrumental", got.DetectInstrumental, bp(false))
+
+	// List must surface the same settings (exercises the List SELECT/Scan path,
+	// which is distinct from Get's single-row query).
+	libs, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var listed *models.Library
+	for i := range libs {
+		if libs[i].ID == explicit.ID {
+			listed = &libs[i]
+		}
+	}
+	if listed == nil {
+		t.Fatalf("List did not return library %d", explicit.ID)
+	}
+	wantBoolPtr(t, "list.EnrichRecording", listed.EnrichRecording, bp(true))
+	wantBoolPtr(t, "list.DetectInstrumental", listed.DetectInstrumental, bp(false))
 }
 
 func TestUpdatePreservesAndSetsSettings(t *testing.T) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -83,6 +83,20 @@ type Library struct {
 	Name      string `json:"name,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
+
+	// EnrichRecording and DetectInstrumental are tri-state per-library toggles.
+	// A nil pointer means "inherit the global default"; a non-nil pointer is an
+	// explicit on/off. They map to nullable INTEGER columns (NULL/0/1).
+	EnrichRecording    *bool `json:"enrich_recording,omitempty"`
+	DetectInstrumental *bool `json:"detect_instrumental,omitempty"`
+}
+
+// LibrarySettings carries the per-library tri-state toggles for create/update
+// operations. A nil field means "inherit" on Add and "leave unchanged" on
+// Update; a non-nil field is an explicit on/off.
+type LibrarySettings struct {
+	EnrichRecording    *bool
+	DetectInstrumental *bool
 }
 
 // ScanResult represents an audio file discovered during a library scan.

--- a/internal/scan/album_metadata_test.go
+++ b/internal/scan/album_metadata_test.go
@@ -12,7 +12,7 @@ import (
 func TestRepo_UpsertRoundTripsAlbumMetadata(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)
-	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music")
+	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("add library: %v", err)
 	}

--- a/internal/scan/list_deferred_test.go
+++ b/internal/scan/list_deferred_test.go
@@ -16,7 +16,7 @@ import (
 func TestRepo_ListDeferred(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)
-	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music")
+	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("add library: %v", err)
 	}

--- a/internal/scan/repository_busy_test.go
+++ b/internal/scan/repository_busy_test.go
@@ -55,7 +55,7 @@ func TestRepo_UpsertConcurrentWriterRetries(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = connA.Close() })
 
-	lib, err := library.New(connA).Add(ctx, "/music", "Music")
+	lib, err := library.New(connA).Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("add library: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestRepo_UpsertConcurrentWriterRetries(t *testing.T) {
 // through every batch and returning a generic aggregate failure.
 func TestRepo_UpsertContextCanceledAbortsEarly(t *testing.T) {
 	sqlDB := openTestDB(t)
-	lib, err := library.New(sqlDB).Add(context.Background(), "/music", "Music")
+	lib, err := library.New(sqlDB).Add(context.Background(), "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("add library: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestRepo_UpsertContextCanceledAbortsEarly(t *testing.T) {
 func TestRepo_UpsertPartialBatchFailure(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)
-	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music")
+	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("add library: %v", err)
 	}

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -28,7 +28,7 @@ func TestRepo_UpsertAndListByLibrary(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestRepo_FindByTrackMatchesNormalizedKeys(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestRepo_FindByTrackOrdersNonTerminalFirst(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestRepo_UpsertWithForceStatusOverwritesExisting(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestRepo_UpsertDefaultsStatus(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestRepo_UpsertPreservesExistingStatusWhenStatusUnspecified(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -273,11 +273,11 @@ func TestRepo_ListByLibrary_IsolatedByLibrary(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	libA, err := libRepo.Add(ctx, "/music/a", "A", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library A: %v", err)
 	}
-	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	libB, err := libRepo.Add(ctx, "/music/b", "B", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library B: %v", err)
 	}
@@ -317,11 +317,11 @@ func TestRepo_ListWithFilters(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	libA, err := libRepo.Add(ctx, "/music/a", "A", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library A: %v", err)
 	}
-	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	libB, err := libRepo.Add(ctx, "/music/b", "B", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library B: %v", err)
 	}
@@ -380,11 +380,11 @@ func TestRepo_ClearByLibraryOnlyAffectsTargetedLibrary(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	libA, err := libRepo.Add(ctx, "/music/a", "A", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library A: %v", err)
 	}
-	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	libB, err := libRepo.Add(ctx, "/music/b", "B", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library B: %v", err)
 	}
@@ -443,7 +443,7 @@ func TestRepo_ListPendingByLibraryAndSetStatus(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}
@@ -494,11 +494,11 @@ func TestRepo_ClearByLibraryTx_CommitsViaCaller(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	libA, err := libRepo.Add(ctx, "/music/a", "A")
+	libA, err := libRepo.Add(ctx, "/music/a", "A", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library A: %v", err)
 	}
-	libB, err := libRepo.Add(ctx, "/music/b", "B")
+	libB, err := libRepo.Add(ctx, "/music/b", "B", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library B: %v", err)
 	}
@@ -573,7 +573,7 @@ func TestRepo_ClearByLibraryTx_RollbackPreservesRows(t *testing.T) {
 	libRepo := library.New(sqlDB)
 	scanRepo := scan.New(sqlDB)
 
-	lib, err := libRepo.Add(ctx, "/music", "Music")
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
 	if err != nil {
 		t.Fatalf("Add library: %v", err)
 	}


### PR DESCRIPTION
## Summary

Foundation for per-library tri-state feature toggles. Adds the shared settings surface and resolution rule that recording enrichment (#217) and instrumental detection (#218) build on; lands first per decompose-before-building.

- Migration `015`: nullable `enrich_recording` / `detect_instrumental` columns on `libraries` (NULL = inherit global default, 0 = off, 1 = on). Symmetric `ALTER TABLE ... DROP COLUMN` down, matching the repo's additive-migration convention (008/013).
- `models.Library` gains `*bool` `EnrichRecording` / `DetectInstrumental`; new `models.LibrarySettings` carrier for create/update.
- `internal/library` repo `Add`/`Update` take a `LibrarySettings` (COALESCE leaves an absent column unchanged on update); `List`/`Get`/`GetByName` read the columns.
- `config.ResolveBool(cli, lib, globalDefault)` precedence helper (CLI > per-library > global).
- `library add` / `library update` expose tri-state `--enrich` / `--detect-instrumental` flags (omit = inherit/unchanged; `--enrich` / `--enrich=false` to set).

## Linked issues

Closes #216. Unblocks #217 (enrichment) and #218 (detection).

## Behavior

No user-visible behavior change yet: the columns are persisted but not consumed until #217/#218 gate on them. Existing libraries default to NULL (inherit), preserving current always-on behavior. CLI docs for the flags land with #217/#218 when the flags actually affect output.

## Test plan

- [x] Built test-first (3 red/green cycles: `ResolveBool`, repository tri-state round-trip, CLI flags)
- [x] `make gate` green: race tests, golangci-lint (0 issues), actionlint, govulncheck
- [x] Patch coverage 96.7% (local, Codecov parity)
- [x] Single squashed commit