### PR TITLE
fix(docker): apk upgrade runtime stage to clear Image Scan OpenSSL CVEs (#221)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.licenses="GPL-3.0"
 
 RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
+    apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \
     mkdir -p /config /music && \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.licenses="GPL-3.0"
 
 RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
+    apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \
     mkdir -p /config /music && \


### PR DESCRIPTION
## Summary

CI `Image Scan` (grype, HIGH+ fail) is red on every build because the `alpine:3.23.4` runtime base ships `libcrypto3`/`libssl3` **3.5.6-r0**, now flagged by a batch of OpenSSL advisories (Critical CVE-2026-34182 + 8 High). Fixed in **3.5.7-r0**, which is in the Alpine apk repo but not yet baked into any published `alpine:3.23.x` image - so a base-digest bump cannot help.

Fix: add `apk upgrade --no-cache` to the runtime stage of both `Dockerfile` and `build/docker/Dockerfile.goreleaser` (KEEP IN SYNC), mirroring sydlexius/stillwater, to pull the patched packages at build time on top of the pinned base. No `.grype.yaml` carve-out - a real fix is available (stillwater retired its grype openssl/curl ignores for the same reason in #1925).

## Verification (local, rendered)

- Before: `grype` on the built image reports 9 HIGH+ OpenSSL CVEs (`libcrypto3`/`libssl3` 3.5.6-r0).
- After `apk upgrade --no-cache`: image installs openssl **3.5.7-r0**, `grype` reports **0 HIGH+**.

## Linked issue

Closes #221. Unblocks the `Image Scan` required check on open PRs (e.g. #220, which will be rebased onto main once this lands).

## Test plan

- [x] `make scan` / grype clean of HIGH+ after the change (openssl 3.5.7-r0)
- [x] Pre-push gate green (no Go changes; Dockerfile-only)
- [ ] CI `Image Scan` green on this PR (self-validates the fix)