### PR TITLE
feat(enrichment): per-library recording enrichment with global default + scan override

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -172,6 +172,19 @@ sample_duration_seconds = 30
 min_confidence = 0.85
 min_similarity = 0.35
 
+[enrichment]
+# Recording enrichment reads the ISRC, MusicBrainz recording ID, and duration
+# from each file's audio tags and feeds them to the matcher to disambiguate
+# results. This is the GLOBAL DEFAULT; it can be overridden per library (via
+# `library add/update --enrich/--enrich=false`) and per run (via the scan
+# `--enrich` / `--no-enrich` flags). Resolution precedence (highest wins):
+# CLI flag > per-library setting > this global default.
+#
+# Default true, preserving the always-on behavior from before per-library
+# control existed. Set to false to skip enrichment by default (tracks then use
+# the duration_bucket=0 cache fallback). Env override: MXLRC_ENRICHMENT_ENABLED.
+enabled = true
+
 [guard]
 # Optional language/script guard. It rejects fetched lyrics whose body is
 # dominated by scripts outside the allowlist below, so a wrong-language match

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -192,6 +192,18 @@ Even signed binaries can trigger the "Windows protected your PC" prompt on first
 
 This prompt should not appear again after the first run. See [issue #183](https://github.com/sydlexius/mxlrcgo-svc/issues/183) for background on code signing.
 
+## Recording enrichment
+
+Recording enrichment reads the ISRC, MusicBrainz recording ID, and duration from each file's audio tags and passes them to the matcher to disambiguate results (for example, telling two same-titled recordings apart). It is on by default.
+
+You can control it at three levels, resolved with the precedence **CLI flag > per-library setting > global default**:
+
+- **Global default** (`config.toml`): `[enrichment] enabled = true` (env `MXLRC_ENRICHMENT_ENABLED`). Default `true`. Set `false` to skip enrichment everywhere unless a library or run opts back in.
+- **Per library**: `mxlrcgo-svc library add/update --enrich` (force on) or `--enrich=false` (force off). Omit the flag to inherit the global default.
+- **Per run**: `mxlrcgo-svc scan --enrich` or `--no-enrich` overrides both for that single scan (the two flags are mutually exclusive). The serve-mode scheduler has no per-run flag; it resolves per library against the global default.
+
+When enrichment is off for a track, the scanner skips ISRC, MBID, and duration extraction as a unit, and the track keeps the `duration_bucket = 0` cache fallback (no behavior regression). A per-library or global change only affects scans run after the change; it does not restamp already-scanned rows.
+
 ## Filesystem watcher (optional, low-latency scans)
 
 By default, `serve` only scans on the scheduler's tick (`--scan-interval`, default 900s), so a new track dropped into the library waits up to that interval before lyrics are fetched. An optional filesystem watcher reacts within seconds for the common single-host case. It is disabled by default and configured entirely through environment variables:

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -112,6 +112,8 @@ type ScanCmd struct {
 	Upgrade        bool     `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
 	BFS            bool     `arg:"--bfs" help:"use breadth-first traversal"`
 	EmbeddedLyrics *string  `arg:"--embedded-lyrics" help:"embedded unsynced lyrics handling: off, respect, or extract (default: output.embedded_lyrics or off)"`
+	Enrich         bool     `arg:"--enrich" help:"force recording enrichment (ISRC/MBID/duration) on for this scan, overriding per-library and global settings; mutually exclusive with --no-enrich"`
+	NoEnrich       bool     `arg:"--no-enrich" help:"force recording enrichment off for this scan, overriding per-library and global settings; mutually exclusive with --enrich"`
 	Libraries      []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
 	Results *ScanResultsCmd `arg:"subcommand:results" help:"list persisted scan_results rows"`
@@ -943,6 +945,9 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 	})
+	// serve has no per-run enrichment override; resolve per library against the
+	// global default (and the per-library setting) inside the scheduler.
+	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	s.Interval = serveScanInterval(cfg, args)
 	if err := s.Run(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		slog.Warn("scheduler failed", "error", err)
@@ -960,6 +965,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 	})
+	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	wch := watcher.New(watchCfg, library.New(sqlDB), func(ctx context.Context, lib models.Library, path string) error {
 		return sched.RunOnceForPath(ctx, lib, path)
 	})
@@ -1034,6 +1040,13 @@ func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 	})
+	enrichOverride, err := resolveEnrichOverride(args.Enrich, args.NoEnrich)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 1
+	}
+	s.EnrichOverride = enrichOverride
+	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	if len(args.Libraries) > 0 {
 		libRepo := library.New(sqlDB)
 		libs := make([]models.Library, 0, len(args.Libraries))
@@ -1077,6 +1090,25 @@ func embeddedLyricsMode(flag *string, cfgVal string) string {
 		return "extract"
 	default:
 		return "off"
+	}
+}
+
+// resolveEnrichOverride converts the mutually-exclusive scan --enrich/--no-enrich
+// flags into a tri-state override for recording enrichment: nil = no override
+// (fall back to per-library then global), &true = force on, &false = force off.
+// Passing both flags is a usage error.
+func resolveEnrichOverride(enrich, noEnrich bool) (*bool, error) {
+	switch {
+	case enrich && noEnrich:
+		return nil, fmt.Errorf("--enrich and --no-enrich are mutually exclusive")
+	case enrich:
+		v := true
+		return &v, nil
+	case noEnrich:
+		v := false
+		return &v, nil
+	default:
+		return nil, nil
 	}
 }
 

--- a/internal/commands/enrichment_test.go
+++ b/internal/commands/enrichment_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import "testing"
+
+// TestResolveEnrichOverride covers the scan --enrich/--no-enrich mutual-exclusion
+// resolution into a tri-state *bool (nil = no override).
+func TestResolveEnrichOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		enrich    bool
+		noEnrich  bool
+		wantNil   bool
+		wantVal   bool
+		wantError bool
+	}{
+		{name: "neither set -> nil", wantNil: true},
+		{name: "enrich -> true", enrich: true, wantVal: true},
+		{name: "no-enrich -> false", noEnrich: true, wantVal: false},
+		{name: "both set -> error", enrich: true, noEnrich: true, wantError: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveEnrichOverride(tc.enrich, tc.noEnrich)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected error for conflicting --enrich/--no-enrich; got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("override = %v; want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("override = nil; want %v", tc.wantVal)
+			}
+			if *got != tc.wantVal {
+				t.Errorf("override = %v; want %v", *got, tc.wantVal)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Providers            ProvidersConfig            `toml:"providers"`
 	Verification         VerificationConfig         `toml:"verification"`
 	InstrumentalDetector InstrumentalDetectorConfig `toml:"instrumental_detector"`
+	Enrichment           EnrichmentConfig           `toml:"enrichment"`
 	Guard                GuardConfig                `toml:"guard"`
 	Queue                QueueConfig                `toml:"queue"`
 	Logging              LoggingConfig              `toml:"logging"`
@@ -228,6 +229,18 @@ type InstrumentalDetectorConfig struct {
 	CooldownSeconds int `toml:"cooldown_seconds"`
 }
 
+// EnrichmentConfig holds the global default for recording enrichment (reading
+// ISRC / MusicBrainz recording ID / duration from audio tags and feeding them to
+// the matcher). Per-library settings and the scan CLI override resolve against
+// this default via ResolveBool.
+type EnrichmentConfig struct {
+	// Enabled is the global default for recording enrichment. Default true,
+	// preserving the pre-#217 always-on behavior. A per-library setting or the
+	// scan --enrich/--no-enrich flag overrides it.
+	// Override: MXLRC_ENRICHMENT_ENABLED.
+	Enabled bool `toml:"enabled"`
+}
+
 // GuardConfig holds optional language/script guard settings. An empty
 // AcceptedScripts disables the guard.
 type GuardConfig struct {
@@ -280,8 +293,9 @@ func defaults() Config {
 			InstrumentalClasses:   []string{"Music", "Musical instrument"},
 			CooldownSeconds:       5,
 		},
-		Guard: GuardConfig{Threshold: guardThresholdDefault},
-		Queue: QueueConfig{Randomize: true},
+		Enrichment: EnrichmentConfig{Enabled: true},
+		Guard:      GuardConfig{Threshold: guardThresholdDefault},
+		Queue:      QueueConfig{Randomize: true},
 		Logging: LoggingConfig{
 			Level:      "info",
 			Format:     "text",
@@ -455,7 +469,7 @@ func Load(path string) (Config, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 func applyEnvOverrides(cfg *Config) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
@@ -646,6 +660,14 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "value", v, "current", cfg.InstrumentalDetector.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.InstrumentalDetector.Enabled = enabled
+		}
+	}
+	if v := os.Getenv("MXLRC_ENRICHMENT_ENABLED"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_ENRICHMENT_ENABLED", "value", v, "current", cfg.Enrichment.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Enrichment.Enabled = enabled
 		}
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL"); v != "" {

--- a/internal/config/enrichment_test.go
+++ b/internal/config/enrichment_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+// TestLoad_EnrichmentDefault verifies recording enrichment is on by default,
+// preserving the pre-#217 always-on behavior when no TOML or env override is set.
+func TestLoad_EnrichmentDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Enrichment.Enabled {
+		t.Error("Enrichment.Enabled = false; want true (enabled by default)")
+	}
+}
+
+// TestLoad_EnrichmentEnvDisabled verifies MXLRC_ENRICHMENT_ENABLED overrides the
+// default off.
+func TestLoad_EnrichmentEnvDisabled(t *testing.T) {
+	t.Setenv("MXLRC_ENRICHMENT_ENABLED", "false")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Enrichment.Enabled {
+		t.Error("Enrichment.Enabled = true; want false (env override)")
+	}
+}
+
+// TestLoad_EnrichmentEnvInvalidIgnored verifies an unparsable env value leaves
+// the current (default true) value untouched.
+func TestLoad_EnrichmentEnvInvalidIgnored(t *testing.T) {
+	t.Setenv("MXLRC_ENRICHMENT_ENABLED", "notabool")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Enrichment.Enabled {
+		t.Error("Enrichment.Enabled = false; want true (invalid env ignored)")
+	}
+}

--- a/internal/scan/enrichment_test.go
+++ b/internal/scan/enrichment_test.go
@@ -1,0 +1,68 @@
+package scan_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
+)
+
+// optsCapturingScanner records the ScanOptions passed to each ScanLibrary call so
+// tests can assert the resolved per-library EnrichRecording value.
+type optsCapturingScanner struct {
+	results []models.ScanResult
+	opts    []scanner.ScanOptions
+}
+
+func (c *optsCapturingScanner) ScanLibrary(_ context.Context, _ string, opts scanner.ScanOptions) ([]models.ScanResult, error) {
+	c.opts = append(c.opts, opts)
+	return c.results, nil
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestScheduler_ResolvesEnrichRecording verifies the scheduler resolves the
+// per-library enrichment toggle with precedence CLI override > per-library
+// setting > global default, and stamps it onto the ScanOptions for the scan.
+func TestScheduler_ResolvesEnrichRecording(t *testing.T) {
+	cases := []struct {
+		name          string
+		override      *bool
+		libSetting    *bool
+		globalDefault bool
+		want          bool
+	}{
+		{"cli override beats lib and global", boolPtr(false), boolPtr(true), true, false},
+		{"lib setting beats global", nil, boolPtr(false), true, false},
+		{"global default when lib unset", nil, nil, true, true},
+		{"global default off", nil, nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &optsCapturingScanner{results: []models.ScanResult{{
+				FilePath: "/music/a.mp3",
+				Track:    models.Track{TrackName: "Title"},
+			}}}
+			s := scan.Scheduler{
+				Libraries: fakeLibraries{libs: []models.Library{
+					{ID: 7, Path: "/music", Name: "Music", EnrichRecording: tc.libSetting},
+				}},
+				Results:             &fakeResults{},
+				Scanner:             cap,
+				EnrichOverride:      tc.override,
+				GlobalEnrichDefault: tc.globalDefault,
+			}
+			if err := s.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+			if len(cap.opts) != 1 {
+				t.Fatalf("ScanLibrary calls = %d; want 1", len(cap.opts))
+			}
+			if got := cap.opts[0].EnrichRecording; got != tc.want {
+				t.Errorf("resolved EnrichRecording = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scan/scheduler.go
+++ b/internal/scan/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
@@ -38,6 +39,13 @@ type Scheduler struct {
 	Interval       time.Duration
 	MaxRuntime     time.Duration
 	OnScanComplete OnCompleteFunc
+	// EnrichOverride is the scan-CLI override for recording enrichment
+	// (--enrich/--no-enrich); nil means no override. GlobalEnrichDefault is the
+	// config default used when neither the override nor the per-library setting
+	// is set. scanAndPersist resolves EnrichRecording per library from these via
+	// config.ResolveBool and stamps it onto each scan's Options.
+	EnrichOverride      *bool
+	GlobalEnrichDefault bool
 }
 
 // RunOnce scans every configured library exactly once.
@@ -107,7 +115,12 @@ func (s *Scheduler) RunOnceForPath(ctx context.Context, lib models.Library, path
 // scanAndPersist scans path, stamps results with lib.ID and a default status,
 // upserts them, and invokes OnScanComplete.
 func (s *Scheduler) scanAndPersist(ctx context.Context, lib models.Library, path string) error {
-	results, err := s.Scanner.ScanLibrary(ctx, path, s.Options)
+	// Resolve recording enrichment for this library (CLI override > per-library
+	// setting > global default) and stamp it onto a per-scan copy of Options so
+	// the shared template is not mutated across libraries.
+	opts := s.Options
+	opts.EnrichRecording = config.ResolveBool(s.EnrichOverride, lib.EnrichRecording, s.GlobalEnrichDefault)
+	results, err := s.Scanner.ScanLibrary(ctx, path, opts)
 	if err != nil {
 		return fmt.Errorf("scan: scan library %d: %w", lib.ID, err)
 	}

--- a/internal/scanner/enrichment_test.go
+++ b/internal/scanner/enrichment_test.go
@@ -1,0 +1,80 @@
+package scanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/testutil"
+)
+
+// enrichFixtureDir writes a single track carrying both an ISRC and a MusicBrainz
+// recording ID, used by the enrichment-gating tests.
+func enrichFixtureDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFileExtended(dir, "track.mp3", "Artist", "Title", "Album", "",
+		map[string]string{"TSRC": testISRC},
+		map[string]string{"MusicBrainz Track Id": testMBID}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return dir
+}
+
+// TestScanLibrary_EnrichOn_ExtractsAll verifies that with EnrichRecording=true the
+// scanner extracts ISRC, recording MBID, and duration.
+func TestScanLibrary_EnrichOn_ExtractsAll(t *testing.T) {
+	dir := enrichFixtureDir(t)
+	sc := &Scanner{probeFunc: func(string) (int, error) { return 180, nil }}
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	got := results[0].Track
+	if got.ISRC != testISRC {
+		t.Errorf("ISRC = %q; want %q", got.ISRC, testISRC)
+	}
+	if got.RecordingMBID != testMBID {
+		t.Errorf("RecordingMBID = %q; want %q", got.RecordingMBID, testMBID)
+	}
+	if got.TrackLength != 180 {
+		t.Errorf("TrackLength = %d; want 180", got.TrackLength)
+	}
+}
+
+// TestScanLibrary_EnrichOff_SkipsAll verifies that with EnrichRecording=false the
+// scanner skips ISRC, MBID, and duration extraction entirely (the whole #191
+// enrichment unit is one switch) - and never even invokes the duration prober.
+func TestScanLibrary_EnrichOff_SkipsAll(t *testing.T) {
+	dir := enrichFixtureDir(t)
+	probed := false
+	sc := &Scanner{probeFunc: func(string) (int, error) { probed = true; return 180, nil }}
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: false})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1 (track must still be scanned)", len(results))
+	}
+	got := results[0].Track
+	if got.ISRC != "" {
+		t.Errorf("ISRC = %q; want empty (enrichment off)", got.ISRC)
+	}
+	if got.RecordingMBID != "" {
+		t.Errorf("RecordingMBID = %q; want empty (enrichment off)", got.RecordingMBID)
+	}
+	if got.TrackLength != 0 {
+		t.Errorf("TrackLength = %d; want 0 (enrichment off)", got.TrackLength)
+	}
+	if probed {
+		t.Error("duration prober was called; want skipped when enrichment is off")
+	}
+	// Core (non-enrichment) metadata must still be populated.
+	if got.TrackName != "Title" || got.ArtistName != "Artist" {
+		t.Errorf("core tags lost: ArtistName=%q TrackName=%q", got.ArtistName, got.TrackName)
+	}
+}

--- a/internal/scanner/recording_test.go
+++ b/internal/scanner/recording_test.go
@@ -29,7 +29,7 @@ func TestExtractISRC_Present(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestExtractISRC_Absent(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestExtractRecordingMBID_Present(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestExtractRecordingMBID_Absent(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := skipDurationScanner().ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestProbeDuration_ProberCalled(t *testing.T) {
 		}
 		return 180, nil
 	}}
-	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestProbeDuration_ProberError_GracefulDegrade(t *testing.T) {
 	}
 
 	sc := &Scanner{probeFunc: func(string) (int, error) { return 0, errors.New("corrupt file") }}
-	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1})
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
 	if err != nil {
 		t.Fatalf("ScanLibrary must not fail on per-file probe error: %v", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -64,6 +64,14 @@ type ScanOptions struct {
 	// skips fetching). Synced (SYLT) tags are intentionally not handled. "off"
 	// (default) is a no-op.
 	EmbeddedLyrics string
+	// EnrichRecording controls recording enrichment: reading ISRC, MusicBrainz
+	// recording ID, and duration from audio tags into the Track. When false, all
+	// three are skipped (the duration prober is not even invoked) and the track
+	// keeps the duration_bucket=0 fallback. Callers resolve this per library via
+	// config.ResolveBool; the scheduler stamps it before each ScanLibrary call.
+	// The zero value is false, so direct callers that want the historical
+	// always-on behavior must set it true explicitly.
+	EnrichRecording bool
 }
 
 // NewScanner creates a new Scanner.
@@ -299,19 +307,30 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			}
 		}
 
-		// Duration: audioduration reads only the file header (no audio decode).
-		// The library seeks to 0 internally, so f may be at any position from
-		// tag.ReadFrom above. Parse errors degrade gracefully to TrackLength=0
-		// (duration_bucket sentinel for "unknown").
+		// Recording enrichment (ISRC, MusicBrainz recording ID, duration) is a
+		// single switch (#217). When off, skip all three: do not probe duration
+		// (avoids the header read entirely), leave ISRC/MBID empty, and let the
+		// track keep the duration_bucket=0 fallback.
 		filePath := filepath.Join(dir, file.Name())
-		dur, durErr := sc.probeDuration(f, ext)
-		_ = f.Close()
-		if durErr != nil {
-			slog.Debug("duration parse failed; using 0", "file", file.Name(), "error", durErr)
-			dur = 0
+		var dur int
+		var isrc, recordingMBID string
+		if opts.EnrichRecording {
+			// Duration: audioduration reads only the file header (no audio decode).
+			// The library seeks to 0 internally, so f may be at any position from
+			// tag.ReadFrom above. Parse errors degrade gracefully to TrackLength=0
+			// (duration_bucket sentinel for "unknown").
+			var durErr error
+			dur, durErr = sc.probeDuration(f, ext)
+			if durErr != nil {
+				slog.Debug("duration parse failed; using 0", "file", file.Name(), "error", durErr)
+				dur = 0
+			}
+			isrc = extractISRC(m)
+			recordingMBID = extractRecordingMBID(m)
 		}
+		_ = f.Close()
 
-		slog.Debug("adding file", "file", file.Name())
+		slog.Debug("adding file", "file", file.Name(), "enrich", opts.EnrichRecording)
 		*results = append(*results, models.ScanResult{
 			FilePath: filePath,
 			Track: models.Track{
@@ -320,8 +339,8 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 				AlbumName:     m.Album(),
 				AlbumArtist:   m.AlbumArtist(),
 				TrackLength:   dur,
-				ISRC:          extractISRC(m),
-				RecordingMBID: extractRecordingMBID(m),
+				ISRC:          isrc,
+				RecordingMBID: recordingMBID,
 			},
 			Outdir:   dir,
 			Filename: stem + ".lrc",
@@ -374,6 +393,10 @@ func (sc *Scanner) GetSongDir(dir string, songs *queue.InputsQueue, update bool,
 		Upgrade:  upgrade,
 		MaxDepth: limit - depth,
 		BFS:      bfs,
+		// Directory mode (legacy one-shot fetch) has no library row to carry a
+		// per-library setting, so it preserves the historical always-on
+		// enrichment behavior. Library scans resolve this per-library upstream.
+		EnrichRecording: true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Make recording enrichment (ISRC / MusicBrainz recording ID / duration read from audio tags and fed to the matcher) controllable instead of unconditional, resolved with precedence **CLI flag > per-library setting > global config default**. Builds on the #216 per-library foundation.

- **config**: new `[enrichment] enabled` (default `true`, preserving the always-on behavior) + `MXLRC_ENRICHMENT_ENABLED` env override.
- **scanner**: `ScanOptions.EnrichRecording` gates ISRC/MBID/duration extraction as a single unit; when off it skips the duration prober entirely and keeps the `duration_bucket=0` cache fallback. Directory mode stays always-on (no library row to carry a setting).
- **scheduler**: `EnrichOverride`/`GlobalEnrichDefault`; `scanAndPersist` resolves per library via `config.ResolveBool` and stamps `EnrichRecording` per scan.
- **scan CLI**: mutually-exclusive `--enrich` / `--no-enrich` per-run override; serve resolves per library against the global default.
- **docs**: `config.example.toml [enrichment]` section + USER_GUIDE enrichment guide.

No behavior change unless the new knob is set. A setting change only affects scans run after the change (no restamp of already-scanned rows).

Size note: 11 files is one over the 10-file guide, driven by TDD (4 paired test files) + 2 docs files; 373 LOC is well under the LOC threshold and the change is one cohesive feature.

## Linked issue

Closes #217

## Test plan

- [x] `make gate` green (race tests, patch coverage, golangci-lint 0, actionlint, govulncheck)
- [x] TDD: config defaults/env, scanner enrich-on/off gating, scheduler precedence (CLI > lib > global), CLI `--enrich`/`--no-enrich` mutual exclusion
- [ ] Codoki auto-review (CR skipped, same as #216)