### PR TITLE
feat(detector): per-library instrumental detection with global default + scan override

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -204,6 +204,18 @@ You can control it at three levels, resolved with the precedence **CLI flag > pe
 
 When enrichment is off for a track, the scanner skips ISRC, MBID, and duration extraction as a unit, and the track keeps the `duration_bucket = 0` cache fallback (no behavior regression). A per-library or global change only affects scans run after the change; it does not restamp already-scanned rows.
 
+## Instrumental detection
+
+The optional instrumental-detection sidecar samples each track's audio with ffmpeg and asks an external classifier whether it is instrumental, writing an instrumental marker on a provider miss. It runs only when a classifier URL is configured (`[instrumental_detector] classifier_url`). Because it costs an ffmpeg sample plus an inference call per track, you may want it on a small curated or soundtrack-heavy library but off on a large bulk one.
+
+You control it at three levels, resolved with the precedence **CLI flag > per-library setting > global default**:
+
+- **Global default** (`config.toml`): `[instrumental_detector] enabled` (env `MXLRC_INSTRUMENTAL_DETECTOR_ENABLED`). Default `false`.
+- **Per library**: `mxlrcgo-svc library add/update --detect-instrumental` (force on) or `--detect-instrumental=false` (force off). Omit the flag to inherit the global default.
+- **Per run**: `mxlrcgo-svc scan --detect-instrumental` or `--no-detect-instrumental` overrides both for the tracks enqueued by that scan (the two flags are mutually exclusive). serve has no per-run flag; it resolves per library against the global default.
+
+The decision is resolved and stamped onto each work-queue item when it is enqueued (like the provider-set version), so a per-library or global change only affects tracks enqueued after the change. Tracks queued before per-library detection existed carry no decision and fall back to the global default at processing time. If an item requests detection but no `classifier_url` is configured, the worker logs an error and proceeds without detection (it never silently skips).
+
 ## Filesystem watcher (optional, low-latency scans)
 
 By default, `serve` only scans on the scheduler's tick (`--scan-interval`, default 900s), so a new track dropped into the library waits up to that interval before lyrics are fetched. An optional filesystem watcher reacts within seconds for the common single-host case. It is disabled by default and configured entirely through environment variables:

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -106,15 +106,17 @@ type ServeCmd struct {
 // nested inspection subcommands (results, clear). When neither nested
 // subcommand is set, the legacy run-once scan path is taken.
 type ScanCmd struct {
-	ConfigPath     string   `arg:"--config" help:"path to config file (default: XDG)" default:""`
-	Depth          int      `arg:"-d,--depth" help:"maximum recursion depth" default:"100"`
-	Update         bool     `arg:"-u,--update" help:"re-fetch and overwrite existing .lrc files"`
-	Upgrade        bool     `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
-	BFS            bool     `arg:"--bfs" help:"use breadth-first traversal"`
-	EmbeddedLyrics *string  `arg:"--embedded-lyrics" help:"embedded unsynced lyrics handling: off, respect, or extract (default: output.embedded_lyrics or off)"`
-	Enrich         bool     `arg:"--enrich" help:"force recording enrichment (ISRC/MBID/duration) on for this scan, overriding per-library and global settings; mutually exclusive with --no-enrich"`
-	NoEnrich       bool     `arg:"--no-enrich" help:"force recording enrichment off for this scan, overriding per-library and global settings; mutually exclusive with --enrich"`
-	Libraries      []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
+	ConfigPath           string   `arg:"--config" help:"path to config file (default: XDG)" default:""`
+	Depth                int      `arg:"-d,--depth" help:"maximum recursion depth" default:"100"`
+	Update               bool     `arg:"-u,--update" help:"re-fetch and overwrite existing .lrc files"`
+	Upgrade              bool     `arg:"--upgrade" help:"re-fetch .txt lyrics to promote them"`
+	BFS                  bool     `arg:"--bfs" help:"use breadth-first traversal"`
+	EmbeddedLyrics       *string  `arg:"--embedded-lyrics" help:"embedded unsynced lyrics handling: off, respect, or extract (default: output.embedded_lyrics or off)"`
+	Enrich               bool     `arg:"--enrich" help:"force recording enrichment (ISRC/MBID/duration) on for this scan, overriding per-library and global settings; mutually exclusive with --no-enrich"`
+	NoEnrich             bool     `arg:"--no-enrich" help:"force recording enrichment off for this scan, overriding per-library and global settings; mutually exclusive with --enrich"`
+	DetectInstrumental   bool     `arg:"--detect-instrumental" help:"force instrumental detection on for tracks enqueued by this scan, overriding per-library and global settings; mutually exclusive with --no-detect-instrumental"`
+	NoDetectInstrumental bool     `arg:"--no-detect-instrumental" help:"force instrumental detection off for tracks enqueued by this scan, overriding per-library and global settings; mutually exclusive with --detect-instrumental"`
+	Libraries            []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
 	Results *ScanResultsCmd `arg:"subcommand:results" help:"list persisted scan_results rows"`
 	Clear   *ScanClearCmd   `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
@@ -667,6 +669,7 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		return 1
 	}
 	configureWorkerAudioDetector(w, audioDetector)
+	w.SetInstrumentalDetectionDefault(cfg.InstrumentalDetector.Enabled)
 	configureWorkerGuard(w, newGuard(cfg))
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -882,11 +885,14 @@ func configureWorkerVerification(w *worker.Worker, cfg config.Config, verifier v
 	w.EnableVerification(verifier, cfg.Verification.MinConfidence)
 }
 
-// newAudioDetector builds the instrumental detector from config. Returns (nil, nil)
-// when the detector is disabled (the default). Callers must treat a nil return as
-// the disabled/no-op state.
+// newAudioDetector builds the instrumental detector from config. It is built
+// whenever a classifier URL is configured - decoupled from the global enable flag
+// (#218) so per-library detection works even when the global default is off. The
+// global default and per-item decisions gate whether the worker actually calls it.
+// Returns (nil, nil) when no classifier URL is set; callers treat a nil return as
+// "no classifier configured".
 func newAudioDetector(cfg config.Config) (detector.Detector, error) {
-	if !cfg.InstrumentalDetector.Enabled {
+	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
 		return nil, nil
 	}
 	return detector.NewHTTPDetector(
@@ -938,13 +944,15 @@ func configureWriterBilingual(w lyrics.Writer, cfg config.Config) {
 }
 
 func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd) {
+	// serve has no per-run detect override; resolve per library against the global
+	// default (and the per-library setting) at enqueue time.
 	s := scheduler(sqlDB, scanner.ScanOptions{
 		Update:         args.Update,
 		Upgrade:        args.Upgrade,
 		MaxDepth:       args.Depth,
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-	})
+	}, nil, cfg.InstrumentalDetector.Enabled)
 	// serve has no per-run enrichment override; resolve per library against the
 	// global default (and the per-library setting) inside the scheduler.
 	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
@@ -964,7 +972,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 		MaxDepth:       args.Depth,
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-	})
+	}, nil, cfg.InstrumentalDetector.Enabled)
 	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	wch := watcher.New(watchCfg, library.New(sqlDB), func(ctx context.Context, lib models.Library, path string) error {
 		return sched.RunOnceForPath(ctx, lib, path)
@@ -1033,18 +1041,23 @@ func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 	}
 	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
 
+	enrichOverride, err := resolveEnrichOverride(args.Enrich, args.NoEnrich)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 1
+	}
+	detectOverride, err := resolveDetectOverride(args.DetectInstrumental, args.NoDetectInstrumental)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, err)
+		return 1
+	}
 	s := scheduler(sqlDB, scanner.ScanOptions{
 		Update:         args.Update,
 		Upgrade:        args.Upgrade,
 		MaxDepth:       args.Depth,
 		BFS:            args.BFS,
 		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-	})
-	enrichOverride, err := resolveEnrichOverride(args.Enrich, args.NoEnrich)
-	if err != nil {
-		_, _ = fmt.Fprintln(out, err)
-		return 1
-	}
+	}, detectOverride, cfg.InstrumentalDetector.Enabled)
 	s.EnrichOverride = enrichOverride
 	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	if len(args.Libraries) > 0 {
@@ -1093,18 +1106,18 @@ func embeddedLyricsMode(flag *string, cfgVal string) string {
 	}
 }
 
-// resolveEnrichOverride converts the mutually-exclusive scan --enrich/--no-enrich
-// flags into a tri-state override for recording enrichment: nil = no override
-// (fall back to per-library then global), &true = force on, &false = force off.
-// Passing both flags is a usage error.
-func resolveEnrichOverride(enrich, noEnrich bool) (*bool, error) {
+// resolveFlagOverride converts a mutually-exclusive on/off bool flag pair into a
+// tri-state override: nil = no override (fall back to per-library then global),
+// &true = force on, &false = force off. label names the flag pair for the
+// conflict error. Passing both flags is a usage error.
+func resolveFlagOverride(on, off bool, label string) (*bool, error) {
 	switch {
-	case enrich && noEnrich:
-		return nil, fmt.Errorf("--enrich and --no-enrich are mutually exclusive")
-	case enrich:
+	case on && off:
+		return nil, fmt.Errorf("%s are mutually exclusive", label)
+	case on:
 		v := true
 		return &v, nil
-	case noEnrich:
+	case off:
 		v := false
 		return &v, nil
 	default:
@@ -1112,13 +1125,26 @@ func resolveEnrichOverride(enrich, noEnrich bool) (*bool, error) {
 	}
 }
 
-func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions) scan.Scheduler {
+// resolveEnrichOverride resolves the scan --enrich/--no-enrich override (#217).
+func resolveEnrichOverride(enrich, noEnrich bool) (*bool, error) {
+	return resolveFlagOverride(enrich, noEnrich, "--enrich and --no-enrich")
+}
+
+// resolveDetectOverride resolves the scan --detect-instrumental/--no-detect-instrumental
+// override (#218).
+func resolveDetectOverride(detect, noDetect bool) (*bool, error) {
+	return resolveFlagOverride(detect, noDetect, "--detect-instrumental and --no-detect-instrumental")
+}
+
+func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, globalDetectDefault bool) scan.Scheduler {
 	results := scan.New(sqlDB)
 	enq := scan.Enqueuer{
-		Results:  results,
-		Cache:    cache.New(sqlDB),
-		Queue:    queue.NewDBQueue(sqlDB),
-		Priority: queue.PriorityScan,
+		Results:             results,
+		Cache:               cache.New(sqlDB),
+		Queue:               queue.NewDBQueue(sqlDB),
+		Priority:            queue.PriorityScan,
+		DetectOverride:      detectOverride,
+		GlobalDetectDefault: globalDetectDefault,
 	}
 	return scan.Scheduler{
 		Libraries: library.New(sqlDB),
@@ -1126,7 +1152,7 @@ func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions) scan.Scheduler {
 		Scanner:   scanner.NewScanner(),
 		Options:   opts,
 		OnScanComplete: func(ctx context.Context, lib models.Library, found []models.ScanResult) error {
-			enqueued, cacheHits, err := enq.EnqueuePending(ctx, lib.ID)
+			enqueued, cacheHits, err := enq.EnqueuePending(ctx, lib)
 			if err != nil {
 				// Counts are partial on an aborted enqueue; don't log "complete".
 				slog.Warn("scheduled scan incomplete (enqueue aborted)",

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -235,11 +235,17 @@ func TestNewAudioDetectorDecoupledFromEnableFlag(t *testing.T) {
 	}
 
 	// Enabled=false but a classifier URL IS set -> detector still built (decoupled).
+	// Point FFmpegPath at a stub executable so construction does not depend on a
+	// real ffmpeg being on PATH (CI runners do not have one).
+	stubFFmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+	if err := os.WriteFile(stubFFmpeg, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub ffmpeg: %v", err)
+	}
 	got, err = newAudioDetector(config.Config{
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
 			Enabled:               false,
 			ClassifierURL:         "http://yamnet:8080",
-			FFmpegPath:            "ffmpeg",
+			FFmpegPath:            stubFFmpeg,
 			SampleDurationSeconds: 30,
 			MinConfidence:         0.90,
 			InstrumentalClasses:   []string{"Music"},

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -216,10 +216,11 @@ func TestConfigureWorkerGuardAcceptsNilGuard(t *testing.T) {
 	configureWorkerGuard(w, nil)
 }
 
-// TestNewAudioDetectorDisabledReturnsNil verifies that when
-// InstrumentalDetector.Enabled is false (the default), newAudioDetector returns
-// (nil, nil) and does not attempt to locate ffmpeg.
-func TestNewAudioDetectorDisabledReturnsNil(t *testing.T) {
+// TestNewAudioDetectorDecoupledFromEnableFlag verifies the #218 decoupling: the
+// detector is built whenever a classifier URL is configured, independent of the
+// global Enabled flag, and is nil only when no classifier URL is set.
+func TestNewAudioDetectorDecoupledFromEnableFlag(t *testing.T) {
+	// Enabled=false but no classifier URL -> nil (no classifier configured).
 	got, err := newAudioDetector(config.Config{
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
 			Enabled:    false,
@@ -227,10 +228,28 @@ func TestNewAudioDetectorDisabledReturnsNil(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("newAudioDetector: %v", err)
+		t.Fatalf("newAudioDetector (no URL): %v", err)
 	}
 	if got != nil {
-		t.Fatalf("newAudioDetector = %#v; want nil (disabled)", got)
+		t.Fatalf("newAudioDetector (no URL) = %#v; want nil", got)
+	}
+
+	// Enabled=false but a classifier URL IS set -> detector still built (decoupled).
+	got, err = newAudioDetector(config.Config{
+		InstrumentalDetector: config.InstrumentalDetectorConfig{
+			Enabled:               false,
+			ClassifierURL:         "http://yamnet:8080",
+			FFmpegPath:            "ffmpeg",
+			SampleDurationSeconds: 30,
+			MinConfidence:         0.90,
+			InstrumentalClasses:   []string{"Music"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newAudioDetector (URL set, Enabled=false): %v", err)
+	}
+	if got == nil {
+		t.Fatal("newAudioDetector (URL set, Enabled=false) = nil; want a detector (decoupled from Enabled)")
 	}
 }
 
@@ -253,10 +272,13 @@ func TestNewAudioDetectorEnabledWithoutFFmpegErrors(t *testing.T) {
 	}
 }
 
-// TestNewAudioDetectorEnabledWithoutClassifierURLErrors verifies that enabling
-// the detector with a blank classifier URL returns an error.
-func TestNewAudioDetectorEnabledWithoutClassifierURLErrors(t *testing.T) {
-	_, err := newAudioDetector(config.Config{
+// TestNewAudioDetectorBlankClassifierURLReturnsNil verifies that a blank classifier
+// URL yields no detector (nil, nil) even when the global flag is enabled. Detector
+// construction is decoupled from the enable flag (#218); a row that requests
+// detection without a configured classifier is loud-skipped by the worker at
+// runtime rather than failing detector construction.
+func TestNewAudioDetectorBlankClassifierURLReturnsNil(t *testing.T) {
+	d, err := newAudioDetector(config.Config{
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
 			Enabled:               true,
 			ClassifierURL:         "", // blank
@@ -265,8 +287,11 @@ func TestNewAudioDetectorEnabledWithoutClassifierURLErrors(t *testing.T) {
 			InstrumentalClasses:   []string{"Music"},
 		},
 	})
-	if err == nil {
-		t.Fatal("newAudioDetector with blank ClassifierURL returned nil error; want error")
+	if err != nil {
+		t.Fatalf("newAudioDetector with blank ClassifierURL returned error %v; want nil", err)
+	}
+	if d != nil {
+		t.Fatal("newAudioDetector with blank ClassifierURL returned a detector; want nil (no classifier configured)")
 	}
 }
 
@@ -437,7 +462,7 @@ func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 		t.Fatalf("Upsert scan result: %v", err)
 	}
 
-	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7})
+	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7}, nil, false)
 	if got.OnScanComplete == nil {
 		t.Fatal("scheduler OnScanComplete = nil; want enqueue callback")
 	}

--- a/internal/commands/detect_instrumental_test.go
+++ b/internal/commands/detect_instrumental_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import "testing"
+
+// TestResolveDetectOverride covers the scan --detect-instrumental/--no-detect-instrumental
+// mutual-exclusion resolution into a tri-state *bool (nil = no override).
+func TestResolveDetectOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		detect    bool
+		noDetect  bool
+		wantNil   bool
+		wantVal   bool
+		wantError bool
+	}{
+		{name: "neither set -> nil", wantNil: true},
+		{name: "detect -> true", detect: true, wantVal: true},
+		{name: "no-detect -> false", noDetect: true, wantVal: false},
+		{name: "both set -> error", detect: true, noDetect: true, wantError: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveDetectOverride(tc.detect, tc.noDetect)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected error for conflicting flags; got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("override = %v; want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("override = nil; want %v", tc.wantVal)
+			}
+			if *got != tc.wantVal {
+				t.Errorf("override = %v; want %v", *got, tc.wantVal)
+			}
+		})
+	}
+}

--- a/internal/db/migrations/016_work_queue_detect_instrumental.sql
+++ b/internal/db/migrations/016_work_queue_detect_instrumental.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-item instrumental-detection decision, resolved and stamped at enqueue time
+-- (mirrors providers_version). NULL = no decision stamped; the worker falls back
+-- to the global config default (covers all pre-existing rows, preserving current
+-- behavior). 0 = detection off for this item, 1 = on. Plain ADD COLUMN needs no
+-- table rebuild (no CHECK/constraint change); existing rows default to NULL.
+ALTER TABLE work_queue ADD COLUMN detect_instrumental INTEGER;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN detect_instrumental;
+-- +goose StatementEnd

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -68,6 +68,12 @@ type Inputs struct {
 	// ScanResultID links this work item back to its originating scan_results row.
 	// Zero means the item did not originate from a library scan (e.g. ad-hoc fetch).
 	ScanResultID int64
+	// DetectInstrumental carries the per-item instrumental-detection decision
+	// resolved at enqueue time (CLI > per-library > global). It is stamped onto the
+	// work_queue row on initial insert. nil means "no decision" -> the worker falls
+	// back to the global config default. Set by the scan enqueuer; other enqueue
+	// paths (e.g. webhook) leave it nil.
+	DetectInstrumental *bool
 }
 
 // OutputPath represents one lyrics output destination.

--- a/internal/queue/detect_instrumental_test.go
+++ b/internal/queue/detect_instrumental_test.go
@@ -1,0 +1,82 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestDBQueue_DetectInstrumentalRoundTrip verifies the per-item detect_instrumental
+// decision is stamped on insert and read back, with NULL (nil) preserved.
+func TestDBQueue_DetectInstrumentalRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		value *bool
+	}{
+		{"on", boolPtr(true)},
+		{"off", boolPtr(false)},
+		{"unset", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewDBQueue(openQueueTestDB(t))
+			item, err := q.Enqueue(ctx, models.Inputs{
+				Track:              models.Track{ArtistName: "Artist", TrackName: "Title"},
+				Outdir:             "out",
+				Filename:           "a.lrc",
+				DetectInstrumental: tc.value,
+			}, 1)
+			if err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			switch {
+			case tc.value == nil && item.DetectInstrumental != nil:
+				t.Errorf("DetectInstrumental = %v; want nil", *item.DetectInstrumental)
+			case tc.value != nil && item.DetectInstrumental == nil:
+				t.Errorf("DetectInstrumental = nil; want %v", *tc.value)
+			case tc.value != nil && *item.DetectInstrumental != *tc.value:
+				t.Errorf("DetectInstrumental = %v; want %v", *item.DetectInstrumental, *tc.value)
+			}
+		})
+	}
+}
+
+// TestDBQueue_DetectInstrumentalStampOnInsertOnly verifies the value is written
+// only on the initial insert; an ON CONFLICT refresh of the same key leaves it
+// unchanged (mirrors providers_version).
+func TestDBQueue_DetectInstrumentalStampOnInsertOnly(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC) }
+
+	first, err := q.Enqueue(ctx, models.Inputs{
+		Track:              models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:             "out",
+		Filename:           "a.lrc",
+		DetectInstrumental: boolPtr(true),
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue first: %v", err)
+	}
+	// Re-enqueue the same normalized key with a conflicting decision.
+	second, err := q.Enqueue(ctx, models.Inputs{
+		Track:              models.Track{ArtistName: "artist", TrackName: "title"},
+		Outdir:             "out",
+		Filename:           "a.lrc",
+		DetectInstrumental: boolPtr(false),
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue conflict: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("conflict produced new row %d; want %d", second.ID, first.ID)
+	}
+	if second.DetectInstrumental == nil || *second.DetectInstrumental != true {
+		t.Errorf("DetectInstrumental = %v; want the original true (stamp-on-insert only)", second.DetectInstrumental)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -101,11 +101,17 @@ type WorkItem struct {
 	// worker compares it against the current generation to invalidate cached
 	// results when the provider set changes. 0 means "no generation configured".
 	ProvidersVersion int
-	NextAttemptAt    time.Time
-	LastError        string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	CompletedAt      *time.Time
+	// DetectInstrumental is the per-item instrumental-detection decision stamped
+	// onto the row at enqueue time (resolved CLI > per-library > global). Written
+	// only on the initial insert; the ON CONFLICT refresh and Defer/RecheckDeferred
+	// paths leave it unchanged. nil (NULL) means "no decision stamped" -> the worker
+	// falls back to the global config default, which covers all pre-existing rows.
+	DetectInstrumental *bool
+	NextAttemptAt      time.Time
+	LastError          string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	CompletedAt        *time.Time
 }
 
 // DBQueue is a SQLite-backed queue for durable lyrics work.
@@ -188,9 +194,9 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 
 	row := tx.QueryRowContext(ctx,
 		`INSERT INTO work_queue (
-             artist, title, album, album_artist, artist_key, title_key, outdir, filename, source_path, output_paths, scan_result_id, status, priority, providers_version, next_attempt_at
+             artist, title, album, album_artist, artist_key, title_key, outdir, filename, source_path, output_paths, scan_result_id, status, priority, providers_version, detect_instrumental, next_attempt_at
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(artist_key, title_key) DO UPDATE SET
              artist = CASE
                  WHEN work_queue.status IN ('done', 'processing') THEN work_queue.artist
@@ -251,7 +257,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE NULL
              END
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		inputs.Track.ArtistName,
 		inputs.Track.TrackName,
 		inputs.Track.AlbumName,
@@ -266,6 +272,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 		StatusPending,
 		priority,
 		q.providersVersion,
+		nullableBool(inputs.DetectInstrumental),
 		now,
 		refreshFailedBackoff,
 		refreshFailedBackoff,
@@ -304,7 +311,7 @@ const dequeueRandomizedSQL = `UPDATE work_queue
              LIMIT 1
          )
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
 
 // dequeueDeterministicSQL claims the next ready item in stable FIFO order within
 // a priority tier (created_at, then id).
@@ -319,7 +326,7 @@ const dequeueDeterministicSQL = `UPDATE work_queue
              LIMIT 1
          )
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
 
 // Dequeue atomically claims the next ready item and marks it processing.
 func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
@@ -461,7 +468,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		nextAttempts,
 		nextAttemptAt,
 		lastError,
@@ -513,7 +520,7 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		nextAttemptAt,
 		lastError,
 		id,
@@ -565,7 +572,7 @@ func (q *DBQueue) RetireMiss(ctx context.Context, id int64) (WorkItem, error) {
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		now,
 		missLimitReachedError,
 		id,
@@ -807,7 +814,7 @@ type ListFilter struct {
 // optionally filtered by status and capped by limit.
 func (q *DBQueue) List(ctx context.Context, filter ListFilter) (items []WorkItem, retErr error) {
 	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                       miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
                        FROM work_queue`
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	const limitClause = ` LIMIT ?`
@@ -872,7 +879,7 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
          WHERE id = ?
            AND status = 'failed'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
 		now,
 		id,
 	)
@@ -1170,6 +1177,7 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 	var nextAttemptAt, createdAt, updatedAt, outputPaths string
 	var completedAt sql.NullString
 	var scanResultID sql.NullInt64
+	var detectInstrumental sql.NullBool
 	err := row.Scan(
 		&item.ID,
 		&item.Inputs.Track.ArtistName,
@@ -1184,6 +1192,7 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 		&item.Attempts,
 		&item.MissCount,
 		&item.ProvidersVersion,
+		&detectInstrumental,
 		&nextAttemptAt,
 		&item.LastError,
 		&createdAt,
@@ -1197,6 +1206,10 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 	}
 	if scanResultID.Valid {
 		item.Inputs.ScanResultID = scanResultID.Int64
+	}
+	if detectInstrumental.Valid {
+		b := detectInstrumental.Bool
+		item.DetectInstrumental = &b
 	}
 	item.NextAttemptAt, err = parseTime(nextAttemptAt)
 	if err != nil {
@@ -1273,6 +1286,15 @@ func nullableID(id int64) any {
 		return nil
 	}
 	return id
+}
+
+// nullableBool maps a tri-state *bool to a SQL value: nil -> NULL, else the bool.
+// Used to stamp the per-item detect_instrumental decision (NULL = no decision).
+func nullableBool(b *bool) any {
+	if b == nil {
+		return nil
+	}
+	return *b
 }
 
 func requireAffected(res sql.Result, op string) error {

--- a/internal/scan/detect_instrumental_test.go
+++ b/internal/scan/detect_instrumental_test.go
@@ -1,0 +1,61 @@
+package scan_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
+)
+
+func detectBoolPtr(b bool) *bool { return &b }
+
+// TestEnqueuer_ResolvesDetectInstrumental verifies the enqueuer resolves the
+// per-item detect decision with precedence CLI override > per-library setting >
+// global default, and stamps it onto the enqueued Inputs.
+func TestEnqueuer_ResolvesDetectInstrumental(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name          string
+		override      *bool
+		libSetting    *bool
+		globalDefault bool
+		want          bool
+	}{
+		{"cli beats lib and global", detectBoolPtr(false), detectBoolPtr(true), true, false},
+		{"lib beats global", nil, detectBoolPtr(true), false, true},
+		{"global default when lib unset", nil, nil, true, true},
+		{"global default off", nil, nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakePendingStore{results: []models.ScanResult{{
+				ID:       2,
+				FilePath: "/music/x.mp3",
+				Track:    models.Track{ArtistName: "A", TrackName: "T"},
+			}}}
+			work := &fakeWorkQueue{}
+			e := scan.Enqueuer{
+				Results:             store,
+				Cache:               fakeLyricsCache{},
+				Queue:               work,
+				Priority:            5,
+				DetectOverride:      tc.override,
+				GlobalDetectDefault: tc.globalDefault,
+			}
+			if _, _, err := e.EnqueuePending(ctx, models.Library{ID: 7, DetectInstrumental: tc.libSetting}); err != nil {
+				t.Fatalf("EnqueuePending: %v", err)
+			}
+			if len(work.inputs) != 1 {
+				t.Fatalf("enqueued inputs = %d; want 1", len(work.inputs))
+			}
+			got := work.inputs[0].DetectInstrumental
+			if got == nil {
+				t.Fatalf("DetectInstrumental = nil; want %v", tc.want)
+			}
+			if *got != tc.want {
+				t.Errorf("DetectInstrumental = %v; want %v", *got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 )
@@ -36,13 +37,21 @@ type Enqueuer struct {
 	Cache    LyricsCache
 	Queue    WorkQueue
 	Priority int
+	// DetectOverride is the scan-CLI override for instrumental detection
+	// (--detect-instrumental/--no-detect-instrumental); nil means no override.
+	// GlobalDetectDefault is the global config default used when neither the
+	// override nor the per-library setting is set. EnqueuePending resolves the
+	// per-item decision from these via config.ResolveBool and stamps it onto each
+	// enqueued item (stamp-on-insert; the worker reads it back later).
+	DetectOverride      *bool
+	GlobalDetectDefault bool
 }
 
 // EnqueuePending reads pending scan results for libraryID, skips cache hits,
 // and enqueues cache misses for worker processing. It returns the number of
 // rows enqueued and the number short-circuited as cache hits so callers can log
 // a per-scan summary; on error the partial counts so far are returned alongside.
-func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) (enqueued, cacheHits int, retErr error) {
+func (e *Enqueuer) EnqueuePending(ctx context.Context, lib models.Library) (enqueued, cacheHits int, retErr error) {
 	if e.Results == nil {
 		return 0, 0, fmt.Errorf("scan: enqueuer results dependency is nil")
 	}
@@ -55,6 +64,12 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) (enqueue
 	if err := ctx.Err(); err != nil {
 		return 0, 0, err
 	}
+
+	// Resolve the per-library instrumental-detection decision once (CLI override >
+	// per-library setting > global default) and stamp it onto every item enqueued
+	// for this library; the worker reads it back at fetch time.
+	detect := config.ResolveBool(e.DetectOverride, lib.DetectInstrumental, e.GlobalDetectDefault)
+	libraryID := lib.ID
 
 	results, err := e.Results.ListPendingByLibrary(ctx, libraryID)
 	if err != nil {
@@ -89,6 +104,7 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) (enqueue
 			}
 			return enqueued, cacheHits, fmt.Errorf("scan: build inputs for result %d: %w", res.ID, err)
 		}
+		inputs.DetectInstrumental = &detect
 		if _, err := e.Queue.Enqueue(ctx, inputs, e.Priority); err != nil {
 			if restoreErr := e.Results.SetStatus(ctx, []int64{res.ID}, StatusPending); restoreErr != nil {
 				return enqueued, cacheHits, fmt.Errorf("scan: enqueue result %d: %w; restore pending: %w", res.ID, err, restoreErr)
@@ -102,7 +118,7 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, libraryID int64) (enqueue
 
 // OnScanComplete adapts EnqueuePending to Scheduler.OnScanComplete.
 func (e *Enqueuer) OnScanComplete(ctx context.Context, lib models.Library, _ []models.ScanResult) error {
-	_, _, err := e.EnqueuePending(ctx, lib.ID)
+	_, _, err := e.EnqueuePending(ctx, lib)
 	return err
 }
 

--- a/internal/scan/enqueuer_test.go
+++ b/internal/scan/enqueuer_test.go
@@ -122,7 +122,7 @@ func TestEnqueuer_EnqueuePendingSkipsCacheHitsAndEnqueuesMisses(t *testing.T) {
 	work := &fakeWorkQueue{}
 	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work, Priority: 5}
 
-	enqueued, cacheHits, err := e.EnqueuePending(ctx, 7)
+	enqueued, cacheHits, err := e.EnqueuePending(ctx, models.Library{ID: 7})
 	if err != nil {
 		t.Fatalf("EnqueuePending: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestEnqueuer_ReservesMissBeforeEnqueue(t *testing.T) {
 	}}
 	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
 
-	if _, _, err := e.EnqueuePending(ctx, 7); err != nil {
+	if _, _, err := e.EnqueuePending(ctx, models.Library{ID: 7}); err != nil {
 		t.Fatalf("EnqueuePending: %v", err)
 	}
 	if !reservedBeforeEnqueue {
@@ -190,7 +190,7 @@ func TestEnqueuer_RestoresPendingWhenEnqueueFails(t *testing.T) {
 	work := &fakeWorkQueue{err: queueErr}
 	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
 
-	_, _, err := e.EnqueuePending(ctx, 7)
+	_, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
 	if !errors.Is(err, queueErr) {
 		t.Fatalf("EnqueuePending error = %v; want wrapping %v", err, queueErr)
 	}
@@ -212,7 +212,7 @@ func TestEnqueuer_RestoresPendingWhenScanResultDestinationInvalid(t *testing.T) 
 	work := &fakeWorkQueue{}
 	e := scan.Enqueuer{Results: store, Cache: cache, Queue: work}
 
-	_, _, err := e.EnqueuePending(ctx, 7)
+	_, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
 	if err == nil {
 		t.Fatal("EnqueuePending returned nil error; want invalid destination error")
 	}
@@ -279,7 +279,7 @@ func TestEnqueuer_PropagatesCacheAndQueueErrors(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			store := &fakePendingStore{results: results}
 			e := scan.Enqueuer{Results: store, Cache: v.cache, Queue: v.queue}
-			_, _, err := e.EnqueuePending(ctx, 1)
+			_, _, err := e.EnqueuePending(ctx, models.Library{ID: 1})
 			if !errors.Is(err, v.want) {
 				t.Fatalf("EnqueuePending error = %v; want wrapping %v", err, v.want)
 			}

--- a/internal/scan/list_deferred_test.go
+++ b/internal/scan/list_deferred_test.go
@@ -33,7 +33,7 @@ func TestRepo_ListDeferred(t *testing.T) {
 	// Enqueue the pending row (creates the work_queue + junction link), then
 	// dequeue and Defer it so the linked work_queue row is in 'deferred' state.
 	enq := scan.Enqueuer{Results: repo, Cache: cache.New(sqlDB), Queue: queue.NewDBQueue(sqlDB), Priority: queue.PriorityScan}
-	if _, _, err := enq.EnqueuePending(ctx, lib.ID); err != nil {
+	if _, _, err := enq.EnqueuePending(ctx, lib); err != nil {
 		t.Fatalf("enqueue pending: %v", err)
 	}
 	q := queue.NewDBQueue(sqlDB)

--- a/internal/worker/detect_instrumental_test.go
+++ b/internal/worker/detect_instrumental_test.go
@@ -1,0 +1,110 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func detectItem(id int64, detect *bool) queue.WorkItem {
+	return queue.WorkItem{
+		ID: id,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Composer", TrackName: "Interlude"},
+			Outdir:     "out",
+			Filename:   "interlude.lrc",
+			SourcePath: "/music/interlude.flac",
+		},
+		DetectInstrumental: detect,
+	}
+}
+
+// TestRunOnce_DetectItemFlagOffSkipsDetection verifies a per-item decision of
+// "off" suppresses detection even when the global default is on.
+func TestRunOnce_DetectItemFlagOffSkipsDetection(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{detectItem(300, boolPtr(false))}}
+	det := &fakeDetector{instrumental: true}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNoLyrics}, &fakeWriter{})
+	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true) // global on, but item says off
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(det.calls) != 0 {
+		t.Errorf("detector calls = %v; want none (item opted out)", det.calls)
+	}
+	if len(q.deferred) != 1 {
+		t.Errorf("deferred = %v; want the item deferred as a normal miss", q.deferred)
+	}
+}
+
+// TestRunOnce_DetectItemFlagOnOverridesDefaultOff verifies a per-item decision of
+// "on" runs detection even when the global default is off.
+func TestRunOnce_DetectItemFlagOnOverridesDefaultOff(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{detectItem(301, boolPtr(true))}}
+	det := &fakeDetector{instrumental: true}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.EnableAudioDetector(det)
+	// global default left false on purpose
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(det.calls) != 1 {
+		t.Errorf("detector calls = %v; want 1 (item opted in)", det.calls)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 301 {
+		t.Errorf("completed = %v; want [301] (instrumental marker)", q.completed)
+	}
+}
+
+// TestRunOnce_DetectNilFallsBackToDefaultOff verifies a NULL (nil) per-item
+// decision falls back to the global default (here off), preserving the behavior
+// of pre-existing rows.
+func TestRunOnce_DetectNilFallsBackToDefaultOff(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{detectItem(302, nil)}}
+	det := &fakeDetector{instrumental: true}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNoLyrics}, &fakeWriter{})
+	w.EnableAudioDetector(det)
+	// global default false: nil item must not detect
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(det.calls) != 0 {
+		t.Errorf("detector calls = %v; want none (nil falls back to default off)", det.calls)
+	}
+}
+
+// TestDetectInstrumental_WantedButNoClassifierLoudSkips verifies that when an
+// item requests detection but no classifier is configured, the worker logs an
+// error (loud-skip, no silent no-op) and returns (false, nil).
+func TestDetectInstrumental_WantedButNoClassifierLoudSkips(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(prev)
+
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	// no EnableAudioDetector: classifier unconfigured
+	instrumental, err := w.detectInstrumental(context.Background(), detectItem(303, boolPtr(true)))
+	if err != nil {
+		t.Fatalf("detectInstrumental err = %v; want nil (non-fatal loud-skip)", err)
+	}
+	if instrumental {
+		t.Error("instrumental = true; want false when no classifier configured")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "level=ERROR") || !strings.Contains(logged, "no classifier") {
+		t.Errorf("expected an ERROR loud-skip log mentioning the missing classifier; got: %q", logged)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -102,10 +102,16 @@ type Worker struct {
 	verifier              verification.Verifier
 	verifyBelowConfidence float64
 	// audioDetector, when non-nil, is invoked on provider misses to detect
-	// instrumental tracks via an external AudioSet classifier sidecar. It is
-	// optional (nil means disabled) and errors from it are non-fatal (the miss
-	// path continues normally). Enabled via EnableAudioDetector.
+	// instrumental tracks via an external AudioSet classifier sidecar. It is built
+	// whenever a classifier URL is configured (decoupled from the global enable
+	// flag) so per-library detection works even with the global default off. Errors
+	// from it are non-fatal (the miss path continues normally). Set via
+	// EnableAudioDetector.
 	audioDetector detector.Detector
+	// detectInstrumentalDefault is the global config default for instrumental
+	// detection, used to resolve work items whose per-item decision is nil (NULL in
+	// the DB, e.g. pre-existing rows). Set via SetInstrumentalDetectionDefault.
+	detectInstrumentalDefault bool
 	// scriptGuard, when non-nil and Enabled, rejects fetched lyrics whose script
 	// mix falls outside the configured allowlist. Named scriptGuard (not guard)
 	// to avoid colliding with the guardReject helper. Default nil (no guard).
@@ -392,6 +398,13 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 // so the worker keeps no copy of it.
 func (w *Worker) EnableAudioDetector(d detector.Detector) {
 	w.audioDetector = d
+}
+
+// SetInstrumentalDetectionDefault sets the global default used to resolve work
+// items whose per-item detect decision is nil (NULL). It mirrors
+// config.InstrumentalDetector.Enabled.
+func (w *Worker) SetInstrumentalDetectionDefault(enabled bool) {
+	w.detectInstrumentalDefault = enabled
 }
 
 // EnableGuard configures the language/script guard used to reject lyric
@@ -689,12 +702,28 @@ func (w *Worker) verify(ctx context.Context, item queue.WorkItem, song models.So
 	return nil
 }
 
-// detectInstrumental invokes the audio detector on the item's source path.
-// It returns (false, nil) when the detector is disabled or the source path is
-// absent. Any detector error is returned non-fatally: the caller logs a warning
-// and falls through to normal miss handling.
+// detectInstrumental invokes the audio detector on the item's source path when
+// instrumental detection is enabled for this item. The decision is resolved from
+// the per-item stamp (item.DetectInstrumental) falling back to the global default
+// when nil (NULL rows). It returns (false, nil) when detection is off for the
+// item or the source path is absent. When an item requests detection but no
+// classifier is configured, it logs an error and proceeds without detection
+// (loud-skip, never a silent no-op). Any detector error is returned non-fatally:
+// the caller logs a warning and falls through to normal miss handling.
 func (w *Worker) detectInstrumental(ctx context.Context, item queue.WorkItem) (bool, error) {
-	if w.audioDetector == nil || strings.TrimSpace(item.Inputs.SourcePath) == "" {
+	detect := w.detectInstrumentalDefault
+	if item.DetectInstrumental != nil {
+		detect = *item.DetectInstrumental
+	}
+	if !detect {
+		return false, nil
+	}
+	if w.audioDetector == nil {
+		slog.Error("instrumental detection requested for item but no classifier is configured; skipping detection",
+			"id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName)
+		return false, nil
+	}
+	if strings.TrimSpace(item.Inputs.SourcePath) == "" {
 		return false, nil
 	}
 	res, err := w.audioDetector.Detect(ctx, item.Inputs.SourcePath)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1803,6 +1803,7 @@ func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1860,6 +1861,7 @@ func TestRunOnceDetectorReturnsFalseDefersNormally(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1904,6 +1906,7 @@ func TestRunOnceDetectorErrorTreatsAsMiss(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1945,6 +1948,7 @@ func TestRunOnceDetectorDisabledWhenNilSourcePath(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -1981,6 +1985,7 @@ func TestRunOnceDetectorInstrumentalWriteErrorDefersAsMiss(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
@@ -2022,6 +2027,7 @@ func TestRunOnceDetectorNotCalledOnSuccess(t *testing.T) {
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
 
 	if err := w.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)


### PR DESCRIPTION
## Summary

Make the optional instrumental-detection sidecar controllable per library instead of a single global flag, resolved with precedence **CLI flag > per-library setting > global config default**. Mirrors the `WorkItem.ProvidersVersion` resolve-and-stamp pattern so a `scan`-time override is meaningful even though the worker detects later. Final piece of the per-library settings design (#216 foundation -> #217 enrichment -> #218 detection).

- **migration 016**: nullable `work_queue.detect_instrumental` (NULL = no decision -> fall back to the global default at worker time; covers all pre-existing rows).
- **queue**: `WorkItem.DetectInstrumental` + `Inputs.DetectInstrumental`; stamped on initial insert only (ON CONFLICT / Defer / RecheckDeferred leave it, like `providers_version`).
- **enqueuer**: resolves per library via `config.ResolveBool` and stamps the decision onto each enqueued item.
- **worker**: gates `Detect` on the per-item flag (nil falls back to the global default); **loud-skip** (`slog.Error`) when an item requests detection but no classifier is configured - never a silent no-op.
- **commands**: `newAudioDetector` built whenever `classifier_url` is set (decoupled from the global `enabled` flag) so per-library detection works with the global off; worker default wired from config.
- **scan CLI**: mutually-exclusive `--detect-instrumental` / `--no-detect-instrumental` (shares `resolveFlagOverride` with #217's `--enrich`).
- **docs**: USER_GUIDE instrumental-detection section.

No behavior change unless the new knob is set. A per-library or global change only affects tracks enqueued after the change (no restamp of already-queued rows).

Size note: 15 files is over the 10-file guide, driven by 5 paired TDD test files + migration + docs; 616 LOC is under the LOC threshold and the change is one cohesive feature (migration -> queue -> enqueuer -> worker -> CLI can't be split without breaking it).

## Linked issue

Closes #218

## Test plan

- [x] `make gate` green (race tests, patch coverage, golangci-lint 0, actionlint, govulncheck)
- [x] TDD: queue round-trip + stamp-on-insert-only, enqueuer precedence (CLI > lib > global), worker gating + NULL fallback + loud-skip, CLI `--detect-instrumental`/`--no-detect-instrumental` mutual exclusion
- [ ] Codoki auto-review (CR decision pending the maintainer)