### PR TITLE
docs: refresh for native packages, --upgrade instrumental behavior, and recording enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,24 @@ sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
 
 The package installs the binary to `/usr/local/bin/mxlrcgo-svc`, a systemd unit
 (or OpenRC script on Alpine), and an example config at
-`/etc/mxlrcgo-svc/config.example.toml`. Copy the example to
-`/etc/mxlrcgo-svc/config.toml` and edit it before starting the service.
+`/etc/mxlrcgo-svc/config.example.toml`. It also creates a `mxlrcgo-svc`
+system user and a state directory at `/var/lib/mxlrcgo-svc` (mode `0750`) that
+holds the SQLite database. The service does **not** start automatically on
+install.
+
+After installing, copy the example config, set your token, and start the service:
+
+```sh
+sudo cp /etc/mxlrcgo-svc/config.example.toml /etc/mxlrcgo-svc/config.toml
+# edit /etc/mxlrcgo-svc/config.toml and set [api] token = "YOUR_TOKEN"
+sudo systemctl enable --now mxlrcgo-svc   # systemd
+# or: sudo rc-update add mxlrcgo-svc default && sudo rc-service mxlrcgo-svc start  # Alpine OpenRC
+```
+
+The state directory and system user are preserved on package removal so the
+database survives upgrades and reinstalls. See the
+[User Guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/#native-packages)
+for service commands, log access, and data paths.
 
 **Tarballs / macOS / Windows:** Versioned archives for all platforms are also
 available on the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -66,7 +66,9 @@ mxlrcgo-svc "Dream Theater"
 >
 > **_The `-d/--depth` argument limits the depth of subdirectories to scan; use `-d 0` or `--depth 0` to only scan the specified directory._**
 
-The `--upgrade` flag re-fetches songs that previously produced a `.txt` (unsynced) file, to promote them to `.lrc` when synced lyrics later become available.
+The `--upgrade` flag re-fetches tracks that previously produced a `.txt` (unsynced) file, to promote them to `.lrc` when synced lyrics later become available. Instrumental tracks are always written as `.txt` and are excluded from upgrade - only `--update` (full re-fetch) overrides them.
+
+In directory mode, when audio tags carry ISRC, MusicBrainz recording ID, or duration, those values are read and passed to Musixmatch to improve match precision - for example, distinguishing two recordings of the same title.
 
 ## Serve
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,15 +28,23 @@ To obtain a token, follow steps 1 to 5 from the [Spicetify guide](https://spicet
 
 For all settings, precedence is **CLI flag > environment variable > config file > built-in default**.
 
-## Storage paths (XDG defaults)
+## Storage paths
 
-`mxlrcgo-svc` resolves its config file and SQLite database using XDG base directories by default. When `MXLRC_DOCKER=true` (set automatically in the published images), storage defaults resolve under `/config` instead:
+`mxlrcgo-svc` resolves its config file and SQLite database using XDG base directories by default, with overrides for Docker and native packages.
 
-- Config file: XDG config dir, or `/config/config.toml` in Docker.
-- Database: XDG data dir, or `/config/mxlrcgo.db` in Docker.
-- Output dir: XDG, or `/music` (the image default).
+| Install method | Config file | Database |
+|----------------|-------------|----------|
+| XDG (default) | `$XDG_CONFIG_HOME/mxlrcgo-svc/config.toml` | `$XDG_DATA_HOME/mxlrcgo-svc/mxlrcgo.db` |
+| Docker (`MXLRC_DOCKER=true`) | `/config/config.toml` | `/config/mxlrcgo.db` |
+| Native package (`.deb`/`.rpm`/`.apk`) | `/etc/mxlrcgo-svc/config.toml` | `/var/lib/mxlrcgo-svc/mxlrcgo.db` |
 
-Override any of these explicitly with `MXLRC_DB_PATH`, `MXLRC_OUTPUT_DIR`, or the `--config` flag.
+Native packages run the service as the `mxlrcgo-svc` system user; that user owns `/var/lib/mxlrcgo-svc` (mode `0750`). The state directory and system user are preserved on package removal so the database survives an upgrade or reinstall.
+
+Override any path explicitly with `MXLRC_DB_PATH`, `MXLRC_OUTPUT_DIR`, or the `--config` flag.
+
+### Instrumental tracks and `--upgrade`
+
+Instrumental tracks always write a `.txt` marker file. These files are intentionally excluded from `--upgrade` promotion: re-fetching an instrumental would simply produce the same marker. Use `--update` (full re-fetch) if you want to force a re-check of an instrumental marker after a catalog change.
 
 ## Environment variables
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -44,7 +44,7 @@ On success, a lyric file is written to the current directory (or to the director
 - **`.lrc`** - synced lyrics, with per-line `[MM:SS.cc]` timestamps. This is the goal.
 - **`.txt`** - unsynced (plain) lyrics, or an instrumental marker (`♪ Instrumental ♪`) when the track has no words.
 
-A `.txt` result is not a failure. It means synced lyrics were not available, so the best available content was written instead. If synced lyrics appear later, you can promote the file (see `--upgrade` below).
+A `.txt` result is not a failure. It means synced lyrics were not available, so the best available content was written instead. If synced lyrics appear later, you can promote the file (see `--upgrade` below). Note: if the file is an instrumental marker (`♪ Instrumental ♪`), it is excluded from `--upgrade` promotion - `--update` is the only flag that forces a re-fetch of instrumental markers.
 
 For multiple songs, a text-file batch, and every flag, see the [CLI Reference](CLI_REFERENCE.md#fetch).
 
@@ -60,7 +60,8 @@ Notes:
 
 - The lyric file is written **next to each audio file**, so `-o/--outdir` is ignored in directory mode.
 - `-d/--depth` limits recursion depth (default `100`); `-d 0` scans only the given directory.
-- `--upgrade` re-fetches tracks that previously produced a `.txt` (unsynced) file, to promote them to `.lrc` once synced lyrics become available.
+- `--upgrade` re-fetches tracks that previously produced a `.txt` (unsynced) file, to promote them to `.lrc` once synced lyrics become available. **Instrumental `.txt` files are excluded from upgrade**; use `--update` to force a re-fetch of those.
+- When audio files contain ISRC, MusicBrainz recording ID, or duration tags, the scanner reads them automatically and passes them to Musixmatch to improve match precision - especially useful for albums with tracks that share the same title. See [Recording enrichment](USER_GUIDE.md#recording-enrichment) for controls.
 
 A bare argument that matches an existing directory triggers a recursive scan. That means `mxlrcgo-svc "Dream Theater"` scans a folder named `Dream Theater`; it is not interpreted as a song query. Use the `artist,title` form for one-shot fetches.
 
@@ -69,6 +70,8 @@ Test on a single album first to confirm the result before scanning a whole libra
 ## Daemon / serve
 
 For Lidarr or always-on container use, run the HTTP server. It accepts Lidarr webhooks, scans your registered libraries on a schedule, and processes work through a durable queue.
+
+If you installed via a `.deb`, `.rpm`, or `.apk` package, the service is managed with `systemctl` (or `rc-service` on Alpine) and stores its data under `/var/lib/mxlrcgo-svc`. See [Native packages](USER_GUIDE.md#native-packages) in the User Guide before starting.
 
 Register a library, then start the server:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,152 @@
+# Install Guide
+
+This page compares the available install methods and helps you pick one. For a quick start after installing, see [Getting Started](GETTING_STARTED.md).
+
+## Comparison
+
+| Method | Best for | Auto-updates | System service | State location |
+|--------|----------|:------------:|:--------------:|----------------|
+| Native package (`.deb` / `.rpm` / `.apk`) | Linux servers, headless hosts | via package manager | yes (systemd / OpenRC) | `/var/lib/mxlrcgo-svc` |
+| Docker / Compose | Containers, Unraid, NAS | via image tag | via compose / container runtime | `/config` volume |
+| Homebrew | macOS, Linuxbrew | `brew upgrade` | via `brew services` | XDG data dir |
+| Tarball / zip | Any platform, air-gapped | manual | manual | XDG data dir |
+| `go install` | Developers, bleeding-edge | manual | manual | XDG data dir |
+
+---
+
+## Native packages (Linux)
+
+Download the `.deb`, `.rpm`, or `.apk` for your distro from the
+[GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases) page.
+
+```sh
+# Debian / Ubuntu
+sudo dpkg -i mxlrcgo-svc_*.deb
+
+# RHEL / Fedora / Rocky
+sudo rpm -i mxlrcgo-svc_*.rpm
+
+# Alpine
+sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
+```
+
+**What the package does:**
+
+- Installs the binary to `/usr/local/bin/mxlrcgo-svc`.
+- Creates a `mxlrcgo-svc` system user and group (no login shell).
+- Creates `/var/lib/mxlrcgo-svc` (mode `0750`, owned by `mxlrcgo-svc:mxlrcgo-svc`) for the SQLite database and state.
+- Installs a systemd unit (or OpenRC script on Alpine) with hardening (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`).
+- Places an example config at `/etc/mxlrcgo-svc/config.example.toml`.
+- Does **not** enable or start the service automatically.
+
+**First-time setup:**
+
+```sh
+sudo cp /etc/mxlrcgo-svc/config.example.toml /etc/mxlrcgo-svc/config.toml
+# Edit config.toml and set [api] token = "YOUR_TOKEN" (and any other settings)
+sudo systemctl enable --now mxlrcgo-svc        # systemd
+# or on Alpine:
+# sudo rc-update add mxlrcgo-svc default
+# sudo rc-service mxlrcgo-svc start
+```
+
+**Service commands (systemd):**
+
+```sh
+sudo systemctl start   mxlrcgo-svc
+sudo systemctl stop    mxlrcgo-svc
+sudo systemctl restart mxlrcgo-svc
+sudo systemctl status  mxlrcgo-svc
+sudo journalctl -u mxlrcgo-svc -f
+```
+
+**Service commands (OpenRC / Alpine):**
+
+```sh
+sudo rc-service mxlrcgo-svc start
+sudo rc-service mxlrcgo-svc stop
+sudo rc-service mxlrcgo-svc restart
+sudo rc-service mxlrcgo-svc status
+```
+
+**Uninstall note:** Package removal stops the service but preserves
+`/var/lib/mxlrcgo-svc` and the system user so the database survives a
+reinstall or upgrade. Remove them manually for a clean uninstall:
+
+```sh
+sudo rm -rf /var/lib/mxlrcgo-svc
+sudo userdel mxlrcgo-svc
+sudo groupdel mxlrcgo-svc
+```
+
+See [Native packages](USER_GUIDE.md#native-packages) in the User Guide for the
+full operational reference.
+
+---
+
+## Docker
+
+The published image is `ghcr.io/sydlexius/mxlrcgo-svc`. It runs the server on
+port `50705` and stores config and the SQLite database under the `/config`
+volume. Mount your media data parent to `/data`:
+
+```sh
+docker run -d \
+  --name mxlrcgo-svc \
+  -p 50705:50705 \
+  -e MUSIXMATCH_TOKEN=YOUR_TOKEN \
+  -e MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key \
+  -e PUID=99 -e PGID=100 \
+  -e MXLRC_OUTPUT_DIR=/data/media/music \
+  -v mxlrcgo-svc-config:/config \
+  -v /path/to/your/data:/data:rw \
+  --restart unless-stopped \
+  ghcr.io/sydlexius/mxlrcgo-svc:latest
+```
+
+For Docker Compose, copy `docker-compose.example.yml`, fill in the token and
+key, adjust the music volume, and run `docker compose up -d`.
+
+See the [User Guide](USER_GUIDE.md#docker) for the full Docker and Unraid
+setup.
+
+---
+
+## Homebrew (macOS / Linuxbrew)
+
+```sh
+brew install sydlexius/tap/mxlrcgo-svc
+```
+
+Upgrade with `brew upgrade mxlrcgo-svc`. Run as a background service with
+`brew services start mxlrcgo-svc`. Storage defaults follow XDG base directories.
+
+---
+
+## Tarball / zip
+
+Download the archive for your platform from the
+[GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases) page,
+extract the binary, and place it on your `PATH`. On Windows, the signed `.zip`
+extracts `mxlrcgo-svc.exe`; see the [Windows](USER_GUIDE.md#windows) section of
+the User Guide for NSSM service installation.
+
+---
+
+## Build from source
+
+Requires Go 1.26.4 or later.
+
+```sh
+go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest
+```
+
+Or clone the repository and use `make`:
+
+```sh
+git clone https://github.com/sydlexius/mxlrcgo-svc.git
+cd mxlrcgo-svc
+make build
+```
+
+See the [Developer Guide](DEVELOPER.md) for the full build and test setup.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,10 +21,10 @@ Download the `.deb`, `.rpm`, or `.apk` for your distro from the
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i mxlrcgo-svc_*.deb
+sudo apt install ./mxlrcgo-svc_*.deb
 
 # RHEL / Fedora / Rocky
-sudo rpm -i mxlrcgo-svc_*.rpm
+sudo dnf install ./mxlrcgo-svc_*.rpm
 
 # Alpine
 sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
@@ -90,12 +90,19 @@ The published image is `ghcr.io/sydlexius/mxlrcgo-svc`. It runs the server on
 port `50705` and stores config and the SQLite database under the `/config`
 volume. Mount your media data parent to `/data`:
 
+Export secrets first so they are not inlined in the command (prevents shell history and `ps` exposure):
+
+```sh
+export MUSIXMATCH_TOKEN=YOUR_TOKEN
+export MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key
+```
+
 ```sh
 docker run -d \
   --name mxlrcgo-svc \
   -p 50705:50705 \
-  -e MUSIXMATCH_TOKEN=YOUR_TOKEN \
-  -e MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key \
+  -e MUSIXMATCH_TOKEN \
+  -e MXLRC_WEBHOOK_API_KEY \
   -e PUID=99 -e PGID=100 \
   -e MXLRC_OUTPUT_DIR=/data/media/music \
   -v mxlrcgo-svc-config:/config \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -35,7 +35,7 @@ sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
 - Installs the binary to `/usr/local/bin/mxlrcgo-svc`.
 - Creates a `mxlrcgo-svc` system user and group (no login shell).
 - Creates `/var/lib/mxlrcgo-svc` (mode `0750`, owned by `mxlrcgo-svc:mxlrcgo-svc`) for the SQLite database and state.
-- Installs a systemd unit (or OpenRC script on Alpine) with hardening (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`).
+- Installs a systemd unit with hardening (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`), or an OpenRC script on Alpine (manages ownership and permissions via `start_pre`).
 - Places an example config at `/etc/mxlrcgo-svc/config.example.toml`.
 - Does **not** enable or start the service automatically.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -192,6 +192,62 @@ Even signed binaries can trigger the "Windows protected your PC" prompt on first
 
 This prompt should not appear again after the first run. See [issue #183](https://github.com/sydlexius/mxlrcgo-svc/issues/183) for background on code signing.
 
+## Native packages
+
+The `.deb`, `.rpm`, and `.apk` packages install the binary, a service unit, and an example config. They do not enable or start the service on install; you must do that manually after setting your token.
+
+### System user and state directory
+
+The post-install script creates a `mxlrcgo-svc` system user and group (no login shell, no home-directory creation), then initializes `/var/lib/mxlrcgo-svc` (mode `0750`, owned by `mxlrcgo-svc:mxlrcgo-svc`). The service unit sets `MXLRC_DB_PATH=/var/lib/mxlrcgo-svc/mxlrcgo.db` and `MXLRC_LOG_FORMAT=json` in its environment.
+
+### Hardening
+
+The systemd unit runs with `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`, and `NoNewPrivileges=true`. Only `/var/lib/mxlrcgo-svc` is writable. The OpenRC service on Alpine enforces the same ownership via `start_pre`.
+
+### Config file
+
+Copy the example and set your token before starting the service:
+
+```sh
+sudo cp /etc/mxlrcgo-svc/config.example.toml /etc/mxlrcgo-svc/config.toml
+sudo editor /etc/mxlrcgo-svc/config.toml
+```
+
+The service reads `/etc/mxlrcgo-svc/config.toml` automatically when `MXLRC_DB_PATH` is the native-package default. Pass `--config /etc/mxlrcgo-svc/config.toml` explicitly if you override the database path.
+
+### Service management
+
+**systemd (Debian / Ubuntu / RHEL / Fedora / Rocky):**
+
+```sh
+sudo systemctl enable mxlrcgo-svc   # start on boot
+sudo systemctl start mxlrcgo-svc
+sudo systemctl stop mxlrcgo-svc
+sudo systemctl restart mxlrcgo-svc
+sudo systemctl status mxlrcgo-svc
+sudo journalctl -u mxlrcgo-svc -f   # follow logs
+```
+
+**OpenRC (Alpine):**
+
+```sh
+sudo rc-update add mxlrcgo-svc default   # start on boot
+sudo rc-service mxlrcgo-svc start
+sudo rc-service mxlrcgo-svc stop
+sudo rc-service mxlrcgo-svc restart
+sudo rc-service mxlrcgo-svc status
+```
+
+### Data preservation on removal
+
+Package removal stops the service but intentionally preserves `/var/lib/mxlrcgo-svc` (the SQLite database and any config) and the `mxlrcgo-svc` system user. This means reinstalling or upgrading the package keeps your cache and settings. Remove the directory manually for a clean uninstall:
+
+```sh
+sudo rm -rf /var/lib/mxlrcgo-svc
+sudo userdel mxlrcgo-svc
+sudo groupdel mxlrcgo-svc
+```
+
 ## Recording enrichment
 
 Recording enrichment reads the ISRC, MusicBrainz recording ID, and duration from each file's audio tags and passes them to the matcher to disambiguate results (for example, telling two same-titled recordings apart). It is on by default.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,10 @@ New here? Start with the [Getting Started](GETTING_STARTED.md) guide - it picks 
 
 ## Documentation
 
-- [User Guide](USER_GUIDE.md) - run the webhook server, Docker and Unraid deployment, path resolution, health endpoints, the filesystem watcher, shell completion, and inspection commands.
+- [Install Guide](INSTALL.md) - comparison of native packages, Docker, Homebrew, tarball, and source installs; first-time setup per method.
+- [User Guide](USER_GUIDE.md) - run the webhook server, Docker and Unraid deployment, native-package service management, path resolution, health endpoints, the filesystem watcher, shell completion, and inspection commands.
 - [CLI Reference](CLI_REFERENCE.md) - the full usage text, every subcommand and flag, `--version` output, and the library/key-management commands.
-- [Configuration](CONFIGURATION.md) - the complete environment-variable table, the TOML config keys, token precedence, and XDG path defaults.
+- [Configuration](CONFIGURATION.md) - the complete environment-variable table, the TOML config keys, token precedence, and XDG/Docker/native-package path defaults.
 - [Developer Guide](DEVELOPER.md) - development setup, make targets, the quality gate, contributing notes, and design decisions.
 
 ## Legal

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -78,6 +78,7 @@ extra:
 nav:
   - Home: index.md
   - Getting Started: GETTING_STARTED.md
+  - Install Guide: INSTALL.md
   - User Guide: USER_GUIDE.md
   - CLI Reference: CLI_REFERENCE.md
   - Configuration: CONFIGURATION.md


### PR DESCRIPTION
## Summary

Refresh the user-facing docs for behaviors shipped since the last docs pass, and add a unified install guide.

- **`--upgrade` instrumental caveat**: document that `--upgrade` does NOT re-fetch instrumental `.txt` markers (only `--update` overrides them) - the docs previously implied otherwise (CLI_REFERENCE, GETTING_STARTED, CONFIGURATION, USER_GUIDE).
- **Native-package operation**: document the system user, state dir (`/var/lib/mxlrcgo-svc`), hardening (systemd directives vs OpenRC `start_pre`), service commands for systemd AND OpenRC, and data preservation on removal (README, CONFIGURATION, USER_GUIDE, GETTING_STARTED).
- **Recording enrichment**: surface ISRC / MusicBrainz recording ID / duration tag enrichment in user-facing docs.
- **`docs/INSTALL.md`** (new): unified install guide (native package / Docker / Homebrew / tarball / source) with a comparison table, wired into the nav.

All facts verified against the code and packaging scripts (scanner.go, `build/package/*`). Docs-only; no behavior change.

## Linked issue

Closes #205

## Test plan

- [x] Hostile doc-accuracy review (lead-driven): every claim verified vs code/packaging; 1 finding (OpenRC hardening attribution) found + fixed + re-verified
- [x] Pre-commit clean; nav entries resolve; no conflict markers
- [ ] Codoki auto-review