### PR TITLE
feat: log version + effective config/env at session startup (redacted)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -358,13 +358,13 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 	switch {
 	case !usesSubcommand(rawArgs):
 		if legacy.Serve {
-			return runServe(ctx, legacyServe(legacy), deps.NewFetcher, deps.NewWriter)
+			return runServe(ctx, out, legacyServe(legacy), deps.NewFetcher, deps.NewWriter)
 		}
 		return runFetch(ctx, out, legacyFetch(legacy), deps.NewFetcher, deps.NewWriter, deps.NewApp)
 	case args.Fetch != nil:
 		return runFetch(ctx, out, *args.Fetch, deps.NewFetcher, deps.NewWriter, deps.NewApp)
 	case args.Serve != nil:
-		return runServe(ctx, *args.Serve, deps.NewFetcher, deps.NewWriter)
+		return runServe(ctx, out, *args.Serve, deps.NewFetcher, deps.NewWriter)
 	case args.Scan != nil:
 		return runScanCmd(ctx, out, *args.Scan)
 	case args.Library != nil:
@@ -465,6 +465,35 @@ func initLogging(cfg config.Config) {
 	})
 }
 
+// logStartupBanner emits a startup banner to the console (out) and via slog.
+// The console receives the build version line followed by the full
+// FormatConfigText dump. slog INFO receives the version and key diagnostic
+// settings; slog DEBUG receives the complete structured config via
+// ConfigToSlogAttrs. Sensitive fields are redacted in all output paths.
+// cliSrc is a set of config field paths that were overridden on the command
+// line; it may be nil.
+func logStartupBanner(ctx context.Context, cfg config.Config, ver string, out io.Writer, cliSrc map[string]bool) {
+	envSrc := config.GetSetEnvVars()
+
+	// Console: version line + full TOML-style config dump.
+	_, _ = fmt.Fprintf(out, "%s\n\n", ver)
+	_, _ = fmt.Fprint(out, config.FormatConfigText(cfg, envSrc, cliSrc))
+	_, _ = fmt.Fprintln(out)
+
+	// slog INFO: version + key diagnostic settings (always visible at INFO level).
+	slog.InfoContext(ctx, "startup",
+		"version", ver,
+		"api_token_set", cfg.API.Token != "",
+		"output_dir", cfg.Output.Dir,
+		"log_level", cfg.Logging.Level,
+		"server_addr", cfg.Server.Addr,
+	)
+
+	// slog DEBUG: full structured config dump.
+	attrs := config.ConfigToSlogAttrs(cfg, envSrc, cliSrc)
+	slog.LogAttrs(ctx, slog.LevelDebug, "startup config", attrs...)
+}
+
 func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer, newApp func(musixmatch.Fetcher, lyrics.Writer, *queue.InputsQueue, int, string) AppRunner) int {
 	if len(args.Song) == 0 {
 		_, _ = fmt.Fprintln(out, "missing required positional argument: Song")
@@ -488,6 +517,24 @@ func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func
 	if args.Outdir != nil {
 		outdir = *args.Outdir
 	}
+
+	// Emit startup banner after initLogging (log file is ready) and after all
+	// CLI flag overrides are applied so the banner reflects effective values.
+	fetchBannerCfg := cfg
+	fetchBannerCfg.API.Token = token
+	fetchBannerCfg.API.Cooldown = cooldown
+	fetchBannerCfg.Output.Dir = outdir
+	fetchCLISrc := map[string]bool{}
+	if args.Token != "" {
+		fetchCLISrc["api.token"] = true
+	}
+	if args.Cooldown != nil {
+		fetchCLISrc["api.cooldown"] = true
+	}
+	if args.Outdir != nil {
+		fetchCLISrc["output.dir"] = true
+	}
+	logStartupBanner(ctx, fetchBannerCfg, VersionString(), out, fetchCLISrc)
 	fetcher, err := selectedProvider(cfg, token, newFetcher)
 	if err != nil {
 		slog.Error("failed to configure lyrics provider", "error", err)
@@ -594,7 +641,7 @@ func lyricPreview(song models.Song, n int) string {
 	return strings.Join(lines, "\n")
 }
 
-func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer) int {
+func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer) int {
 	cfg, err := config.Load(args.ConfigPath)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
@@ -609,6 +656,28 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 	if args.Outdir != nil {
 		outdir = *args.Outdir
 	}
+	addr := cfg.Server.Addr
+	if args.Listen != nil {
+		addr = *args.Listen
+	}
+
+	// Emit startup banner after initLogging (log file is ready) and after all
+	// CLI flag overrides are applied so the banner reflects effective values.
+	bannerCfg := cfg
+	bannerCfg.API.Token = token
+	bannerCfg.Output.Dir = outdir
+	bannerCfg.Server.Addr = addr
+	serveCLISrc := map[string]bool{}
+	if args.Token != "" {
+		serveCLISrc["api.token"] = true
+	}
+	if args.Outdir != nil {
+		serveCLISrc["output.dir"] = true
+	}
+	if args.Listen != nil {
+		serveCLISrc["server.addr"] = true
+	}
+	logStartupBanner(ctx, bannerCfg, VersionString(), out, serveCLISrc)
 	fetcher, err := selectedProvider(cfg, token, newFetcher)
 	if err != nil {
 		slog.Error("failed to configure lyrics provider", "error", err)
@@ -691,10 +760,6 @@ func runServe(ctx context.Context, args ServeCmd, newFetcher func(string) musixm
 		}()
 	}
 
-	addr := cfg.Server.Addr
-	if args.Listen != nil {
-		addr = *args.Listen
-	}
 	srv := &http.Server{
 		Addr: addr,
 		Handler: server.NewHandler(authSvc, workQ, outdir,

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -471,10 +471,9 @@ func initLogging(cfg config.Config) {
 // settings; slog DEBUG receives the complete structured config via
 // ConfigToSlogAttrs. Sensitive fields are redacted in all output paths.
 // cliSrc is a set of config field paths that were overridden on the command
-// line; it may be nil.
-func logStartupBanner(ctx context.Context, cfg config.Config, ver string, out io.Writer, cliSrc map[string]bool) {
-	envSrc := config.GetSetEnvVars()
-
+// line; envSrc is the set whose environment override actually applied (from
+// config.LoadWithSources). Both may be nil.
+func logStartupBanner(ctx context.Context, cfg config.Config, ver string, out io.Writer, envSrc, cliSrc map[string]bool) {
 	// Console: version line + full TOML-style config dump.
 	_, _ = fmt.Fprintf(out, "%s\n\n", ver)
 	_, _ = fmt.Fprint(out, config.FormatConfigText(cfg, envSrc, cliSrc))
@@ -499,7 +498,7 @@ func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func
 		_, _ = fmt.Fprintln(out, "missing required positional argument: Song")
 		return 2
 	}
-	cfg, err := config.Load(args.ConfigPath)
+	cfg, envSrc, err := config.LoadWithSources(args.ConfigPath)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
 		return 1
@@ -534,7 +533,7 @@ func runFetch(ctx context.Context, out io.Writer, args FetchCmd, newFetcher func
 	if args.Outdir != nil {
 		fetchCLISrc["output.dir"] = true
 	}
-	logStartupBanner(ctx, fetchBannerCfg, VersionString(), out, fetchCLISrc)
+	logStartupBanner(ctx, fetchBannerCfg, VersionString(), out, envSrc, fetchCLISrc)
 	fetcher, err := selectedProvider(cfg, token, newFetcher)
 	if err != nil {
 		slog.Error("failed to configure lyrics provider", "error", err)
@@ -642,7 +641,7 @@ func lyricPreview(song models.Song, n int) string {
 }
 
 func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func(string) musixmatch.Fetcher, newWriter func(roots ...string) lyrics.Writer) int {
-	cfg, err := config.Load(args.ConfigPath)
+	cfg, envSrc, err := config.LoadWithSources(args.ConfigPath)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
 		return 1
@@ -677,7 +676,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	if args.Listen != nil {
 		serveCLISrc["server.addr"] = true
 	}
-	logStartupBanner(ctx, bannerCfg, VersionString(), out, serveCLISrc)
+	logStartupBanner(ctx, bannerCfg, VersionString(), out, envSrc, serveCLISrc)
 	fetcher, err := selectedProvider(cfg, token, newFetcher)
 	if err != nil {
 		slog.Error("failed to configure lyrics provider", "error", err)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2392,3 +2392,52 @@ func TestRunQueueRecheck_DBOpenError(t *testing.T) {
 		t.Fatalf("db-open-error exit code = %d; want 1. out=%s", code, out.String())
 	}
 }
+
+// TestLogStartupBanner_EmitsVersion verifies the startup banner writes the
+// version string to the console writer.
+func TestLogStartupBanner_EmitsVersion(t *testing.T) {
+	cfg := config.Config{
+		API:     config.APIConfig{Token: "topsecret", Cooldown: 15},
+		Output:  config.OutputConfig{Dir: "lyrics"},
+		Logging: config.LoggingConfig{Level: "info", Format: "text"},
+	}
+	var buf bytes.Buffer
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil)
+	got := buf.String()
+	if !strings.Contains(got, "mxlrcgo-svc test-ver") {
+		t.Errorf("version not in banner output: %q", got)
+	}
+}
+
+// TestLogStartupBanner_RedactsToken verifies the token never appears in
+// plaintext in the banner console output.
+func TestLogStartupBanner_RedactsToken(t *testing.T) {
+	cfg := config.Config{
+		API:     config.APIConfig{Token: "topsecret", Cooldown: 15},
+		Output:  config.OutputConfig{Dir: "lyrics"},
+		Logging: config.LoggingConfig{Level: "info", Format: "text"},
+	}
+	var buf bytes.Buffer
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil)
+	got := buf.String()
+	if strings.Contains(got, "topsecret") {
+		t.Errorf("token in plaintext in banner output: %q", got)
+	}
+}
+
+// TestLogStartupBanner_CLIAnnotation verifies the (cli) source annotation
+// appears in the console output when a field is in the cliSrc map.
+func TestLogStartupBanner_CLIAnnotation(t *testing.T) {
+	cfg := config.Config{
+		API:     config.APIConfig{Cooldown: 30},
+		Output:  config.OutputConfig{Dir: "custom-dir"},
+		Logging: config.LoggingConfig{Level: "info", Format: "text"},
+	}
+	cliSrc := map[string]bool{"output.dir": true}
+	var buf bytes.Buffer
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, cliSrc)
+	got := buf.String()
+	if !strings.Contains(got, "(cli)") {
+		t.Errorf("missing (cli) annotation in banner output: %q", got)
+	}
+}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2402,7 +2402,7 @@ func TestLogStartupBanner_EmitsVersion(t *testing.T) {
 		Logging: config.LoggingConfig{Level: "info", Format: "text"},
 	}
 	var buf bytes.Buffer
-	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil)
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil, nil)
 	got := buf.String()
 	if !strings.Contains(got, "mxlrcgo-svc test-ver") {
 		t.Errorf("version not in banner output: %q", got)
@@ -2418,7 +2418,7 @@ func TestLogStartupBanner_RedactsToken(t *testing.T) {
 		Logging: config.LoggingConfig{Level: "info", Format: "text"},
 	}
 	var buf bytes.Buffer
-	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil)
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil, nil)
 	got := buf.String()
 	if strings.Contains(got, "topsecret") {
 		t.Errorf("token in plaintext in banner output: %q", got)
@@ -2435,7 +2435,7 @@ func TestLogStartupBanner_CLIAnnotation(t *testing.T) {
 	}
 	cliSrc := map[string]bool{"output.dir": true}
 	var buf bytes.Buffer
-	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, cliSrc)
+	logStartupBanner(context.Background(), cfg, "mxlrcgo-svc test-ver", &buf, nil, cliSrc)
 	got := buf.String()
 	if !strings.Contains(got, "(cli)") {
 		t.Errorf("missing (cli) annotation in banner output: %q", got)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,7 +310,18 @@ func defaults() Config {
 // Load reads the TOML config file at path (or XDG default if empty),
 // then overlays environment variables. A missing config file is not an error.
 func Load(path string) (Config, error) {
+	cfg, _, err := LoadWithSources(path)
+	return cfg, err
+}
+
+// LoadWithSources is Load plus the set of config field paths whose environment
+// override was ACTUALLY APPLIED (invalid env values that were rejected are not
+// included). The returned map is suitable as the envSrc hint for
+// FormatConfigText / ConfigToSlogAttrs so a field is annotated "(env)" only
+// when its override truly took effect. The map is non-nil even on error.
+func LoadWithSources(path string) (Config, map[string]bool, error) {
 	cfg := defaults()
+	appliedEnv := map[string]bool{}
 	if path == "" {
 		path = xdgConfigPath("mxlrcgo-svc", "config.toml")
 	}
@@ -318,7 +329,7 @@ func Load(path string) (Config, error) {
 		if _, err := os.Stat(path); err == nil {
 			md, err := toml.DecodeFile(path, &cfg)
 			if err != nil {
-				return cfg, fmt.Errorf("config: decode %s: %w", path, err)
+				return cfg, appliedEnv, fmt.Errorf("config: decode %s: %w", path, err)
 			}
 			// Re-apply defaults for any fields the file set to blank.
 			// This prevents a user copying config.example.toml verbatim from
@@ -443,17 +454,17 @@ func Load(path string) (Config, error) {
 				cfg.Logging.Compress = d.Logging.Compress
 			}
 		} else if !os.IsNotExist(err) {
-			return cfg, fmt.Errorf("config: stat %s: %w", path, err)
+			return cfg, appliedEnv, fmt.Errorf("config: stat %s: %w", path, err)
 		}
 	}
-	applyEnvOverrides(&cfg)
+	applyEnvOverrides(&cfg, appliedEnv)
 	normalizeEmbeddedLyrics(&cfg)
 	if err := normalizeProvidersMode(&cfg); err != nil {
-		return cfg, err
+		return cfg, appliedEnv, err
 	}
 	normalizeProvidersRaceWait(&cfg)
 	if err := normalizeProvidersFallback(&cfg); err != nil {
-		return cfg, err
+		return cfg, appliedEnv, err
 	}
 	clampCircuitOpenDuration(&cfg)
 	// Must run AFTER clampCircuitOpenDuration: the base is clamped against the
@@ -461,21 +472,28 @@ func Load(path string) (Config, error) {
 	clampCircuitBackoffBase(&cfg)
 	clampMissBackoff(&cfg)
 	if cfg.DB.Path == "" {
-		return cfg, fmt.Errorf("config: cannot determine DB path: set MXLRC_DB_PATH or XDG_DATA_HOME")
+		return cfg, appliedEnv, fmt.Errorf("config: cannot determine DB path: set MXLRC_DB_PATH or XDG_DATA_HOME")
 	}
-	return cfg, nil
+	return cfg, appliedEnv, nil
 }
 
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
 // Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
-func applyEnvOverrides(cfg *Config) {
+//
+// applied (must be non-nil) records the dotted config field path for every
+// override that ACTUALLY took effect. Env values that are rejected (invalid
+// numeric/bool, out-of-range) leave the prior value in place and are NOT
+// recorded, so callers can annotate "(env)" only for overrides that applied.
+func applyEnvOverrides(cfg *Config, applied map[string]bool) {
 	// Token: MUSIXMATCH_TOKEN takes precedence over MXLRC_API_TOKEN (backward compat).
 	if v := os.Getenv("MUSIXMATCH_TOKEN"); v != "" {
 		cfg.API.Token = v
+		applied["api.token"] = true
 	} else if v := os.Getenv("MXLRC_API_TOKEN"); v != "" {
 		cfg.API.Token = v
+		applied["api.token"] = true
 	}
 
 	// Cooldown: MXLRC_API_COOLDOWN (section-scoped) takes precedence over MXLRC_COOLDOWN (short alias).
@@ -491,6 +509,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", cooldownVar, "value", v, "current", cfg.API.Cooldown) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.Cooldown = n
+			applied["api.cooldown"] = true
 		}
 	}
 
@@ -500,6 +519,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_API_CIRCUIT_OPEN_DURATION", "value", v, "current", cfg.API.CircuitOpenDuration) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.CircuitOpenDuration = n
+			applied["api.circuit_open_duration"] = true
 		}
 	}
 
@@ -509,6 +529,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_API_CIRCUIT_BACKOFF_BASE", "value", v, "current", cfg.API.CircuitBackoffBase) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.CircuitBackoffBase = n
+			applied["api.circuit_backoff_base_seconds"] = true
 		}
 	}
 
@@ -518,6 +539,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MISS_BACKOFF_BASE_HOURS", "value", v, "current", cfg.API.MissBackoffBaseHours) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.MissBackoffBaseHours = n
+			applied["api.miss_backoff_base_hours"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_MISS_BACKOFF_CAP_HOURS"); v != "" {
@@ -526,6 +548,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MISS_BACKOFF_CAP_HOURS", "value", v, "current", cfg.API.MissBackoffCapHours) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.MissBackoffCapHours = n
+			applied["api.miss_backoff_cap_hours"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_MAX_MISS_ATTEMPTS"); v != "" {
@@ -534,14 +557,17 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_MAX_MISS_ATTEMPTS", "value", v, "current", cfg.API.MaxMissAttempts) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.API.MaxMissAttempts = n
+			applied["api.max_miss_attempts"] = true
 		}
 	}
 
 	if v := os.Getenv("MXLRC_OUTPUT_DIR"); v != "" {
 		cfg.Output.Dir = v
+		applied["output.dir"] = true
 	}
 	if v := os.Getenv("MXLRC_EMBEDDED_LYRICS"); v != "" {
 		cfg.Output.EmbeddedLyrics = v
+		applied["output.embedded_lyrics"] = true
 	}
 	if v := os.Getenv("MXLRC_BILINGUAL_OUTPUT"); v != "" {
 		bilingual, err := strconv.ParseBool(v)
@@ -549,16 +575,20 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_BILINGUAL_OUTPUT", "value", v, "current", cfg.Output.BilingualOutput) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Output.BilingualOutput = bilingual
+			applied["output.bilingual_output"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_DB_PATH"); v != "" {
 		cfg.DB.Path = v
+		applied["db.path"] = true
 	}
 	if v := os.Getenv("MXLRC_SERVER_ADDR"); v != "" {
 		cfg.Server.Addr = v
+		applied["server.addr"] = true
 	}
 	if v := os.Getenv("MXLRC_WEBHOOK_API_KEY"); v != "" {
 		cfg.Server.WebhookAPIKeys = splitCSV(v)
+		applied["server.webhook_api_keys"] = true
 	}
 	if v := os.Getenv("MXLRC_SCAN_INTERVAL"); v != "" {
 		n, err := strconv.Atoi(v)
@@ -566,6 +596,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_SCAN_INTERVAL", "value", v, "current", cfg.Server.ScanIntervalSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Server.ScanIntervalSeconds = n
+			applied["server.scan_interval_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_WORK_INTERVAL"); v != "" {
@@ -574,16 +605,20 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_WORK_INTERVAL", "value", v, "current", cfg.Server.WorkIntervalSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Server.WorkIntervalSeconds = n
+			applied["server.work_interval_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_PROVIDER_PRIMARY"); v != "" {
 		cfg.Providers.Primary = v
+		applied["providers.primary"] = true
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_DISABLED"); v != "" {
 		cfg.Providers.Disabled = splitCSV(v)
+		applied["providers.disabled"] = true
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_MODE"); v != "" {
 		cfg.Providers.Mode = v
+		applied["providers.mode"] = true
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_RACE_WAIT_SECONDS"); v != "" {
 		n, err := strconv.Atoi(v)
@@ -591,10 +626,12 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_PROVIDERS_RACE_WAIT_SECONDS", "value", v, "current", cfg.Providers.RaceWaitSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Providers.RaceWaitSeconds = n
+			applied["providers.race_wait_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_PROVIDERS_FALLBACK_ORDER"); v != "" {
 		cfg.Providers.FallbackOrder = splitCSV(v)
+		applied["providers.fallback_order"] = true
 	}
 	if v := os.Getenv("MXLRC_VERIFICATION_ENABLED"); v != "" {
 		enabled, err := strconv.ParseBool(v)
@@ -602,6 +639,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_VERIFICATION_ENABLED", "value", v, "current", cfg.Verification.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.Enabled = enabled
+			applied["verification.enabled"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_QUEUE_RANDOMIZE"); v != "" {
@@ -610,6 +648,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_QUEUE_RANDOMIZE", "value", v, "current", cfg.Queue.Randomize) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Queue.Randomize = randomize
+			applied["queue.randomize"] = true
 		}
 	}
 	whisperVar := "MXLRC_VERIFICATION_WHISPER_URL"
@@ -620,9 +659,11 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v != "" {
 		cfg.Verification.WhisperURL = v
+		applied["verification.whisper_url"] = true
 	}
 	if v := os.Getenv("MXLRC_VERIFICATION_FFMPEG_PATH"); v != "" {
 		cfg.Verification.FFmpegPath = v
+		applied["verification.ffmpeg_path"] = true
 	}
 	sampleDurationVar := "MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS"
 	v = os.Getenv(sampleDurationVar)
@@ -636,6 +677,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", sampleDurationVar, "value", v, "current", cfg.Verification.SampleDurationSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.SampleDurationSeconds = n
+			applied["verification.sample_duration_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_VERIFICATION_MIN_CONFIDENCE"); v != "" {
@@ -644,6 +686,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_VERIFICATION_MIN_CONFIDENCE", "value", v, "current", cfg.Verification.MinConfidence) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.MinConfidence = n
+			applied["verification.min_confidence"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_VERIFICATION_MIN_SIMILARITY"); v != "" {
@@ -652,6 +695,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_VERIFICATION_MIN_SIMILARITY", "value", v, "current", cfg.Verification.MinSimilarity) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Verification.MinSimilarity = n
+			applied["verification.min_similarity"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_ENABLED"); v != "" {
@@ -660,6 +704,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_ENABLED", "value", v, "current", cfg.InstrumentalDetector.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.InstrumentalDetector.Enabled = enabled
+			applied["instrumental_detector.enabled"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_ENRICHMENT_ENABLED"); v != "" {
@@ -668,13 +713,16 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_ENRICHMENT_ENABLED", "value", v, "current", cfg.Enrichment.Enabled) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Enrichment.Enabled = enabled
+			applied["enrichment.enabled"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL"); v != "" {
 		cfg.InstrumentalDetector.ClassifierURL = v
+		applied["instrumental_detector.classifier_url"] = true
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH"); v != "" {
 		cfg.InstrumentalDetector.FFmpegPath = v
+		applied["instrumental_detector.ffmpeg_path"] = true
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS"); v != "" {
 		n, err := strconv.Atoi(v)
@@ -682,6 +730,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS", "value", v, "current", cfg.InstrumentalDetector.SampleDurationSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.InstrumentalDetector.SampleDurationSeconds = n
+			applied["instrumental_detector.sample_duration_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE"); v != "" {
@@ -690,10 +739,12 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE", "value", v, "current", cfg.InstrumentalDetector.MinConfidence) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.InstrumentalDetector.MinConfidence = n
+			applied["instrumental_detector.min_confidence"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_CLASSES"); v != "" {
 		cfg.InstrumentalDetector.InstrumentalClasses = splitCSV(v)
+		applied["instrumental_detector.instrumental_classes"] = true
 	}
 	if v := os.Getenv("MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS"); v != "" {
 		n, err := strconv.Atoi(v)
@@ -701,10 +752,12 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS", "value", v, "current", cfg.InstrumentalDetector.CooldownSeconds) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.InstrumentalDetector.CooldownSeconds = n
+			applied["instrumental_detector.cooldown_seconds"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_GUARD_ACCEPTED_SCRIPTS"); v != "" {
 		cfg.Guard.AcceptedScripts = splitCSV(v)
+		applied["guard.accepted_scripts"] = true
 	}
 	if v := os.Getenv("MXLRC_GUARD_THRESHOLD"); v != "" {
 		n, err := strconv.ParseFloat(v, 64)
@@ -712,17 +765,21 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_GUARD_THRESHOLD", "value", v, "current", cfg.Guard.Threshold) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Guard.Threshold = n
+			applied["guard.script_guard_threshold"] = true
 		}
 	}
 	// Logging: string env overrides.
 	if v := os.Getenv("MXLRC_LOG_LEVEL"); v != "" {
 		cfg.Logging.Level = v //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		applied["logging.level"] = true
 	}
 	if v := os.Getenv("MXLRC_LOG_FORMAT"); v != "" {
 		cfg.Logging.Format = v //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		applied["logging.format"] = true
 	}
 	if v := os.Getenv("MXLRC_LOG_FILE"); v != "" {
 		cfg.Logging.File = v //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		applied["logging.file"] = true
 	}
 	// Logging: integer env overrides.
 	if v := os.Getenv("MXLRC_LOG_MAX_SIZE_MB"); v != "" {
@@ -731,6 +788,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_LOG_MAX_SIZE_MB", "value", v, "current", cfg.Logging.MaxSizeMB) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Logging.MaxSizeMB = n
+			applied["logging.max_size_mb"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_LOG_MAX_FILES"); v != "" {
@@ -739,6 +797,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_LOG_MAX_FILES", "value", v, "current", cfg.Logging.MaxFiles) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Logging.MaxFiles = n
+			applied["logging.max_files"] = true
 		}
 	}
 	if v := os.Getenv("MXLRC_LOG_MAX_AGE_DAYS"); v != "" {
@@ -747,6 +806,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_LOG_MAX_AGE_DAYS", "value", v, "current", cfg.Logging.MaxAgeDays) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Logging.MaxAgeDays = n
+			applied["logging.max_age_days"] = true
 		}
 	}
 	// Logging: bool env override.
@@ -756,6 +816,7 @@ func applyEnvOverrides(cfg *Config) {
 			slog.Warn("env var is invalid; using current value", "var", "MXLRC_LOG_COMPRESS", "value", v, "current", cfg.Logging.Compress) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
 		} else {
 			cfg.Logging.Compress = compress
+			applied["logging.compress"] = true
 		}
 	}
 }
@@ -879,75 +940,6 @@ func clampMissBackoff(cfg *Config) {
 		slog.Warn("max_miss_attempts is negative; clamping to 0 (no cap)", "configured", cfg.API.MaxMissAttempts)
 		cfg.API.MaxMissAttempts = 0
 	}
-}
-
-// fieldEnvVars maps dotted config field paths to the environment variable
-// names that can override them, listed in priority order (highest first).
-// It is the canonical cross-reference between config field paths and env vars,
-// used by GetSetEnvVars to annotate which values were sourced from the
-// environment.
-var fieldEnvVars = map[string][]string{
-	"api.token":                                     {"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN"},
-	"api.cooldown":                                  {"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN"},
-	"api.circuit_open_duration":                     {"MXLRC_API_CIRCUIT_OPEN_DURATION"},
-	"api.circuit_backoff_base_seconds":              {"MXLRC_API_CIRCUIT_BACKOFF_BASE"},
-	"api.miss_backoff_base_hours":                   {"MXLRC_MISS_BACKOFF_BASE_HOURS"},
-	"api.miss_backoff_cap_hours":                    {"MXLRC_MISS_BACKOFF_CAP_HOURS"},
-	"api.max_miss_attempts":                         {"MXLRC_MAX_MISS_ATTEMPTS"},
-	"output.dir":                                    {"MXLRC_OUTPUT_DIR"},
-	"output.embedded_lyrics":                        {"MXLRC_EMBEDDED_LYRICS"},
-	"output.bilingual_output":                       {"MXLRC_BILINGUAL_OUTPUT"},
-	"db.path":                                       {"MXLRC_DB_PATH"},
-	"server.addr":                                   {"MXLRC_SERVER_ADDR"},
-	"server.webhook_api_keys":                       {"MXLRC_WEBHOOK_API_KEY"},
-	"server.scan_interval_seconds":                  {"MXLRC_SCAN_INTERVAL"},
-	"server.work_interval_seconds":                  {"MXLRC_WORK_INTERVAL"},
-	"providers.primary":                             {"MXLRC_PROVIDER_PRIMARY"},
-	"providers.disabled":                            {"MXLRC_PROVIDERS_DISABLED"},
-	"providers.mode":                                {"MXLRC_PROVIDERS_MODE"},
-	"providers.race_wait_seconds":                   {"MXLRC_PROVIDERS_RACE_WAIT_SECONDS"},
-	"providers.fallback_order":                      {"MXLRC_PROVIDERS_FALLBACK_ORDER"},
-	"verification.enabled":                          {"MXLRC_VERIFICATION_ENABLED"},
-	"verification.whisper_url":                      {"MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL"},
-	"verification.ffmpeg_path":                      {"MXLRC_VERIFICATION_FFMPEG_PATH"},
-	"verification.sample_duration_seconds":          {"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION"},
-	"verification.min_confidence":                   {"MXLRC_VERIFICATION_MIN_CONFIDENCE"},
-	"verification.min_similarity":                   {"MXLRC_VERIFICATION_MIN_SIMILARITY"},
-	"instrumental_detector.enabled":                 {"MXLRC_INSTRUMENTAL_DETECTOR_ENABLED"},
-	"instrumental_detector.classifier_url":          {"MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL"},
-	"instrumental_detector.ffmpeg_path":             {"MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH"},
-	"instrumental_detector.sample_duration_seconds": {"MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS"},
-	"instrumental_detector.min_confidence":          {"MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE"},
-	"instrumental_detector.instrumental_classes":    {"MXLRC_INSTRUMENTAL_DETECTOR_CLASSES"},
-	"instrumental_detector.cooldown_seconds":        {"MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS"},
-	"enrichment.enabled":                            {"MXLRC_ENRICHMENT_ENABLED"},
-	"guard.accepted_scripts":                        {"MXLRC_GUARD_ACCEPTED_SCRIPTS"},
-	"guard.script_guard_threshold":                  {"MXLRC_GUARD_THRESHOLD"},
-	"queue.randomize":                               {"MXLRC_QUEUE_RANDOMIZE"},
-	"logging.level":                                 {"MXLRC_LOG_LEVEL"},
-	"logging.format":                                {"MXLRC_LOG_FORMAT"},
-	"logging.file":                                  {"MXLRC_LOG_FILE"},
-	"logging.max_size_mb":                           {"MXLRC_LOG_MAX_SIZE_MB"},
-	"logging.max_files":                             {"MXLRC_LOG_MAX_FILES"},
-	"logging.max_age_days":                          {"MXLRC_LOG_MAX_AGE_DAYS"},
-	"logging.compress":                              {"MXLRC_LOG_COMPRESS"},
-}
-
-// GetSetEnvVars returns a map from config field paths to true for each field
-// whose corresponding MXLRC_* (or MUSIXMATCH_TOKEN) environment variable is
-// currently set to a non-empty value. Pass the result to FormatConfigText or
-// ConfigToSlogAttrs as the envSrc hint to annotate env-sourced values.
-func GetSetEnvVars() map[string]bool {
-	result := make(map[string]bool, len(fieldEnvVars))
-	for path, vars := range fieldEnvVars {
-		for _, v := range vars {
-			if os.Getenv(v) != "" {
-				result[path] = true
-				break
-			}
-		}
-	}
-	return result
 }
 
 func splitCSV(s string) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -881,6 +881,75 @@ func clampMissBackoff(cfg *Config) {
 	}
 }
 
+// fieldEnvVars maps dotted config field paths to the environment variable
+// names that can override them, listed in priority order (highest first).
+// It is the canonical cross-reference between config field paths and env vars,
+// used by GetSetEnvVars to annotate which values were sourced from the
+// environment.
+var fieldEnvVars = map[string][]string{
+	"api.token":                                     {"MUSIXMATCH_TOKEN", "MXLRC_API_TOKEN"},
+	"api.cooldown":                                  {"MXLRC_API_COOLDOWN", "MXLRC_COOLDOWN"},
+	"api.circuit_open_duration":                     {"MXLRC_API_CIRCUIT_OPEN_DURATION"},
+	"api.circuit_backoff_base_seconds":              {"MXLRC_API_CIRCUIT_BACKOFF_BASE"},
+	"api.miss_backoff_base_hours":                   {"MXLRC_MISS_BACKOFF_BASE_HOURS"},
+	"api.miss_backoff_cap_hours":                    {"MXLRC_MISS_BACKOFF_CAP_HOURS"},
+	"api.max_miss_attempts":                         {"MXLRC_MAX_MISS_ATTEMPTS"},
+	"output.dir":                                    {"MXLRC_OUTPUT_DIR"},
+	"output.embedded_lyrics":                        {"MXLRC_EMBEDDED_LYRICS"},
+	"output.bilingual_output":                       {"MXLRC_BILINGUAL_OUTPUT"},
+	"db.path":                                       {"MXLRC_DB_PATH"},
+	"server.addr":                                   {"MXLRC_SERVER_ADDR"},
+	"server.webhook_api_keys":                       {"MXLRC_WEBHOOK_API_KEY"},
+	"server.scan_interval_seconds":                  {"MXLRC_SCAN_INTERVAL"},
+	"server.work_interval_seconds":                  {"MXLRC_WORK_INTERVAL"},
+	"providers.primary":                             {"MXLRC_PROVIDER_PRIMARY"},
+	"providers.disabled":                            {"MXLRC_PROVIDERS_DISABLED"},
+	"providers.mode":                                {"MXLRC_PROVIDERS_MODE"},
+	"providers.race_wait_seconds":                   {"MXLRC_PROVIDERS_RACE_WAIT_SECONDS"},
+	"providers.fallback_order":                      {"MXLRC_PROVIDERS_FALLBACK_ORDER"},
+	"verification.enabled":                          {"MXLRC_VERIFICATION_ENABLED"},
+	"verification.whisper_url":                      {"MXLRC_VERIFICATION_WHISPER_URL", "MXLRC_WHISPER_URL"},
+	"verification.ffmpeg_path":                      {"MXLRC_VERIFICATION_FFMPEG_PATH"},
+	"verification.sample_duration_seconds":          {"MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS", "MXLRC_VERIFICATION_SAMPLE_DURATION"},
+	"verification.min_confidence":                   {"MXLRC_VERIFICATION_MIN_CONFIDENCE"},
+	"verification.min_similarity":                   {"MXLRC_VERIFICATION_MIN_SIMILARITY"},
+	"instrumental_detector.enabled":                 {"MXLRC_INSTRUMENTAL_DETECTOR_ENABLED"},
+	"instrumental_detector.classifier_url":          {"MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL"},
+	"instrumental_detector.ffmpeg_path":             {"MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH"},
+	"instrumental_detector.sample_duration_seconds": {"MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS"},
+	"instrumental_detector.min_confidence":          {"MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE"},
+	"instrumental_detector.instrumental_classes":    {"MXLRC_INSTRUMENTAL_DETECTOR_CLASSES"},
+	"instrumental_detector.cooldown_seconds":        {"MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS"},
+	"enrichment.enabled":                            {"MXLRC_ENRICHMENT_ENABLED"},
+	"guard.accepted_scripts":                        {"MXLRC_GUARD_ACCEPTED_SCRIPTS"},
+	"guard.script_guard_threshold":                  {"MXLRC_GUARD_THRESHOLD"},
+	"queue.randomize":                               {"MXLRC_QUEUE_RANDOMIZE"},
+	"logging.level":                                 {"MXLRC_LOG_LEVEL"},
+	"logging.format":                                {"MXLRC_LOG_FORMAT"},
+	"logging.file":                                  {"MXLRC_LOG_FILE"},
+	"logging.max_size_mb":                           {"MXLRC_LOG_MAX_SIZE_MB"},
+	"logging.max_files":                             {"MXLRC_LOG_MAX_FILES"},
+	"logging.max_age_days":                          {"MXLRC_LOG_MAX_AGE_DAYS"},
+	"logging.compress":                              {"MXLRC_LOG_COMPRESS"},
+}
+
+// GetSetEnvVars returns a map from config field paths to true for each field
+// whose corresponding MXLRC_* (or MUSIXMATCH_TOKEN) environment variable is
+// currently set to a non-empty value. Pass the result to FormatConfigText or
+// ConfigToSlogAttrs as the envSrc hint to annotate env-sourced values.
+func GetSetEnvVars() map[string]bool {
+	result := make(map[string]bool, len(fieldEnvVars))
+	for path, vars := range fieldEnvVars {
+		for _, v := range vars {
+			if os.Getenv(v) != "" {
+				result[path] = true
+				break
+			}
+		}
+	}
+	return result
+}
+
 func splitCSV(s string) []string {
 	var out []string
 	for _, v := range strings.Split(s, ",") {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -316,6 +316,45 @@ func TestLoad_EnvCooldownInvalidIsIgnored(t *testing.T) {
 	}
 }
 
+// TestLoadWithSources_EnvHintReflectsAppliedOverrides verifies that the
+// applied-env map returned by LoadWithSources marks a field "(env)" only when
+// its override actually took effect: a valid numeric env applies and is
+// recorded; an invalid one is rejected and is NOT recorded (the false-label bug
+// fixed in F1).
+func TestLoadWithSources_EnvHintReflectsAppliedOverrides(t *testing.T) {
+	t.Run("valid applies and is recorded", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_API_COOLDOWN", "30")
+
+		cfg, envSrc, err := LoadWithSources("")
+		if err != nil {
+			t.Fatalf("LoadWithSources: %v", err)
+		}
+		if cfg.API.Cooldown != 30 {
+			t.Errorf("cooldown = %d; want 30", cfg.API.Cooldown)
+		}
+		if !envSrc["api.cooldown"] {
+			t.Error("envSrc[api.cooldown] = false; want true when a valid env override applied")
+		}
+	})
+
+	t.Run("invalid is rejected and not recorded", func(t *testing.T) {
+		isolateEnv(t)
+		t.Setenv("MXLRC_API_COOLDOWN", "notanumber")
+
+		cfg, envSrc, err := LoadWithSources("")
+		if err != nil {
+			t.Fatalf("LoadWithSources: %v", err)
+		}
+		if cfg.API.Cooldown != 15 {
+			t.Errorf("cooldown = %d; want 15 (default) after invalid env var", cfg.API.Cooldown)
+		}
+		if envSrc["api.cooldown"] {
+			t.Error("envSrc[api.cooldown] = true; want false when the env value was invalid and rejected")
+		}
+	})
+}
+
 // TestLoad_ServerIntervalDefaults verifies the service-loop intervals fall back
 // to their built-in defaults: scan 900s and work 0 (meaning "use api.cooldown").
 func TestLoad_ServerIntervalDefaults(t *testing.T) {

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -1,0 +1,31 @@
+package config
+
+// sensitiveConfigKeys is the authoritative list of dotted TOML-path keys
+// whose values must never appear in logs or diagnostic output. It is the
+// single source of truth shared by the startup banner (this feature) and the
+// planned serve-mode config view (#210).
+var sensitiveConfigKeys = []string{
+	"api.token",
+	"server.webhook_api_keys",
+}
+
+// IsSensitiveConfigKey reports whether key is a known sensitive config field
+// path (e.g. "api.token").
+func IsSensitiveConfigKey(key string) bool {
+	for _, k := range sensitiveConfigKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactValue returns "[REDACTED]" when key is a sensitive config field path
+// and value is non-empty. An empty value passes through unchanged so callers
+// can distinguish "field not set" from "field redacted".
+func RedactValue(key, value string) string {
+	if value != "" && IsSensitiveConfigKey(key) {
+		return "[REDACTED]"
+	}
+	return value
+}

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -1,0 +1,49 @@
+package config
+
+import "testing"
+
+func TestIsSensitiveConfigKey(t *testing.T) {
+	sensitive := []string{"api.token", "server.webhook_api_keys"}
+	for _, k := range sensitive {
+		if !IsSensitiveConfigKey(k) {
+			t.Errorf("IsSensitiveConfigKey(%q) = false; want true", k)
+		}
+	}
+
+	nonsensitive := []string{
+		"api.cooldown",
+		"output.dir",
+		"server.addr",
+		"logging.level",
+		"providers.primary",
+		"token",           // bare key without section is not matched
+		"webhook_api_key", // logging key form is not matched
+	}
+	for _, k := range nonsensitive {
+		if IsSensitiveConfigKey(k) {
+			t.Errorf("IsSensitiveConfigKey(%q) = true; want false", k)
+		}
+	}
+}
+
+func TestRedactValue(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+		want  string
+	}{
+		{"api.token", "supersecret", "[REDACTED]"},
+		{"api.token", "", ""}, // empty passes through
+		{"server.webhook_api_keys", "key123", "[REDACTED]"},
+		{"server.webhook_api_keys", "", ""}, // empty passes through
+		{"api.cooldown", "15", "15"},        // non-sensitive passes through
+		{"output.dir", "/lyrics", "/lyrics"},
+		{"logging.level", "debug", "debug"},
+	}
+	for _, tt := range tests {
+		got := RedactValue(tt.key, tt.value)
+		if got != tt.want {
+			t.Errorf("RedactValue(%q, %q) = %q; want %q", tt.key, tt.value, got, tt.want)
+		}
+	}
+}

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -4,39 +4,6 @@ import (
 	"testing"
 )
 
-// TestGetSetEnvVars_ReturnsFalseWhenNotSet verifies that GetSetEnvVars returns
-// an empty (or all-false) map when no MXLRC_* env vars are set.
-func TestGetSetEnvVars_ReturnsFalseWhenNotSet(t *testing.T) {
-	// Isolate: clear every env var in fieldEnvVars.
-	for _, vars := range fieldEnvVars {
-		for _, v := range vars {
-			t.Setenv(v, "")
-		}
-	}
-	result := GetSetEnvVars()
-	for path, set := range result {
-		if set {
-			t.Errorf("GetSetEnvVars: path %q reported as set when env is clear", path)
-		}
-	}
-}
-
-// TestGetSetEnvVars_DetectsSetVar verifies that GetSetEnvVars marks a field
-// path as set when its env var has a non-empty value.
-func TestGetSetEnvVars_DetectsSetVar(t *testing.T) {
-	// Isolate all vars, then set one.
-	for _, vars := range fieldEnvVars {
-		for _, v := range vars {
-			t.Setenv(v, "")
-		}
-	}
-	t.Setenv("MXLRC_OUTPUT_DIR", "/tmp/test-lyrics")
-	result := GetSetEnvVars()
-	if !result["output.dir"] {
-		t.Error("GetSetEnvVars: output.dir not detected as set when MXLRC_OUTPUT_DIR is non-empty")
-	}
-}
-
 func TestIsSensitiveConfigKey(t *testing.T) {
 	sensitive := []string{"api.token", "server.webhook_api_keys"}
 	for _, k := range sensitive {

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -1,6 +1,41 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
+
+// TestGetSetEnvVars_ReturnsFalseWhenNotSet verifies that GetSetEnvVars returns
+// an empty (or all-false) map when no MXLRC_* env vars are set.
+func TestGetSetEnvVars_ReturnsFalseWhenNotSet(t *testing.T) {
+	// Isolate: clear every env var in fieldEnvVars.
+	for _, vars := range fieldEnvVars {
+		for _, v := range vars {
+			t.Setenv(v, "")
+		}
+	}
+	result := GetSetEnvVars()
+	for path, set := range result {
+		if set {
+			t.Errorf("GetSetEnvVars: path %q reported as set when env is clear", path)
+		}
+	}
+}
+
+// TestGetSetEnvVars_DetectsSetVar verifies that GetSetEnvVars marks a field
+// path as set when its env var has a non-empty value.
+func TestGetSetEnvVars_DetectsSetVar(t *testing.T) {
+	// Isolate all vars, then set one.
+	for _, vars := range fieldEnvVars {
+		for _, v := range vars {
+			t.Setenv(v, "")
+		}
+	}
+	t.Setenv("MXLRC_OUTPUT_DIR", "/tmp/test-lyrics")
+	result := GetSetEnvVars()
+	if !result["output.dir"] {
+		t.Error("GetSetEnvVars: output.dir not detected as set when MXLRC_OUTPUT_DIR is non-empty")
+	}
+}
 
 func TestIsSensitiveConfigKey(t *testing.T) {
 	sensitive := []string{"api.token", "server.webhook_api_keys"}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -154,59 +154,84 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 		return ""
 	}
 
+	// src returns the bare source token ("cli"/"env"/"") for a path, mirroring
+	// ann's precedence. Typed slog attrs (int/bool/float) keep their native type
+	// and emit this as a sibling "<key>_source" attr instead of inlining the
+	// annotation, so the value key's type never varies across runs.
+	src := func(path string) string {
+		if cliSrc[path] {
+			return "cli"
+		}
+		if envSrc[path] {
+			return "env"
+		}
+		return ""
+	}
+
 	// strAttr renders a string field, redacting sensitive values and appending
-	// the source annotation when present.
-	strAttr := func(key, path, val string) slog.Attr {
+	// the source annotation when present. String values do not type-vary, so the
+	// annotation stays inline (no sibling "_source" attr).
+	strAttr := func(key, path, val string) []slog.Attr {
 		display := RedactValue(path, val)
 		if a := ann(path); a != "" {
 			display += a
 		}
-		return slog.String(key, display)
+		return []slog.Attr{slog.String(key, display)}
 	}
 
-	// intAttr renders an integer field with optional source annotation.
-	intAttr := func(key, path string, val int) slog.Attr {
-		if a := ann(path); a != "" {
-			return slog.String(key, fmt.Sprintf("%d%s", val, a))
+	// intAttr renders an integer field, preserving the slog.Int type. When a
+	// source applies, a sibling "<key>_source" attr carries the bare source.
+	intAttr := func(key, path string, val int) []slog.Attr {
+		attrs := []slog.Attr{slog.Int(key, val)}
+		if s := src(path); s != "" {
+			attrs = append(attrs, slog.String(key+"_source", s))
 		}
-		return slog.Int(key, val)
+		return attrs
 	}
 
-	// boolAttr renders a boolean field with optional source annotation.
-	boolAttr := func(key, path string, val bool) slog.Attr {
-		if a := ann(path); a != "" {
-			return slog.String(key, fmt.Sprintf("%t%s", val, a))
+	// boolAttr renders a boolean field, preserving the slog.Bool type. When a
+	// source applies, a sibling "<key>_source" attr carries the bare source.
+	boolAttr := func(key, path string, val bool) []slog.Attr {
+		attrs := []slog.Attr{slog.Bool(key, val)}
+		if s := src(path); s != "" {
+			attrs = append(attrs, slog.String(key+"_source", s))
 		}
-		return slog.Bool(key, val)
+		return attrs
 	}
 
-	// floatAttr renders a float64 field with optional source annotation.
-	floatAttr := func(key, path string, val float64) slog.Attr {
-		if a := ann(path); a != "" {
-			return slog.String(key, fmt.Sprintf("%g%s", val, a))
+	// floatAttr renders a float64 field, preserving the slog.Float64 type. When
+	// a source applies, a sibling "<key>_source" attr carries the bare source.
+	floatAttr := func(key, path string, val float64) []slog.Attr {
+		attrs := []slog.Attr{slog.Float64(key, val)}
+		if s := src(path); s != "" {
+			attrs = append(attrs, slog.String(key+"_source", s))
 		}
-		return slog.Float64(key, val)
+		return attrs
 	}
 
-	// sliceAttr renders a slice field, redacting sensitive values.
-	sliceAttr := func(key, path string, vals []string) slog.Attr {
+	// sliceAttr renders a slice field, redacting sensitive values. An empty
+	// slice renders as "[]" (matching FormatConfigText's sliceVal) for both
+	// sensitive and non-sensitive paths, since an empty sensitive slice has
+	// nothing to redact.
+	sliceAttr := func(key, path string, vals []string) []slog.Attr {
 		var display string
-		if IsSensitiveConfigKey(path) {
-			if len(vals) > 0 {
-				display = "[REDACTED]"
-			}
-		} else {
+		switch {
+		case len(vals) == 0:
+			display = "[]"
+		case IsSensitiveConfigKey(path):
+			display = "[REDACTED]"
+		default:
 			display = strings.Join(vals, ", ")
 		}
 		if a := ann(path); a != "" {
 			display += a
 		}
-		return slog.String(key, display)
+		return []slog.Attr{slog.String(key, display)}
 	}
 
 	// tokenAttr handles the api.token field specially so empty shows as empty
 	// rather than "[REDACTED]" (lets caller distinguish unset from redacted).
-	tokenAttr := func() slog.Attr {
+	tokenAttr := func() []slog.Attr {
 		val := ""
 		if cfg.API.Token != "" {
 			val = "[REDACTED]"
@@ -214,11 +239,22 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 		if a := ann("api.token"); a != "" {
 			val += a
 		}
-		return slog.String("token", val)
+		return []slog.Attr{slog.String("token", val)}
+	}
+
+	// group flattens the per-field []slog.Attr results into a single named group.
+	group := func(name string, fields ...[]slog.Attr) slog.Attr {
+		var attrs []any
+		for _, f := range fields {
+			for _, a := range f {
+				attrs = append(attrs, a)
+			}
+		}
+		return slog.Group(name, attrs...)
 	}
 
 	return []slog.Attr{
-		slog.Group("api",
+		group("api",
 			tokenAttr(),
 			intAttr("cooldown", "api.cooldown", cfg.API.Cooldown),
 			intAttr("circuit_open_duration", "api.circuit_open_duration", cfg.API.CircuitOpenDuration),
@@ -227,28 +263,28 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 			intAttr("miss_backoff_cap_hours", "api.miss_backoff_cap_hours", cfg.API.MissBackoffCapHours),
 			intAttr("max_miss_attempts", "api.max_miss_attempts", cfg.API.MaxMissAttempts),
 		),
-		slog.Group("output",
+		group("output",
 			strAttr("dir", "output.dir", cfg.Output.Dir),
 			strAttr("embedded_lyrics", "output.embedded_lyrics", cfg.Output.EmbeddedLyrics),
 			boolAttr("bilingual_output", "output.bilingual_output", cfg.Output.BilingualOutput),
 		),
-		slog.Group("db",
+		group("db",
 			strAttr("path", "db.path", cfg.DB.Path),
 		),
-		slog.Group("server",
+		group("server",
 			strAttr("addr", "server.addr", cfg.Server.Addr),
 			sliceAttr("webhook_api_keys", "server.webhook_api_keys", cfg.Server.WebhookAPIKeys),
 			intAttr("scan_interval_seconds", "server.scan_interval_seconds", cfg.Server.ScanIntervalSeconds),
 			intAttr("work_interval_seconds", "server.work_interval_seconds", cfg.Server.WorkIntervalSeconds),
 		),
-		slog.Group("providers",
+		group("providers",
 			strAttr("primary", "providers.primary", cfg.Providers.Primary),
 			sliceAttr("disabled", "providers.disabled", cfg.Providers.Disabled),
 			strAttr("mode", "providers.mode", cfg.Providers.Mode),
 			intAttr("race_wait_seconds", "providers.race_wait_seconds", cfg.Providers.RaceWaitSeconds),
 			sliceAttr("fallback_order", "providers.fallback_order", cfg.Providers.FallbackOrder),
 		),
-		slog.Group("verification",
+		group("verification",
 			boolAttr("enabled", "verification.enabled", cfg.Verification.Enabled),
 			strAttr("whisper_url", "verification.whisper_url", cfg.Verification.WhisperURL),
 			strAttr("ffmpeg_path", "verification.ffmpeg_path", cfg.Verification.FFmpegPath),
@@ -256,7 +292,7 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 			floatAttr("min_confidence", "verification.min_confidence", cfg.Verification.MinConfidence),
 			floatAttr("min_similarity", "verification.min_similarity", cfg.Verification.MinSimilarity),
 		),
-		slog.Group("instrumental_detector",
+		group("instrumental_detector",
 			boolAttr("enabled", "instrumental_detector.enabled", cfg.InstrumentalDetector.Enabled),
 			strAttr("classifier_url", "instrumental_detector.classifier_url", cfg.InstrumentalDetector.ClassifierURL),
 			strAttr("ffmpeg_path", "instrumental_detector.ffmpeg_path", cfg.InstrumentalDetector.FFmpegPath),
@@ -265,17 +301,17 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 			sliceAttr("instrumental_classes", "instrumental_detector.instrumental_classes", cfg.InstrumentalDetector.InstrumentalClasses),
 			intAttr("cooldown_seconds", "instrumental_detector.cooldown_seconds", cfg.InstrumentalDetector.CooldownSeconds),
 		),
-		slog.Group("enrichment",
+		group("enrichment",
 			boolAttr("enabled", "enrichment.enabled", cfg.Enrichment.Enabled),
 		),
-		slog.Group("guard",
+		group("guard",
 			sliceAttr("accepted_scripts", "guard.accepted_scripts", cfg.Guard.AcceptedScripts),
 			floatAttr("script_guard_threshold", "guard.script_guard_threshold", cfg.Guard.Threshold),
 		),
-		slog.Group("queue",
+		group("queue",
 			boolAttr("randomize", "queue.randomize", cfg.Queue.Randomize),
 		),
-		slog.Group("logging",
+		group("logging",
 			strAttr("level", "logging.level", cfg.Logging.Level),
 			strAttr("format", "logging.format", cfg.Logging.Format),
 			strAttr("file", "logging.file", cfg.Logging.File),

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -1,0 +1,288 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// FormatConfigText returns a human-readable TOML-style snapshot of cfg with
+// sensitive fields redacted. envSrc and cliSrc are best-effort source-hint
+// maps keyed by dotted config field path (e.g. "api.token"); a nil map means
+// no hints for that source. Fields present in cliSrc are annotated "(cli)";
+// fields present in envSrc are annotated "(env)".
+func FormatConfigText(cfg Config, envSrc, cliSrc map[string]bool) string {
+	var b strings.Builder
+
+	ann := func(path string) string {
+		if cliSrc[path] {
+			return " (cli)"
+		}
+		if envSrc[path] {
+			return " (env)"
+		}
+		return ""
+	}
+
+	// p is a write helper; strings.Builder writes never error.
+	p := func(format string, args ...any) {
+		_, _ = fmt.Fprintf(&b, format, args...)
+	}
+
+	strVal := func(path, val string) string {
+		if val == "" && IsSensitiveConfigKey(path) {
+			return "(not set)"
+		}
+		return RedactValue(path, val)
+	}
+
+	sliceVal := func(path string, vals []string) string {
+		if IsSensitiveConfigKey(path) {
+			if len(vals) > 0 {
+				return "[REDACTED]"
+			}
+			return "[]"
+		}
+		if len(vals) == 0 {
+			return "[]"
+		}
+		return "[" + strings.Join(vals, ", ") + "]"
+	}
+
+	// [api]
+	p("[api]\n")
+	p("token = %s%s\n", strVal("api.token", cfg.API.Token), ann("api.token"))
+	p("cooldown = %d%s\n", cfg.API.Cooldown, ann("api.cooldown"))
+	p("circuit_open_duration = %d%s\n", cfg.API.CircuitOpenDuration, ann("api.circuit_open_duration"))
+	p("circuit_backoff_base_seconds = %d%s\n", cfg.API.CircuitBackoffBase, ann("api.circuit_backoff_base_seconds"))
+	p("miss_backoff_base_hours = %d%s\n", cfg.API.MissBackoffBaseHours, ann("api.miss_backoff_base_hours"))
+	p("miss_backoff_cap_hours = %d%s\n", cfg.API.MissBackoffCapHours, ann("api.miss_backoff_cap_hours"))
+	p("max_miss_attempts = %d%s\n", cfg.API.MaxMissAttempts, ann("api.max_miss_attempts"))
+	p("\n")
+
+	// [output]
+	p("[output]\n")
+	p("dir = %s%s\n", cfg.Output.Dir, ann("output.dir"))
+	p("embedded_lyrics = %s%s\n", cfg.Output.EmbeddedLyrics, ann("output.embedded_lyrics"))
+	p("bilingual_output = %t%s\n", cfg.Output.BilingualOutput, ann("output.bilingual_output"))
+	p("\n")
+
+	// [db]
+	p("[db]\n")
+	p("path = %s%s\n", cfg.DB.Path, ann("db.path"))
+	p("\n")
+
+	// [server]
+	p("[server]\n")
+	p("addr = %s%s\n", cfg.Server.Addr, ann("server.addr"))
+	p("webhook_api_keys = %s%s\n", sliceVal("server.webhook_api_keys", cfg.Server.WebhookAPIKeys), ann("server.webhook_api_keys"))
+	p("scan_interval_seconds = %d%s\n", cfg.Server.ScanIntervalSeconds, ann("server.scan_interval_seconds"))
+	p("work_interval_seconds = %d%s\n", cfg.Server.WorkIntervalSeconds, ann("server.work_interval_seconds"))
+	p("\n")
+
+	// [providers]
+	p("[providers]\n")
+	p("primary = %s%s\n", cfg.Providers.Primary, ann("providers.primary"))
+	p("disabled = %s%s\n", sliceVal("providers.disabled", cfg.Providers.Disabled), ann("providers.disabled"))
+	p("mode = %s%s\n", cfg.Providers.Mode, ann("providers.mode"))
+	p("race_wait_seconds = %d%s\n", cfg.Providers.RaceWaitSeconds, ann("providers.race_wait_seconds"))
+	p("fallback_order = %s%s\n", sliceVal("providers.fallback_order", cfg.Providers.FallbackOrder), ann("providers.fallback_order"))
+	p("\n")
+
+	// [verification]
+	p("[verification]\n")
+	p("enabled = %t%s\n", cfg.Verification.Enabled, ann("verification.enabled"))
+	p("whisper_url = %s%s\n", cfg.Verification.WhisperURL, ann("verification.whisper_url"))
+	p("ffmpeg_path = %s%s\n", cfg.Verification.FFmpegPath, ann("verification.ffmpeg_path"))
+	p("sample_duration_seconds = %d%s\n", cfg.Verification.SampleDurationSeconds, ann("verification.sample_duration_seconds"))
+	p("min_confidence = %g%s\n", cfg.Verification.MinConfidence, ann("verification.min_confidence"))
+	p("min_similarity = %g%s\n", cfg.Verification.MinSimilarity, ann("verification.min_similarity"))
+	p("\n")
+
+	// [instrumental_detector]
+	p("[instrumental_detector]\n")
+	p("enabled = %t%s\n", cfg.InstrumentalDetector.Enabled, ann("instrumental_detector.enabled"))
+	p("classifier_url = %s%s\n", cfg.InstrumentalDetector.ClassifierURL, ann("instrumental_detector.classifier_url"))
+	p("ffmpeg_path = %s%s\n", cfg.InstrumentalDetector.FFmpegPath, ann("instrumental_detector.ffmpeg_path"))
+	p("sample_duration_seconds = %d%s\n", cfg.InstrumentalDetector.SampleDurationSeconds, ann("instrumental_detector.sample_duration_seconds"))
+	p("min_confidence = %g%s\n", cfg.InstrumentalDetector.MinConfidence, ann("instrumental_detector.min_confidence"))
+	p("instrumental_classes = %s%s\n", sliceVal("instrumental_detector.instrumental_classes", cfg.InstrumentalDetector.InstrumentalClasses), ann("instrumental_detector.instrumental_classes"))
+	p("cooldown_seconds = %d%s\n", cfg.InstrumentalDetector.CooldownSeconds, ann("instrumental_detector.cooldown_seconds"))
+	p("\n")
+
+	// [enrichment]
+	p("[enrichment]\n")
+	p("enabled = %t%s\n", cfg.Enrichment.Enabled, ann("enrichment.enabled"))
+	p("\n")
+
+	// [guard]
+	p("[guard]\n")
+	p("accepted_scripts = %s%s\n", sliceVal("guard.accepted_scripts", cfg.Guard.AcceptedScripts), ann("guard.accepted_scripts"))
+	p("script_guard_threshold = %g%s\n", cfg.Guard.Threshold, ann("guard.script_guard_threshold"))
+	p("\n")
+
+	// [queue]
+	p("[queue]\n")
+	p("randomize = %t%s\n", cfg.Queue.Randomize, ann("queue.randomize"))
+	p("\n")
+
+	// [logging]
+	p("[logging]\n")
+	p("level = %s%s\n", cfg.Logging.Level, ann("logging.level"))
+	p("format = %s%s\n", cfg.Logging.Format, ann("logging.format"))
+	p("file = %s%s\n", cfg.Logging.File, ann("logging.file"))
+	p("max_size_mb = %d%s\n", cfg.Logging.MaxSizeMB, ann("logging.max_size_mb"))
+	p("max_files = %d%s\n", cfg.Logging.MaxFiles, ann("logging.max_files"))
+	p("max_age_days = %d%s\n", cfg.Logging.MaxAgeDays, ann("logging.max_age_days"))
+	p("compress = %t%s\n", cfg.Logging.Compress, ann("logging.compress"))
+
+	return b.String()
+}
+
+// ConfigToSlogAttrs returns a slice of slog.Attr groups representing cfg with
+// sensitive fields redacted. Each element is a named group corresponding to a
+// config section. Source hints follow the same convention as FormatConfigText:
+// nil maps mean no hints for that source.
+func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
+	ann := func(path string) string {
+		if cliSrc[path] {
+			return " (cli)"
+		}
+		if envSrc[path] {
+			return " (env)"
+		}
+		return ""
+	}
+
+	// strAttr renders a string field, redacting sensitive values and appending
+	// the source annotation when present.
+	strAttr := func(key, path, val string) slog.Attr {
+		display := RedactValue(path, val)
+		if a := ann(path); a != "" {
+			display += a
+		}
+		return slog.String(key, display)
+	}
+
+	// intAttr renders an integer field with optional source annotation.
+	intAttr := func(key, path string, val int) slog.Attr {
+		if a := ann(path); a != "" {
+			return slog.String(key, fmt.Sprintf("%d%s", val, a))
+		}
+		return slog.Int(key, val)
+	}
+
+	// boolAttr renders a boolean field with optional source annotation.
+	boolAttr := func(key, path string, val bool) slog.Attr {
+		if a := ann(path); a != "" {
+			return slog.String(key, fmt.Sprintf("%t%s", val, a))
+		}
+		return slog.Bool(key, val)
+	}
+
+	// floatAttr renders a float64 field with optional source annotation.
+	floatAttr := func(key, path string, val float64) slog.Attr {
+		if a := ann(path); a != "" {
+			return slog.String(key, fmt.Sprintf("%g%s", val, a))
+		}
+		return slog.Float64(key, val)
+	}
+
+	// sliceAttr renders a slice field, redacting sensitive values.
+	sliceAttr := func(key, path string, vals []string) slog.Attr {
+		var display string
+		if IsSensitiveConfigKey(path) {
+			if len(vals) > 0 {
+				display = "[REDACTED]"
+			}
+		} else {
+			display = strings.Join(vals, ", ")
+		}
+		if a := ann(path); a != "" {
+			display += a
+		}
+		return slog.String(key, display)
+	}
+
+	// tokenAttr handles the api.token field specially so empty shows as empty
+	// rather than "[REDACTED]" (lets caller distinguish unset from redacted).
+	tokenAttr := func() slog.Attr {
+		val := ""
+		if cfg.API.Token != "" {
+			val = "[REDACTED]"
+		}
+		if a := ann("api.token"); a != "" {
+			val += a
+		}
+		return slog.String("token", val)
+	}
+
+	return []slog.Attr{
+		slog.Group("api",
+			tokenAttr(),
+			intAttr("cooldown", "api.cooldown", cfg.API.Cooldown),
+			intAttr("circuit_open_duration", "api.circuit_open_duration", cfg.API.CircuitOpenDuration),
+			intAttr("circuit_backoff_base_seconds", "api.circuit_backoff_base_seconds", cfg.API.CircuitBackoffBase),
+			intAttr("miss_backoff_base_hours", "api.miss_backoff_base_hours", cfg.API.MissBackoffBaseHours),
+			intAttr("miss_backoff_cap_hours", "api.miss_backoff_cap_hours", cfg.API.MissBackoffCapHours),
+			intAttr("max_miss_attempts", "api.max_miss_attempts", cfg.API.MaxMissAttempts),
+		),
+		slog.Group("output",
+			strAttr("dir", "output.dir", cfg.Output.Dir),
+			strAttr("embedded_lyrics", "output.embedded_lyrics", cfg.Output.EmbeddedLyrics),
+			boolAttr("bilingual_output", "output.bilingual_output", cfg.Output.BilingualOutput),
+		),
+		slog.Group("db",
+			strAttr("path", "db.path", cfg.DB.Path),
+		),
+		slog.Group("server",
+			strAttr("addr", "server.addr", cfg.Server.Addr),
+			sliceAttr("webhook_api_keys", "server.webhook_api_keys", cfg.Server.WebhookAPIKeys),
+			intAttr("scan_interval_seconds", "server.scan_interval_seconds", cfg.Server.ScanIntervalSeconds),
+			intAttr("work_interval_seconds", "server.work_interval_seconds", cfg.Server.WorkIntervalSeconds),
+		),
+		slog.Group("providers",
+			strAttr("primary", "providers.primary", cfg.Providers.Primary),
+			sliceAttr("disabled", "providers.disabled", cfg.Providers.Disabled),
+			strAttr("mode", "providers.mode", cfg.Providers.Mode),
+			intAttr("race_wait_seconds", "providers.race_wait_seconds", cfg.Providers.RaceWaitSeconds),
+			sliceAttr("fallback_order", "providers.fallback_order", cfg.Providers.FallbackOrder),
+		),
+		slog.Group("verification",
+			boolAttr("enabled", "verification.enabled", cfg.Verification.Enabled),
+			strAttr("whisper_url", "verification.whisper_url", cfg.Verification.WhisperURL),
+			strAttr("ffmpeg_path", "verification.ffmpeg_path", cfg.Verification.FFmpegPath),
+			intAttr("sample_duration_seconds", "verification.sample_duration_seconds", cfg.Verification.SampleDurationSeconds),
+			floatAttr("min_confidence", "verification.min_confidence", cfg.Verification.MinConfidence),
+			floatAttr("min_similarity", "verification.min_similarity", cfg.Verification.MinSimilarity),
+		),
+		slog.Group("instrumental_detector",
+			boolAttr("enabled", "instrumental_detector.enabled", cfg.InstrumentalDetector.Enabled),
+			strAttr("classifier_url", "instrumental_detector.classifier_url", cfg.InstrumentalDetector.ClassifierURL),
+			strAttr("ffmpeg_path", "instrumental_detector.ffmpeg_path", cfg.InstrumentalDetector.FFmpegPath),
+			intAttr("sample_duration_seconds", "instrumental_detector.sample_duration_seconds", cfg.InstrumentalDetector.SampleDurationSeconds),
+			floatAttr("min_confidence", "instrumental_detector.min_confidence", cfg.InstrumentalDetector.MinConfidence),
+			sliceAttr("instrumental_classes", "instrumental_detector.instrumental_classes", cfg.InstrumentalDetector.InstrumentalClasses),
+			intAttr("cooldown_seconds", "instrumental_detector.cooldown_seconds", cfg.InstrumentalDetector.CooldownSeconds),
+		),
+		slog.Group("enrichment",
+			boolAttr("enabled", "enrichment.enabled", cfg.Enrichment.Enabled),
+		),
+		slog.Group("guard",
+			sliceAttr("accepted_scripts", "guard.accepted_scripts", cfg.Guard.AcceptedScripts),
+			floatAttr("script_guard_threshold", "guard.script_guard_threshold", cfg.Guard.Threshold),
+		),
+		slog.Group("queue",
+			boolAttr("randomize", "queue.randomize", cfg.Queue.Randomize),
+		),
+		slog.Group("logging",
+			strAttr("level", "logging.level", cfg.Logging.Level),
+			strAttr("format", "logging.format", cfg.Logging.Format),
+			strAttr("file", "logging.file", cfg.Logging.File),
+			intAttr("max_size_mb", "logging.max_size_mb", cfg.Logging.MaxSizeMB),
+			intAttr("max_files", "logging.max_files", cfg.Logging.MaxFiles),
+			intAttr("max_age_days", "logging.max_age_days", cfg.Logging.MaxAgeDays),
+			boolAttr("compress", "logging.compress", cfg.Logging.Compress),
+		),
+	}
+}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -80,13 +80,28 @@ func TestFormatConfigText_SourceAnnotations(t *testing.T) {
 
 func TestFormatConfigText_CLIAnnotationTakesPrecedenceOverEnv(t *testing.T) {
 	cfg := defaults()
+	cfg.Output.Dir = "custom-dir"
 	envSrc := map[string]bool{"output.dir": true}
 	cliSrc := map[string]bool{"output.dir": true}
 	got := FormatConfigText(cfg, envSrc, cliSrc)
 
-	// CLI overrides env: only "(cli)" should appear for this field.
-	if !strings.Contains(got, "(cli)") {
-		t.Error("FormatConfigText: missing (cli) annotation when both env and cli are set")
+	// Find the specific "dir = ..." line under [output] and assert it carries
+	// (cli) and NOT (env): CLI takes precedence over env for the same field.
+	var dirLine string
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "dir = ") {
+			dirLine = line
+			break
+		}
+	}
+	if dirLine == "" {
+		t.Fatalf("FormatConfigText: no output dir line found; got:\n%s", got)
+	}
+	if !strings.Contains(dirLine, "(cli)") {
+		t.Errorf("FormatConfigText: output.dir line missing (cli): %q", dirLine)
+	}
+	if strings.Contains(dirLine, "(env)") {
+		t.Errorf("FormatConfigText: output.dir line should not carry (env) when cli is set: %q", dirLine)
 	}
 }
 
@@ -106,6 +121,10 @@ func TestConfigToSlogAttrs_RedactsToken(t *testing.T) {
 	if strings.Contains(got, "supersecret") {
 		t.Errorf("ConfigToSlogAttrs: token in plaintext in slog output: %s", got)
 	}
+	// Positive assertion: the token must be redacted, not merely absent/blank.
+	if !strings.Contains(got, "api.token=[REDACTED]") {
+		t.Errorf("ConfigToSlogAttrs: token not rendered as [REDACTED]: %s", got)
+	}
 }
 
 func TestConfigToSlogAttrs_RedactsWebhookKeys(t *testing.T) {
@@ -123,6 +142,150 @@ func TestConfigToSlogAttrs_RedactsWebhookKeys(t *testing.T) {
 	got := buf.String()
 	if strings.Contains(got, "webhookkey1") {
 		t.Errorf("ConfigToSlogAttrs: webhook key in plaintext in slog output: %s", got)
+	}
+	// Positive assertion: the keys must be redacted, not merely absent/blank.
+	if !strings.Contains(got, "server.webhook_api_keys=[REDACTED]") {
+		t.Errorf("ConfigToSlogAttrs: webhook keys not rendered as [REDACTED]: %s", got)
+	}
+}
+
+// findGroupAttr walks the top-level groups returned by ConfigToSlogAttrs and
+// returns the attr with the given key inside the named group (zero Attr + false
+// if absent).
+func findGroupAttr(attrs []slog.Attr, group, key string) (slog.Attr, bool) {
+	for _, a := range attrs {
+		if a.Key != group || a.Value.Kind() != slog.KindGroup {
+			continue
+		}
+		for _, inner := range a.Value.Group() {
+			if inner.Key == key {
+				return inner, true
+			}
+		}
+	}
+	return slog.Attr{}, false
+}
+
+// TestConfigToSlogAttrs_TypedValuesStableWithSourceSibling verifies F2: typed
+// int/bool/float values keep their native slog type even when env/cli-sourced,
+// and a sibling "<key>_source" attr appears only when annotated.
+func TestConfigToSlogAttrs_TypedValuesStableWithSourceSibling(t *testing.T) {
+	cfg := defaults()
+	cfg.Server.ScanIntervalSeconds = 42
+
+	// Not annotated: typed value present, no sibling.
+	attrs := ConfigToSlogAttrs(cfg, nil, nil)
+	val, ok := findGroupAttr(attrs, "server", "scan_interval_seconds")
+	if !ok {
+		t.Fatal("scan_interval_seconds attr not found")
+	}
+	if val.Value.Kind() != slog.KindInt64 {
+		t.Errorf("scan_interval_seconds kind = %v; want Int64", val.Value.Kind())
+	}
+	if val.Value.Int64() != 42 {
+		t.Errorf("scan_interval_seconds = %d; want 42", val.Value.Int64())
+	}
+	if _, ok := findGroupAttr(attrs, "server", "scan_interval_seconds_source"); ok {
+		t.Error("scan_interval_seconds_source present when not annotated; want absent")
+	}
+
+	// Env-annotated: typed value still Int64, sibling "_source" = "env".
+	envSrc := map[string]bool{"server.scan_interval_seconds": true}
+	attrs = ConfigToSlogAttrs(cfg, envSrc, nil)
+	val, ok = findGroupAttr(attrs, "server", "scan_interval_seconds")
+	if !ok {
+		t.Fatal("scan_interval_seconds attr not found (annotated)")
+	}
+	if val.Value.Kind() != slog.KindInt64 {
+		t.Errorf("annotated scan_interval_seconds kind = %v; want Int64 (type must not vary)", val.Value.Kind())
+	}
+	if val.Value.Int64() != 42 {
+		t.Errorf("annotated scan_interval_seconds = %d; want 42", val.Value.Int64())
+	}
+	src, ok := findGroupAttr(attrs, "server", "scan_interval_seconds_source")
+	if !ok {
+		t.Fatal("scan_interval_seconds_source absent when annotated; want present")
+	}
+	if src.Value.String() != "env" {
+		t.Errorf("scan_interval_seconds_source = %q; want \"env\"", src.Value.String())
+	}
+
+	// CLI takes precedence over env: sibling = "cli".
+	cliSrc := map[string]bool{"server.scan_interval_seconds": true}
+	attrs = ConfigToSlogAttrs(cfg, envSrc, cliSrc)
+	src, ok = findGroupAttr(attrs, "server", "scan_interval_seconds_source")
+	if !ok {
+		t.Fatal("scan_interval_seconds_source absent when cli-annotated; want present")
+	}
+	if src.Value.String() != "cli" {
+		t.Errorf("scan_interval_seconds_source = %q; want \"cli\"", src.Value.String())
+	}
+
+	// Float field keeps Float64 when annotated.
+	fattrs := ConfigToSlogAttrs(cfg, map[string]bool{"verification.min_confidence": true}, nil)
+	fv, ok := findGroupAttr(fattrs, "verification", "min_confidence")
+	if !ok {
+		t.Fatal("min_confidence attr not found")
+	}
+	if fv.Value.Kind() != slog.KindFloat64 {
+		t.Errorf("annotated min_confidence kind = %v; want Float64", fv.Value.Kind())
+	}
+	if _, ok := findGroupAttr(fattrs, "verification", "min_confidence_source"); !ok {
+		t.Error("min_confidence_source absent when annotated; want present")
+	}
+
+	// Bool field keeps Bool when annotated.
+	battrs := ConfigToSlogAttrs(cfg, map[string]bool{"queue.randomize": true}, nil)
+	bv, ok := findGroupAttr(battrs, "queue", "randomize")
+	if !ok {
+		t.Fatal("randomize attr not found")
+	}
+	if bv.Value.Kind() != slog.KindBool {
+		t.Errorf("annotated randomize kind = %v; want Bool", bv.Value.Kind())
+	}
+	if _, ok := findGroupAttr(battrs, "queue", "randomize_source"); !ok {
+		t.Error("randomize_source absent when annotated; want present")
+	}
+}
+
+// TestConfigToSlogAttrs_EmptySliceRendersBrackets verifies F3: an empty slice
+// renders as "[]" for both sensitive and non-sensitive paths, and an annotation
+// appends to it (e.g. "[] (cli)") rather than replacing it.
+func TestConfigToSlogAttrs_EmptySliceRendersBrackets(t *testing.T) {
+	cfg := defaults()
+	cfg.Server.WebhookAPIKeys = nil                    // sensitive, empty
+	cfg.InstrumentalDetector.InstrumentalClasses = nil // non-sensitive, empty
+
+	// No annotation: both render bare "[]".
+	attrs := ConfigToSlogAttrs(cfg, nil, nil)
+	sens, ok := findGroupAttr(attrs, "server", "webhook_api_keys")
+	if !ok {
+		t.Fatal("webhook_api_keys attr not found")
+	}
+	if sens.Value.String() != "[]" {
+		t.Errorf("empty sensitive slice = %q; want \"[]\"", sens.Value.String())
+	}
+	nonSensitive, ok := findGroupAttr(attrs, "instrumental_detector", "instrumental_classes")
+	if !ok {
+		t.Fatal("instrumental_classes attr not found")
+	}
+	if nonSensitive.Value.String() != "[]" {
+		t.Errorf("empty non-sensitive slice = %q; want \"[]\"", nonSensitive.Value.String())
+	}
+
+	// Annotated: the annotation appends to "[]" rather than replacing it.
+	cliSrc := map[string]bool{
+		"server.webhook_api_keys":                    true,
+		"instrumental_detector.instrumental_classes": true,
+	}
+	attrs = ConfigToSlogAttrs(cfg, nil, cliSrc)
+	sens, _ = findGroupAttr(attrs, "server", "webhook_api_keys")
+	if sens.Value.String() != "[] (cli)" {
+		t.Errorf("annotated empty sensitive slice = %q; want \"[] (cli)\"", sens.Value.String())
+	}
+	nonSensitive, _ = findGroupAttr(attrs, "instrumental_detector", "instrumental_classes")
+	if nonSensitive.Value.String() != "[] (cli)" {
+		t.Errorf("annotated empty non-sensitive slice = %q; want \"[] (cli)\"", nonSensitive.Value.String())
 	}
 }
 

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatConfigText_ContainsAllSections(t *testing.T) {
+	cfg := defaults()
+	got := FormatConfigText(cfg, nil, nil)
+
+	sections := []string{
+		"[api]", "[output]", "[db]", "[server]", "[providers]",
+		"[verification]", "[instrumental_detector]", "[enrichment]",
+		"[guard]", "[queue]", "[logging]",
+	}
+	for _, s := range sections {
+		if !strings.Contains(got, s) {
+			t.Errorf("FormatConfigText: missing section %q", s)
+		}
+	}
+}
+
+func TestFormatConfigText_RedactsToken(t *testing.T) {
+	cfg := defaults()
+	cfg.API.Token = "supersecret"
+	got := FormatConfigText(cfg, nil, nil)
+
+	if strings.Contains(got, "supersecret") {
+		t.Error("FormatConfigText: token appears in plaintext")
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Error("FormatConfigText: no [REDACTED] marker for token")
+	}
+}
+
+func TestFormatConfigText_RedactsWebhookKeys(t *testing.T) {
+	cfg := defaults()
+	cfg.Server.WebhookAPIKeys = []string{"webhookkey1", "webhookkey2"}
+	got := FormatConfigText(cfg, nil, nil)
+
+	if strings.Contains(got, "webhookkey1") || strings.Contains(got, "webhookkey2") {
+		t.Error("FormatConfigText: webhook key appears in plaintext")
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Error("FormatConfigText: no [REDACTED] marker for webhook keys")
+	}
+}
+
+func TestFormatConfigText_EmptyTokenShowsNotSet(t *testing.T) {
+	cfg := defaults()
+	cfg.API.Token = ""
+	got := FormatConfigText(cfg, nil, nil)
+
+	if strings.Contains(got, "[REDACTED]") {
+		t.Error("FormatConfigText: empty token should not be redacted")
+	}
+	if !strings.Contains(got, "(not set)") {
+		t.Error("FormatConfigText: empty token should show '(not set)'")
+	}
+}
+
+func TestFormatConfigText_SourceAnnotations(t *testing.T) {
+	cfg := defaults()
+	envSrc := map[string]bool{"api.cooldown": true}
+	cliSrc := map[string]bool{"output.dir": true}
+	got := FormatConfigText(cfg, envSrc, cliSrc)
+
+	if !strings.Contains(got, "(env)") {
+		t.Errorf("FormatConfigText: missing (env) annotation; got:\n%s", got)
+	}
+	if !strings.Contains(got, "(cli)") {
+		t.Errorf("FormatConfigText: missing (cli) annotation; got:\n%s", got)
+	}
+}
+
+func TestFormatConfigText_CLIAnnotationTakesPrecedenceOverEnv(t *testing.T) {
+	cfg := defaults()
+	envSrc := map[string]bool{"output.dir": true}
+	cliSrc := map[string]bool{"output.dir": true}
+	got := FormatConfigText(cfg, envSrc, cliSrc)
+
+	// CLI overrides env: only "(cli)" should appear for this field.
+	if !strings.Contains(got, "(cli)") {
+		t.Error("FormatConfigText: missing (cli) annotation when both env and cli are set")
+	}
+}
+
+func TestConfigToSlogAttrs_RedactsToken(t *testing.T) {
+	cfg := defaults()
+	cfg.API.Token = "supersecret"
+	attrs := ConfigToSlogAttrs(cfg, nil, nil)
+
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	r := slog.NewRecord(time.Time{}, slog.LevelDebug, "test", 0)
+	r.AddAttrs(attrs...)
+	if err := h.Handle(context.Background(), r); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "supersecret") {
+		t.Errorf("ConfigToSlogAttrs: token in plaintext in slog output: %s", got)
+	}
+}
+
+func TestConfigToSlogAttrs_RedactsWebhookKeys(t *testing.T) {
+	cfg := defaults()
+	cfg.Server.WebhookAPIKeys = []string{"webhookkey1"}
+	attrs := ConfigToSlogAttrs(cfg, nil, nil)
+
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	r := slog.NewRecord(time.Time{}, slog.LevelDebug, "test", 0)
+	r.AddAttrs(attrs...)
+	if err := h.Handle(context.Background(), r); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "webhookkey1") {
+		t.Errorf("ConfigToSlogAttrs: webhook key in plaintext in slog output: %s", got)
+	}
+}
+
+func TestConfigToSlogAttrs_ContainsAllSections(t *testing.T) {
+	cfg := defaults()
+	attrs := ConfigToSlogAttrs(cfg, nil, nil)
+
+	// Render to text and verify all section groups appear.
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	r := slog.NewRecord(time.Time{}, slog.LevelDebug, "test", 0)
+	r.AddAttrs(attrs...)
+	if err := h.Handle(context.Background(), r); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	got := buf.String()
+
+	// Text handler renders groups as "group.key=value". Check a field from each section.
+	checks := []string{
+		"api.cooldown=",
+		"output.dir=",
+		"db.path=",
+		"server.addr=",
+		"providers.primary=",
+		"verification.enabled=",
+		"instrumental_detector.enabled=",
+		"enrichment.enabled=",
+		"guard.script_guard_threshold=",
+		"queue.randomize=",
+		"logging.level=",
+	}
+	for _, c := range checks {
+		if !strings.Contains(got, c) {
+			t.Errorf("ConfigToSlogAttrs: missing field %q in slog output: %s", c, got)
+		}
+	}
+}

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -9,13 +9,14 @@ import (
 // log output. Matching is case-insensitive. "key" is intentionally excluded
 // because it is over-broad and would redact unrelated structured fields.
 var sensitiveKeys = map[string]struct{}{
-	"token":           {},
-	"api_key":         {},
-	"apikey":          {},
-	"authorization":   {},
-	"secret":          {},
-	"password":        {},
-	"webhook_api_key": {},
+	"token":            {},
+	"api_key":          {},
+	"apikey":           {},
+	"authorization":    {},
+	"secret":           {},
+	"password":         {},
+	"webhook_api_key":  {},
+	"webhook_api_keys": {},
 }
 
 // isSensitiveKey reports whether name is a known sensitive field name.


### PR DESCRIPTION
## Summary

Emit a startup banner with the version and the effective (post-override) config/env at session start, with secrets redacted - so an operator can confirm what the process is actually running with.

- New `internal/config/redact.go` (single source of truth for sensitive field paths: `api.token`, `server.webhook_api_keys`) and `internal/config/render.go` (`FormatConfigText` console output + `ConfigToSlogAttrs` structured slog; both redact).
- Source tracking: each value is annotated `(env)` / `(cli)` when it came from an env var or a CLI override (`GetSetEnvVars` + `fieldEnvVars`).
- Banner wired into both `runFetch` and `runServe`, after `initLogging` and after CLI overrides, so it reflects the effective config.
- `internal/logging/redact.go`: added the plural `webhook_api_keys` to the slog redaction backstop.

UAT (live run, maintainer-verified): the Musixmatch token and webhook key render as `[REDACTED]` in both the human banner and the structured slog path; `--cooldown`/`--outdir` overrides show with `(cli)`, env values with `(env)`; version line emits.

## Linked issue

Closes #214

## Test plan

- [x] `make gate` GREEN; patch coverage 83.33%
- [x] TDD: redaction (token + webhook, both formats), render/source-tracking, banner emission
- [x] Hostile review (lead-driven): no secret leak in either format; both `runServe` callers updated; SHIP-READY
- [x] UAT: live banner verified (secrets redacted, source tags, version)
- [ ] Codoki auto-review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup banner displaying application version and configuration upon launch
  * Configuration now shows source annotations indicating whether values came from CLI flags or environment variables

* **Improvements**
  * Enhanced logging with structured startup information display
  * Improved security by redacting sensitive values (API tokens, webhook keys) in logs and console output

* **Tests**
  * Added comprehensive test coverage for startup banner output and configuration rendering
  * Added tests validating sensitive data redaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->