### PR TITLE
feat(serve): add /metrics Prometheus endpoint (#212)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -764,6 +764,8 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		Handler: server.NewHandler(authSvc, workQ, outdir,
 			server.WithReadiness(sqlDB),
 			server.WithStatusReporter(workQ),
+			// WithMetricsReporter is required: omitting it causes GET /metrics to return 500.
+			server.WithMetricsReporter(workQ),
 			server.WithInventory(scan.New(sqlDB)),
 			server.WithAllowedRoots(allowedRoots),
 		),

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -12,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
@@ -22,6 +25,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
+	"github.com/sydlexius/mxlrcgo-svc/internal/server"
 	"github.com/sydlexius/mxlrcgo-svc/internal/worker"
 )
 
@@ -2439,5 +2443,54 @@ func TestLogStartupBanner_CLIAnnotation(t *testing.T) {
 	got := buf.String()
 	if !strings.Contains(got, "(cli)") {
 		t.Errorf("missing (cli) annotation in banner output: %q", got)
+	}
+}
+
+// serveTestAuth is a minimal Authenticator for use in serve-handler regression
+// tests. It accepts every key as if it were admin-scoped.
+type serveTestAuth struct{}
+
+func (serveTestAuth) ValidateKey(_ context.Context, _ string, _ auth.Scope) (auth.Key, error) {
+	return auth.Key{ID: "test-admin"}, nil
+}
+
+// TestServeHandlerWiresMetricsReporter guards the serve command wiring: if
+// WithMetricsReporter is ever removed from the serve handler option list,
+// GET /metrics will return 500 instead of 200. This test constructs the
+// handler with the same option set the serve command uses and asserts that
+// /metrics returns 200 with the expected Prometheus metric families.
+func TestServeHandlerWiresMetricsReporter(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	workQ := queue.NewDBQueue(sqlDB)
+
+	// Build the handler with the same option set as the serve command.
+	// WithMetricsReporter is required here; omitting it causes /metrics to 500.
+	h := server.NewHandler(&serveTestAuth{}, workQ, t.TempDir(),
+		server.WithReadiness(sqlDB),
+		server.WithStatusReporter(workQ),
+		server.WithMetricsReporter(workQ),
+		server.WithInventory(scan.New(sqlDB)),
+		server.WithAllowedRoots(nil),
+	)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=test-key", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d; want 200 (body: %q)", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "mxlrcgo_queue_items") {
+		t.Errorf("response body missing mxlrcgo_queue_items\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "mxlrcgo_queue_failures") {
+		t.Errorf("response body missing mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -949,6 +949,36 @@ func (q *DBQueue) CountDone(ctx context.Context) (int64, error) {
 	return n, nil
 }
 
+// CountFailuresByReason returns the count of work_queue rows with status
+// 'failed' grouped by last_error. Rows whose last_error is empty are grouped
+// under "unknown". Deferred rows (benign misses) are excluded because they are
+// not errors. Used by the GET /metrics endpoint.
+func (q *DBQueue) CountFailuresByReason(ctx context.Context) (map[string]int64, error) {
+	rows, err := q.db.QueryContext(ctx,
+		`SELECT COALESCE(NULLIF(last_error, ''), 'unknown') AS reason, COUNT(*)
+         FROM work_queue
+         WHERE status = 'failed'
+         GROUP BY last_error`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue: count failures by reason: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var reason string
+		var n int64
+		if err := rows.Scan(&reason, &n); err != nil {
+			return nil, fmt.Errorf("queue: scan failure reason count: %w", err)
+		}
+		counts[reason] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: count failures by reason rows: %w", err)
+	}
+	return counts, nil
+}
+
 // CountByStatus returns the number of work_queue rows grouped by status.
 // Statuses with no rows are omitted from the map.
 func (q *DBQueue) CountByStatus(ctx context.Context) (map[string]int64, error) {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -958,7 +958,7 @@ func (q *DBQueue) CountFailuresByReason(ctx context.Context) (map[string]int64, 
 		`SELECT COALESCE(NULLIF(last_error, ''), 'unknown') AS reason, COUNT(*)
          FROM work_queue
          WHERE status = 'failed'
-         GROUP BY last_error`,
+         GROUP BY reason`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("queue: count failures by reason: %w", err)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -2818,6 +2818,86 @@ func TestDBQueue_EnqueueOnConflictPreservesProvidersVersion(t *testing.T) {
 	}
 }
 
+// TestDBQueue_CountFailuresByReason verifies the aggregate count used by the
+// /metrics endpoint.
+func TestDBQueue_CountFailuresByReason(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	enqAndFail := func(artist, title, reason string) {
+		t.Helper()
+		if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: artist, TrackName: title}}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %s/%s: %v", artist, title, err)
+		}
+		item, err := q.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("Dequeue %s/%s: %v", artist, title, err)
+		}
+		var cause error
+		if reason != "" {
+			cause = errors.New(reason)
+		}
+		if _, err := q.Fail(ctx, item.ID, cause); err != nil {
+			t.Fatalf("Fail %s/%s: %v", artist, title, err)
+		}
+	}
+
+	// Empty queue: no failures.
+	counts, err := q.CountFailuresByReason(ctx)
+	if err != nil {
+		t.Fatalf("CountFailuresByReason empty: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("empty queue: got %v; want empty map", counts)
+	}
+
+	// Two failures with the same reason, one with a different reason, one with no reason.
+	enqAndFail("Artist A", "Track 1", "connection refused")
+	enqAndFail("Artist A", "Track 2", "connection refused")
+	enqAndFail("Artist B", "Track 3", "timeout")
+	enqAndFail("Artist C", "Track 4", "") // empty last_error -> "unknown"
+
+	counts, err = q.CountFailuresByReason(ctx)
+	if err != nil {
+		t.Fatalf("CountFailuresByReason: %v", err)
+	}
+	if counts["connection refused"] != 2 {
+		t.Errorf("connection refused = %d; want 2", counts["connection refused"])
+	}
+	if counts["timeout"] != 1 {
+		t.Errorf("timeout = %d; want 1", counts["timeout"])
+	}
+	if counts["unknown"] != 1 {
+		t.Errorf("unknown (empty reason) = %d; want 1", counts["unknown"])
+	}
+	if len(counts) != 3 {
+		t.Errorf("len(counts) = %d; want 3 (got %v)", len(counts), counts)
+	}
+
+	// Deferred rows (benign misses) must NOT appear in the failure counts.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist D", TrackName: "Deferred Track"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue deferred: %v", err)
+	}
+	dItem, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue deferred: %v", err)
+	}
+	if _, err := q.Defer(ctx, dItem.ID, time.Hour, errors.New("no match")); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	counts2, err := q.CountFailuresByReason(ctx)
+	if err != nil {
+		t.Fatalf("CountFailuresByReason after defer: %v", err)
+	}
+	if len(counts2) != 3 {
+		t.Errorf("deferred row leaked into failure counts: got %v; want same 3 reasons", counts2)
+	}
+}
+
 // TestDBQueue_RecheckClosedDB verifies the recheck methods return a wrapped
 // error (rather than panicking) when the underlying handle is closed.
 func TestDBQueue_RecheckClosedDB(t *testing.T) {

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
+)
+
+// MetricsReporter provides aggregate queue data for the GET /metrics endpoint.
+type MetricsReporter interface {
+	CountByStatus(ctx context.Context) (map[string]int64, error)
+	CountFailuresByReason(ctx context.Context) (map[string]int64, error)
+}
+
+// handleMetrics writes a Prometheus text-exposition response. It applies the
+// same admin-scope auth gate as handleStatus so operational data is not exposed
+// to unauthenticated callers. Metrics are computed from read-only DB queries at
+// request time (query-on-scrape); there is no in-process registry or caching.
+func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if h.auth == nil {
+		http.Error(w, "auth unavailable", http.StatusInternalServerError)
+		return
+	}
+	if _, err := h.auth.ValidateKey(r.Context(), apiKey(r), auth.ScopeAdmin); err != nil {
+		switch {
+		case errors.Is(err, auth.ErrForbiddenScope):
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		case errors.Is(err, auth.ErrInvalidKey), errors.Is(err, auth.ErrRevokedKey):
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		default:
+			slog.Error("metrics authentication failed", "error", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if h.metrics == nil {
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	statusCounts, err := h.metrics.CountByStatus(r.Context())
+	if err != nil {
+		slog.Error("metrics: count by status failed", "error", err)
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	failureCounts, err := h.metrics.CountFailuresByReason(r.Context())
+	if err != nil {
+		slog.Error("metrics: count failures by reason failed", "error", err)
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	writeMetrics(w, statusCounts, failureCounts)
+}
+
+// writeMetrics serializes all metric families in Prometheus text-exposition
+// format (version 0.0.4). Each family includes the required # HELP and # TYPE
+// comment lines followed by one sample line per label set. Label sets are
+// sorted to ensure a deterministic response order. All metrics use gauge
+// semantics because they are computed from DB snapshots, not monotonic counters.
+func writeMetrics(w io.Writer, statusCounts, failureCounts map[string]int64) {
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_queue_items Current number of items in the work queue by status.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_queue_items gauge")
+	for _, status := range sortedKeys(statusCounts) {
+		_, _ = fmt.Fprintf(w, "mxlrcgo_queue_items{status=\"%s\"} %d\n", promEscape(status), statusCounts[status])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_failures_total Current number of failed work queue items by error reason.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_failures_total gauge")
+	for _, reason := range sortedKeys(failureCounts) {
+		_, _ = fmt.Fprintf(w, "mxlrcgo_failures_total{reason=\"%s\"} %d\n", promEscape(reason), failureCounts[reason])
+	}
+}
+
+// sortedKeys returns the keys of m in ascending lexicographic order.
+func sortedKeys(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// promEscape escapes a label value per the Prometheus text-exposition format
+// spec: backslashes, double-quotes, and newlines must be escaped.
+func promEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return s
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -61,6 +61,7 @@ func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store") // prevent proxies from caching stale metrics
 	w.WriteHeader(http.StatusOK)
 	writeMetrics(w, statusCounts, failureCounts)
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -77,10 +77,10 @@ func writeMetrics(w io.Writer, statusCounts, failureCounts map[string]int64) {
 		_, _ = fmt.Fprintf(w, "mxlrcgo_queue_items{status=\"%s\"} %d\n", promEscape(status), statusCounts[status])
 	}
 
-	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_failures_total Current number of failed work queue items by error reason.")
-	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_failures_total gauge")
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_queue_failures Current number of failed work queue items by error reason.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_queue_failures gauge")
 	for _, reason := range sortedKeys(failureCounts) {
-		_, _ = fmt.Fprintf(w, "mxlrcgo_failures_total{reason=\"%s\"} %d\n", promEscape(reason), failureCounts[reason])
+		_, _ = fmt.Fprintf(w, "mxlrcgo_queue_failures{reason=\"%s\"} %d\n", promEscape(reason), failureCounts[reason])
 	}
 }
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -122,13 +122,13 @@ func TestMetricsResponseIsValidPrometheusFormat(t *testing.T) {
 	}
 
 	// Metric family: failures.
-	if !strings.Contains(body, "# HELP mxlrcgo_failures_total") {
-		t.Errorf("missing HELP line for mxlrcgo_failures_total\nbody:\n%s", body)
+	if !strings.Contains(body, "# HELP mxlrcgo_queue_failures") {
+		t.Errorf("missing HELP line for mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
-	if !strings.Contains(body, "# TYPE mxlrcgo_failures_total gauge") {
-		t.Errorf("missing TYPE gauge line for mxlrcgo_failures_total\nbody:\n%s", body)
+	if !strings.Contains(body, "# TYPE mxlrcgo_queue_failures gauge") {
+		t.Errorf("missing TYPE gauge line for mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
-	if !strings.Contains(body, `mxlrcgo_failures_total{reason="connection refused"} 2`) {
+	if !strings.Contains(body, `mxlrcgo_queue_failures{reason="connection refused"} 2`) {
 		t.Errorf("missing failure sample\nbody:\n%s", body)
 	}
 }
@@ -153,11 +153,11 @@ func TestMetricsEmptyQueueProducesHelpAndTypeLines(t *testing.T) {
 	if !strings.Contains(body, "# TYPE mxlrcgo_queue_items gauge") {
 		t.Errorf("missing TYPE for mxlrcgo_queue_items\nbody:\n%s", body)
 	}
-	if !strings.Contains(body, "# HELP mxlrcgo_failures_total") {
-		t.Errorf("missing HELP for mxlrcgo_failures_total\nbody:\n%s", body)
+	if !strings.Contains(body, "# HELP mxlrcgo_queue_failures") {
+		t.Errorf("missing HELP for mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
-	if !strings.Contains(body, "# TYPE mxlrcgo_failures_total gauge") {
-		t.Errorf("missing TYPE for mxlrcgo_failures_total\nbody:\n%s", body)
+	if !strings.Contains(body, "# TYPE mxlrcgo_queue_failures gauge") {
+		t.Errorf("missing TYPE for mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
 }
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -102,6 +102,11 @@ func TestMetricsResponseIsValidPrometheusFormat(t *testing.T) {
 		t.Fatalf("Content-Type = %q; want text/plain", ct)
 	}
 
+	cc := rec.Header().Get("Cache-Control")
+	if cc != "no-store" {
+		t.Fatalf("Cache-Control = %q; want no-store", cc)
+	}
+
 	body := rec.Body.String()
 
 	// Metric family: queue items.

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,0 +1,223 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
+)
+
+type fakeMetrics struct {
+	statusCounts  map[string]int64
+	failureCounts map[string]int64
+	statusErr     error
+	failureErr    error
+}
+
+func (f *fakeMetrics) CountByStatus(_ context.Context) (map[string]int64, error) {
+	return f.statusCounts, f.statusErr
+}
+
+func (f *fakeMetrics) CountFailuresByReason(_ context.Context) (map[string]int64, error) {
+	return f.failureCounts, f.failureErr
+}
+
+func TestMetricsRequiresAdminAuth(t *testing.T) {
+	t.Run("no api key returns 401", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{err: auth.ErrInvalidKey}, &fakeQueue{}, "lyrics",
+			WithMetricsReporter(&fakeMetrics{}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=bad", nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rec.Code)
+		}
+	})
+
+	t.Run("webhook-scoped key returns 403", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{err: auth.ErrForbiddenScope}, &fakeQueue{}, "lyrics",
+			WithMetricsReporter(&fakeMetrics{}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=webhook-key", nil))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d; want 403", rec.Code)
+		}
+	})
+
+	t.Run("auth backend error returns 500", func(t *testing.T) {
+		h := NewHandler(&fakeAuth{err: errors.New("auth store down")}, &fakeQueue{}, "lyrics",
+			WithMetricsReporter(&fakeMetrics{}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d; want 500", rec.Code)
+		}
+	})
+
+	t.Run("valid admin key passes auth gate", func(t *testing.T) {
+		a := &fakeAuth{}
+		h := NewHandler(a, &fakeQueue{}, "lyrics",
+			WithMetricsReporter(&fakeMetrics{
+				statusCounts:  map[string]int64{},
+				failureCounts: map[string]int64{},
+			}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=admin", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d; want 200 (body %q)", rec.Code, rec.Body.String())
+		}
+		if a.required != auth.ScopeAdmin {
+			t.Fatalf("required scope = %q; want admin", a.required)
+		}
+	})
+}
+
+func TestMetricsWithoutReporterReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics") // no WithMetricsReporter
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 when no reporter configured", rec.Code)
+	}
+}
+
+func TestMetricsResponseIsValidPrometheusFormat(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:  map[string]int64{"pending": 5, "done": 12, "failed": 2},
+			failureCounts: map[string]int64{"connection refused": 2},
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/plain") {
+		t.Fatalf("Content-Type = %q; want text/plain", ct)
+	}
+
+	body := rec.Body.String()
+
+	// Metric family: queue items.
+	if !strings.Contains(body, "# HELP mxlrcgo_queue_items") {
+		t.Errorf("missing HELP line for mxlrcgo_queue_items\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_queue_items gauge") {
+		t.Errorf("missing TYPE gauge line for mxlrcgo_queue_items\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_queue_items{status="pending"} 5`) {
+		t.Errorf("missing pending sample\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_queue_items{status="done"} 12`) {
+		t.Errorf("missing done sample\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_queue_items{status="failed"} 2`) {
+		t.Errorf("missing failed sample\nbody:\n%s", body)
+	}
+
+	// Metric family: failures.
+	if !strings.Contains(body, "# HELP mxlrcgo_failures_total") {
+		t.Errorf("missing HELP line for mxlrcgo_failures_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_failures_total gauge") {
+		t.Errorf("missing TYPE gauge line for mxlrcgo_failures_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_failures_total{reason="connection refused"} 2`) {
+		t.Errorf("missing failure sample\nbody:\n%s", body)
+	}
+}
+
+func TestMetricsEmptyQueueProducesHelpAndTypeLines(t *testing.T) {
+	// No items in the queue: HELP/TYPE lines must still appear, but no samples.
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:  map[string]int64{},
+			failureCounts: map[string]int64{},
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "# HELP mxlrcgo_queue_items") {
+		t.Errorf("missing HELP for mxlrcgo_queue_items\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_queue_items gauge") {
+		t.Errorf("missing TYPE for mxlrcgo_queue_items\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# HELP mxlrcgo_failures_total") {
+		t.Errorf("missing HELP for mxlrcgo_failures_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_failures_total gauge") {
+		t.Errorf("missing TYPE for mxlrcgo_failures_total\nbody:\n%s", body)
+	}
+}
+
+func TestMetricsStatusQueryErrorReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{statusErr: errors.New("db error")}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 on query error", rec.Code)
+	}
+}
+
+func TestMetricsFailureQueryErrorReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts: map[string]int64{"pending": 1},
+			failureErr:   errors.New("db error"),
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 on query error", rec.Code)
+	}
+}
+
+func TestWriteMetricsLabelEscaping(t *testing.T) {
+	// Verify promEscape handles the characters mandated by the Prometheus spec.
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`normal`, `normal`},
+		{`has "quotes"`, `has \"quotes\"`},
+		{`back\slash`, `back\\slash`},
+		{"new\nline", `new\nline`},
+	}
+	for _, tc := range cases {
+		got := promEscape(tc.input)
+		if got != tc.want {
+			t.Errorf("promEscape(%q) = %q; want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestWriteMetricsSortedOutput(t *testing.T) {
+	// Samples must appear in lexicographic order regardless of map iteration.
+	var sb strings.Builder
+	writeMetrics(&sb, map[string]int64{"pending": 1, "done": 2, "failed": 3}, map[string]int64{})
+	body := sb.String()
+
+	doneIdx := strings.Index(body, `status="done"`)
+	failedIdx := strings.Index(body, `status="failed"`)
+	pendingIdx := strings.Index(body, `status="pending"`)
+
+	if doneIdx < 0 || failedIdx < 0 || pendingIdx < 0 {
+		t.Fatalf("missing sample lines\nbody:\n%s", body)
+	}
+	if doneIdx >= failedIdx || failedIdx >= pendingIdx {
+		t.Errorf("samples not in sorted order (done=%d failed=%d pending=%d)\nbody:\n%s",
+			doneIdx, failedIdx, pendingIdx, body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,6 +75,7 @@ type Handler struct {
 	priority     int
 	ready        Readiness
 	stats        StatusReporter
+	metrics      MetricsReporter
 	inventory    Inventory
 	allowedRoots []string
 	pathChecker  func(string) error
@@ -92,6 +93,11 @@ func WithReadiness(r Readiness) Option {
 // WithStatusReporter wires a queue summary source used by GET /api/v1/status.
 func WithStatusReporter(s StatusReporter) Option {
 	return func(h *Handler) { h.stats = s }
+}
+
+// WithMetricsReporter wires a metrics source used by GET /metrics.
+func WithMetricsReporter(m MetricsReporter) Option {
+	return func(h *Handler) { h.metrics = m }
 }
 
 // WithInventory wires the scan-result inventory used to resolve webhook events
@@ -143,6 +149,7 @@ func NewHandler(a Authenticator, q WorkQueue, outdir string, opts ...Option) *Ha
 	h.mux.HandleFunc("GET /healthz", h.handleHealthz)
 	h.mux.HandleFunc("GET /readyz", h.handleReadyz)
 	h.mux.HandleFunc("GET /api/v1/status", h.handleStatus)
+	h.mux.HandleFunc("GET /metrics", h.handleMetrics)
 	return h
 }
 


### PR DESCRIPTION
Adds a `GET /metrics` Prometheus text-exposition endpoint in serve mode. **Closes #212.**

## What
- Hand-rolled Prometheus exposition (no `client_golang` dependency / no protobuf transitive cost, no CGO), query-on-scrape, no in-process registry - per the maintainer-steered coding plan on #212.
- Two metric families derivable from existing columns (no schema migrations):
  - `mxlrcgo_queue_items{status}` (gauge) - queue counts by status, from existing `CountByStatus`.
  - `mxlrcgo_queue_failures{reason}` (gauge) - failed items by error reason, from a new read-only `CountFailuresByReason` (COALESCE/NULLIF on the existing `last_error`).
- `/metrics` is **admin-scoped**, mirroring `/api/v1/status` (localhost default; admin API key for remote). A webhook-scoped key is 403 by design.

## Deferred (tracked in #231)
`mxlrcgo_provider_hits/misses_total{lane}` and `mxlrcgo_instrumental_tracks` are **not** included - there is no DB column tracking provider outcomes or instrumental *results*, and this issue mandated no migrations. Follow-up: **#231**.

## Tests
- Scrape-shape test (valid Prometheus format, HELP/TYPE/sample lines, label escaping, deterministic ordering, empty-queue, error paths, auth gate 401/403/500).
- Regression test `TestServeHandlerWiresMetricsReporter` - guards the serve-command wiring (a live UAT caught that the route was registered but the data reporter was not injected, so `/metrics` 500d in production; this test fails if the wiring is removed).

## Verification
Local: race tests green, patch coverage ~82-84%, golangci-lint 0, govulncheck clean. Live UAT against a real serve instance: `/metrics` returns HTTP 200 + valid Prometheus output; auth gate verified 401 (no key) / 403 (wrong scope) / 200 (admin).