### PR TITLE
feat(secrets): AES-256-GCM secret store foundation (#229 phase 1)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -398,3 +398,70 @@ func TestOpen_NormalizeKeySQLFunction(t *testing.T) {
 		t.Fatalf("normalize_key SQL result = %q; want %q", got, want)
 	}
 }
+
+// TestMigration017SecretsUpDown drives migration 017 directly: it migrates to
+// v16 (no secrets table), applies 017 and asserts the secrets table exists with
+// a usable upsert, then down-migrates and asserts the table is dropped.
+func TestMigration017SecretsUpDown(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig017.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	sqlDB.SetMaxOpenConns(1)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+
+	// At v16 the secrets table does not exist yet.
+	if _, err := provider.UpTo(ctx, 16); err != nil {
+		t.Fatalf("UpTo(16): %v", err)
+	}
+	var present int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='secrets'`).Scan(&present); err != nil {
+		t.Fatalf("query secrets pre-017: %v", err)
+	}
+	if present != 0 {
+		t.Fatalf("secrets table present before migration 017")
+	}
+
+	// Apply 017 and exercise the upsert + NOT NULL ciphertext.
+	if _, err := provider.UpTo(ctx, 17); err != nil {
+		t.Fatalf("UpTo(17): %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO secrets (name, ciphertext) VALUES (?, ?)
+         ON CONFLICT(name) DO UPDATE SET ciphertext = excluded.ciphertext`,
+		"musixmatch_token", []byte{0x01, 0x02}); err != nil {
+		t.Fatalf("insert secret: %v", err)
+	}
+	var updatedAt string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT updated_at FROM secrets WHERE name = ?`, "musixmatch_token").Scan(&updatedAt); err != nil {
+		t.Fatalf("query updated_at: %v", err)
+	}
+	if updatedAt == "" {
+		t.Fatal("updated_at default not applied")
+	}
+
+	// Down-migrate 017 and confirm the table is dropped.
+	if _, err := provider.Down(ctx); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='secrets'`).Scan(&present); err != nil {
+		t.Fatalf("query secrets post-down: %v", err)
+	}
+	if present != 0 {
+		t.Fatalf("secrets table still present after down-migration")
+	}
+}

--- a/internal/db/migrations/017_secrets.sql
+++ b/internal/db/migrations/017_secrets.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Encrypted-at-rest secret store. Each row holds one secret as an AES-256-GCM
+-- blob: nonce(12) || ciphertext || tag(16). The encryption key is NOT stored
+-- here (see docs/design/2026-06-13-223-secrets-encryption.md). General store:
+-- `name` is a stable identifier; v1 uses 'musixmatch_token' and 'webhook_api_key'.
+CREATE TABLE secrets (
+    name       TEXT PRIMARY KEY,
+    ciphertext BLOB NOT NULL,
+    updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS secrets;
+-- +goose StatementEnd

--- a/internal/secrets/crypto.go
+++ b/internal/secrets/crypto.go
@@ -1,0 +1,90 @@
+// Package secrets provides an encrypted-at-rest store for the small set of
+// recoverable runtime secrets (the Musixmatch API token and the serve-mode
+// webhook API key). Values are sealed with AES-256-GCM under a managed 32-byte
+// key and persisted as opaque BLOBs in the existing pure-Go SQLite database.
+//
+// The design of record is docs/design/2026-06-13-223-secrets-encryption.md.
+// This package is the storage foundation only: precedence wiring, the CLI, and
+// docs are separate follow-on work.
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+)
+
+const (
+	// KeySize is the AES-256 key length in bytes.
+	KeySize = 32
+	// NonceSize is the AES-GCM nonce length in bytes. It matches
+	// gcm.NonceSize() for the standard 96-bit GCM nonce.
+	NonceSize = 12
+	// tagSize is the AES-GCM authentication tag length in bytes.
+	tagSize = 16
+)
+
+// newGCM builds an AES-256-GCM AEAD from a 32-byte key.
+func newGCM(key []byte) (cipher.AEAD, error) {
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("secrets: key must be %d bytes, got %d", KeySize, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: new cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: new gcm: %w", err)
+	}
+	return gcm, nil
+}
+
+// Encrypt seals plaintext with AES-256-GCM under key, binding the ciphertext to
+// name via the GCM additional authenticated data (AAD). The returned blob is
+// laid out as nonce(12) || ciphertext || tag(16): a fresh 12-byte random nonce
+// is generated per call and prefixed, so the blob is self-describing for
+// decryption (and for future per-row key rotation). name must match on Decrypt
+// or authentication fails.
+func Encrypt(key, plaintext []byte, name string) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("secrets: read nonce: %w", err)
+	}
+	// Seal appends ciphertext||tag to the nonce prefix, yielding the full blob.
+	return gcm.Seal(nonce, nonce, plaintext, []byte(name)), nil
+}
+
+// Decrypt opens a nonce(12) || ciphertext || tag(16) blob produced by Encrypt,
+// verifying integrity and the name binding (AAD). A tampered or truncated blob,
+// the wrong key, or a mismatched name all fail loudly with an error rather than
+// returning garbage plaintext.
+func Decrypt(key, blob []byte, name string) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(blob) < NonceSize+tagSize {
+		return nil, fmt.Errorf("secrets: ciphertext blob too short: %d bytes", len(blob))
+	}
+	nonce, ciphertext := blob[:NonceSize], blob[NonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(name))
+	if err != nil {
+		return nil, fmt.Errorf("secrets: decrypt %q: %w", name, err)
+	}
+	return plaintext, nil
+}
+
+// GenerateKey returns a fresh random 32-byte AES-256 key.
+func GenerateKey() ([]byte, error) {
+	key := make([]byte, KeySize)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("secrets: generate key: %w", err)
+	}
+	return key, nil
+}

--- a/internal/secrets/crypto_test.go
+++ b/internal/secrets/crypto_test.go
@@ -1,0 +1,111 @@
+package secrets
+
+import (
+	"bytes"
+	"testing"
+)
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if len(key) != KeySize {
+		t.Fatalf("key len = %d, want %d", len(key), KeySize)
+	}
+	return key
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key := testKey(t)
+	plaintext := []byte("super-secret-musixmatch-token")
+	blob, err := Encrypt(key, plaintext, "musixmatch_token")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Blob layout: nonce(12) || ciphertext || tag(16). Plaintext must not appear.
+	if len(blob) != NonceSize+len(plaintext)+tagSize {
+		t.Fatalf("blob len = %d, want %d", len(blob), NonceSize+len(plaintext)+tagSize)
+	}
+	if bytes.Contains(blob, plaintext) {
+		t.Fatal("blob contains plaintext")
+	}
+	got, err := Decrypt(key, blob, "musixmatch_token")
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip = %q, want %q", got, plaintext)
+	}
+}
+
+func TestDecryptTamperedBlobFails(t *testing.T) {
+	key := testKey(t)
+	blob, err := Encrypt(key, []byte("value"), "name")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Flip a bit in the ciphertext/tag region (past the nonce).
+	tampered := bytes.Clone(blob)
+	tampered[len(tampered)-1] ^= 0x01
+	if _, err := Decrypt(key, tampered, "name"); err == nil {
+		t.Fatal("Decrypt of tampered blob succeeded; want error")
+	}
+}
+
+func TestDecryptWrongKeyFails(t *testing.T) {
+	key := testKey(t)
+	other := testKey(t)
+	blob, err := Encrypt(key, []byte("value"), "name")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := Decrypt(other, blob, "name"); err == nil {
+		t.Fatal("Decrypt with wrong key succeeded; want error")
+	}
+}
+
+func TestDecryptAADMismatchFails(t *testing.T) {
+	key := testKey(t)
+	blob, err := Encrypt(key, []byte("value"), "webhook_api_key")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Decrypting under a different name (a row-swap) must fail.
+	if _, err := Decrypt(key, blob, "musixmatch_token"); err == nil {
+		t.Fatal("Decrypt with mismatched AAD name succeeded; want error")
+	}
+}
+
+func TestDecryptShortBlobFails(t *testing.T) {
+	key := testKey(t)
+	if _, err := Decrypt(key, []byte("too-short"), "name"); err == nil {
+		t.Fatal("Decrypt of short blob succeeded; want error")
+	}
+}
+
+func TestEncryptNonceUniqueness(t *testing.T) {
+	key := testKey(t)
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		blob, err := Encrypt(key, []byte("value"), "name")
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		nonce := string(blob[:NonceSize])
+		if seen[nonce] {
+			t.Fatal("duplicate nonce across encryptions")
+		}
+		seen[nonce] = true
+	}
+}
+
+func TestNewGCMRejectsBadKeyLength(t *testing.T) {
+	if _, err := Encrypt([]byte("short"), []byte("v"), "n"); err == nil {
+		t.Fatal("Encrypt with short key succeeded; want error")
+	}
+	if _, err := Decrypt([]byte("short"), make([]byte, NonceSize+tagSize), "n"); err == nil {
+		t.Fatal("Decrypt with short key succeeded; want error")
+	}
+}

--- a/internal/secrets/key.go
+++ b/internal/secrets/key.go
@@ -1,0 +1,147 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// DefaultKeyFileName is the hidden key file written alongside the database on
+// native installs. Its directory is resolved by the caller (the XDG data dir).
+const DefaultKeyFileName = ".mxlrcgo.key"
+
+// KeyOptions describes how to resolve the 32-byte master key. The caller (the
+// config/startup layer) supplies the already-resolved inputs so this package
+// stays decoupled from config and easily testable: MasterKeyB64 is the raw
+// MXLRC_MASTER_KEY env value, KeyFilePath is the resolved key file location
+// (default DefaultKeyFileName under the data dir, or a secrets.key_file /
+// MXLRC_SECRETS_KEY_FILE override), and DockerMode reports whether the daemon
+// is running with /config paths.
+type KeyOptions struct {
+	MasterKeyB64 string
+	KeyFilePath  string
+	DockerMode   bool
+	Logger       *slog.Logger
+}
+
+func (o KeyOptions) logger() *slog.Logger {
+	if o.Logger != nil {
+		return o.Logger
+	}
+	return slog.Default()
+}
+
+// FirstRunError is returned by ResolveKey on the first Docker run when no
+// MXLRC_MASTER_KEY is set. It carries a freshly generated, base64-encoded
+// suggested key. The caller must print Message() to stderr exactly once (never
+// to the slog file) and fatal-exit without serving; the daemon must never run
+// unencrypted. See decision A=(c) in the design of record.
+type FirstRunError struct {
+	SuggestedKeyB64 string
+}
+
+func (e *FirstRunError) Error() string {
+	return "secrets: MXLRC_MASTER_KEY is required in Docker mode; see the suggested key printed to stderr"
+}
+
+// Message returns the one-time onboarding text for stderr. The first line is the
+// copy-pasteable MXLRC_MASTER_KEY=<base64> assignment; the remainder explains
+// what to do. This must go to stderr only, never the rotating slog file.
+func (e *FirstRunError) Message() string {
+	return "MXLRC_MASTER_KEY=" + e.SuggestedKeyB64 + "\n" +
+		"\n" +
+		"No encryption master key is configured. A new one was generated above.\n" +
+		"Set MXLRC_MASTER_KEY to this value in your container/Unraid template (or a\n" +
+		".env kept outside the data volume) and restart. Store it safely: it will not\n" +
+		"be shown again, and losing it makes the encrypted secrets unrecoverable.\n" +
+		"The daemon will not start until MXLRC_MASTER_KEY is set."
+}
+
+// ResolveKey returns the 32-byte AES-256 master key.
+//
+// Resolution order (first present wins):
+//  1. MXLRC_MASTER_KEY (MasterKeyB64): base64 of exactly 32 bytes. A malformed
+//     value (bad base64 or wrong length) is a loud, fatal error - never a
+//     silent fallback to no encryption.
+//  2. Docker mode with no master key: returns *FirstRunError so the caller can
+//     print the onboarding hint and exit. A colocated key file is never
+//     auto-created in /config.
+//  3. Native key file: read it (warning on loose perms), or auto-generate a
+//     0600 file on first use. An unreadable/unwritable/malformed key file is a
+//     loud, fatal error.
+func ResolveKey(opts KeyOptions) ([]byte, error) {
+	if opts.MasterKeyB64 != "" {
+		key, err := decodeMasterKey(opts.MasterKeyB64)
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+
+	if opts.DockerMode {
+		suggested, err := GenerateKey()
+		if err != nil {
+			return nil, err
+		}
+		return nil, &FirstRunError{SuggestedKeyB64: base64.StdEncoding.EncodeToString(suggested)}
+	}
+
+	return loadOrCreateKeyFile(opts)
+}
+
+// decodeMasterKey decodes a base64-encoded 32-byte key, failing loudly on bad
+// encoding or wrong length.
+func decodeMasterKey(b64 string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: MXLRC_MASTER_KEY is not valid base64: %w", err)
+	}
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("secrets: MXLRC_MASTER_KEY must decode to %d bytes, got %d", KeySize, len(key))
+	}
+	return key, nil
+}
+
+// loadOrCreateKeyFile reads the 32-byte key file, or creates it 0600 on first
+// use. Loose permissions on an existing file warn (non-fatal); any other I/O or
+// length problem is fatal.
+func loadOrCreateKeyFile(opts KeyOptions) ([]byte, error) {
+	if opts.KeyFilePath == "" {
+		return nil, errors.New("secrets: key file path must not be empty")
+	}
+
+	info, err := os.Stat(opts.KeyFilePath)
+	switch {
+	case err == nil:
+		if info.Mode().Perm()&0o077 != 0 {
+			opts.logger().Warn("secrets: key file has loose permissions",
+				"path", opts.KeyFilePath, "mode", info.Mode().Perm().String())
+		}
+		key, err := os.ReadFile(opts.KeyFilePath) //nolint:gosec // path is operator-configured, not attacker-controlled
+		if err != nil {
+			return nil, fmt.Errorf("secrets: read key file %s: %w", opts.KeyFilePath, err)
+		}
+		if len(key) != KeySize {
+			return nil, fmt.Errorf("secrets: key file %s must contain %d bytes, got %d", opts.KeyFilePath, KeySize, len(key))
+		}
+		return key, nil
+	case errors.Is(err, os.ErrNotExist):
+		return createKeyFile(opts.KeyFilePath)
+	default:
+		return nil, fmt.Errorf("secrets: stat key file %s: %w", opts.KeyFilePath, err)
+	}
+}
+
+// createKeyFile generates a fresh 32-byte key and writes it 0600.
+func createKeyFile(path string) ([]byte, error) {
+	key, err := GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		return nil, fmt.Errorf("secrets: write key file %s: %w", path, err)
+	}
+	return key, nil
+}

--- a/internal/secrets/key_test.go
+++ b/internal/secrets/key_test.go
@@ -1,0 +1,150 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveKeyEnvWinsOverFile(t *testing.T) {
+	// Write a key file that should be ignored when MXLRC_MASTER_KEY is set.
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, DefaultKeyFileName)
+	fileKey := bytes.Repeat([]byte{0xAA}, KeySize)
+	if err := os.WriteFile(keyPath, fileKey, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	envKey := bytes.Repeat([]byte{0xBB}, KeySize)
+	got, err := ResolveKey(KeyOptions{
+		MasterKeyB64: base64.StdEncoding.EncodeToString(envKey),
+		KeyFilePath:  keyPath,
+	})
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if !bytes.Equal(got, envKey) {
+		t.Fatal("env key did not win over key file")
+	}
+}
+
+func TestResolveKeyMalformedMasterKeyFatal(t *testing.T) {
+	cases := map[string]string{
+		"bad base64":   "not!valid!base64!",
+		"wrong length": base64.StdEncoding.EncodeToString([]byte("only-a-few-bytes")),
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ResolveKey(KeyOptions{MasterKeyB64: val}); err == nil {
+				t.Fatal("ResolveKey accepted malformed MXLRC_MASTER_KEY; want fatal error")
+			}
+		})
+	}
+}
+
+func TestResolveKeyAutoCreatesKeyFile0600(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, DefaultKeyFileName)
+	got, err := ResolveKey(KeyOptions{KeyFilePath: keyPath})
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if len(got) != KeySize {
+		t.Fatalf("generated key len = %d, want %d", len(got), KeySize)
+	}
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("key file mode = %v, want 0600", info.Mode().Perm())
+	}
+	// A second resolve reads the same key back.
+	again, err := ResolveKey(KeyOptions{KeyFilePath: keyPath})
+	if err != nil {
+		t.Fatalf("ResolveKey (reload): %v", err)
+	}
+	if !bytes.Equal(got, again) {
+		t.Fatal("reloaded key differs from generated key")
+	}
+}
+
+func TestResolveKeyLoosePermsWarns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits unreliable on Windows")
+	}
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, DefaultKeyFileName)
+	if err := os.WriteFile(keyPath, bytes.Repeat([]byte{0x11}, KeySize), 0o644); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if _, err := ResolveKey(KeyOptions{KeyFilePath: keyPath, Logger: logger}); err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if !strings.Contains(buf.String(), "loose permissions") {
+		t.Fatalf("expected loose-permissions warning, got: %q", buf.String())
+	}
+}
+
+func TestResolveKeyBadLengthFileFatal(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, DefaultKeyFileName)
+	if err := os.WriteFile(keyPath, []byte("too short"), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	if _, err := ResolveKey(KeyOptions{KeyFilePath: keyPath}); err == nil {
+		t.Fatal("ResolveKey accepted wrong-length key file; want fatal error")
+	}
+}
+
+func TestResolveKeyEmptyKeyFilePathFatal(t *testing.T) {
+	if _, err := ResolveKey(KeyOptions{}); err == nil {
+		t.Fatal("ResolveKey with no master key and no key file path succeeded; want error")
+	}
+}
+
+func TestResolveKeyDockerFirstRunHint(t *testing.T) {
+	_, err := ResolveKey(KeyOptions{DockerMode: true})
+	var fr *FirstRunError
+	if !errors.As(err, &fr) {
+		t.Fatalf("ResolveKey Docker first-run err = %v; want *FirstRunError", err)
+	}
+	// The suggested key must be valid base64 of 32 bytes.
+	raw, decErr := base64.StdEncoding.DecodeString(fr.SuggestedKeyB64)
+	if decErr != nil {
+		t.Fatalf("suggested key not base64: %v", decErr)
+	}
+	if len(raw) != KeySize {
+		t.Fatalf("suggested key decodes to %d bytes, want %d", len(raw), KeySize)
+	}
+	// Message carries the copy-pasteable assignment line, once, for stderr.
+	msg := fr.Message()
+	if !strings.HasPrefix(msg, "MXLRC_MASTER_KEY="+fr.SuggestedKeyB64) {
+		t.Fatalf("Message does not start with the key assignment line: %q", msg)
+	}
+	if strings.Count(msg, "MXLRC_MASTER_KEY=") != 1 {
+		t.Fatalf("MXLRC_MASTER_KEY= should appear exactly once, got: %q", msg)
+	}
+}
+
+func TestResolveKeyDockerEnvKeyServes(t *testing.T) {
+	// Docker mode WITH a valid master key resolves normally (no hint, no file).
+	envKey := bytes.Repeat([]byte{0xCC}, KeySize)
+	got, err := ResolveKey(KeyOptions{
+		DockerMode:   true,
+		MasterKeyB64: base64.StdEncoding.EncodeToString(envKey),
+	})
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if !bytes.Equal(got, envKey) {
+		t.Fatal("docker-mode env key not resolved")
+	}
+}

--- a/internal/secrets/memory.go
+++ b/internal/secrets/memory.go
@@ -1,0 +1,57 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// MemoryStore is an in-memory Store for tests and single-process use, mirroring
+// auth.MemoryStore. Values are held in plaintext in a map (there is no at-rest
+// surface to protect in memory), so it exercises the same Store contract as
+// SQLStore without a key or database.
+type MemoryStore struct {
+	mu      sync.RWMutex
+	secrets map[string]string
+}
+
+// NewMemoryStore returns an empty in-memory secret store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{secrets: map[string]string{}}
+}
+
+// Set stores plaintext under name, overwriting any existing value.
+func (s *MemoryStore) Set(ctx context.Context, name, plaintext string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if name == "" {
+		return errors.New("secrets: name must not be empty")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.secrets[name] = plaintext
+	return nil
+}
+
+// Get returns the plaintext for name; ok is false when absent.
+func (s *MemoryStore) Get(ctx context.Context, name string) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", false, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.secrets[name]
+	return v, ok, nil
+}
+
+// Delete removes name; deleting an absent name is a no-op.
+func (s *MemoryStore) Delete(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.secrets, name)
+	return nil
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -25,9 +25,13 @@ type SQLStore struct {
 }
 
 // NewSQLStore returns a SQL-backed secret store using key for AES-256-GCM. key
-// must be 32 bytes; an invalid key surfaces at Set/Get time.
+// must be 32 bytes; an invalid key surfaces at Set/Get time. The key is copied
+// internally, so a later mutation or zeroing of the caller's slice does not
+// affect the store's effective key.
 func NewSQLStore(db *sql.DB, key []byte) *SQLStore {
-	return &SQLStore{db: db, key: key}
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+	return &SQLStore{db: db, key: keyCopy}
 }
 
 // Set encrypts plaintext and upserts it under name, refreshing updated_at.

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -1,0 +1,82 @@
+package secrets
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Store is the secret repository. Callers Set/Get/Delete plaintext values by
+// name; encryption and decryption happen inside the implementation so callers
+// never see ciphertext or the key. Get reports absence via ok=false (no error).
+type Store interface {
+	Set(ctx context.Context, name, plaintext string) error
+	Get(ctx context.Context, name string) (plaintext string, ok bool, err error)
+	Delete(ctx context.Context, name string) error
+}
+
+// SQLStore persists secrets encrypted-at-rest in the SQLite `secrets` table.
+// It holds the 32-byte master key in memory and seals/opens each value with
+// AES-256-GCM (AAD bound to the secret name).
+type SQLStore struct {
+	db  *sql.DB
+	key []byte
+}
+
+// NewSQLStore returns a SQL-backed secret store using key for AES-256-GCM. key
+// must be 32 bytes; an invalid key surfaces at Set/Get time.
+func NewSQLStore(db *sql.DB, key []byte) *SQLStore {
+	return &SQLStore{db: db, key: key}
+}
+
+// Set encrypts plaintext and upserts it under name, refreshing updated_at.
+func (s *SQLStore) Set(ctx context.Context, name, plaintext string) error {
+	if name == "" {
+		return errors.New("secrets: name must not be empty")
+	}
+	blob, err := Encrypt(s.key, []byte(plaintext), name)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO secrets (name, ciphertext, updated_at)
+         VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+         ON CONFLICT(name) DO UPDATE SET
+             ciphertext = excluded.ciphertext,
+             updated_at = excluded.updated_at`,
+		name, blob,
+	)
+	if err != nil {
+		return fmt.Errorf("secrets: set %q: %w", name, err)
+	}
+	return nil
+}
+
+// Get returns the decrypted plaintext for name. ok is false when no such secret
+// exists; a decryption failure (tampering, wrong key) is returned as an error.
+func (s *SQLStore) Get(ctx context.Context, name string) (string, bool, error) {
+	var blob []byte
+	err := s.db.QueryRowContext(ctx,
+		`SELECT ciphertext FROM secrets WHERE name = ?`, name,
+	).Scan(&blob)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("secrets: get %q: %w", name, err)
+	}
+	plaintext, err := Decrypt(s.key, blob, name)
+	if err != nil {
+		return "", false, err
+	}
+	return string(plaintext), true, nil
+}
+
+// Delete removes the secret named name. Deleting an absent name is a no-op.
+func (s *SQLStore) Delete(ctx context.Context, name string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM secrets WHERE name = ?`, name); err != nil {
+		return fmt.Errorf("secrets: delete %q: %w", name, err)
+	}
+	return nil
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -37,6 +37,35 @@ func TestSQLStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestNewSQLStoreCopiesKey(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	key := testKey(t)
+	store := NewSQLStore(sqlDB, key)
+
+	// Zero the caller's original key slice after construction. If the store held
+	// the slice by reference, this would corrupt its key and break the round-trip.
+	for i := range key {
+		key[i] = 0
+	}
+
+	if err := store.Set(ctx, "k", "plain-value"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || got != "plain-value" {
+		t.Fatalf("Get = (%q, %v), want (%q, true); store key not independent of caller slice", got, ok, "plain-value")
+	}
+}
+
 func TestSQLStoreCiphertextNotPlaintext(t *testing.T) {
 	ctx := context.Background()
 	store, sqlDB := newTestStore(t)

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,187 @@
+package secrets
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+)
+
+// newTestStore opens a migrated SQLite DB (temp file) and returns a SQLStore
+// keyed with a fresh random key. Real SQLite, no mocks, per repo convention.
+func newTestStore(t *testing.T) (*SQLStore, *sql.DB) {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return NewSQLStore(sqlDB, testKey(t)), sqlDB
+}
+
+func TestSQLStoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+
+	if err := store.Set(ctx, "musixmatch_token", "tok-123"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "musixmatch_token")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || got != "tok-123" {
+		t.Fatalf("Get = (%q, %v), want (%q, true)", got, ok, "tok-123")
+	}
+}
+
+func TestSQLStoreCiphertextNotPlaintext(t *testing.T) {
+	ctx := context.Background()
+	store, sqlDB := newTestStore(t)
+	if err := store.Set(ctx, "webhook_api_key", "plain-value"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	var blob []byte
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT ciphertext FROM secrets WHERE name = ?`, "webhook_api_key").Scan(&blob); err != nil {
+		t.Fatalf("scan ciphertext: %v", err)
+	}
+	if string(blob) == "plain-value" {
+		t.Fatal("stored ciphertext equals plaintext")
+	}
+}
+
+func TestSQLStoreUpsertOverwrites(t *testing.T) {
+	ctx := context.Background()
+	store, sqlDB := newTestStore(t)
+
+	if err := store.Set(ctx, "k", "first"); err != nil {
+		t.Fatalf("Set first: %v", err)
+	}
+	var firstUpdated string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT updated_at FROM secrets WHERE name = ?`, "k").Scan(&firstUpdated); err != nil {
+		t.Fatalf("scan updated_at: %v", err)
+	}
+
+	// Force a strictly later timestamp so the advance is observable despite the
+	// 1-second strftime resolution.
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE secrets SET updated_at = '2000-01-01T00:00:00Z' WHERE name = ?`, "k"); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	if err := store.Set(ctx, "k", "second"); err != nil {
+		t.Fatalf("Set second: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "k")
+	if err != nil || !ok {
+		t.Fatalf("Get: %v ok=%v", err, ok)
+	}
+	if got != "second" {
+		t.Fatalf("Get = %q, want %q (upsert did not overwrite)", got, "second")
+	}
+
+	// Exactly one row for the name (upsert, not insert).
+	var count int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM secrets WHERE name = ?`, "k").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("row count = %d, want 1", count)
+	}
+
+	var secondUpdated string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT updated_at FROM secrets WHERE name = ?`, "k").Scan(&secondUpdated); err != nil {
+		t.Fatalf("scan updated_at: %v", err)
+	}
+	if secondUpdated <= "2000-01-01T00:00:00Z" {
+		t.Fatalf("updated_at did not advance on re-set: %q", secondUpdated)
+	}
+}
+
+func TestSQLStoreGetAbsentNotFound(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+	got, ok, err := store.Get(ctx, "missing")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ok || got != "" {
+		t.Fatalf("Get absent = (%q, %v), want (\"\", false)", got, ok)
+	}
+}
+
+func TestSQLStoreDelete(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+	if err := store.Set(ctx, "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, _ := store.Get(ctx, "k"); ok {
+		t.Fatal("secret present after Delete")
+	}
+	// Deleting an absent name is a no-op.
+	if err := store.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete absent: %v", err)
+	}
+}
+
+func TestSQLStoreSetEmptyNameFails(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+	if err := store.Set(ctx, "", "v"); err == nil {
+		t.Fatal("Set with empty name succeeded; want error")
+	}
+}
+
+func TestSQLStoreWrongKeyGetFails(t *testing.T) {
+	ctx := context.Background()
+	store, sqlDB := newTestStore(t)
+	if err := store.Set(ctx, "k", "v"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// A store with a different key cannot decrypt existing ciphertext.
+	other := NewSQLStore(sqlDB, testKey(t))
+	if _, _, err := other.Get(ctx, "k"); err == nil {
+		t.Fatal("Get with wrong key succeeded; want decrypt error")
+	}
+}
+
+func TestMemoryStoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	var store Store = NewMemoryStore()
+
+	if _, ok, _ := store.Get(ctx, "k"); ok {
+		t.Fatal("empty store reported a secret")
+	}
+	if err := store.Set(ctx, "k", "v1"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok, err := store.Get(ctx, "k")
+	if err != nil || !ok || got != "v1" {
+		t.Fatalf("Get = (%q, %v, %v), want (v1, true, nil)", got, ok, err)
+	}
+	if err := store.Set(ctx, "k", "v2"); err != nil {
+		t.Fatalf("Set overwrite: %v", err)
+	}
+	if got, _, _ := store.Get(ctx, "k"); got != "v2" {
+		t.Fatalf("Get after overwrite = %q, want v2", got)
+	}
+	if err := store.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, _ := store.Get(ctx, "k"); ok {
+		t.Fatal("secret present after Delete")
+	}
+	if err := store.Set(ctx, "", "v"); err == nil {
+		t.Fatal("Set empty name succeeded; want error")
+	}
+}


### PR DESCRIPTION
## Phase 1 of #229 - encrypted secrets foundation

Implements the crypto + storage foundation from the design-of-record (`docs/design/2026-06-13-223-secrets-encryption.md`, merged in #230). This is the first of four phases; it adds the building blocks only - no precedence wiring, CLI, or docs yet (those are Phases 2-4, each a separate PR).

### What's in this PR
- **`internal/db/migrations/017_secrets.sql`** - `secrets` table (`name` PK, `ciphertext` BLOB NOT NULL, `updated_at` default), with up/down.
- **`internal/secrets/crypto.go`** - AES-256-GCM `Encrypt`/`Decrypt`. Blob layout is `nonce(12) || ciphertext || tag(16)`, fresh `crypto/rand` nonce per encrypt, GCM AAD bound to the secret name (decision B). `GenerateKey` + `KeySize`/`NonceSize` consts.
- **`internal/secrets/key.go`** - `ResolveKey`: `MXLRC_MASTER_KEY` (base64 32B) wins; in Docker mode a first run with no key returns a `*FirstRunError` carrying a generated suggested key and its one-time stderr message (decision A - refuse silent auto-create in `/config`, hint once); native mode auto-creates a `0600` key file, warns on loose perms, and treats a malformed/short/unreadable key as fatal. Never silently runs unencrypted.
- **`internal/secrets/store.go`** - `Store` interface (`Set`/`Get`/`Delete`) + `SQLStore` (encrypt-on-set upsert, decrypt-on-get, `ok=false` on absent).
- **`internal/secrets/memory.go`** - in-memory `Store` mirroring `auth.MemoryStore` for tests.
- **Tests** - crypto/key/store unit tests + a migration-017 up/down test in `internal/db`, all on real in-memory/temp SQLite (no mocks).

### Note for Phase 2
`ResolveKey` is deliberately decoupled from `internal/config`: the caller supplies already-resolved inputs (`MasterKeyB64`, `KeyFilePath`, `DockerMode`). `config`'s `xdgDataPath`/`dockerMode` are unexported, so Phase 2 must export a helper or pass resolved values through. The first-run hint is a returned `*FirstRunError` (not an `os.Exit`) so it stays testable - Phase 2/main prints `fr.Message()` to stderr and exits non-zero.

### Validation
`make gate` green: race tests pass, secrets package coverage 84.5%, patch coverage 72.97% (above the 70% floor), golangci-lint 0 issues, govulncheck clean.

Part of #229 (Phase 1 of 4). Does not close the issue.
