### PR TITLE
feat(secrets): precedence wiring + startup key resolution (#229 phase 2)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -212,6 +212,17 @@ script_guard_threshold = 0.20
 # deterministic created_at/id ordering. Env override: MXLRC_QUEUE_RANDOMIZE.
 randomize = true
 
+[secrets]
+# Encrypted-at-rest storage for the Musixmatch token and webhook API key. The
+# 32-byte AES-256 master key is resolved from MXLRC_MASTER_KEY (recommended for
+# Docker; keeps the key out of the data volume) or a 0600 key file. key_file
+# overrides the default key-file location (the hidden .mxlrcgo.key beside the
+# database); leave empty to use that default. In Docker mode MXLRC_MASTER_KEY is
+# required and no key file is auto-created. The DB store is the LOWEST-precedence
+# source for both secrets: CLI/env/TOML still win. Env override:
+# MXLRC_SECRETS_KEY_FILE.
+key_file = ""
+
 [logging]
 # Minimum log level to emit: debug, info, warn, error. Default info.
 # DEBUG exposes per-request detail, worker idle-polls, and watcher events.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
+	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
 	"github.com/sydlexius/mxlrcgo-svc/internal/server"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 	"github.com/sydlexius/mxlrcgo-svc/internal/watcher"
@@ -660,10 +661,53 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		addr = *args.Listen
 	}
 
+	// Open the DB before the banner so the encrypted secret store can serve as
+	// the lowest-precedence source for the token and webhook key, and the banner
+	// reflects the effective (redacted) values.
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+
+	// Resolve the master key and build the encrypted secret store. On the Docker
+	// first-run case (no MXLRC_MASTER_KEY) print the onboarding hint to stderr
+	// exactly once and exit without serving - never run unencrypted. The hint and
+	// key bytes never go to the slog file.
+	store, firstRun, err := resolveSecretStore(cfg, sqlDB)
+	if err != nil {
+		_ = sqlDB.Close()
+		slog.Error("failed to initialize secret store", "error", err)
+		return 1
+	}
+	if firstRun != nil {
+		_ = sqlDB.Close()
+		_, _ = fmt.Fprintln(os.Stderr, firstRun.Message())
+		return 1
+	}
+
+	// DB is the lowest-precedence source for both secrets: consulted only when the
+	// higher tiers (CLI/env/TOML) are empty, and a DB-sourced value is never
+	// auto-persisted back.
+	token, tokenFromDB, err := resolveTokenWithStore(ctx, token, store)
+	if err != nil {
+		_ = sqlDB.Close()
+		slog.Error("failed to resolve musixmatch token", "error", err)
+		return 1
+	}
+	webhookKeys, webhookFromDB, err := resolveWebhookKeysWithStore(ctx, cfg.Server.WebhookAPIKeys, store)
+	if err != nil {
+		_ = sqlDB.Close()
+		slog.Error("failed to resolve webhook API key", "error", err)
+		return 1
+	}
+
 	// Emit startup banner after initLogging (log file is ready) and after all
-	// CLI flag overrides are applied so the banner reflects effective values.
+	// CLI flag overrides and DB-tier fallbacks are applied so the banner reflects
+	// effective values. DB-sourced secrets are redacted exactly like plaintext.
 	bannerCfg := cfg
 	bannerCfg.API.Token = token
+	bannerCfg.Server.WebhookAPIKeys = webhookKeys
 	bannerCfg.Output.Dir = outdir
 	bannerCfg.Server.Addr = addr
 	serveCLISrc := map[string]bool{}
@@ -676,24 +720,27 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	if args.Listen != nil {
 		serveCLISrc["server.addr"] = true
 	}
+	if tokenFromDB {
+		slog.Info("musixmatch token sourced from encrypted secret store")
+	}
+	if webhookFromDB {
+		slog.Info("webhook API key sourced from encrypted secret store")
+	}
 	logStartupBanner(ctx, bannerCfg, VersionString(), out, envSrc, serveCLISrc)
 	fetcher, err := selectedProvider(cfg, token, newFetcher)
 	if err != nil {
+		_ = sqlDB.Close()
 		slog.Error("failed to configure lyrics provider", "error", err)
 		return 1
 	}
 	verifier, err := newVerifier(cfg)
 	if err != nil {
+		_ = sqlDB.Close()
 		slog.Error("failed to configure verification", "error", err)
 		return 1
 	}
-	sqlDB, err := db.Open(ctx, cfg.DB.Path)
-	if err != nil {
-		slog.Error("failed to open database", "error", err)
-		return 1
-	}
 
-	authSvc, err := keyService(ctx, sqlDB, cfg.Server.WebhookAPIKeys)
+	authSvc, err := keyService(ctx, sqlDB, webhookKeys)
 	if err != nil {
 		_ = sqlDB.Close()
 		slog.Error("failed to configure authentication", "error", err)
@@ -1409,6 +1456,69 @@ func parseScopes(values []string) ([]auth.Scope, error) {
 		scopes = append(scopes, auth.Scope(v))
 	}
 	return auth.NormalizeScopes(scopes)
+}
+
+// resolveSecretStore resolves the AES-256 master key and constructs the
+// SQL-backed encrypted secret store. The key is resolved from MXLRC_MASTER_KEY
+// (env, never logged) > the resolved secrets.key_file > the native default key
+// file, via secrets.ResolveKey.
+//
+// On the Docker first-run case (no MXLRC_MASTER_KEY in Docker mode) it returns a
+// non-nil *secrets.FirstRunError and a nil store, so the caller can print the
+// onboarding hint to stderr exactly once and exit without serving - the daemon
+// never runs unencrypted. Any other resolution failure (malformed master key,
+// unreadable key file) is returned as a wrapped error and is fatal at the call
+// site. The key bytes never touch slog.
+func resolveSecretStore(cfg config.Config, sqlDB *sql.DB) (secrets.Store, *secrets.FirstRunError, error) {
+	opts := cfg.SecretsKeyOptions()
+	opts.MasterKeyB64 = os.Getenv("MXLRC_MASTER_KEY")
+	key, err := secrets.ResolveKey(opts)
+	if err != nil {
+		var fr *secrets.FirstRunError
+		if errors.As(err, &fr) {
+			return nil, fr, nil
+		}
+		return nil, nil, fmt.Errorf("resolve secrets master key: %w", err)
+	}
+	return secrets.NewSQLStore(sqlDB, key), nil, nil
+}
+
+// resolveTokenWithStore appends the encrypted DB store as the LOWEST-precedence
+// Musixmatch token source. higher is the already-resolved value from the higher
+// tiers (--token CLI > MUSIXMATCH_TOKEN > MXLRC_API_TOKEN > TOML api.token). The
+// DB is consulted only when higher is empty; a present higher tier is used as-is
+// and is NEVER auto-persisted to the DB (import is an explicit operator action).
+func resolveTokenWithStore(ctx context.Context, higher string, store secrets.Store) (token string, fromDB bool, err error) {
+	if strings.TrimSpace(higher) != "" || store == nil {
+		return higher, false, nil
+	}
+	v, ok, err := store.Get(ctx, secrets.NameMusixmatchToken)
+	if err != nil {
+		return "", false, fmt.Errorf("read musixmatch token from secret store: %w", err)
+	}
+	if !ok {
+		return higher, false, nil
+	}
+	return v, true, nil
+}
+
+// resolveWebhookKeysWithStore appends the encrypted DB store as the
+// LOWEST-precedence webhook API key source. higher is the already-resolved value
+// from the higher tiers (CLI/env MXLRC_WEBHOOK_API_KEY > TOML
+// server.webhook_api_keys). The DB is consulted only when higher is empty; a
+// present higher tier is used as-is and is NEVER auto-persisted.
+func resolveWebhookKeysWithStore(ctx context.Context, higher []string, store secrets.Store) (keys []string, fromDB bool, err error) {
+	if len(higher) > 0 || store == nil {
+		return higher, false, nil
+	}
+	v, ok, err := store.Get(ctx, secrets.NameWebhookAPIKey)
+	if err != nil {
+		return nil, false, fmt.Errorf("read webhook API key from secret store: %w", err)
+	}
+	if !ok || strings.TrimSpace(v) == "" {
+		return higher, false, nil
+	}
+	return []string{v}, true, nil
 }
 
 func keyService(ctx context.Context, sqlDB *sql.DB, rawKeys []string) (*auth.Service, error) {

--- a/internal/commands/secrets_precedence_test.go
+++ b/internal/commands/secrets_precedence_test.go
@@ -1,0 +1,393 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
+)
+
+// newSecretStore opens a migrated SQLite DB (temp file) and returns an encrypted
+// SQL-backed secret store. Real SQLite, no mocks, per repo convention.
+func newSecretStore(t *testing.T) *secrets.SQLStore {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	key, err := secrets.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return secrets.NewSQLStore(sqlDB, key)
+}
+
+func TestResolveTokenWithStore_DBUsedOnlyWhenHigherAbsent(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	if err := store.Set(ctx, secrets.NameMusixmatchToken, "db-token"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Higher tier present: DB is NOT consulted and not used.
+	got, fromDB, err := resolveTokenWithStore(ctx, "higher-token", store)
+	if err != nil {
+		t.Fatalf("resolveTokenWithStore: %v", err)
+	}
+	if got != "higher-token" || fromDB {
+		t.Fatalf("higher present: got (%q, fromDB=%v), want (higher-token, false)", got, fromDB)
+	}
+
+	// Higher tier empty: DB tier is used.
+	got, fromDB, err = resolveTokenWithStore(ctx, "", store)
+	if err != nil {
+		t.Fatalf("resolveTokenWithStore: %v", err)
+	}
+	if got != "db-token" || !fromDB {
+		t.Fatalf("higher absent: got (%q, fromDB=%v), want (db-token, true)", got, fromDB)
+	}
+}
+
+func TestResolveTokenWithStore_NoAutoPersist(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+
+	// A present higher tier must never be written back to the DB.
+	if _, _, err := resolveTokenWithStore(ctx, "higher-token", store); err != nil {
+		t.Fatalf("resolveTokenWithStore: %v", err)
+	}
+	if _, ok, err := store.Get(ctx, secrets.NameMusixmatchToken); err != nil {
+		t.Fatalf("Get: %v", err)
+	} else if ok {
+		t.Fatalf("token was auto-persisted to the DB; precedence must never write back")
+	}
+}
+
+func TestResolveTokenWithStore_AbsentEverywhere(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	got, fromDB, err := resolveTokenWithStore(ctx, "", store)
+	if err != nil {
+		t.Fatalf("resolveTokenWithStore: %v", err)
+	}
+	if got != "" || fromDB {
+		t.Fatalf("absent everywhere: got (%q, fromDB=%v), want (\"\", false)", got, fromDB)
+	}
+}
+
+func TestResolveWebhookKeysWithStore_DBUsedOnlyWhenHigherAbsent(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	if err := store.Set(ctx, secrets.NameWebhookAPIKey, "db-key"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Higher tier present: DB is NOT used.
+	got, fromDB, err := resolveWebhookKeysWithStore(ctx, []string{"higher-key"}, store)
+	if err != nil {
+		t.Fatalf("resolveWebhookKeysWithStore: %v", err)
+	}
+	if len(got) != 1 || got[0] != "higher-key" || fromDB {
+		t.Fatalf("higher present: got (%v, fromDB=%v), want ([higher-key], false)", got, fromDB)
+	}
+
+	// Higher tier empty: DB tier is used.
+	got, fromDB, err = resolveWebhookKeysWithStore(ctx, nil, store)
+	if err != nil {
+		t.Fatalf("resolveWebhookKeysWithStore: %v", err)
+	}
+	if len(got) != 1 || got[0] != "db-key" || !fromDB {
+		t.Fatalf("higher absent: got (%v, fromDB=%v), want ([db-key], true)", got, fromDB)
+	}
+}
+
+func TestResolveWebhookKeysWithStore_NoAutoPersist(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+
+	if _, _, err := resolveWebhookKeysWithStore(ctx, []string{"higher-key"}, store); err != nil {
+		t.Fatalf("resolveWebhookKeysWithStore: %v", err)
+	}
+	if _, ok, err := store.Get(ctx, secrets.NameWebhookAPIKey); err != nil {
+		t.Fatalf("Get: %v", err)
+	} else if ok {
+		t.Fatalf("webhook key was auto-persisted to the DB; precedence must never write back")
+	}
+}
+
+// TestResolveSecretStore_DockerFirstRun verifies the startup SEAM returns a
+// FirstRunError (rather than os.Exit) in Docker mode with no MXLRC_MASTER_KEY,
+// and that the hint Message carries the copy-pasteable assignment line.
+func TestResolveSecretStore_DockerFirstRun(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "true")
+	t.Setenv("MXLRC_MASTER_KEY", "")
+
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	cfg := config.Config{} // DockerMode is detected via MXLRC_DOCKER, not a field.
+	store, firstRun, err := resolveSecretStore(cfg, sqlDB)
+	if err != nil {
+		t.Fatalf("resolveSecretStore: unexpected error %v", err)
+	}
+	if store != nil {
+		t.Fatalf("Docker first run: store must be nil")
+	}
+	if firstRun == nil {
+		t.Fatalf("Docker first run: expected a FirstRunError")
+	}
+	msg := firstRun.Message()
+	if !strings.HasPrefix(msg, "MXLRC_MASTER_KEY=") {
+		t.Fatalf("first line must be the MXLRC_MASTER_KEY= assignment, got %q", msg)
+	}
+}
+
+// TestResolveSecretStore_NativeAutoCreatesKeyFile verifies native mode (no
+// Docker) auto-creates a 0600 key file and builds a usable store.
+func TestResolveSecretStore_NativeAutoCreatesKeyFile(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MXLRC_MASTER_KEY", "")
+	keyFile := filepath.Join(t.TempDir(), "test.key")
+
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	cfg := config.Config{Secrets: config.SecretsConfig{KeyFile: keyFile}}
+	store, firstRun, err := resolveSecretStore(cfg, sqlDB)
+	if err != nil {
+		t.Fatalf("resolveSecretStore: %v", err)
+	}
+	if firstRun != nil {
+		t.Fatalf("native mode must not return a FirstRunError")
+	}
+	if store == nil {
+		t.Fatalf("native mode: expected a usable store")
+	}
+	// Round-trip through the constructed store to confirm the auto-created key works.
+	ctx := context.Background()
+	if err := store.Set(ctx, secrets.NameMusixmatchToken, "tok"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got, ok, err := store.Get(ctx, secrets.NameMusixmatchToken); err != nil || !ok || got != "tok" {
+		t.Fatalf("Get = (%q, %v, %v), want (tok, true, nil)", got, ok, err)
+	}
+}
+
+// TestResolveSecretStore_MalformedMasterKey verifies that a non-FirstRun key
+// resolution failure (a malformed MXLRC_MASTER_KEY) surfaces loudly as a wrapped
+// error, with no store and no FirstRunError, so the call site exits fatally.
+func TestResolveSecretStore_MalformedMasterKey(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MXLRC_MASTER_KEY", "not-valid-base64!!!")
+
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "secrets.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	store, firstRun, err := resolveSecretStore(config.Config{}, sqlDB)
+	if err == nil {
+		t.Fatalf("malformed master key: expected a fatal error")
+	}
+	if store != nil || firstRun != nil {
+		t.Fatalf("malformed master key: want (nil store, nil firstRun), got (%v, %v)", store, firstRun)
+	}
+	if !strings.Contains(err.Error(), "resolve secrets master key") {
+		t.Fatalf("error must be wrapped with context, got %q", err.Error())
+	}
+}
+
+// closedStore returns an encrypted store over a CLOSED DB so that Store.Get
+// returns a non-ErrNoRows error, exercising the helpers' read-error branches.
+func closedStore(t *testing.T) secrets.Store {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "closed.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	key, err := secrets.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	store := secrets.NewSQLStore(sqlDB, key)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return store
+}
+
+func TestResolveTokenWithStore_NilStore(t *testing.T) {
+	got, fromDB, err := resolveTokenWithStore(context.Background(), "", nil)
+	if err != nil {
+		t.Fatalf("resolveTokenWithStore: %v", err)
+	}
+	if got != "" || fromDB {
+		t.Fatalf("nil store: got (%q, fromDB=%v), want (\"\", false)", got, fromDB)
+	}
+}
+
+func TestResolveTokenWithStore_ReadError(t *testing.T) {
+	_, _, err := resolveTokenWithStore(context.Background(), "", closedStore(t))
+	if err == nil {
+		t.Fatal("expected a read error from a closed store")
+	}
+	if !strings.Contains(err.Error(), "read musixmatch token from secret store") {
+		t.Fatalf("error must be wrapped with context, got %q", err.Error())
+	}
+}
+
+func TestResolveWebhookKeysWithStore_NilStore(t *testing.T) {
+	got, fromDB, err := resolveWebhookKeysWithStore(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("resolveWebhookKeysWithStore: %v", err)
+	}
+	if len(got) != 0 || fromDB {
+		t.Fatalf("nil store: got (%v, fromDB=%v), want (nil, false)", got, fromDB)
+	}
+}
+
+func TestResolveWebhookKeysWithStore_ReadError(t *testing.T) {
+	_, _, err := resolveWebhookKeysWithStore(context.Background(), nil, closedStore(t))
+	if err == nil {
+		t.Fatal("expected a read error from a closed store")
+	}
+	if !strings.Contains(err.Error(), "read webhook API key from secret store") {
+		t.Fatalf("error must be wrapped with context, got %q", err.Error())
+	}
+}
+
+// TestResolveWebhookKeysWithStore_BlankDBValue verifies that a present-but-blank
+// DB value is treated as absent (no fallback key), not as a usable key.
+func TestResolveWebhookKeysWithStore_BlankDBValue(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	if err := store.Set(ctx, secrets.NameWebhookAPIKey, "   "); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, fromDB, err := resolveWebhookKeysWithStore(ctx, nil, store)
+	if err != nil {
+		t.Fatalf("resolveWebhookKeysWithStore: %v", err)
+	}
+	if len(got) != 0 || fromDB {
+		t.Fatalf("blank DB value: got (%v, fromDB=%v), want (nil, false)", got, fromDB)
+	}
+}
+
+// TestRunServe_DockerFirstRun drives runServe through the startup wiring up to
+// the Docker first-run exit: it loads config, opens the DB, calls
+// resolveSecretStore, and (with no MXLRC_MASTER_KEY in Docker mode) prints the
+// onboarding hint to stderr and returns 1 without serving.
+func TestRunServe_DockerFirstRun(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "true")
+	t.Setenv("MXLRC_MASTER_KEY", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeServeConfig(t, cfgPath, filepath.Join(dir, "serve.db"), false, "")
+
+	var out bytes.Buffer
+	code := runServe(
+		context.Background(),
+		&out,
+		ServeCmd{ConfigPath: cfgPath},
+		func(string) musixmatch.Fetcher { return fakeFetcher{} },
+		func(...string) lyrics.Writer { return fakeWriter{} },
+	)
+	if code != 1 {
+		t.Fatalf("Docker first run: exit code = %d, want 1", code)
+	}
+}
+
+// TestRunServe_DBSecretsThenVerifierFailure drives runServe through the full
+// secret-store wiring: a usable store (key via MXLRC_MASTER_KEY), DB-sourced
+// token and webhook key (higher tiers empty -> the fromDB slog branches fire),
+// the startup banner, and provider selection - then fails deterministically at
+// verifier construction (verification enabled with a nonexistent ffmpeg) so the
+// HTTP server never starts. Exit code 1.
+func TestRunServe_DBSecretsThenVerifierFailure(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "")
+	key, err := secrets.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	t.Setenv("MXLRC_MASTER_KEY", base64.StdEncoding.EncodeToString(key))
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "serve.db")
+
+	// Seed both secrets into the DB encrypted with the SAME key runServe resolves.
+	sqlDB, err := db.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	seed := secrets.NewSQLStore(sqlDB, key)
+	ctx := context.Background()
+	if err := seed.Set(ctx, secrets.NameMusixmatchToken, "db-token"); err != nil {
+		t.Fatalf("Set token: %v", err)
+	}
+	if err := seed.Set(ctx, secrets.NameWebhookAPIKey, "mxk_dbwebhookkey000000000000000000"); err != nil {
+		t.Fatalf("Set webhook: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	// Verification enabled with a nonexistent ffmpeg -> newVerifier fails after
+	// the banner and provider selection, before the server starts.
+	writeServeConfig(t, cfgPath, dbPath, true, filepath.Join(dir, "no-such-ffmpeg"))
+
+	var out bytes.Buffer
+	code := runServe(
+		ctx,
+		&out,
+		ServeCmd{ConfigPath: cfgPath},
+		func(string) musixmatch.Fetcher { return fakeFetcher{} },
+		func(...string) lyrics.Writer { return fakeWriter{} },
+	)
+	if code != 1 {
+		t.Fatalf("verifier-failure path: exit code = %d, want 1", code)
+	}
+}
+
+// writeServeConfig writes a minimal serve config TOML pointing at dbPath with
+// the musixmatch provider. When verifyEnabled is true it enables verification
+// with the given ffmpeg path (used to force a deterministic newVerifier failure).
+func writeServeConfig(t *testing.T, path, dbPath string, verifyEnabled bool, ffmpegPath string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("[db]\n")
+	b.WriteString("path = " + tomlString(dbPath) + "\n\n")
+	b.WriteString("[providers]\n")
+	b.WriteString("primary = \"musixmatch\"\n\n")
+	if verifyEnabled {
+		b.WriteString("[verification]\n")
+		b.WriteString("enabled = true\n")
+		b.WriteString("whisper_url = \"http://127.0.0.1:1\"\n")
+		b.WriteString("ffmpeg_path = " + tomlString(ffmpegPath) + "\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func tomlString(s string) string {
+	return "\"" + strings.ReplaceAll(s, `\`, `\\`) + "\""
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
+	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
 )
 
 // Config holds all application configuration.
@@ -26,6 +27,35 @@ type Config struct {
 	Guard                GuardConfig                `toml:"guard"`
 	Queue                QueueConfig                `toml:"queue"`
 	Logging              LoggingConfig              `toml:"logging"`
+	Secrets              SecretsConfig              `toml:"secrets"`
+}
+
+// SecretsConfig holds the encrypted-at-rest secret store settings.
+type SecretsConfig struct {
+	// KeyFile is the path to the 32-byte AES-256 master key file used to
+	// encrypt secrets at rest. Empty (the default) resolves to the hidden file
+	// beside the database (xdgDataPath ".mxlrcgo.key"). The Docker path requires
+	// MXLRC_MASTER_KEY instead and never auto-creates a colocated key file.
+	// Override: MXLRC_SECRETS_KEY_FILE.
+	KeyFile string `toml:"key_file"`
+}
+
+// SecretsKeyOptions builds the secrets.KeyOptions used to resolve the master
+// key at startup, keeping the data-dir/Docker-mode logic in config (the single
+// source of those paths). MasterKeyB64 is sourced from MXLRC_MASTER_KEY by the
+// caller (it is never persisted in Config and must stay out of logs), so it is
+// left empty here; the caller fills it in. KeyFilePath is the resolved
+// secrets.key_file (env > TOML > default), and DockerMode mirrors the same
+// /config detection used for the XDG data dir.
+func (c *Config) SecretsKeyOptions() secrets.KeyOptions {
+	keyFile := strings.TrimSpace(c.Secrets.KeyFile)
+	if keyFile == "" {
+		keyFile = xdgDataPath("mxlrcgo-svc", secrets.DefaultKeyFileName)
+	}
+	return secrets.KeyOptions{
+		KeyFilePath: keyFile,
+		DockerMode:  dockerMode(),
+	}
 }
 
 // LoggingConfig holds log-output settings.
@@ -480,7 +510,7 @@ func LoadWithSources(path string) (Config, map[string]bool, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SECRETS_KEY_FILE, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 //
 // applied (must be non-nil) records the dotted config field path for every
 // override that ACTUALLY took effect. Env values that are rejected (invalid
@@ -581,6 +611,10 @@ func applyEnvOverrides(cfg *Config, applied map[string]bool) {
 	if v := os.Getenv("MXLRC_DB_PATH"); v != "" {
 		cfg.DB.Path = v
 		applied["db.path"] = true
+	}
+	if v := os.Getenv("MXLRC_SECRETS_KEY_FILE"); v != "" {
+		cfg.Secrets.KeyFile = v
+		applied["secrets.key_file"] = true
 	}
 	if v := os.Getenv("MXLRC_SERVER_ADDR"); v != "" {
 		cfg.Server.Addr = v

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -126,6 +126,13 @@ func FormatConfigText(cfg Config, envSrc, cliSrc map[string]bool) string {
 	p("randomize = %t%s\n", cfg.Queue.Randomize, ann("queue.randomize"))
 	p("\n")
 
+	// [secrets]
+	// Only the key-file PATH is shown; the key bytes it contains are never read
+	// into Config and never logged.
+	p("[secrets]\n")
+	p("key_file = %s%s\n", cfg.Secrets.KeyFile, ann("secrets.key_file"))
+	p("\n")
+
 	// [logging]
 	p("[logging]\n")
 	p("level = %s%s\n", cfg.Logging.Level, ann("logging.level"))
@@ -310,6 +317,10 @@ func ConfigToSlogAttrs(cfg Config, envSrc, cliSrc map[string]bool) []slog.Attr {
 		),
 		group("queue",
 			boolAttr("randomize", "queue.randomize", cfg.Queue.Randomize),
+		),
+		group("secrets",
+			// Only the key-file path; key bytes are never read into Config.
+			strAttr("key_file", "secrets.key_file", cfg.Secrets.KeyFile),
 		),
 		group("logging",
 			strAttr("level", "logging.level", cfg.Logging.Level),

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecretsKeyFileEnvOverride(t *testing.T) {
+	t.Setenv("MXLRC_SECRETS_KEY_FILE", "/run/secrets/mxlrcgo_key")
+	cfg, applied, err := LoadWithSources("")
+	if err != nil {
+		t.Fatalf("LoadWithSources: %v", err)
+	}
+	if cfg.Secrets.KeyFile != "/run/secrets/mxlrcgo_key" {
+		t.Fatalf("KeyFile = %q, want /run/secrets/mxlrcgo_key", cfg.Secrets.KeyFile)
+	}
+	if !applied["secrets.key_file"] {
+		t.Fatalf("secrets.key_file env override not recorded as applied")
+	}
+}
+
+func TestSecretsKeyOptionsDefaultPath(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MXLRC_SECRETS_KEY_FILE", "")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cfg := defaults()
+	opts := cfg.SecretsKeyOptions()
+	if opts.DockerMode {
+		t.Fatalf("DockerMode should be false in native mode")
+	}
+	if !strings.HasSuffix(opts.KeyFilePath, filepath.Join("mxlrcgo-svc", ".mxlrcgo.key")) {
+		t.Fatalf("default KeyFilePath = %q, want a path ending in mxlrcgo-svc/.mxlrcgo.key", opts.KeyFilePath)
+	}
+	if opts.MasterKeyB64 != "" {
+		t.Fatalf("MasterKeyB64 must be left empty for the caller to fill from env")
+	}
+}
+
+func TestSecretsKeyOptionsExplicitPathAndDocker(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "true")
+	cfg := Config{Secrets: SecretsConfig{KeyFile: "/custom/key"}}
+	opts := cfg.SecretsKeyOptions()
+	if opts.KeyFilePath != "/custom/key" {
+		t.Fatalf("KeyFilePath = %q, want /custom/key", opts.KeyFilePath)
+	}
+	if !opts.DockerMode {
+		t.Fatalf("DockerMode should be true when MXLRC_DOCKER=true")
+	}
+}
+
+// TestRedactionParityForDBSourcedSecrets verifies that a token/webhook value
+// (such as one sourced from the encrypted DB store and placed into the banner
+// config) is redacted in the config dump exactly like a plaintext value.
+func TestRedactionParityForDBSourcedSecrets(t *testing.T) {
+	cfg := defaults()
+	cfg.API.Token = "db-sourced-token"
+	cfg.Server.WebhookAPIKeys = []string{"db-sourced-webhook"}
+
+	text := FormatConfigText(cfg, nil, nil)
+	if strings.Contains(text, "db-sourced-token") {
+		t.Fatalf("DB-sourced token leaked into config dump:\n%s", text)
+	}
+	if strings.Contains(text, "db-sourced-webhook") {
+		t.Fatalf("DB-sourced webhook key leaked into config dump:\n%s", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] in config dump:\n%s", text)
+	}
+	// The key-file path itself is informational and shown (not the key bytes).
+	cfg.Secrets.KeyFile = "/data/.mxlrcgo.key"
+	text = FormatConfigText(cfg, nil, nil)
+	if !strings.Contains(text, "key_file = /data/.mxlrcgo.key") {
+		t.Fatalf("expected secrets.key_file path in config dump:\n%s", text)
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -7,6 +7,15 @@ import (
 	"fmt"
 )
 
+// Stable secret names used as the `secrets` table primary keys. v1 wires only
+// these two; the table is a general store so future credentials reuse it.
+const (
+	// NameMusixmatchToken is the secret name for the Musixmatch API token.
+	NameMusixmatchToken = "musixmatch_token"
+	// NameWebhookAPIKey is the secret name for the serve-mode webhook API key.
+	NameWebhookAPIKey = "webhook_api_key" //nolint:gosec // G101: this is a stable secret-store row name (a lookup key), not a hardcoded credential value
+)
+
 // Store is the secret repository. Callers Set/Get/Delete plaintext values by
 // name; encryption and decryption happen inside the implementation so callers
 // never see ciphertext or the key. Get reports absence via ok=false (no error).


### PR DESCRIPTION
## Phase 2 of #229 - precedence wiring + startup key resolution

Builds on the Phase 1 foundation (#233). Slots the encrypted secret store in as the **lowest-precedence** source for the Musixmatch token and webhook API key, resolves the master key at serve startup, and adds the `secrets.key_file` config field. Per the design-of-record (`docs/design/2026-06-13-223-secrets-encryption.md`, section "Precedence and migration").

### What's in this PR
- **`internal/config`** - new `[secrets].key_file` field (+ `MXLRC_SECRETS_KEY_FILE` env override, recorded in the applied-source map). `Config.SecretsKeyOptions()` builds `secrets.KeyOptions{KeyFilePath, DockerMode}` from config; it deliberately leaves `MasterKeyB64` empty for the caller to fill from `MXLRC_MASTER_KEY`, so the master key never lands in `Config` or any log/dump. Render parity (path only, never the key bytes) in `FormatConfigText` + `ConfigToSlogAttrs`.
- **`internal/commands` `runServe`** - after `db.Open`, `resolveSecretStore` resolves the key via `secrets.ResolveKey`. A `*secrets.FirstRunError` (Docker first run, no `MXLRC_MASTER_KEY`) prints `fr.Message()` to **stderr once** and exits non-zero **without serving**; any other key error is loud+fatal; success constructs a `secrets.SQLStore`. The Musixmatch token and webhook key fall back to the DB store (`musixmatch_token` / `webhook_api_key`) **only when all higher-precedence tiers are empty**, and a higher-tier value is **never** auto-persisted to the DB (that's Phase 3's explicit `secrets import`).
- **Redaction parity** - DB-sourced token/webhook values are redacted in the startup-config dump and Config view exactly like the existing plaintext ones.
- **`config.example.toml`** - documents the `[secrets]` block.

### Precedence (unchanged for existing deployments; DB is new + lowest)
- Token: `--token` > `MUSIXMATCH_TOKEN` > `MXLRC_API_TOKEN` > TOML `api.token` > **DB `secrets`**.
- Webhook key: CLI > `MXLRC_WEBHOOK_API_KEY` > TOML `server.webhook_api_keys` > **DB `secrets`**.

### Scope note
The DB tier is wired into `serve` only (the path that opens a DB). `fetch` opens no DB today, so wiring a store there would be a behavior change beyond Phase 2's "after the DB is open" seam - left for a later phase if needed.

### Validation
`make gate` green: race tests pass, patch coverage 78.35% (`commands.go` 71.2%, config 100%), golangci-lint 0 issues, govulncheck clean. New tests cover the precedence matrix (higher tier wins + no auto-persist; DB fallback when empty; nil-store/absent paths), the Docker first-run stderr-exit seam, and redaction parity - all on real SQLite, no mocks.

Part of #229 (Phase 2 of 4). Does not close the issue. Phases 3 (`secrets import/set/list` CLI) and 4 (docs) follow.
