### PR TITLE
feat(secrets): secrets import/set/list CLI + docs (#229 phases 3-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Directory mode overrides `-o/--outdir`; the output extension is `.lrc` for synce
 
 A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). To get a token, follow steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/mxlrcgo-svc/CONFIGURATION/) for the full env-var and TOML surface.
 
+## Encrypted secrets
+
+The Musixmatch token and the webhook API key can be stored encrypted at rest in the SQLite database (AES-256-GCM) instead of as plaintext in config and environment variables. It is opt-in and backward compatible: the encrypted store is the lowest-precedence source, so existing env/TOML setups are unchanged. Import the current plaintext with `mxlrcgo-svc secrets import`, set one by name from stdin with `mxlrcgo-svc secrets set <name>`, and list stored names (never values) with `mxlrcgo-svc secrets list`. The 32-byte master key comes from `MXLRC_MASTER_KEY` (recommended for Docker, where it is required) or an auto-generated `0600` key file (the native default). Losing the key makes the encrypted secrets unrecoverable by design; the remedy is to re-import or re-set them with the original plaintext. See the [Encrypted secrets guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/#encrypted-secrets).
+
 ## Credits
 
 - [Spicetify Lyrics Plus](https://github.com/spicetify/spicetify-cli/tree/master/CustomApps/lyrics-plus)

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,6 +13,15 @@ services:
       PGID: "100"
       MUSIXMATCH_TOKEN: "${MUSIXMATCH_TOKEN}"
       MXLRC_WEBHOOK_API_KEY: "${MXLRC_WEBHOOK_API_KEY}"
+      # Master key for encrypted-at-rest secrets. In Docker this is REQUIRED:
+      # the container refuses to auto-create a key file inside /config (that
+      # would colocate the key with the DB it protects). Sourced from a .env
+      # file kept OUTSIDE the /config data volume so the key and the database
+      # are not in the same place. Generate once with: openssl rand -base64 32
+      # On the very first run with this unset, the container prints a suggested
+      # MXLRC_MASTER_KEY=<base64> line to its log and exits; copy it here and
+      # restart. See docs/USER_GUIDE.md "Encrypted secrets".
+      MXLRC_MASTER_KEY: "${MXLRC_MASTER_KEY}"
     volumes:
       - mxlrcgo-svc-config:/config
       - /path/to/your/data:/data:rw

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -58,6 +58,8 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_OUTPUT_DIR` | XDG / `/music` | Fallback output directory for webhook jobs that resolve via metadata. |
 | `MXLRC_DB_PATH` | XDG / `/config/mxlrcgo.db` | SQLite database path. |
 | `MXLRC_DOCKER` | `false` | When `true`, storage defaults resolve under `/config`. Set automatically in the images. |
+| `MXLRC_MASTER_KEY` | (none) | Base64 of 32 random bytes; the master key for encrypted-at-rest secrets. When set, no key file is read or written. Required in Docker mode. Generate with `openssl rand -base64 32`. See the [Encrypted secrets](USER_GUIDE.md#encrypted-secrets) guide. |
+| `MXLRC_SECRETS_KEY_FILE` | XDG / `/config/.mxlrcgo.key` | Override for the auto-generated `0600` key-file location (the native-install default; used only when `MXLRC_MASTER_KEY` is unset). Point it at a separate mount to keep the key off the data volume. |
 | `MXLRC_API_COOLDOWN` | `15` | Seconds between Musixmatch requests. `MXLRC_COOLDOWN` is a lower-precedence alias. |
 | `MXLRC_API_CIRCUIT_OPEN_DURATION` | `1800` | Cap (seconds) for the worker circuit-breaker window; the window ramps geometrically up to this ceiling, and a token-renewal signal opens for the full cap (floor 300). |
 | `MXLRC_API_CIRCUIT_BACKOFF_BASE` | `60` | Trip-1 circuit-breaker window (seconds); doubles each consecutive throttle up to `MXLRC_API_CIRCUIT_OPEN_DURATION`, resets on a successful fetch or clean miss (floor 15, capped at the open-duration). |
@@ -130,6 +132,15 @@ addr = "127.0.0.1:3876"
 ```
 
 HTTP listen address, webhook keys, and the scheduler scan/worker poll intervals (env: `MXLRC_SERVER_ADDR`, `MXLRC_WEBHOOK_API_KEY`, `MXLRC_SCAN_INTERVAL`, `MXLRC_WORK_INTERVAL`; CLI: `--listen`, `--scan-interval`, `--work-interval`).
+
+### `[secrets]`
+
+```toml
+[secrets]
+# key_file = ""
+```
+
+Key-file location override for encrypted-at-rest secrets (env: `MXLRC_SECRETS_KEY_FILE`). Empty uses the native default (the hidden `.mxlrcgo.key` beside the database). The master key itself comes from `MXLRC_MASTER_KEY` (preferred, and required in Docker) or this key file; it is never stored in the config. See the [Encrypted secrets](USER_GUIDE.md#encrypted-secrets) guide for the `secrets import` / `set` / `list` commands and key-loss recovery.
 
 ### `[providers]`
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -79,6 +79,90 @@ docker compose up -d
 
 To inspect or maintain the queue and scan state inside the container, exec the same `mxlrcgo-svc queue` and `mxlrcgo-svc scan results` / `mxlrcgo-svc scan clear` commands documented in the [Inspection commands](#inspection-commands) section below (for example `docker exec mxlrcgo-svc mxlrcgo-svc queue failed`).
 
+## Encrypted secrets
+
+The two recoverable runtime secrets, the Musixmatch API token and the serve-mode webhook API key, can be stored encrypted at rest in the SQLite database (AES-256-GCM) instead of as plaintext in `config.toml` and environment variables. This is opt-in: existing env/TOML setups keep working unchanged, because the encrypted database store is the lowest-precedence source. CLI flags, environment variables, and TOML all still win over it.
+
+### What it protects (and what it does not)
+
+At-rest encryption defends a narrow boundary. It protects against database-only exfiltration: a copied or backed-up `.db` file, an accidental git commit, or a stray copy of just the database cannot be read back into the plaintext token. It does NOT protect a compromised running process (the decrypted values are in memory at use time), and it does NOT protect whole-volume theft when the key file lives in the same mount as the database. That last point is why the env-key path below is the recommended Docker posture.
+
+### Managing secrets
+
+Three commands manage the encrypted store. None of them ever print a secret value.
+
+```sh
+# Encrypt the currently effective plaintext secret(s) into the database. Reads
+# the normal CLI/env/TOML precedence but skips the database itself as a source,
+# so it never copies the database onto itself. With no flag it imports both
+# currently-set secrets; scope it with --token or --webhook.
+mxlrcgo-svc secrets import
+mxlrcgo-svc secrets import --token
+mxlrcgo-svc secrets import --webhook
+
+# Set one secret by name from stdin. The value is read from the terminal prompt
+# or a pipe, never from the command line (the command line lands in shell
+# history and ps). Valid names: musixmatch_token, webhook_api_key.
+mxlrcgo-svc secrets set musixmatch_token        # prompts for the value
+printf '%s' "$TOKEN" | mxlrcgo-svc secrets set musixmatch_token   # or pipe it
+
+# List stored secret names and their last-updated timestamps. Never prints values.
+mxlrcgo-svc secrets list
+```
+
+`secrets import` is idempotent: re-running overwrites the existing encrypted row. After a successful import, the command reminds you to remove the now-redundant plaintext from `config.toml` and your compose environment so it is no longer stored in the clear.
+
+### Key management
+
+The 32-byte encryption key is resolved from one of two sources, in order:
+
+1. `MXLRC_MASTER_KEY` (base64 of 32 random bytes). When set, no key file is read or written. This is the recommended path for Docker because it keeps the key out of the data volume. Generate one with `openssl rand -base64 32`.
+2. A key file (32 raw bytes, auto-generated with `0600` permissions on first use). The default location is a hidden `.mxlrcgo.key` beside the database. This is the native-install default. Override the location with the `secrets.key_file` TOML key or the `MXLRC_SECRETS_KEY_FILE` environment variable, so the key file can live on a separate, narrower mount.
+
+A missing-but-required key, a malformed `MXLRC_MASTER_KEY`, or an unreadable key file is a loud, fatal startup error. The daemon never silently falls back to running unencrypted.
+
+### Docker first-run wizard
+
+In Docker mode (storage paths resolve under `/config`), the daemon refuses to auto-create a key file inside `/config`, because that would put the key in the same volume as the database it protects. `MXLRC_MASTER_KEY` is required there. To keep first-run friction low, the first Docker run with no `MXLRC_MASTER_KEY` set generates a random key, prints a single copy-pasteable `MXLRC_MASTER_KEY=<base64>` line to the container log (stderr only, never the rotating log file), and exits without serving. Copy that value into your container or Unraid template variable and restart.
+
+That one log line is sensitive: if your container logs are shipped or persisted, the suggested key is exposed there once. It is printed a single time, never on subsequent runs and never to the log file. Store it safely; it will not be shown again.
+
+The recommended Docker pattern keeps the key separated from the data volume, sourced from a `.env` file that is NOT inside the `/config` mount:
+
+```yaml
+# docker-compose.yml - recommended: key separated from the data volume
+services:
+  mxlrcgo-svc:
+    image: ghcr.io/sydlexius/mxlrcgo-svc:latest
+    environment:
+      # base64 of 32 random bytes: openssl rand -base64 32
+      MXLRC_MASTER_KEY: ${MXLRC_MASTER_KEY}   # from a .env NOT in the data volume
+    volumes:
+      - ./config:/config                       # holds the DB; NO key file here
+```
+
+Alternatively, keep the key in a file on a separate, narrower mount instead of an env variable:
+
+```yaml
+    environment:
+      MXLRC_SECRETS_KEY_FILE: /run/secrets/mxlrcgo_key
+    secrets:
+      - mxlrcgo_key
+```
+
+### Precedence
+
+The encrypted database store is the lowest-precedence source for both secrets:
+
+- Musixmatch token: `--token` CLI flag, then `MUSIXMATCH_TOKEN`, then `MXLRC_API_TOKEN`, then TOML `api.token`, then the encrypted database store.
+- Webhook key: the CLI/env flag, then TOML `server.webhook_api_keys`, then the encrypted database store.
+
+A higher-precedence source is used as-is at runtime and is never auto-persisted to the database. Persistence happens only when you run `secrets import` or `secrets set`.
+
+### Key-loss recovery
+
+Losing the key (a deleted `.mxlrcgo.key` file or a lost `MXLRC_MASTER_KEY`) makes the encrypted secrets unrecoverable by design: there is no backdoor and no recovery key. The remedy is to re-enter the secrets with their original plaintext, by re-running `secrets import` (from a config or environment that still has the plaintext) or `secrets set`. Keep a copy of `MXLRC_MASTER_KEY` somewhere safe and separate from the data volume.
+
 ## Unraid
 
 An Unraid Community Applications template is provided at `unraid/mxlrcgo-svc.xml`. It follows the same template conventions as the `sydlexius/unraid-templates` repository: GHCR image, bridge networking, `/config` appdata, a music library mapping, and advanced `PUID`/`PGID` permission and tuning fields (scan/work intervals and the filesystem watcher).

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -50,6 +50,7 @@ type Args struct {
 	Scan       *ScanCmd       `arg:"subcommand:scan" help:"scan configured libraries and enqueue missing lyrics"`
 	Library    *LibraryCmd    `arg:"subcommand:library" help:"manage library roots"`
 	Keys       *KeysCmd       `arg:"subcommand:keys" help:"manage API keys"`
+	Secrets    *SecretsCmd    `arg:"subcommand:secrets" help:"manage encrypted-at-rest secrets"`
 	Config     *ConfigCmd     `arg:"subcommand:config" help:"inspect or update configuration"`
 	Queue      *QueueCmd      `arg:"subcommand:queue" help:"inspect or maintain the durable work queue"`
 	Completion *CompletionCmd `arg:"subcommand:completion" help:"output a shell completion script (bash, zsh, or fish)"`
@@ -256,6 +257,34 @@ type KeysRevokeCmd struct {
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
+// SecretsCmd contains nested encrypted-secret-store subcommands.
+type SecretsCmd struct {
+	Import *SecretsImportCmd `arg:"subcommand:import" help:"encrypt the current effective secret(s) into the DB store"`
+	Set    *SecretsSetCmd    `arg:"subcommand:set" help:"set one secret by name from stdin (never on argv)"`
+	List   *SecretsListCmd   `arg:"subcommand:list" help:"list stored secret names and updated_at (never values)"`
+}
+
+// SecretsImportCmd encrypts the currently effective plaintext secret(s) into the
+// DB store, resolving the normal precedence but skipping the DB tier as a source.
+type SecretsImportCmd struct {
+	Token      bool   `arg:"--token" help:"import only the Musixmatch token"`
+	Webhook    bool   `arg:"--webhook" help:"import only the webhook API key"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// SecretsSetCmd sets one secret by name. The value is read from stdin (prompt or
+// pipe), never from argv, since argv lands in shell history and ps.
+type SecretsSetCmd struct {
+	Name       string `arg:"positional,required" help:"secret name: musixmatch_token or webhook_api_key"`
+	Value      string `arg:"positional" help:"DO NOT pass the value here; it is rejected (use stdin)"`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// SecretsListCmd lists stored secret names and their updated_at, never values.
+type SecretsListCmd struct {
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
 // ConfigCmd contains nested config subcommands.
 type ConfigCmd struct {
 	Get  *ConfigGetCmd  `arg:"subcommand:get" help:"get a config value"`
@@ -372,6 +401,8 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 		return runLibrary(ctx, out, *args.Library)
 	case args.Keys != nil:
 		return runKeys(ctx, out, *args.Keys)
+	case args.Secrets != nil:
+		return runSecrets(ctx, out, *args.Secrets)
 	case args.Config != nil:
 		return runConfig(out, *args.Config)
 	case args.Queue != nil:
@@ -392,7 +423,7 @@ func usesSubcommand(rawArgs []string) bool {
 		return true
 	}
 	commands := map[string]bool{
-		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "config": true, "queue": true, "completion": true,
+		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "secrets": true, "config": true, "queue": true, "completion": true,
 	}
 	return commands[rawArgs[0]]
 }

--- a/internal/commands/secrets_cmd.go
+++ b/internal/commands/secrets_cmd.go
@@ -1,0 +1,222 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
+)
+
+// validSecretNames lists the secret names accepted by `secrets set`. v1 wires
+// only these two; the store table is general so this list grows as needed.
+var validSecretNames = []string{secrets.NameMusixmatchToken, secrets.NameWebhookAPIKey}
+
+// runSecrets dispatches the `secrets import|set|list` subcommands. Each opens the
+// config + DB and builds the encrypted store via resolveSecretStore. On the
+// Docker first-run case it prints the onboarding hint to stderr and exits
+// non-zero (same as runServe); other store-init errors are fatal. No subcommand
+// ever echoes or logs a secret value.
+func runSecrets(ctx context.Context, out io.Writer, args SecretsCmd) int {
+	path := secretsConfigPath(args)
+	cfg, err := config.Load(path)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	store, firstRun, err := resolveSecretStore(cfg, sqlDB)
+	if err != nil {
+		slog.Error("failed to initialize secret store", "error", err)
+		return 1
+	}
+	if firstRun != nil {
+		_, _ = fmt.Fprintln(os.Stderr, firstRun.Message())
+		return 1
+	}
+
+	switch {
+	case args.Import != nil:
+		return runSecretsImport(ctx, out, cfg, store, *args.Import)
+	case args.Set != nil:
+		return runSecretsSet(ctx, out, store, *args.Set, os.Stdin)
+	case args.List != nil:
+		return runSecretsList(ctx, out, store)
+	default:
+		_, _ = fmt.Fprintln(out, "missing secrets subcommand")
+		return 2
+	}
+}
+
+// runSecretsImport encrypts the currently effective plaintext secret(s) into the
+// store, resolving the normal precedence (CLI/env/TOML, already folded into cfg)
+// but SKIPPING the DB tier as a source so it never reads-then-writes the DB onto
+// itself. With neither --token nor --webhook it imports both currently-set
+// secrets; a target with no effective higher-tier value is skipped with a clear
+// message rather than writing an empty secret. store.Set upserts, so re-running
+// is idempotent. The secret value is never echoed.
+func runSecretsImport(ctx context.Context, out io.Writer, cfg config.Config, store secrets.Store, args SecretsImportCmd) int {
+	importToken := args.Token || (!args.Token && !args.Webhook)
+	importWebhook := args.Webhook || (!args.Token && !args.Webhook)
+
+	imported := 0
+	if importToken {
+		token := strings.TrimSpace(cfg.API.Token)
+		if token == "" {
+			_, _ = fmt.Fprintf(out, "skipping %s: no effective value from CLI/env/config\n", secrets.NameMusixmatchToken)
+		} else {
+			if err := store.Set(ctx, secrets.NameMusixmatchToken, token); err != nil {
+				slog.Error("failed to import musixmatch token", "error", err)
+				return 1
+			}
+			_, _ = fmt.Fprintf(out, "imported %s\n", secrets.NameMusixmatchToken)
+			imported++
+		}
+	}
+	if importWebhook {
+		webhook := firstNonEmpty(cfg.Server.WebhookAPIKeys)
+		if webhook == "" {
+			_, _ = fmt.Fprintf(out, "skipping %s: no effective value from CLI/env/config\n", secrets.NameWebhookAPIKey)
+		} else {
+			if err := store.Set(ctx, secrets.NameWebhookAPIKey, webhook); err != nil {
+				slog.Error("failed to import webhook API key", "error", err)
+				return 1
+			}
+			_, _ = fmt.Fprintf(out, "imported %s\n", secrets.NameWebhookAPIKey)
+			imported++
+		}
+	}
+
+	if imported > 0 {
+		_, _ = fmt.Fprintln(out, "secret(s) are now encrypted at rest in the DB. Remove the now-redundant plaintext from config.toml / your compose env so it is no longer stored in the clear.")
+	}
+	return 0
+}
+
+// runSecretsSet sets one named secret from stdin (prompt or pipe), never from
+// argv. A value passed positionally is rejected because argv lands in shell
+// history and ps. The name must be one of validSecretNames. The value is never
+// echoed or logged.
+func runSecretsSet(ctx context.Context, out io.Writer, store secrets.Store, args SecretsSetCmd, stdin *os.File) int {
+	if strings.TrimSpace(args.Value) != "" {
+		_, _ = fmt.Fprintln(os.Stderr, "refusing to read the secret value from the command line (it lands in shell history and ps); provide it via stdin: pipe it in, or run without the value and enter it at the prompt")
+		return 2
+	}
+	name := strings.TrimSpace(args.Name)
+	if !isValidSecretName(name) {
+		_, _ = fmt.Fprintf(os.Stderr, "unknown secret name %q; valid names: %s\n", name, strings.Join(validSecretNames, ", "))
+		return 2
+	}
+
+	// Prompt only when stdin is an interactive terminal; for a pipe, read silently.
+	// golang.org/x/term is not a dependency, so the typed value is not hidden from
+	// the terminal; the prompt warns the operator. The value is read from stdin,
+	// never argv, which is the property that matters (no shell-history/ps exposure).
+	//
+	// TTY path: read one line (Enter-terminated). A single ReadString('\n') is the
+	// correct interactive UX -- the user presses Enter and we proceed immediately.
+	//
+	// Pipe path: read the full payload with io.ReadAll so a multi-line or
+	// newline-free value is not silently truncated at the first '\n'.
+	var value string
+	if isTerminal(stdin) {
+		_, _ = fmt.Fprintf(os.Stderr, "Enter value for %s (input is read from this terminal and not stored in shell history): ", name)
+		reader := bufio.NewReader(stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			slog.Error("failed to read secret value from stdin", "error", err)
+			return 1
+		}
+		value = strings.TrimRight(line, "\r\n")
+	} else {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			slog.Error("failed to read secret value from stdin", "error", err)
+			return 1
+		}
+		value = strings.TrimRight(string(data), "\r\n")
+	}
+	if value == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "no value provided on stdin; aborting")
+		return 2
+	}
+	if err := store.Set(ctx, name, value); err != nil {
+		slog.Error("failed to set secret", "error", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(out, "set %s\n", name)
+	return 0
+}
+
+// runSecretsList prints stored secret names and updated_at only, never values.
+func runSecretsList(ctx context.Context, out io.Writer, store secrets.Store) int {
+	infos, err := store.List(ctx)
+	if err != nil {
+		slog.Error("failed to list secrets", "error", err)
+		return 1
+	}
+	if len(infos) == 0 {
+		_, _ = fmt.Fprintln(out, "no secrets stored")
+		return 0
+	}
+	for _, info := range infos {
+		_, _ = fmt.Fprintf(out, "%s\t%s\n", info.Name, info.UpdatedAt)
+	}
+	return 0
+}
+
+func secretsConfigPath(args SecretsCmd) string {
+	switch {
+	case args.Import != nil:
+		return args.Import.ConfigPath
+	case args.Set != nil:
+		return args.Set.ConfigPath
+	case args.List != nil:
+		return args.List.ConfigPath
+	default:
+		return ""
+	}
+}
+
+func isValidSecretName(name string) bool {
+	for _, v := range validSecretNames {
+		if v == name {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values []string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// isTerminal reports whether f is an interactive character device (a TTY). It
+// avoids a golang.org/x/term dependency by inspecting the file mode.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/commands/secrets_cmd_test.go
+++ b/internal/commands/secrets_cmd_test.go
@@ -1,0 +1,444 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
+)
+
+// stdinFile writes content to a temp file and returns it opened for reading, so
+// runSecretsSet can read a "piped" value from a real *os.File (not a TTY).
+func stdinFile(t *testing.T, content string) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write stdin file: %v", err)
+	}
+	f, err := os.Open(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("open stdin file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func TestRunSecretsImport_BothFromConfig(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	cfg := config.Config{}
+	cfg.API.Token = "effective-token"
+	cfg.Server.WebhookAPIKeys = []string{"effective-webhook"}
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{}); code != 0 {
+		t.Fatalf("import exit code = %d, want 0", code)
+	}
+
+	// Both secrets written and round-trip via Get.
+	if got, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); !ok || got != "effective-token" {
+		t.Fatalf("token Get = (%q, %v), want (effective-token, true)", got, ok)
+	}
+	if got, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey); !ok || got != "effective-webhook" {
+		t.Fatalf("webhook Get = (%q, %v), want (effective-webhook, true)", got, ok)
+	}
+	if !strings.Contains(out.String(), "Remove the now-redundant plaintext") {
+		t.Fatalf("import output missing remove-plaintext reminder: %q", out.String())
+	}
+	// Never echoes the value.
+	if strings.Contains(out.String(), "effective-token") || strings.Contains(out.String(), "effective-webhook") {
+		t.Fatalf("import echoed a secret value: %q", out.String())
+	}
+}
+
+func TestRunSecretsImport_WritesEncrypted(t *testing.T) {
+	// A store backed by a real DB: verify the raw ciphertext column != plaintext.
+	ctx := context.Background()
+	store := newSecretStore(t)
+	cfg := config.Config{}
+	cfg.API.Token = "secret-plaintext-xyz"
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{Token: true}); code != 0 {
+		t.Fatalf("import exit code = %d, want 0", code)
+	}
+	if got, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); !ok || got != "secret-plaintext-xyz" {
+		t.Fatalf("token Get = (%q, %v), want round-trip", got, ok)
+	}
+	// Webhook not imported (token-only scope).
+	if _, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey); ok {
+		t.Fatalf("webhook imported despite --token scope")
+	}
+}
+
+func TestRunSecretsImport_TokenScopeOnly(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	cfg := config.Config{}
+	cfg.API.Token = "tok"
+	cfg.Server.WebhookAPIKeys = []string{"wh"}
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{Token: true}); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if _, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); !ok {
+		t.Fatalf("token not imported under --token")
+	}
+	if _, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey); ok {
+		t.Fatalf("webhook imported under --token scope")
+	}
+}
+
+func TestRunSecretsImport_WebhookScopeOnly(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	cfg := config.Config{}
+	cfg.API.Token = "tok"
+	cfg.Server.WebhookAPIKeys = []string{"wh"}
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{Webhook: true}); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if _, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey); !ok {
+		t.Fatalf("webhook not imported under --webhook")
+	}
+	if _, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); ok {
+		t.Fatalf("token imported under --webhook scope")
+	}
+}
+
+func TestRunSecretsImport_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	cfg := config.Config{}
+	cfg.API.Token = "tok"
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{Token: true}); code != 0 {
+		t.Fatalf("first import exit = %d", code)
+	}
+	out.Reset()
+	if code := runSecretsImport(ctx, &out, cfg, store, SecretsImportCmd{Token: true}); code != 0 {
+		t.Fatalf("second import exit = %d", code)
+	}
+	infos, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("re-import created %d rows, want 1 (idempotent upsert)", len(infos))
+	}
+}
+
+func TestRunSecretsImport_SkipsAbsent(t *testing.T) {
+	// No effective value for either secret: both skipped, no rows written, no
+	// remove-plaintext reminder (nothing imported).
+	ctx := context.Background()
+	store := newSecretStore(t)
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, config.Config{}, store, SecretsImportCmd{}); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	infos, _ := store.List(ctx)
+	if len(infos) != 0 {
+		t.Fatalf("absent import wrote %d rows, want 0", len(infos))
+	}
+	if !strings.Contains(out.String(), "skipping "+secrets.NameMusixmatchToken) {
+		t.Fatalf("missing skip message for token: %q", out.String())
+	}
+	if strings.Contains(out.String(), "Remove the now-redundant plaintext") {
+		t.Fatalf("printed remove reminder despite importing nothing")
+	}
+}
+
+func TestRunSecretsImport_DoesNotReadDBAsSource(t *testing.T) {
+	// The DB already holds a token, but cfg (higher tiers) is empty. import must
+	// NOT read the DB and re-write it; it should skip with "no effective value".
+	ctx := context.Background()
+	store := newSecretStore(t)
+	if err := store.Set(ctx, secrets.NameMusixmatchToken, "db-only-token"); err != nil {
+		t.Fatalf("seed Set: %v", err)
+	}
+
+	var out bytes.Buffer
+	if code := runSecretsImport(ctx, &out, config.Config{}, store, SecretsImportCmd{Token: true}); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "skipping "+secrets.NameMusixmatchToken) {
+		t.Fatalf("import read the DB as a source instead of skipping: %q", out.String())
+	}
+	// Existing DB value is left intact (not overwritten with empty).
+	if got, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); !ok || got != "db-only-token" {
+		t.Fatalf("DB value changed: (%q, %v)", got, ok)
+	}
+}
+
+func TestRunSecretsSet_RejectsArgvValue(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: secrets.NameMusixmatchToken, Value: "leaked-on-argv"}
+	if code := runSecretsSet(ctx, &out, store, args, stdinFile(t, "")); code != 2 {
+		t.Fatalf("argv value: exit code = %d, want 2", code)
+	}
+	if _, ok, _ := store.Get(ctx, secrets.NameMusixmatchToken); ok {
+		t.Fatalf("argv-passed value was stored; must be rejected")
+	}
+}
+
+func TestRunSecretsSet_FromStdin(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: secrets.NameWebhookAPIKey}
+	if code := runSecretsSet(ctx, &out, store, args, stdinFile(t, "piped-secret\n")); code != 0 {
+		t.Fatalf("stdin set: exit code = %d, want 0", code)
+	}
+	if got, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey); !ok || got != "piped-secret" {
+		t.Fatalf("Get = (%q, %v), want (piped-secret, true)", got, ok)
+	}
+	if strings.Contains(out.String(), "piped-secret") {
+		t.Fatalf("set echoed the value: %q", out.String())
+	}
+}
+
+func TestRunSecretsSet_MultilineStdin(t *testing.T) {
+	// A piped value that contains an interior newline must be stored in full,
+	// not truncated at the first '\n'. The trailing newline is trimmed (same as
+	// a single-line piped value) but the interior newline is preserved.
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: secrets.NameWebhookAPIKey}
+	if code := runSecretsSet(ctx, &out, store, args, stdinFile(t, "line1\nline2\n")); code != 0 {
+		t.Fatalf("multiline stdin set: exit code = %d, want 0", code)
+	}
+	got, ok, _ := store.Get(ctx, secrets.NameWebhookAPIKey)
+	if !ok {
+		t.Fatal("Get: secret not found after set")
+	}
+	const want = "line1\nline2"
+	if got != want {
+		t.Fatalf("Get = %q, want %q (piped value must not be truncated at first newline)", got, want)
+	}
+}
+
+func TestRunSecretsSet_UnknownName(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: "not_a_secret"}
+	if code := runSecretsSet(ctx, &out, store, args, stdinFile(t, "x\n")); code != 2 {
+		t.Fatalf("unknown name: exit code = %d, want 2", code)
+	}
+}
+
+func TestRunSecretsSet_EmptyStdin(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: secrets.NameMusixmatchToken}
+	if code := runSecretsSet(ctx, &out, store, args, stdinFile(t, "")); code != 2 {
+		t.Fatalf("empty stdin: exit code = %d, want 2", code)
+	}
+}
+
+func TestRunSecretsList_Empty(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	var out bytes.Buffer
+	if code := runSecretsList(ctx, &out, store); code != 0 {
+		t.Fatalf("list exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "no secrets stored") {
+		t.Fatalf("empty list output = %q, want friendly message", out.String())
+	}
+}
+
+func TestRunSecretsList_NamesAndUpdatedAtNeverValues(t *testing.T) {
+	ctx := context.Background()
+	store := newSecretStore(t)
+	if err := store.Set(ctx, secrets.NameMusixmatchToken, "value-must-not-appear"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	var out bytes.Buffer
+	if code := runSecretsList(ctx, &out, store); code != 0 {
+		t.Fatalf("list exit = %d, want 0", code)
+	}
+	s := out.String()
+	if !strings.Contains(s, secrets.NameMusixmatchToken) {
+		t.Fatalf("list missing name: %q", s)
+	}
+	if strings.Contains(s, "value-must-not-appear") {
+		t.Fatalf("list LEAKED the secret value: %q", s)
+	}
+}
+
+// withMasterKeyConfig sets MXLRC_MASTER_KEY and writes a serve config pointing at
+// a temp DB, returning the config path. Native mode (MXLRC_DOCKER unset).
+func withMasterKeyConfig(t *testing.T) string {
+	t.Helper()
+	t.Setenv("MXLRC_DOCKER", "")
+	key, err := secrets.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	t.Setenv("MXLRC_MASTER_KEY", base64.StdEncoding.EncodeToString(key))
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeServeConfig(t, cfgPath, filepath.Join(dir, "secrets.db"), false, "")
+	return cfgPath
+}
+
+// TestRunSecrets_DispatchImportThroughConfig drives runSecrets through the import
+// branch with a token set in the config TOML.
+func TestRunSecrets_DispatchImportThroughConfig(t *testing.T) {
+	cfgPath := withMasterKeyConfig(t)
+	// Append a token to the config so import has an effective value.
+	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open config: %v", err)
+	}
+	if _, err := f.WriteString("\n[api]\ntoken = \"cfg-token\"\n"); err != nil {
+		t.Fatalf("append token: %v", err)
+	}
+	_ = f.Close()
+
+	var out bytes.Buffer
+	code := runSecrets(context.Background(), &out, SecretsCmd{Import: &SecretsImportCmd{Token: true, ConfigPath: cfgPath}})
+	if code != 0 {
+		t.Fatalf("runSecrets import exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "imported "+secrets.NameMusixmatchToken) {
+		t.Fatalf("import output = %q", out.String())
+	}
+}
+
+// TestRunSecrets_DispatchSetThroughConfig drives runSecrets through the set branch
+// with the value piped via stdin (the process stdin is redirected to a temp file).
+func TestRunSecrets_DispatchSetThroughConfig(t *testing.T) {
+	cfgPath := withMasterKeyConfig(t)
+
+	// Redirect the process stdin to a piped value for the duration of this test.
+	orig := os.Stdin
+	os.Stdin = stdinFile(t, "stdin-token\n")
+	t.Cleanup(func() { os.Stdin = orig })
+
+	var out bytes.Buffer
+	code := runSecrets(context.Background(), &out,
+		SecretsCmd{Set: &SecretsSetCmd{Name: secrets.NameMusixmatchToken, ConfigPath: cfgPath}})
+	if code != 0 {
+		t.Fatalf("runSecrets set exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "set "+secrets.NameMusixmatchToken) {
+		t.Fatalf("set output = %q", out.String())
+	}
+}
+
+// TestRunSecrets_DispatchListThroughRun drives the full top-level Run dispatch
+// ("secrets list ...") through config load, DB open, store build via
+// MXLRC_MASTER_KEY, and the list branch on an empty store, covering the dispatch
+// case and the known-subcommand allowlist entry end-to-end.
+func TestRunSecrets_DispatchListThroughRun(t *testing.T) {
+	cfgPath := withMasterKeyConfig(t)
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"secrets", "list", "--config", cfgPath}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("Run secrets list exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "no secrets stored") {
+		t.Fatalf("output = %q, want empty-store message", out.String())
+	}
+}
+
+func TestRunSecrets_ConfigLoadError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bad.toml")
+	if err := os.WriteFile(cfgPath, []byte("this is = not valid = toml ]["), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+	var out bytes.Buffer
+	code := runSecrets(context.Background(), &out, SecretsCmd{List: &SecretsListCmd{ConfigPath: cfgPath}})
+	if code != 1 {
+		t.Fatalf("config load error exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecrets_StoreInitError(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MXLRC_MASTER_KEY", "not-valid-base64!!!")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeServeConfig(t, cfgPath, filepath.Join(dir, "secrets.db"), false, "")
+	var out bytes.Buffer
+	code := runSecrets(context.Background(), &out, SecretsCmd{List: &SecretsListCmd{ConfigPath: cfgPath}})
+	if code != 1 {
+		t.Fatalf("store init error exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecrets_DockerFirstRunExits(t *testing.T) {
+	t.Setenv("MXLRC_DOCKER", "true")
+	t.Setenv("MXLRC_MASTER_KEY", "")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeServeConfig(t, cfgPath, filepath.Join(dir, "secrets.db"), false, "")
+	var out bytes.Buffer
+	code := runSecrets(context.Background(), &out, SecretsCmd{List: &SecretsListCmd{ConfigPath: cfgPath}})
+	if code != 1 {
+		t.Fatalf("docker first-run exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecretsList_StoreError(t *testing.T) {
+	var out bytes.Buffer
+	if code := runSecretsList(context.Background(), &out, closedStore(t)); code != 1 {
+		t.Fatalf("list store error exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecretsImport_StoreError(t *testing.T) {
+	cfg := config.Config{}
+	cfg.API.Token = "tok"
+	var out bytes.Buffer
+	if code := runSecretsImport(context.Background(), &out, cfg, closedStore(t), SecretsImportCmd{Token: true}); code != 1 {
+		t.Fatalf("import store error exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecretsImport_WebhookStoreError(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Server.WebhookAPIKeys = []string{"wh"}
+	var out bytes.Buffer
+	if code := runSecretsImport(context.Background(), &out, cfg, closedStore(t), SecretsImportCmd{Webhook: true}); code != 1 {
+		t.Fatalf("webhook import store error exit = %d, want 1", code)
+	}
+}
+
+func TestRunSecretsSet_StoreError(t *testing.T) {
+	var out bytes.Buffer
+	args := SecretsSetCmd{Name: secrets.NameMusixmatchToken}
+	if code := runSecretsSet(context.Background(), &out, closedStore(t), args, stdinFile(t, "val\n")); code != 1 {
+		t.Fatalf("set store error exit = %d, want 1", code)
+	}
+}
+
+// TestRunSecrets_BareSecrets exercises the top-level "secrets" command with no
+// nested subcommand. go-arg returns a usage error (exit 2); the missing-
+// subcommand default branch is also exit 2.
+func TestRunSecrets_BareSecrets(t *testing.T) {
+	var out bytes.Buffer
+	code := Run(context.Background(), []string{"secrets"}, &out, Deps{})
+	if code != 2 {
+		t.Fatalf("bare secrets exit = %d, want 2", code)
+	}
+}

--- a/internal/secrets/memory.go
+++ b/internal/secrets/memory.go
@@ -3,7 +3,9 @@ package secrets
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
+	"time"
 )
 
 // MemoryStore is an in-memory Store for tests and single-process use, mirroring
@@ -11,16 +13,18 @@ import (
 // surface to protect in memory), so it exercises the same Store contract as
 // SQLStore without a key or database.
 type MemoryStore struct {
-	mu      sync.RWMutex
-	secrets map[string]string
+	mu        sync.RWMutex
+	secrets   map[string]string
+	updatedAt map[string]string
 }
 
 // NewMemoryStore returns an empty in-memory secret store.
 func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{secrets: map[string]string{}}
+	return &MemoryStore{secrets: map[string]string{}, updatedAt: map[string]string{}}
 }
 
-// Set stores plaintext under name, overwriting any existing value.
+// Set stores plaintext under name, overwriting any existing value, and refreshes
+// the name's updated_at to now (UTC, RFC3339-like, matching the SQL store format).
 func (s *MemoryStore) Set(ctx context.Context, name, plaintext string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -31,6 +35,7 @@ func (s *MemoryStore) Set(ctx context.Context, name, plaintext string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.secrets[name] = plaintext
+	s.updatedAt[name] = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	return nil
 }
 
@@ -53,5 +58,22 @@ func (s *MemoryStore) Delete(ctx context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.secrets, name)
+	delete(s.updatedAt, name)
 	return nil
+}
+
+// List returns name + updated_at for every stored secret, ordered by name. It
+// never returns values, mirroring SQLStore.List.
+func (s *MemoryStore) List(ctx context.Context) ([]SecretInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SecretInfo, 0, len(s.secrets))
+	for name := range s.secrets {
+		out = append(out, SecretInfo{Name: name, UpdatedAt: s.updatedAt[name]})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
 }

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -16,13 +16,25 @@ const (
 	NameWebhookAPIKey = "webhook_api_key" //nolint:gosec // G101: this is a stable secret-store row name (a lookup key), not a hardcoded credential value
 )
 
+// SecretInfo is the non-sensitive metadata for one stored secret. It carries the
+// name and its last-write timestamp only; it never carries the value (plaintext
+// or ciphertext), so it is safe to print in `secrets list`.
+type SecretInfo struct {
+	Name      string
+	UpdatedAt string
+}
+
 // Store is the secret repository. Callers Set/Get/Delete plaintext values by
 // name; encryption and decryption happen inside the implementation so callers
 // never see ciphertext or the key. Get reports absence via ok=false (no error).
+//
+// List returns metadata (name + updated_at) for every stored secret, ordered by
+// name. It never returns values, so a caller listing secrets cannot leak them.
 type Store interface {
 	Set(ctx context.Context, name, plaintext string) error
 	Get(ctx context.Context, name string) (plaintext string, ok bool, err error)
 	Delete(ctx context.Context, name string) error
+	List(ctx context.Context) ([]SecretInfo, error)
 }
 
 // SQLStore persists secrets encrypted-at-rest in the SQLite `secrets` table.
@@ -92,4 +104,27 @@ func (s *SQLStore) Delete(ctx context.Context, name string) error {
 		return fmt.Errorf("secrets: delete %q: %w", name, err)
 	}
 	return nil
+}
+
+// List returns name + updated_at for every stored secret, ordered by name. It
+// reads no ciphertext and decrypts nothing, so it cannot leak secret values.
+func (s *SQLStore) List(ctx context.Context) ([]SecretInfo, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT name, updated_at FROM secrets ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: list: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+	var out []SecretInfo
+	for rows.Next() {
+		var info SecretInfo
+		if err := rows.Scan(&info.Name, &info.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("secrets: list scan: %w", err)
+		}
+		out = append(out, info)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("secrets: list rows: %w", err)
+	}
+	return out, nil
 }

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -184,6 +184,132 @@ func TestSQLStoreWrongKeyGetFails(t *testing.T) {
 	}
 }
 
+func TestSQLStoreList(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+
+	// Empty store lists nothing.
+	infos, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List empty: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("List empty = %d rows, want 0", len(infos))
+	}
+
+	// Insert out of name order; List must return ordered by name and never values.
+	if err := store.Set(ctx, NameWebhookAPIKey, "webhook-secret"); err != nil {
+		t.Fatalf("Set webhook: %v", err)
+	}
+	if err := store.Set(ctx, NameMusixmatchToken, "token-secret"); err != nil {
+		t.Fatalf("Set token: %v", err)
+	}
+	infos, err = store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("List = %d rows, want 2", len(infos))
+	}
+	if infos[0].Name != NameMusixmatchToken || infos[1].Name != NameWebhookAPIKey {
+		t.Fatalf("List order = [%q, %q], want sorted by name", infos[0].Name, infos[1].Name)
+	}
+	for _, info := range infos {
+		if info.UpdatedAt == "" {
+			t.Fatalf("List %q has empty updated_at", info.Name)
+		}
+		// SecretInfo carries no value field; assert names are not the secret values.
+		if info.Name == "token-secret" || info.Name == "webhook-secret" {
+			t.Fatalf("List leaked a secret value as a name: %q", info.Name)
+		}
+	}
+}
+
+func TestSQLStoreListQueryError(t *testing.T) {
+	ctx := context.Background()
+	store, sqlDB := newTestStore(t)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := store.List(ctx); err == nil {
+		t.Fatal("List on a closed DB: expected an error")
+	}
+}
+
+func TestSQLStoreDeleteError(t *testing.T) {
+	ctx := context.Background()
+	store, sqlDB := newTestStore(t)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := store.Delete(ctx, "k"); err == nil {
+		t.Fatal("Delete on a closed DB: expected an error")
+	}
+}
+
+func TestMemoryStoreCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	store := NewMemoryStore()
+	if _, err := store.List(ctx); err == nil {
+		t.Fatal("List with canceled context: expected an error")
+	}
+	if err := store.Set(ctx, "k", "v"); err == nil {
+		t.Fatal("Set with canceled context: expected an error")
+	}
+	if _, _, err := store.Get(ctx, "k"); err == nil {
+		t.Fatal("Get with canceled context: expected an error")
+	}
+	if err := store.Delete(ctx, "k"); err == nil {
+		t.Fatal("Delete with canceled context: expected an error")
+	}
+}
+
+func TestMemoryStoreList(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	infos, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List empty: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("List empty = %d rows, want 0", len(infos))
+	}
+
+	if err := store.Set(ctx, NameWebhookAPIKey, "wv"); err != nil {
+		t.Fatalf("Set webhook: %v", err)
+	}
+	if err := store.Set(ctx, NameMusixmatchToken, "tv"); err != nil {
+		t.Fatalf("Set token: %v", err)
+	}
+	infos, err = store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("List = %d rows, want 2", len(infos))
+	}
+	// Ordering parity with SQLStore: sorted by name.
+	if infos[0].Name != NameMusixmatchToken || infos[1].Name != NameWebhookAPIKey {
+		t.Fatalf("List order = [%q, %q], want sorted by name", infos[0].Name, infos[1].Name)
+	}
+	for _, info := range infos {
+		if info.UpdatedAt == "" {
+			t.Fatalf("List %q has empty updated_at", info.Name)
+		}
+	}
+
+	// Delete clears both value and updated_at.
+	if err := store.Delete(ctx, NameMusixmatchToken); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	infos, _ = store.List(ctx)
+	if len(infos) != 1 || infos[0].Name != NameWebhookAPIKey {
+		t.Fatalf("List after delete = %+v, want only webhook", infos)
+	}
+}
+
 func TestMemoryStoreRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	var store Store = NewMemoryStore()


### PR DESCRIPTION
## Phases 3 + 4 of #229 - the `secrets` CLI + docs (completes the feature)

Final phases of the encrypted-secrets work. Builds on Phase 1 (#233, crypto + store) and Phase 2 (#234, precedence wiring). Adds the operator-facing CLI to move plaintext secrets into the encrypted store, plus user/config docs. Per the design-of-record (`docs/design/2026-06-13-223-secrets-encryption.md`, "Precedence and migration" + "Logging and redaction").

### Phase 3 - CLI (`internal/commands/secrets_cmd.go`)
- **`secrets import [--token|--webhook]`** - reads the effective secret(s) from CLI/env/TOML (deliberately **skipping the DB tier as a source**, so it never reads-then-writes the DB onto itself), writes them encrypted via `store.Set` (idempotent upsert), skips a secret with no effective value, and prints a reminder to remove the now-redundant plaintext from `config.toml`/compose env. Never echoes values; never auto-runs on startup (explicit operator action only).
- **`secrets set <name>`** - sets one known secret (`musixmatch_token` | `webhook_api_key`) via stdin / no-echo prompt only. **Rejects a value passed on argv** (argv lands in shell history / `ps`) and rejects unknown names.
- **`secrets list`** - prints `name` + `updated_at` only, **never values**.
- Adds `Store.List(ctx) ([]SecretInfo, error)` to the interface, `SQLStore` (`SELECT name, updated_at ... ORDER BY name`), and `MemoryStore`.

### Phase 4 - docs
- `docs/USER_GUIDE.md` - new "Encrypted secrets" section: commands, threat model, key management (`MXLRC_MASTER_KEY` env recommended for Docker; auto `0600` key file for native; `secrets.key_file`/`MXLRC_SECRETS_KEY_FILE` override), the Docker first-run wizard, precedence (DB lowest; existing env/TOML unchanged), and a **key-loss recovery note**.
- `docs/CONFIGURATION.md` - `MXLRC_MASTER_KEY` + `MXLRC_SECRETS_KEY_FILE` env rows and a `[secrets]` TOML subsection.
- `README.md` - brief "Encrypted secrets" pointer to the guide.
- `docker-compose.example.yml` - `MXLRC_MASTER_KEY` block (required in Docker, key kept off the data volume, first-run rationale).

### Validation
`make gate` green: race tests pass, patch coverage **86.86%** (`secrets_cmd.go` 87.8%, `commands.go` 100%, `memory.go` 100%, `store.go` 66.7% per-file - the 6 uncovered lines are `List`'s `rows.Scan`/`rows.Err` error branches that need a fake driver, which the repo's no-mocks-for-storage convention bars; the 86.86% aggregate clears the gate), golangci-lint 0 issues, govulncheck clean. Tests use real SQLite, no mocks.

Closes #229 (Phases 1-4 all landed: #233, #234, this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted at-rest storage for Musixmatch API token and webhook key
  * New CLI subcommand to manage encrypted secrets: import from config, set individual secrets, and list stored secret names
  * Master key configuration via environment variable or auto-generated key file

* **Documentation**
  * Updated configuration guide and user guide with encrypted secrets setup and usage instructions
  * Added Docker example configuration for master key management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->