### PR TITLE
feat(serve): provider hit/miss + instrumental metrics for /metrics (#231)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -817,6 +817,10 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	configureWorkerAudioDetector(w, audioDetector)
 	w.SetInstrumentalDetectionDefault(cfg.InstrumentalDetector.Enabled)
 	configureWorkerGuard(w, newGuard(cfg))
+	// Wire the DB-backed provider outcome recorder so hits and misses are persisted
+	// and exposed via GET /metrics (mxlrcgo_provider_hits_total{lane},
+	// mxlrcgo_provider_misses_total{lane}).
+	configureWorkerProviderRecorder(w, workQ)
 
 	runCtx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
@@ -1075,6 +1079,12 @@ func configureWorkerGuard(w *worker.Worker, g worker.ScriptGuard) {
 		return
 	}
 	w.EnableGuard(g)
+}
+
+// configureWorkerProviderRecorder installs the provider-outcome recorder on the
+// worker. A nil recorder is valid and leaves the worker in no-op mode (default).
+func configureWorkerProviderRecorder(w *worker.Worker, r worker.ProviderRecorder) {
+	w.SetProviderRecorder(r)
 }
 
 // configureWriterBilingual enables interleaved bilingual output on an LRC writer

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -220,6 +220,25 @@ func TestConfigureWorkerGuardAcceptsNilGuard(t *testing.T) {
 	configureWorkerGuard(w, nil)
 }
 
+// TestConfigureWorkerProviderRecorderWiresRecorder guards the serve command
+// wiring: configureWorkerProviderRecorder must install the recorder so that
+// provider outcome events are recorded. This is the testable unit equivalent
+// of the w.SetProviderRecorder(workQ) call in runServe.
+func TestConfigureWorkerProviderRecorderWiresRecorder(t *testing.T) {
+	w := worker.New(nil, nil, fakeFetcher{}, fakeWriter{})
+	// nil recorder is a valid no-op (backward-compatible default).
+	configureWorkerProviderRecorder(w, nil)
+	// A non-nil recorder must also be accepted without panic.
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "wiring.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	workQ := queue.NewDBQueue(sqlDB)
+	configureWorkerProviderRecorder(w, workQ)
+}
+
 // TestNewAudioDetectorDecoupledFromEnableFlag verifies the #218 decoupling: the
 // detector is built whenever a classifier URL is configured, independent of the
 // global Enabled flag, and is nil only when no classifier URL is set.

--- a/internal/db/migrations/018_provider_outcomes.sql
+++ b/internal/db/migrations/018_provider_outcomes.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-lane provider outcome counters for the /metrics endpoint. Each row tracks
+-- cumulative hits (lyrics found) and misses (benign no-result) for one provider
+-- lane. Rows are upserted atomically by the worker write-path; the table starts
+-- empty and self-populates on first use.
+CREATE TABLE provider_outcomes (
+    lane   TEXT    PRIMARY KEY,
+    hits   INTEGER NOT NULL DEFAULT 0,
+    misses INTEGER NOT NULL DEFAULT 0
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+-- Audio-detection result for a work_queue row. NULL = detection was not run for
+-- this item; 0 = detection ran but track is not instrumental; 1 = audio-detected
+-- as instrumental. Distinct from detect_instrumental (the request flag stamped at
+-- enqueue time, migration 016). The gauge mxlrcgo_instrumental_tracks counts rows
+-- with instrumental_result = 1.
+ALTER TABLE work_queue ADD COLUMN instrumental_result INTEGER;
+-- +goose StatementEnd
+-- +goose StatementBegin
+-- Winning provider lane for a completed work_queue row. NULL means the row has
+-- not yet been completed, was retired without a match, or predates this column.
+-- Written by the worker at completion time so per-track provider provenance is
+-- queryable for debugging (separate from the aggregate counters in provider_outcomes).
+ALTER TABLE work_queue ADD COLUMN provider_lane TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN provider_lane;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN instrumental_result;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS provider_outcomes;
+-- +goose StatementEnd

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -56,6 +56,11 @@ type Song struct {
 	// Subtitles. Zero value (empty Lines) means absent. Not interleaved by
 	// default; reserved for a future romanization output flag.
 	RomanizationSubtitles Synced
+	// WinningLane is the provider lane name that returned this song. It is set by
+	// the orchestrator for both suitable results and best-available fallbacks.
+	// Empty on cache hits and zero-value songs. Used by the worker write-path to
+	// record per-lane hit counters without changing the Fetcher interface.
+	WinningLane string `json:"-"`
 }
 
 // Inputs represents a single work item in the processing queue.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -70,6 +70,18 @@ func New(mode string, lanes ...*Lane) (*Orchestrator, error) {
 // whether the orchestrator advances to the next lane.
 func (o *Orchestrator) SetGuard(g ScriptGuard) { o.guard = g }
 
+// LaneNames returns the names of all lanes the orchestrator dispatches over, in
+// priority order. Used by the worker miss-recording path to increment the miss
+// counter for every active lane without touching the orchestrator's internal
+// lane slice directly.
+func (o *Orchestrator) LaneNames() []string {
+	names := make([]string, len(o.lanes))
+	for i, l := range o.lanes {
+		names[i] = l.Name()
+	}
+	return names
+}
+
 // SetRaceWait sets the parallel-mode upgrade window read once per dispatch. A
 // non-positive value is ignored so the constructed DefaultRaceWait is preserved.
 // It has no effect in ordered mode.
@@ -122,9 +134,10 @@ func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (mod
 
 		if err == nil {
 			if IsSuitable(song, o.guard) {
+				song.WinningLane = lane.Name()
 				return song, nil
 			}
-			r.retain(song)
+			r.retain(song, lane.Name())
 			continue
 		}
 
@@ -140,6 +153,7 @@ func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (mod
 // use (QualityNone, OutcomeSuccess).
 type dispatchResult struct {
 	bestSong    models.Song
+	bestLane    string // lane name that provided bestSong
 	haveBest    bool
 	bestQuality Quality
 	topErr      error
@@ -148,9 +162,9 @@ type dispatchResult struct {
 }
 
 // retain keeps song as the best-available fallback if it outranks the current one.
-func (r *dispatchResult) retain(song models.Song) {
+func (r *dispatchResult) retain(song models.Song, laneName string) {
 	if q := QualityOf(song); !r.haveBest || q > r.bestQuality {
-		r.bestSong, r.bestQuality, r.haveBest = song, q, true
+		r.bestSong, r.bestQuality, r.haveBest, r.bestLane = song, q, true, laneName
 	}
 }
 
@@ -170,6 +184,7 @@ func (r *dispatchResult) rankErr(err error, class OutcomeClass) {
 // was canceled, in which case its error wins.
 func (o *Orchestrator) resolve(ctx context.Context, r *dispatchResult) (models.Song, error) {
 	if r.haveBest {
+		r.bestSong.WinningLane = r.bestLane
 		return r.bestSong, nil
 	}
 	if r.consulted == 0 && len(o.lanes) > 0 {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -184,3 +184,64 @@ func TestOrderedGuardRejectionIsUnsuitable(t *testing.T) {
 
 // Ensure the orchestrator satisfies providers.Fetcher (drop-in for the worker).
 var _ providers.Fetcher = (*Orchestrator)(nil)
+
+func TestLaneNamesReturnsAllLanesInOrder(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch"}
+	p2 := &stubProvider{name: "petitlyrics"}
+	o, err := New("ordered", laneFor(p1), laneFor(p2))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	names := o.LaneNames()
+	if len(names) != 2 {
+		t.Fatalf("LaneNames len = %d; want 2", len(names))
+	}
+	if names[0] != "musixmatch" {
+		t.Errorf("names[0] = %q; want musixmatch", names[0])
+	}
+	if names[1] != "petitlyrics" {
+		t.Errorf("names[1] = %q; want petitlyrics", names[1])
+	}
+}
+
+func TestWinningLaneSetOnOrderedHit(t *testing.T) {
+	synced := models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "lyric"}}}}
+	p1 := &stubProvider{name: "musixmatch", song: synced}
+	o, _ := New("ordered", laneFor(p1))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.WinningLane != "musixmatch" {
+		t.Errorf("WinningLane = %q; want musixmatch", song.WinningLane)
+	}
+}
+
+func TestWinningLaneSetOnBestAvailable(t *testing.T) {
+	// An unsuitable (instrumental) result from the only lane is returned as
+	// best-available; WinningLane must still be set.
+	instrumental := models.Song{Track: models.Track{Instrumental: 1}}
+	p1 := &stubProvider{name: "musixmatch", song: instrumental}
+	o, _ := New("ordered", laneFor(p1))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.WinningLane != "musixmatch" {
+		t.Errorf("WinningLane = %q; want musixmatch on best-available", song.WinningLane)
+	}
+}
+
+func TestWinningLaneEmptyOnBenignMiss(t *testing.T) {
+	p1 := &stubProvider{name: "musixmatch", err: musixmatch.ErrNoLyrics}
+	o, _ := New("ordered", laneFor(p1))
+
+	_, err := o.FindLyrics(context.Background(), models.Track{})
+	if !musixmatch.IsBenignMiss(err) {
+		t.Fatalf("err = %v; want benign miss", err)
+	}
+	// On a miss the orchestrator returns an error, not a song, so WinningLane
+	// is inaccessible - this test just verifies no panic and the correct error.
+}

--- a/internal/orchestrator/parallel.go
+++ b/internal/orchestrator/parallel.go
@@ -13,6 +13,7 @@ import (
 type laneResult struct {
 	song models.Song
 	err  error
+	name string // lane name, for WinningLane tagging
 }
 
 // findParallel dispatches every lane concurrently and races the results:
@@ -42,13 +43,14 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 		lane := lane
 		go func() {
 			song, err := lane.FindLyrics(childCtx, track)
-			results <- laneResult{song: song, err: err}
+			results <- laneResult{song: song, err: err, name: lane.Name()}
 		}()
 	}
 
 	var (
 		r        dispatchResult
 		heldSong models.Song
+		heldLane string
 		haveHeld bool // a suitable unsynced result is held, pending a synced upgrade
 		upgrade  <-chan time.Time
 		pending  = len(o.lanes)
@@ -74,19 +76,20 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 				switch {
 				case res.err == nil && IsSuitable(res.song, o.guard):
 					if QualityOf(res.song) >= QualitySynced {
+						res.song.WinningLane = res.name
 						return res.song, nil // synced: commit now; defer cancels the losers.
 					}
 					// Suitable but unsynced: hold the first such result. Arm the upgrade
 					// window only while another lane could still deliver a synced upgrade;
 					// if this was the last lane, the pending == 0 check below commits it.
 					if !haveHeld {
-						heldSong, haveHeld = res.song, true
+						heldSong, haveHeld, heldLane = res.song, true, res.name
 					}
 					if upgrade == nil && pending > 0 {
 						upgrade = time.After(o.raceWait)
 					}
 				case res.err == nil:
-					r.retain(res.song)
+					r.retain(res.song, res.name)
 				default:
 					r.rankErr(res.err, class)
 				}
@@ -96,6 +99,7 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 					return models.Song{}, err
 				}
 				if haveHeld {
+					heldSong.WinningLane = heldLane
 					return heldSong, nil
 				}
 				return o.resolve(ctx, &r)
@@ -106,6 +110,7 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 			if err := ctx.Err(); err != nil {
 				return models.Song{}, err
 			}
+			heldSong.WinningLane = heldLane
 			return heldSong, nil
 		}
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1004,6 +1004,137 @@ func (q *DBQueue) CountByStatus(ctx context.Context) (map[string]int64, error) {
 	return counts, nil
 }
 
+// RecordProviderHit atomically increments the hit counter for the named provider
+// lane. If no row exists for lane yet it is created with hits=1, misses=0.
+func (q *DBQueue) RecordProviderHit(ctx context.Context, lane string) error {
+	if lane == "" {
+		return nil
+	}
+	_, err := q.db.ExecContext(ctx,
+		`INSERT INTO provider_outcomes(lane, hits, misses) VALUES(?, 1, 0)
+         ON CONFLICT(lane) DO UPDATE SET hits = hits + 1`,
+		lane,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: record provider hit for %q: %w", lane, err)
+	}
+	return nil
+}
+
+// RecordProviderMiss atomically increments the miss counter for the named
+// provider lane. If no row exists for lane yet it is created with hits=0,
+// misses=1.
+func (q *DBQueue) RecordProviderMiss(ctx context.Context, lane string) error {
+	if lane == "" {
+		return nil
+	}
+	_, err := q.db.ExecContext(ctx,
+		`INSERT INTO provider_outcomes(lane, hits, misses) VALUES(?, 0, 1)
+         ON CONFLICT(lane) DO UPDATE SET misses = misses + 1`,
+		lane,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: record provider miss for %q: %w", lane, err)
+	}
+	return nil
+}
+
+// SetProviderLane stamps the winning provider lane name onto a work_queue row.
+// Call at completion time (before Complete) so the row permanently records which
+// provider served it. A NULL provider_lane means not-yet-completed, retired
+// without a match, or a row that predates this column.
+func (q *DBQueue) SetProviderLane(ctx context.Context, id int64, lane string) error {
+	if lane == "" {
+		return nil
+	}
+	_, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET provider_lane = ? WHERE id = ?`,
+		lane, id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: set provider lane for id %d: %w", id, err)
+	}
+	return nil
+}
+
+// SetInstrumentalResult stamps the audio-detection outcome onto a work_queue row.
+// result=1 means the audio detector confirmed instrumental; result=0 means the
+// detector ran but the track is not instrumental. Call before Complete so the row
+// is still in 'processing' status (the UPDATE is a no-op on any other status,
+// which is benign).
+func (q *DBQueue) SetInstrumentalResult(ctx context.Context, id int64, result int) error {
+	_, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result = ? WHERE id = ?`,
+		result, id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: set instrumental result for id %d: %w", id, err)
+	}
+	return nil
+}
+
+// ProviderHits returns a map from lane name to cumulative hit count. Lanes that
+// have never recorded a hit are omitted.
+func (q *DBQueue) ProviderHits(ctx context.Context) (map[string]int64, error) {
+	rows, err := q.db.QueryContext(ctx,
+		`SELECT lane, hits FROM provider_outcomes WHERE hits > 0`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue: provider hits: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var lane string
+		var n int64
+		if err := rows.Scan(&lane, &n); err != nil {
+			return nil, fmt.Errorf("queue: scan provider hits: %w", err)
+		}
+		counts[lane] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: provider hits rows: %w", err)
+	}
+	return counts, nil
+}
+
+// ProviderMisses returns a map from lane name to cumulative miss count. Lanes
+// that have never recorded a miss are omitted.
+func (q *DBQueue) ProviderMisses(ctx context.Context) (map[string]int64, error) {
+	rows, err := q.db.QueryContext(ctx,
+		`SELECT lane, misses FROM provider_outcomes WHERE misses > 0`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queue: provider misses: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var lane string
+		var n int64
+		if err := rows.Scan(&lane, &n); err != nil {
+			return nil, fmt.Errorf("queue: scan provider misses: %w", err)
+		}
+		counts[lane] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: provider misses rows: %w", err)
+	}
+	return counts, nil
+}
+
+// CountInstrumental returns the number of work_queue rows where the audio
+// detector confirmed the track as instrumental (instrumental_result = 1).
+func (q *DBQueue) CountInstrumental(ctx context.Context) (int64, error) {
+	var n int64
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue WHERE instrumental_result = 1`,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("queue: count instrumental: %w", err)
+	}
+	return n, nil
+}
+
 // CancelByLibrary rebuilds or deletes pending/failed/deferred work_queue rows whose
 // output_paths derive from libraryID. Each affected row's output_paths JSON is
 // filtered to retain only entries that appear in scan_results from libraries

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -2898,6 +2898,182 @@ func TestDBQueue_CountFailuresByReason(t *testing.T) {
 	}
 }
 
+// TestDBQueue_ProviderOutcomes verifies RecordProviderHit, RecordProviderMiss,
+// ProviderHits, and ProviderMisses round-trip correctly through the DB.
+func TestDBQueue_ProviderOutcomes(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	// Empty table: both maps should be empty.
+	hits, err := q.ProviderHits(ctx)
+	if err != nil {
+		t.Fatalf("ProviderHits empty: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("ProviderHits: want empty map, got %v", hits)
+	}
+	misses, err := q.ProviderMisses(ctx)
+	if err != nil {
+		t.Fatalf("ProviderMisses empty: %v", err)
+	}
+	if len(misses) != 0 {
+		t.Fatalf("ProviderMisses: want empty map, got %v", misses)
+	}
+
+	// Record hits and misses for two lanes.
+	for i := 0; i < 3; i++ {
+		if err := q.RecordProviderHit(ctx, "musixmatch"); err != nil {
+			t.Fatalf("RecordProviderHit musixmatch[%d]: %v", i, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := q.RecordProviderHit(ctx, "petitlyrics"); err != nil {
+			t.Fatalf("RecordProviderHit petitlyrics[%d]: %v", i, err)
+		}
+	}
+	if err := q.RecordProviderMiss(ctx, "musixmatch"); err != nil {
+		t.Fatalf("RecordProviderMiss musixmatch: %v", err)
+	}
+	if err := q.RecordProviderMiss(ctx, "petitlyrics"); err != nil {
+		t.Fatalf("RecordProviderMiss petitlyrics: %v", err)
+	}
+	if err := q.RecordProviderMiss(ctx, "petitlyrics"); err != nil {
+		t.Fatalf("RecordProviderMiss petitlyrics[2]: %v", err)
+	}
+
+	hits, err = q.ProviderHits(ctx)
+	if err != nil {
+		t.Fatalf("ProviderHits: %v", err)
+	}
+	if hits["musixmatch"] != 3 {
+		t.Errorf("musixmatch hits = %d; want 3", hits["musixmatch"])
+	}
+	if hits["petitlyrics"] != 2 {
+		t.Errorf("petitlyrics hits = %d; want 2", hits["petitlyrics"])
+	}
+
+	misses, err = q.ProviderMisses(ctx)
+	if err != nil {
+		t.Fatalf("ProviderMisses: %v", err)
+	}
+	if misses["musixmatch"] != 1 {
+		t.Errorf("musixmatch misses = %d; want 1", misses["musixmatch"])
+	}
+	if misses["petitlyrics"] != 2 {
+		t.Errorf("petitlyrics misses = %d; want 2", misses["petitlyrics"])
+	}
+}
+
+// TestDBQueue_RecordProviderHitEmptyLane verifies that an empty lane name is a
+// no-op (no row inserted, no error).
+func TestDBQueue_RecordProviderHitEmptyLane(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	if err := q.RecordProviderHit(ctx, ""); err != nil {
+		t.Fatalf("RecordProviderHit empty lane: %v", err)
+	}
+	if err := q.RecordProviderMiss(ctx, ""); err != nil {
+		t.Fatalf("RecordProviderMiss empty lane: %v", err)
+	}
+	hits, _ := q.ProviderHits(ctx)
+	misses, _ := q.ProviderMisses(ctx)
+	if len(hits) != 0 || len(misses) != 0 {
+		t.Errorf("empty lane should not insert rows; hits=%v misses=%v", hits, misses)
+	}
+}
+
+// TestDBQueue_SetInstrumentalResultAndCount verifies SetInstrumentalResult and
+// CountInstrumental work together through a real SQLite DB.
+func TestDBQueue_SetInstrumentalResultAndCount(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	// Enqueue and dequeue three items.
+	enqDeq := func(artist, title string) WorkItem {
+		t.Helper()
+		if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: artist, TrackName: title}}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %s/%s: %v", artist, title, err)
+		}
+		item, err := q.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("Dequeue %s/%s: %v", artist, title, err)
+		}
+		return item
+	}
+
+	item1 := enqDeq("Artist A", "Track 1")
+	item2 := enqDeq("Artist B", "Track 2")
+	item3 := enqDeq("Artist C", "Track 3")
+
+	// Initially no instrumental rows.
+	n, err := q.CountInstrumental(ctx)
+	if err != nil {
+		t.Fatalf("CountInstrumental: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("initial count = %d; want 0", n)
+	}
+
+	// Stamp item1 as instrumental (result=1), item2 as not (result=0).
+	if err := q.SetInstrumentalResult(ctx, item1.ID, 1); err != nil {
+		t.Fatalf("SetInstrumentalResult item1: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, item2.ID, 0); err != nil {
+		t.Fatalf("SetInstrumentalResult item2: %v", err)
+	}
+	// item3: leave NULL (detection not run).
+	_ = item3
+
+	n, err = q.CountInstrumental(ctx)
+	if err != nil {
+		t.Fatalf("CountInstrumental after stamps: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d; want 1 (only item1 is instrumental)", n)
+	}
+}
+
+// TestDBQueue_SetProviderLane verifies SetProviderLane persists the winning lane
+// on a work_queue row and that empty lane is a no-op.
+func TestDBQueue_SetProviderLane(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	// Empty lane must be a no-op (no error, no row update).
+	if err := q.SetProviderLane(ctx, item.ID, ""); err != nil {
+		t.Fatalf("SetProviderLane empty: %v", err)
+	}
+
+	// Stamp a real lane and verify it is stored.
+	if err := q.SetProviderLane(ctx, item.ID, "musixmatch"); err != nil {
+		t.Fatalf("SetProviderLane: %v", err)
+	}
+
+	var lane *string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT provider_lane FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&lane); err != nil {
+		t.Fatalf("read provider_lane: %v", err)
+	}
+	if lane == nil || *lane != "musixmatch" {
+		t.Errorf("provider_lane = %v; want musixmatch", lane)
+	}
+}
+
 // TestDBQueue_RecheckClosedDB verifies the recheck methods return a wrapped
 // error (rather than panicking) when the underlying handle is closed.
 func TestDBQueue_RecheckClosedDB(t *testing.T) {
@@ -2921,5 +3097,40 @@ func TestDBQueue_RecheckClosedDB(t *testing.T) {
 	}
 	if _, err := q.CountRecheckRetired(ctx, nil); err == nil {
 		t.Fatal("CountRecheckRetired on closed db: want error, got nil")
+	}
+}
+
+// TestDBQueue_ProviderMethodsClosedDB verifies that the new provider-outcome
+// and instrumental methods return wrapped errors (not panics) when the
+// underlying DB handle is closed.
+func TestDBQueue_ProviderMethodsClosedDB(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "closed2.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	_ = sqlDB.Close()
+	q := NewDBQueue(sqlDB)
+
+	if err := q.RecordProviderHit(ctx, "musixmatch"); err == nil {
+		t.Fatal("RecordProviderHit on closed db: want error, got nil")
+	}
+	if err := q.RecordProviderMiss(ctx, "musixmatch"); err == nil {
+		t.Fatal("RecordProviderMiss on closed db: want error, got nil")
+	}
+	if err := q.SetProviderLane(ctx, 1, "musixmatch"); err == nil {
+		t.Fatal("SetProviderLane on closed db: want error, got nil")
+	}
+	if err := q.SetInstrumentalResult(ctx, 1, 1); err == nil {
+		t.Fatal("SetInstrumentalResult on closed db: want error, got nil")
+	}
+	if _, err := q.ProviderHits(ctx); err == nil {
+		t.Fatal("ProviderHits on closed db: want error, got nil")
+	}
+	if _, err := q.ProviderMisses(ctx); err == nil {
+		t.Fatal("ProviderMisses on closed db: want error, got nil")
+	}
+	if _, err := q.CountInstrumental(ctx); err == nil {
+		t.Fatal("CountInstrumental on closed db: want error, got nil")
 	}
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -17,6 +17,9 @@ import (
 type MetricsReporter interface {
 	CountByStatus(ctx context.Context) (map[string]int64, error)
 	CountFailuresByReason(ctx context.Context) (map[string]int64, error)
+	ProviderHits(ctx context.Context) (map[string]int64, error)
+	ProviderMisses(ctx context.Context) (map[string]int64, error)
+	CountInstrumental(ctx context.Context) (int64, error)
 }
 
 // handleMetrics writes a Prometheus text-exposition response. It applies the
@@ -60,18 +63,39 @@ func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	providerHits, err := h.metrics.ProviderHits(r.Context())
+	if err != nil {
+		slog.Error("metrics: provider hits failed", "error", err)
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	providerMisses, err := h.metrics.ProviderMisses(r.Context())
+	if err != nil {
+		slog.Error("metrics: provider misses failed", "error", err)
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	instrumentalCount, err := h.metrics.CountInstrumental(r.Context())
+	if err != nil {
+		slog.Error("metrics: count instrumental failed", "error", err)
+		http.Error(w, "metrics unavailable", http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store") // prevent proxies from caching stale metrics
 	w.WriteHeader(http.StatusOK)
-	writeMetrics(w, statusCounts, failureCounts)
+	writeMetrics(w, statusCounts, failureCounts, providerHits, providerMisses, instrumentalCount)
 }
 
 // writeMetrics serializes all metric families in Prometheus text-exposition
 // format (version 0.0.4). Each family includes the required # HELP and # TYPE
 // comment lines followed by one sample line per label set. Label sets are
-// sorted to ensure a deterministic response order. All metrics use gauge
-// semantics because they are computed from DB snapshots, not monotonic counters.
-func writeMetrics(w io.Writer, statusCounts, failureCounts map[string]int64) {
+// sorted to ensure a deterministic response order. Queue-snapshot metrics use
+// gauge semantics; provider outcome counters use counter semantics (_total suffix).
+func writeMetrics(w io.Writer, statusCounts, failureCounts, providerHits, providerMisses map[string]int64, instrumentalCount int64) {
 	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_queue_items Current number of items in the work queue by status.")
 	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_queue_items gauge")
 	for _, status := range sortedKeys(statusCounts) {
@@ -83,6 +107,22 @@ func writeMetrics(w io.Writer, statusCounts, failureCounts map[string]int64) {
 	for _, reason := range sortedKeys(failureCounts) {
 		_, _ = fmt.Fprintf(w, "mxlrcgo_queue_failures{reason=\"%s\"} %d\n", promEscape(reason), failureCounts[reason])
 	}
+
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_provider_hits_total Total number of successful lyrics fetches by provider lane.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_provider_hits_total counter")
+	for _, lane := range sortedKeys(providerHits) {
+		_, _ = fmt.Fprintf(w, "mxlrcgo_provider_hits_total{lane=\"%s\"} %d\n", promEscape(lane), providerHits[lane])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_provider_misses_total Total number of benign no-result misses by provider lane.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_provider_misses_total counter")
+	for _, lane := range sortedKeys(providerMisses) {
+		_, _ = fmt.Fprintf(w, "mxlrcgo_provider_misses_total{lane=\"%s\"} %d\n", promEscape(lane), providerMisses[lane])
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP mxlrcgo_instrumental_tracks Number of work queue items confirmed instrumental by audio detection.")
+	_, _ = fmt.Fprintln(w, "# TYPE mxlrcgo_instrumental_tracks gauge")
+	_, _ = fmt.Fprintf(w, "mxlrcgo_instrumental_tracks %d\n", instrumentalCount)
 }
 
 // sortedKeys returns the keys of m in ascending lexicographic order.

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -12,10 +12,16 @@ import (
 )
 
 type fakeMetrics struct {
-	statusCounts  map[string]int64
-	failureCounts map[string]int64
-	statusErr     error
-	failureErr    error
+	statusCounts      map[string]int64
+	failureCounts     map[string]int64
+	providerHits      map[string]int64
+	providerMisses    map[string]int64
+	instrumentalCount int64
+	statusErr         error
+	failureErr        error
+	hitsErr           error
+	missesErr         error
+	instrumentalErr   error
 }
 
 func (f *fakeMetrics) CountByStatus(_ context.Context) (map[string]int64, error) {
@@ -24,6 +30,18 @@ func (f *fakeMetrics) CountByStatus(_ context.Context) (map[string]int64, error)
 
 func (f *fakeMetrics) CountFailuresByReason(_ context.Context) (map[string]int64, error) {
 	return f.failureCounts, f.failureErr
+}
+
+func (f *fakeMetrics) ProviderHits(_ context.Context) (map[string]int64, error) {
+	return f.providerHits, f.hitsErr
+}
+
+func (f *fakeMetrics) ProviderMisses(_ context.Context) (map[string]int64, error) {
+	return f.providerMisses, f.missesErr
+}
+
+func (f *fakeMetrics) CountInstrumental(_ context.Context) (int64, error) {
+	return f.instrumentalCount, f.instrumentalErr
 }
 
 func TestMetricsRequiresAdminAuth(t *testing.T) {
@@ -211,7 +229,13 @@ func TestWriteMetricsLabelEscaping(t *testing.T) {
 func TestWriteMetricsSortedOutput(t *testing.T) {
 	// Samples must appear in lexicographic order regardless of map iteration.
 	var sb strings.Builder
-	writeMetrics(&sb, map[string]int64{"pending": 1, "done": 2, "failed": 3}, map[string]int64{})
+	writeMetrics(&sb,
+		map[string]int64{"pending": 1, "done": 2, "failed": 3},
+		map[string]int64{},
+		map[string]int64{},
+		map[string]int64{},
+		0,
+	)
 	body := sb.String()
 
 	doneIdx := strings.Index(body, `status="done"`)
@@ -224,5 +248,145 @@ func TestWriteMetricsSortedOutput(t *testing.T) {
 	if doneIdx >= failedIdx || failedIdx >= pendingIdx {
 		t.Errorf("samples not in sorted order (done=%d failed=%d pending=%d)\nbody:\n%s",
 			doneIdx, failedIdx, pendingIdx, body)
+	}
+}
+
+func TestMetricsProviderOutcomesAndInstrumental(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:      map[string]int64{"done": 10},
+			failureCounts:     map[string]int64{},
+			providerHits:      map[string]int64{"musixmatch": 8, "petitlyrics": 2},
+			providerMisses:    map[string]int64{"musixmatch": 3},
+			instrumentalCount: 5,
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	// Provider hits counter family.
+	if !strings.Contains(body, "# HELP mxlrcgo_provider_hits_total") {
+		t.Errorf("missing HELP for mxlrcgo_provider_hits_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_provider_hits_total counter") {
+		t.Errorf("missing TYPE counter for mxlrcgo_provider_hits_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_provider_hits_total{lane="musixmatch"} 8`) {
+		t.Errorf("missing musixmatch hit sample\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_provider_hits_total{lane="petitlyrics"} 2`) {
+		t.Errorf("missing petitlyrics hit sample\nbody:\n%s", body)
+	}
+
+	// Provider misses counter family.
+	if !strings.Contains(body, "# HELP mxlrcgo_provider_misses_total") {
+		t.Errorf("missing HELP for mxlrcgo_provider_misses_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_provider_misses_total counter") {
+		t.Errorf("missing TYPE counter for mxlrcgo_provider_misses_total\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, `mxlrcgo_provider_misses_total{lane="musixmatch"} 3`) {
+		t.Errorf("missing musixmatch miss sample\nbody:\n%s", body)
+	}
+
+	// Instrumental gauge.
+	if !strings.Contains(body, "# HELP mxlrcgo_instrumental_tracks") {
+		t.Errorf("missing HELP for mxlrcgo_instrumental_tracks\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "# TYPE mxlrcgo_instrumental_tracks gauge") {
+		t.Errorf("missing TYPE gauge for mxlrcgo_instrumental_tracks\nbody:\n%s", body)
+	}
+	if !strings.Contains(body, "mxlrcgo_instrumental_tracks 5") {
+		t.Errorf("missing instrumental_tracks sample\nbody:\n%s", body)
+	}
+
+	// Sorted output within provider hits (musixmatch < petitlyrics).
+	mmIdx := strings.Index(body, `lane="musixmatch"`)
+	ptIdx := strings.Index(body, `lane="petitlyrics"`)
+	if mmIdx < 0 || ptIdx < 0 {
+		t.Fatalf("missing lane samples\nbody:\n%s", body)
+	}
+	if mmIdx >= ptIdx {
+		t.Errorf("provider hits not in sorted lane order (musixmatch=%d petitlyrics=%d)\nbody:\n%s",
+			mmIdx, ptIdx, body)
+	}
+}
+
+func TestMetricsEmptyProviderTablesProduceHelpAndTypeLines(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:   map[string]int64{},
+			failureCounts:  map[string]int64{},
+			providerHits:   map[string]int64{},
+			providerMisses: map[string]int64{},
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"# HELP mxlrcgo_provider_hits_total",
+		"# TYPE mxlrcgo_provider_hits_total counter",
+		"# HELP mxlrcgo_provider_misses_total",
+		"# TYPE mxlrcgo_provider_misses_total counter",
+		"# HELP mxlrcgo_instrumental_tracks",
+		"# TYPE mxlrcgo_instrumental_tracks gauge",
+		"mxlrcgo_instrumental_tracks 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in body:\n%s", want, body)
+		}
+	}
+}
+
+func TestMetricsProviderHitsQueryErrorReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:  map[string]int64{},
+			failureCounts: map[string]int64{},
+			hitsErr:       errors.New("db error"),
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 on provider hits query error", rec.Code)
+	}
+}
+
+func TestMetricsProviderMissesQueryErrorReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:  map[string]int64{},
+			failureCounts: map[string]int64{},
+			providerHits:  map[string]int64{},
+			missesErr:     errors.New("db error"),
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 on provider misses query error", rec.Code)
+	}
+}
+
+func TestMetricsInstrumentalQueryErrorReturns500(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithMetricsReporter(&fakeMetrics{
+			statusCounts:    map[string]int64{},
+			failureCounts:   map[string]int64{},
+			providerHits:    map[string]int64{},
+			providerMisses:  map[string]int64{},
+			instrumentalErr: errors.New("db error"),
+		}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics?apikey=key", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d; want 500 on instrumental query error", rec.Code)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -36,6 +36,22 @@ type Queue interface {
 	// marking the track as terminal. The scan layer will show the track as done
 	// (not pending) so it is not mistaken for an in-flight item.
 	RetireMiss(ctx context.Context, id int64) (queue.WorkItem, error)
+	// SetInstrumentalResult stamps the audio-detection outcome onto a work_queue
+	// row. result=1 means instrumental confirmed; result=0 means not instrumental.
+	// Call before Complete while the row is still in processing status.
+	SetInstrumentalResult(ctx context.Context, id int64, result int) error
+	// SetProviderLane stamps the winning provider lane name onto a work_queue row
+	// for per-track provenance. Call at completion time before Complete so the row
+	// permanently records which provider served it. An empty lane is a no-op.
+	SetProviderLane(ctx context.Context, id int64, lane string) error
+}
+
+// ProviderRecorder records per-lane provider outcome counters. A nil
+// ProviderRecorder is valid and treated as a no-op; recording failures are
+// logged at Warn and do not affect the processing outcome.
+type ProviderRecorder interface {
+	RecordProviderHit(ctx context.Context, lane string) error
+	RecordProviderMiss(ctx context.Context, lane string) error
 }
 
 // ScriptGuard rejects lyric results whose body is dominated by scripts outside
@@ -115,7 +131,12 @@ type Worker struct {
 	// scriptGuard, when non-nil and Enabled, rejects fetched lyrics whose script
 	// mix falls outside the configured allowlist. Named scriptGuard (not guard)
 	// to avoid colliding with the guardReject helper. Default nil (no guard).
-	scriptGuard         ScriptGuard
+	scriptGuard ScriptGuard
+	// providerRecorder, when non-nil, receives per-lane hit and miss events so the
+	// /metrics endpoint can report mxlrcgo_provider_hits_total{lane} and
+	// mxlrcgo_provider_misses_total{lane}. Errors from it are non-fatal (logged at
+	// Warn). Nil means no recording (safe no-op). Set via SetProviderRecorder.
+	providerRecorder    ProviderRecorder
 	consecutiveFailures int
 	// last* record the most recent hard failure so the backoff WARN can name the
 	// track it is throttling on (the failure cause is logged separately, but the
@@ -423,6 +444,46 @@ func (w *Worker) EnableGuard(g ScriptGuard) {
 	_ = w.rebuildOrchestrator()
 }
 
+// SetProviderRecorder installs a recorder that receives per-lane hit and miss
+// events. A nil recorder disables recording (the default, preserving backward
+// compatibility with callers that do not configure metrics).
+func (w *Worker) SetProviderRecorder(r ProviderRecorder) {
+	w.providerRecorder = r
+}
+
+// recordHit increments the provider outcome hit counter for the winning lane and
+// stamps the lane name onto the work_queue row for per-track provenance. Both
+// operations are non-fatal: errors are logged at Warn and do not affect the
+// processing outcome.
+func (w *Worker) recordHit(ctx context.Context, id int64, lane string) {
+	if lane == "" {
+		return
+	}
+	if w.providerRecorder != nil {
+		if err := w.providerRecorder.RecordProviderHit(ctx, lane); err != nil {
+			slog.Warn("worker: record provider hit failed", "lane", lane, "error", err)
+		}
+	}
+	if err := w.queue.SetProviderLane(ctx, id, lane); err != nil {
+		slog.Warn("worker: stamp provider lane failed", "id", id, "lane", lane, "error", err)
+	}
+}
+
+// recordMisses increments the provider outcome miss counter for every active
+// lane via the orchestrator's LaneNames. Called on the benign-miss path (the
+// orchestrator tried all lanes and found nothing). Errors are logged at Warn
+// and do not affect the processing outcome.
+func (w *Worker) recordMisses(ctx context.Context) {
+	if w.providerRecorder == nil {
+		return
+	}
+	for _, name := range w.orch.LaneNames() {
+		if err := w.providerRecorder.RecordProviderMiss(ctx, name); err != nil {
+			slog.Warn("worker: record provider miss failed", "lane", name, "error", err)
+		}
+	}
+}
+
 // guardReject reports whether the script guard rejects this song. It returns
 // (false, "") when no guard is configured or the guard is disabled, so the
 // caller can treat a nil/disabled guard as a no-op.
@@ -562,6 +623,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// otherwise healthily reaching the provider and getting clean misses.
 		if musixmatch.IsBenignMiss(err) {
 			slog.Debug("worker no lyrics match; requeuing deferred", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", err)
+			// Every active lane was tried and none returned lyrics: record a miss for
+			// each. Errors are non-fatal; recording happens before the Defer/Complete
+			// so the queue state is clean regardless of the recording outcome.
+			w.recordMisses(context.WithoutCancel(ctx))
 			// Optional audio-based instrumental detection. Only runs on provider
 			// misses (no lyrics and not already flagged instrumental). Errors are
 			// non-fatal: starvation of the detector sidecar is acceptable; the miss
@@ -572,6 +637,12 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			}
 			if instrumental {
 				slog.Info("worker audio detector: instrumental track confirmed; writing marker", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "kind", "instrumental")
+				// Stamp the audio-detection result (1 = instrumental) on the queue row
+				// before Complete so the /metrics gauge reflects the outcome durably.
+				// Errors are non-fatal: a failed stamp is not worth aborting the write.
+				if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 1); stampErr != nil {
+					slog.Warn("worker instrumental detection: stamp result failed; continuing", "id", item.ID, "error", stampErr)
+				}
 				instrumentalSong := models.Song{
 					Track: models.Track{
 						ArtistName:   resolvedTrack.ArtistName,
@@ -611,6 +682,19 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 				w.consecutiveFailures = 0
 				return nil
 			}
+			// Detection ran but the track is not instrumental: stamp result=0 so the
+			// row is distinguishable from "never detected" (NULL).
+			if detErr == nil {
+				detect := w.detectInstrumentalDefault
+				if item.DetectInstrumental != nil {
+					detect = *item.DetectInstrumental
+				}
+				if detect && w.audioDetector != nil && strings.TrimSpace(item.Inputs.SourcePath) != "" {
+					if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 0); stampErr != nil {
+						slog.Warn("worker instrumental detection: stamp non-instrumental result failed; continuing", "id", item.ID, "error", stampErr)
+					}
+				}
+			}
 			if derr := w.requeueDeferred(ctx, item, err); derr != nil {
 				return derr
 			}
@@ -628,11 +712,14 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	confidence := Confidence(item.Inputs.Track, song.Track)
 	slog.Debug("worker lyrics match", "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "cache_hit", cacheHit)
 	if !cacheHit {
-		// A non-cache provider fetch succeeded: the lane already recorded the
-		// success and recovered its breaker inside FindLyrics (before any
-		// downstream step), so a later bare 401 is correctly read as throttling
-		// rather than a dead token, and a verify/guard/store failure below does not
-		// make the breaker forget the fetch itself worked.
+		// A non-cache provider fetch succeeded: record the hit and stamp the winning
+		// lane on the queue row before any downstream step so the counter and the
+		// per-track provenance are always written when the provider round-trip
+		// succeeds, even if verify/guard/store fails later.
+		w.recordHit(context.WithoutCancel(ctx), item.ID, song.WinningLane)
+		// The lane already recorded the circuit success and recovered its breaker
+		// inside FindLyrics, so a later bare 401 is correctly read as throttling
+		// rather than a dead token.
 		if err := w.verify(ctx, item, song, confidence); err != nil {
 			slog.Warn("worker verification failed", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "error", err)
 			return w.fail(ctx, item, err)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -97,21 +97,22 @@ func hasLog(recs []logRecord, level slog.Level, msgSub string) bool {
 // can assert that an item was returned to the pending pool without a failure
 // being recorded against it.
 type fakeQueue struct {
-	items          []queue.WorkItem
-	processing     []queue.WorkItem
-	completed      []int64
-	failed         []int64
-	released       []int64
-	deferred       []int64
-	retired        []int64
-	failCauses     []error
-	deferCauses    []error
-	deferDurations []time.Duration
-	completeErr    error
-	failErr        error
-	deferErr       error
-	releaseErr     error
-	retireErr      error
+	items              []queue.WorkItem
+	processing         []queue.WorkItem
+	completed          []int64
+	failed             []int64
+	released           []int64
+	deferred           []int64
+	retired            []int64
+	failCauses         []error
+	deferCauses        []error
+	deferDurations     []time.Duration
+	completeErr        error
+	failErr            error
+	deferErr           error
+	releaseErr         error
+	retireErr          error
+	setProviderLaneErr error
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -172,6 +173,17 @@ func (q *fakeQueue) RetireMiss(_ context.Context, id int64) (queue.WorkItem, err
 	return queue.WorkItem{ID: id, Status: queue.StatusDone}, nil
 }
 
+func (q *fakeQueue) SetInstrumentalResult(_ context.Context, _ int64, _ int) error {
+	return nil
+}
+
+func (q *fakeQueue) SetProviderLane(_ context.Context, _ int64, _ string) error {
+	if q.setProviderLaneErr != nil {
+		return q.setProviderLaneErr
+	}
+	return nil
+}
+
 func (q *fakeQueue) removeFromProcessing(id int64) {
 	for i, item := range q.processing {
 		if item.ID == id {
@@ -220,6 +232,23 @@ func (f *fakeFetcher) FindLyrics(context.Context, models.Track) (models.Song, er
 		return models.Song{}, f.err
 	}
 	return f.song, nil
+}
+
+type fakeProviderRecorder struct {
+	hits    []string
+	misses  []string
+	hitErr  error
+	missErr error
+}
+
+func (r *fakeProviderRecorder) RecordProviderHit(_ context.Context, lane string) error {
+	r.hits = append(r.hits, lane)
+	return r.hitErr
+}
+
+func (r *fakeProviderRecorder) RecordProviderMiss(_ context.Context, lane string) error {
+	r.misses = append(r.misses, lane)
+	return r.missErr
 }
 
 type fakeWriter struct {
@@ -2038,5 +2067,137 @@ func TestRunOnceDetectorNotCalledOnSuccess(t *testing.T) {
 	}
 	if len(q.completed) != 1 || q.completed[0] != 204 {
 		t.Fatalf("completed = %v; want [204]", q.completed)
+	}
+}
+
+func TestRunOnceRecordsProviderHitOnSuccess(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 301, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:       models.Track{ArtistName: "A", TrackName: "T"},
+		WinningLane: "musixmatch",
+		Lyrics:      models.Lyrics{LyricsBody: "lyrics"},
+	}}
+	writer := &fakeWriter{}
+	rec := &fakeProviderRecorder{}
+
+	w := New(q, c, fetcher, writer)
+	w.SetProviderRecorder(rec)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(rec.hits) != 1 || rec.hits[0] != "musixmatch" {
+		t.Errorf("provider hits = %v; want [musixmatch]", rec.hits)
+	}
+	if len(rec.misses) != 0 {
+		t.Errorf("provider misses = %v; want none", rec.misses)
+	}
+}
+
+func TestRunOnceRecordsProviderMissOnBenignMiss(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 302, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	rec := &fakeProviderRecorder{}
+
+	w := New(q, c, fetcher, writer)
+	w.SetProviderRecorder(rec)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// The primary Musixmatch lane must be counted as a miss.
+	if len(rec.misses) != 1 || rec.misses[0] != "musixmatch" {
+		t.Errorf("provider misses = %v; want [musixmatch]", rec.misses)
+	}
+	if len(rec.hits) != 0 {
+		t.Errorf("provider hits = %v; want none on benign miss", rec.hits)
+	}
+	if len(q.deferred) != 1 {
+		t.Errorf("deferred = %v; want [302]", q.deferred)
+	}
+}
+
+func TestRunOnceNoRecorderIsNoop(t *testing.T) {
+	// No SetProviderRecorder: RunOnce must not panic and must complete normally.
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 303, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  models.Track{ArtistName: "A", TrackName: "T"},
+		Lyrics: models.Lyrics{LyricsBody: "lyrics"},
+	}}
+	writer := &fakeWriter{}
+
+	w := New(q, c, fetcher, writer)
+	// No SetProviderRecorder call.
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce without recorder: %v", err)
+	}
+	if len(q.completed) != 1 {
+		t.Errorf("completed = %v; want [303]", q.completed)
+	}
+}
+
+// TestRecordHitEmptyLaneIsNoop verifies that calling recordHit with an empty
+// lane is a no-op: no recorder call, no queue stamp, no error.
+func TestRecordHitEmptyLaneIsNoop(t *testing.T) {
+	q := &fakeQueue{}
+	rec := &fakeProviderRecorder{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+
+	// Call directly; empty lane must short-circuit before any recorder/queue call.
+	w.recordHit(context.Background(), 999, "")
+
+	if len(rec.hits) != 0 {
+		t.Errorf("hits = %v; want none on empty lane", rec.hits)
+	}
+}
+
+// TestRecordHitRecorderErrorIsNonFatal verifies that a RecordProviderHit error
+// is logged but does not propagate (recordHit has no return value and the caller
+// must not crash).
+func TestRecordHitRecorderErrorIsNonFatal(t *testing.T) {
+	q := &fakeQueue{}
+	rec := &fakeProviderRecorder{hitErr: errors.New("recorder down")}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+
+	// Must not panic. The error is slog.Warn only.
+	w.recordHit(context.Background(), 1, "musixmatch")
+
+	if len(rec.hits) != 1 || rec.hits[0] != "musixmatch" {
+		t.Errorf("hits = %v; want [musixmatch] (recorder called even if it errors)", rec.hits)
+	}
+}
+
+// TestRecordHitQueueErrorIsNonFatal verifies that a SetProviderLane DB error is
+// logged (slog.Warn) but does not propagate.
+func TestRecordHitQueueErrorIsNonFatal(t *testing.T) {
+	q := &fakeQueue{setProviderLaneErr: errors.New("db down")}
+	rec := &fakeProviderRecorder{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+
+	// Must not panic.
+	w.recordHit(context.Background(), 1, "musixmatch")
+}
+
+// TestRecordMissesRecorderErrorIsNonFatal verifies that a RecordProviderMiss
+// error is logged (slog.Warn) but does not stop iteration or propagate.
+func TestRecordMissesRecorderErrorIsNonFatal(t *testing.T) {
+	q := &fakeQueue{}
+	rec := &fakeProviderRecorder{missErr: errors.New("recorder down")}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+
+	// Must not panic; the worker has one lane ("musixmatch") via New.
+	w.recordMisses(context.Background())
+
+	// The recorder WAS called (iteration continued despite the error).
+	if len(rec.misses) != 1 || rec.misses[0] != "musixmatch" {
+		t.Errorf("misses = %v; want [musixmatch] (recorder called even if it errors)", rec.misses)
 	}
 }


### PR DESCRIPTION
## #231 - provider hit/miss + instrumental metrics for `/metrics`

Follow-up to #212 (the `/metrics` endpoint) and #232. Adds the two metric families #212 deliberately omitted because no DB column existed to derive them from:

- `mxlrcgo_provider_hits_total{lane}` / `mxlrcgo_provider_misses_total{lane}` (counters)
- `mxlrcgo_instrumental_tracks` (gauge)

Follows CodeRabbit's coding plan for #231 (with the three stale references corrected on the issue: migration 018 not 017, no phantom `LyricsFetcher` interface, and `provider_lane` handled per the plan).

### What's in it
- **Migration 018** (`018_provider_outcomes.sql`): a `provider_outcomes(lane PK, hits, misses)` counters table for atomic hit/miss increments, plus two `work_queue` columns - `instrumental_result INTEGER` (NULL = detection not run, 0 = ran but not instrumental, 1 = audio-detected instrumental) and `provider_lane TEXT` (winning lane per row). Down reverses all three.
- **Lane threading**: `models.Song.WinningLane` (`json:"-"`, transient) carries the winning lane; the orchestrator stamps it on ordered hits and best-available returns; `LaneNames()` exposes the active lanes.
- **Write-path** (`internal/worker`): records a hit for the winning lane on success, a miss for **every active lane** on a benign miss (design choice 1), and the instrumental result (1 detected / 0 ran-but-negative) before Complete. Decoupled via a `ProviderRecorder` interface; the `Fetcher` interface is unchanged.
- **Read-path** (`internal/queue`): `ProviderHits`/`ProviderMisses`/`CountInstrumental` (+ the record/set methods).
- **Exposition** (`internal/server/metrics.go`): the two counter families + the gauge, with `# HELP`/`# TYPE` lines emitted even when the tables are empty (so scrapes always see the families), sorted labels, same admin-scoped query-on-scrape pattern as #212.

### Validation
`make gate` green (lead-verified): patch coverage **72.22%**, race tests pass, golangci-lint 0 issues, govulncheck clean. Tests cover the new queue methods (real SQLite), the worker hit/miss/instrumental wiring, orchestrator lane-stamping, and scrape-shape assertions (TYPE lines + labels) for all three families.

Closes #231.
