### PR TITLE
docs(design): #204 authenticated web access, onboarding, and TLS design-of-record

### DIFF
--- a/docs/design/2026-06-14-204-auth-web-tls.md
+++ b/docs/design/2026-06-14-204-auth-web-tls.md
@@ -1,0 +1,535 @@
+# Design: authenticated web access, onboarding, and TLS (issue #204)
+
+Status: maintainer-signed-off 2026-06-15. The three flagged decisions are resolved:
+S1 = Argon2id, S2 = include self-signed bootstrap in v1, S3 = gate `/metrics` behind
+the trusted-network allowlist (see "Items resolved at sign-off" below).
+Scope: design of record for securing the serve-mode web surface. Covers session
+login, a trusted-network bypass, a first-run onboarding flow, and TLS. This is a
+design-first issue; implementation is tracked in a separate issue that references
+this document (see "Decomposition").
+
+Reference model: sydlexius/stillwater (`internal/server/cert_manager.go`,
+`internal/server/listeners.go`, `internal/auth/auth.go`). We mirror its cert
+strategy and its login/session shape, adapting both to this repo's smaller,
+single-admin scope and its pure-Go-SQLite constraint.
+
+## Summary
+
+The serve-mode daemon exposes an HTTP surface guarded only by the static webhook
+API key (`MXLRC_WEBHOOK_API_KEY`). As the browsable web UI grows (the #186
+reports workspace, built on the #210 foundation), an unauthenticated web surface
+on a self-hosted daemon is real exposure: anyone who can reach the port can view
+operational detail and, in future write-capable views, operate it.
+
+This design adds four things, each independently shippable:
+
+1. Session-based username/password login for the web UI, distinct from the
+   webhook API key. Passwords are stored hashed (Argon2id), never plaintext.
+2. A CIDR allowlist (default closed) that lets trusted LAN clients bypass
+   interactive login, with safe reverse-proxy `X-Forwarded-For` handling.
+3. A first-run browser onboarding flow that sets the admin credentials and enters
+   the runtime secrets through the existing `secrets.Set()` write path (no new
+   crypto), instead of hand-editing TOML.
+4. Optional TLS: bring-your-own certificate as the primary path, an optional
+   self-signed bootstrap for LAN, and ACME autocert as a deferred experimental
+   follow-up. Modeled on stillwater.
+
+Resolved constraint (decision B, maintainer-confirmed 2026-06-14): the
+secrets-at-rest crypto stays decoupled from the login. Login is access control
+(session + TLS); it is not the key that protects the encrypted secrets. See
+"Decision B" below.
+
+## Problem
+
+Today the only auth in serve mode is the webhook API key, checked per request by
+`auth.Service.ValidateKey` inside `server.Handler` (see
+`internal/server/server.go`). That key gates two programmatic endpoints
+(`POST /api/v1/webhooks/lidarr` with `webhook` scope, `GET /api/v1/status` with
+`admin` scope). The new web UI routes registered by `internal/web`
+(`GET /{$}` -> `/config`, `GET /config`, `GET /reports`, `GET /static/`) have no
+auth at all. They are read-only today but already expose effective configuration
+(with secrets redacted) and operational reports, and #204 exists so that the web
+surface has first-class authenticated access before it grows write affordances.
+
+What we need:
+
+- A login that a human uses in a browser, separate from the machine-to-machine
+  webhook key.
+- A way for operators who already firewall their LAN to skip interactive login
+  from trusted networks, without weakening the webhook key or trusting spoofable
+  proxy headers.
+- A friendly first-run setup so a fresh deployment is not "edit TOML by hand,
+  restart, hope".
+- Transport security for operators who expose the daemon directly rather than
+  behind an existing TLS-terminating reverse proxy.
+
+## Non-goals (v1)
+
+- Multi-user accounts, roles, or per-user preferences. v1 is a single admin
+  account. The schema leaves room to grow (a `users` table, not a singleton row)
+  but the UI and flows assume one admin.
+- OIDC / SSO / federated login (stillwater has a media-server federation path;
+  we do not need it).
+- Editing arbitrary configuration through the browser. Onboarding writes exactly
+  the admin credentials and the two runtime secrets; everything else stays
+  TOML-managed and rendered read-only by the #210 Config view. A general
+  settings-editing surface is a separate future issue.
+- Coupling the login to the at-rest secrets encryption (decision B).
+- HTTP/3, mTLS, and DNS-01 ACME (stillwater has or reserves these; out of scope
+  here).
+
+## Proposed design
+
+### Area 1: Authentication (session login)
+
+A new package, `internal/webauth`, owns browser authentication. It is kept
+separate from `internal/auth` (which is API-key-only and intentionally
+stateless/in-memory) because the two have different storage, lifecycle, and
+threat models. `internal/auth` stays unchanged.
+
+**Credential storage.** A new `users` table (migration, single admin in v1):
+
+```sql
+CREATE TABLE users (
+    id            TEXT PRIMARY KEY,            -- random id (hex)
+    username      TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,               -- Argon2id PHC string ($argon2id$v=19$...)
+    created_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+```
+
+The password is never stored or logged in plaintext and never written to TOML.
+The hash is a self-describing PHC string so the parameters (memory, iterations,
+parallelism, salt) travel with the hash and can be tuned later without a
+migration.
+
+**Password hashing: Argon2id (RESOLVED at sign-off, S1).** Passwords are hashed
+with Argon2id (`golang.org/x/crypto/argon2`, `IDKey`), the modern memory-hard
+choice. Suggested v1 parameters: time=1, memory=64 MiB, threads=4, 16-byte random
+salt, 32-byte key, stored as a PHC-format string. Verification is a constant-time
+compare of the recomputed key against the stored key (the existing API-key path
+already uses `crypto/subtle`; reuse that discipline).
+
+  - The maintainer chose Argon2id over the two alternatives that were on the
+    table: (a) reuse the repo's existing PBKDF2-SHA256 `auth.HashKey` (CodeRabbit's
+    coding-plan default; zero new deps, but PBKDF2 is the weakest of the three
+    against GPU cracking and the fixed salt in `auth.HashKey` is wrong for user
+    passwords); (b) bcrypt with a SHA-256 prehash, which is what stillwater does
+    (`internal/auth/auth.go`, `PrehashPassword` + `bcrypt`, cost 10). Argon2id
+    wins for a new, security-sensitive surface despite adding a direct
+    `golang.org/x/crypto` dependency. Recorded for the implementer: this is a
+    deliberate upgrade over stillwater's bcrypt, not a port of it.
+
+**Sessions.** Cookie plus server-side session store in SQLite (durable across
+restarts, revocable, listable). A new `sessions` table:
+
+```sql
+CREATE TABLE sessions (
+    id         TEXT PRIMARY KEY,   -- SHA-256 hex of the raw session token (token itself is never stored)
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at DATETIME NOT NULL,
+    revoked_at DATETIME
+);
+```
+
+  - The raw session token is 32 bytes from `crypto/rand`, hex-encoded, sent only
+    to the browser in the cookie. The DB stores the SHA-256 of the token as the
+    primary key, so a stolen DB does not yield usable session tokens. (This is a
+    deliberate improvement over stillwater, which stores the raw token as the
+    session id; here the token is a bearer credential and is hashed at rest, the
+    same posture the repo already takes for API keys.) Lookup hashes the cookie
+    value and selects by `id`.
+  - Cookie: name `mxlrc_session`; `HttpOnly`; `SameSite=Lax`; `Path=/`;
+    `Secure` set automatically whenever the request is served over TLS (direct
+    TLS, or behind a trusted proxy that terminated TLS, detected via the
+    trusted-proxy logic in Area 2, not via a blindly trusted header). Max-age
+    configurable, default 7 days.
+  - Service surface (`internal/webauth.Service`): `Setup(ctx, username, password)`
+    (first admin only, no-op if a user exists), `Login(ctx, username, password)`
+    -> raw token, `ValidateSession(ctx, rawToken)` -> userID, `Logout(ctx,
+    rawToken)`, `CleanExpiredSessions(ctx)`, `HasUsers(ctx)`. A background sweeper
+    deletes expired/revoked sessions on the existing scheduler cadence (mirrors
+    stillwater's `CleanExpiredSessions`).
+
+**Login / logout endpoints and middleware.**
+
+  - `GET /login` renders a templ login form (extends the #210 shell).
+  - `POST /login` validates credentials, creates a session, sets the cookie,
+    redirects to `/` (Config view). On failure it returns a generic "invalid
+    credentials" (no username/password distinction) and feeds the rate limiter.
+  - `POST /logout` revokes the session row and clears the cookie.
+  - A `RequireSession` middleware wraps the web UI routes: it resolves the client
+    IP (Area 2), allows the request if the IP is in the trusted-network allowlist,
+    else validates the `mxlrc_session` cookie, else 302 -> `/login` (for HTML) or
+    401 (for an XHR/JSON accept header). Health, the webhook API, and static
+    assets are not behind this middleware (see the interaction matrix in Area 2).
+
+**Lockout / rate-limiting.** In-memory per-client-IP failed-attempt tracker
+(no new table; resets on restart, which is acceptable for a single-admin daemon):
+
+  - Exponential backoff on consecutive failures from an IP (for example 0, 1s,
+    2s, 4s, 8s, capped). Each failed `POST /login` sleeps the current backoff
+    before responding, which throttles online guessing without locking out a
+    legitimate admin permanently.
+  - A hard lockout after N consecutive failures (suggested 10) from the same IP
+    for a cool-down window (suggested 15 minutes), returning 429.
+  - Successful login resets that IP's counter. Lockout state is keyed on the
+    resolved client IP, so it composes with the trusted-proxy handling rather
+    than locking out the proxy's own address.
+  - Constant-time password comparison regardless of whether the username exists
+    (look up the user, and on a missing user still run a dummy Argon2id verify) to
+    avoid a username-enumeration timing oracle.
+
+### Area 2: Trusted-network exception
+
+A CIDR allowlist lets requests from operator-trusted networks bypass interactive
+login. Default closed (empty list = every web-UI request needs a session).
+
+**Config (`[server.trusted_networks]`):**
+
+```toml
+[server.trusted_networks]
+cidrs           = []   # e.g. ["192.168.1.0/24", "10.0.0.0/8", "127.0.0.1/32"]; default empty = closed
+trusted_proxies = []   # CIDRs of reverse proxies allowed to set X-Forwarded-For; default empty
+```
+
+  - Env overrides: `MXLRC_TRUSTED_CIDRS`, `MXLRC_TRUSTED_PROXIES` (comma-separated,
+    using the existing `splitCSV` helper). All CIDRs are parsed and validated at
+    startup; an invalid CIDR is a fatal startup error (fail fast, not fail open).
+
+**Reverse-proxy / X-Forwarded-For handling (do not trust XFF blindly).**
+
+  - When `trusted_proxies` is empty (the default), the client IP is the TCP
+    `RemoteAddr` only; `X-Forwarded-For` is ignored entirely. This is the safe
+    default for a directly exposed daemon: an attacker cannot forge a trusted IP
+    by sending a header.
+  - When `trusted_proxies` is set: only if `RemoteAddr` is itself within a trusted
+    proxy CIDR do we consult `X-Forwarded-For`. We then walk the XFF chain
+    right-to-left and take the first address that is not in `trusted_proxies` as
+    the real client IP. This prevents a client from injecting a spoofed leftmost
+    entry.
+  - New helper `clientIP(r *http.Request, trustedProxies []*net.IPNet) net.IP`,
+    unit-tested against spoofing cases (empty proxies, single proxy, chained
+    proxies, forged leftmost entry, IPv6, malformed header).
+
+**How the bypass interacts with the webhook API key.** The trusted-network bypass
+applies only to the interactive session requirement on the web UI. It never
+removes the webhook API key requirement on `POST /api/v1/webhooks/lidarr` or the
+admin-key requirement on `GET /api/v1/status`. Those endpoints keep validating
+the API key exactly as today, from any source IP. Rationale: the API key is a
+capability that integrations (Lidarr) present deliberately; weakening it based on
+source IP would be a surprising and dangerous behavior change, and it is the one
+auth that exists in deployments today.
+
+**Auth interaction matrix (the contract):**
+
+| Route pattern                | Session login | Webhook/API key | Trusted-network bypass |
+|------------------------------|---------------|-----------------|------------------------|
+| `GET /healthz`, `GET /readyz`| no            | no              | n/a (always open)      |
+| `POST /api/v1/webhooks/*`    | no            | yes (webhook)   | no (key always required)|
+| `GET /api/v1/status`         | no            | yes (admin)     | no (key always required)|
+| `GET /metrics`               | no            | no              | yes (allowlist gates it)|
+| `GET /static/*`              | no            | no              | n/a (public assets)    |
+| `GET /login`, onboarding `/setup` | no       | no              | n/a (public, see Area 3)|
+| `GET /` , `/config`, `/reports`, future UI | yes  | no       | yes (bypasses session) |
+
+  - `/metrics` (RESOLVED at sign-off, S3 = gate it): today `GET /metrics` (the
+    #212/#231 Prometheus endpoint) is unauthenticated and open to anyone who can
+    reach the port. The maintainer chose the trusted-network middle path: gate
+    `/metrics` behind the same `[server.trusted_networks]` CIDR allowlist and the
+    same `trusted_proxies` / `X-Forwarded-For` resolution defined in Area 2. The
+    gate is therefore proxy-aware: it resolves the real client IP behind a reverse
+    proxy via the `clientIP` helper (it does not match on a spoofable header or on
+    the proxy's own address). `/metrics` requires no session and no API key; the
+    only condition is that the resolved client IP is trusted. Behavior by allowlist
+    state:
+      - Allowlist empty (default closed): `/metrics` is reachable only from
+        loopback (127.0.0.0/8 and ::1 are treated as implicitly trusted for this
+        endpoint, so a same-host Prometheus or `curl` still works out of the box,
+        and the queue/health surface is unaffected). Requests from any other IP
+        get 403/404.
+      - Allowlist set: `/metrics` is reachable from loopback plus any IP inside a
+        configured CIDR, and from nowhere else.
+    Gating here is access control only, not additional cryptography: it decides
+    who may connect, it does not wrap the response in another layer of encryption,
+    so there is no double-encryption concern for a TLS-terminating reverse proxy in
+    front of the daemon.
+
+    Migration note (behavior change from #212): `/metrics` is open today, so this
+    is a breaking change for existing scrapers. An operator who scrapes from
+    another host must, after upgrade, either add the scraper's source network to
+    `[server.trusted_networks].cidrs`, or (if the scrape arrives through a reverse
+    proxy) put the proxy's address in `trusted_proxies` so the gate resolves the
+    real scraper IP. Same-host scrapers keep working with no config (loopback is
+    implicitly trusted). This is called out in the implementation issue as a
+    documented migration step.
+
+    Reference posture: stillwater keeps its observability/debug surface off the
+    public port entirely (Go pprof is env-gated and bound to a separate
+    `127.0.0.1:6060` listener, never the public listener; `internal/api/pprof.go`).
+    We are taking the middle path: keep `/metrics` on the main listener for
+    operational simplicity, but restrict it to trusted networks rather than leaving
+    it world-readable. Implementation note: the metrics gate is a thin
+    trusted-network check, not the session middleware, so a scraper never needs a
+    cookie. The one sub-decision left to the implementer is the loopback-implicit
+    -trust default (it preserves zero-config same-host scraping); flag it back if
+    the maintainer wants loopback to also require an explicit `127.0.0.1/32`
+    allowlist entry.
+
+### Area 3: Onboarding UI (first run)
+
+**Where it lives.** In `internal/web`, extending the #210 foundation
+(`internal/web/ui.go` route table, `web/templates/*.templ` using the existing
+shell and design tokens). It adds a `/setup` page and the `/login` page, plus the
+session middleware around the existing `/config` and `/reports` routes. The #210
+Config view stays read-only; onboarding is the only write surface in v1 and it
+writes exactly two kinds of data: the admin credential (into `users`) and the
+runtime secrets (via `secrets.Set`).
+
+**First-run definition and daemon posture before onboarding.** "First run" =
+no row exists in `users`. Until an admin exists:
+
+  - The web UI routes (`/`, `/config`, `/reports`) redirect to `/setup`.
+  - `/setup` is reachable only from loopback or a configured trusted-network CIDR
+    (default: loopback only). This is the safe default: a fresh daemon exposed on
+    a LAN port does not let the first stranger to hit it claim the admin account.
+    An operator sets up either by browsing from the host (loopback) or by adding
+    their workstation's subnet to `trusted_networks.cidrs` first. (This mirrors
+    stillwater's setup gating; we tie "who may run setup" to the same
+    trusted-network primitive defined in Area 2 rather than inventing a second
+    mechanism.)
+  - The webhook API and health endpoints keep working unchanged (an existing
+    deployment that has a webhook key but no admin user is not broken by this
+    change; only the new browsable UI is gated). This preserves backward
+    compatibility for current serve users.
+  - After an admin exists, `/setup` returns 404/redirect to `/login` (one-shot;
+    re-running setup is not how you change a password).
+
+**Onboarding flow.**
+
+1. `GET /setup` (gated as above) renders a form: admin username, password (with
+   confirm and a minimum-length check), and optional fields to enter the
+   Musixmatch token and webhook API key.
+2. `POST /setup`:
+   - Re-checks `HasUsers` inside a transaction-guarded path (race-safe: if a user
+     was created concurrently, reject). Creates the admin via
+     `webauth.Setup` (Argon2id hash).
+   - If the secret fields were filled, writes them through the existing path:
+     `secrets.Set(ctx, secrets.NameMusixmatchToken, ...)` and
+     `secrets.Set(ctx, secrets.NameWebhookAPIKey, ...)`. No new crypto: this is
+     the #229 encrypted store (lowest-precedence source), and #238 makes the
+     encryption key auto-create, so onboarding never has to prompt for or manage a
+     master key. Leaving a field blank leaves the existing TOML/env value in
+     place (DB is lowest precedence).
+   - Creates a session and redirects to `/`.
+
+**Migration for existing deployments (no creds yet).** Existing serve
+deployments have a webhook key and no admin user. On upgrade:
+
+  - The webhook API and health endpoints behave exactly as before (no break).
+  - The first time someone opens the web UI they are sent to `/setup`, reachable
+    from loopback or a trusted CIDR. Until they complete it, the UI is locked but
+    the daemon keeps processing the queue and serving webhooks normally.
+  - No automatic admin is created and no default password exists (a default
+    credential would be worse than no UI auth). The daemon does not refuse to
+    start because onboarding is incomplete.
+
+### Area 4: TLS
+
+Adopt stillwater's cert strategy, scaled to this repo. stillwater splits cert
+acquisition behind a `CertManager` interface so the listener does not branch on
+TLS flavor; we adopt the same shape so a future ACME path drops in without
+touching the listener.
+
+**Config (`[server.tls]` and `[server.tls.acme]`):**
+
+```toml
+[server.tls]
+cert_file     = ""    # PEM cert; with key_file set, serve HTTPS directly
+key_file      = ""    # PEM private key
+self_signed   = false # generate+persist a self-signed cert for LAN/testing (mutually exclusive with cert_file/key_file)
+redirect_http = ""    # optional plain-HTTP listen addr that 301s to HTTPS (e.g. ":80"); empty = no redirect listener
+
+[server.tls.acme]      # experimental, deferred to a follow-up issue
+domain    = ""
+email     = ""
+ca        = ""         # ACME directory URL; default Let's Encrypt production
+cache_dir = ""         # default <dir(db_path)>/acme-cache
+```
+
+  - Env overrides: `MXLRC_TLS_CERT_FILE`, `MXLRC_TLS_KEY_FILE`,
+    `MXLRC_TLS_SELF_SIGNED`, `MXLRC_TLS_REDIRECT_HTTP`, and (when ACME lands)
+    `MXLRC_ACME_DOMAIN` / `MXLRC_ACME_EMAIL` / `MXLRC_ACME_CA` /
+    `MXLRC_ACME_CACHE_DIR`.
+
+**What we adopt now vs defer.**
+
+  - v1: bring-your-own certificate (primary, mirrors stillwater's `TLSConfig`):
+    when `cert_file` and `key_file` are both set, the serve listener terminates
+    TLS itself via `ListenAndServeTLS` (or `http.Server{TLSConfig}` +
+    `ServeTLS`). MinVersion TLS 1.2. Optional `redirect_http` listener that 301s
+    to the HTTPS address.
+  - v1 (RESOLVED at sign-off, S2 = include): self-signed bootstrap.
+    When `self_signed = true` (and no cert/key supplied), generate an ECDSA P-256
+    (or RSA-2048) cert on first run, persist it `0600` under `<dir(db_path)>/tls/`,
+    `CN=mxlrcgo-svc`, ~365-day validity, regenerate when missing/expired, and log
+    a clear warning that browsers will show an untrusted-cert prompt. This is the
+    one piece stillwater does not itself implement (stillwater is BYO + ACME); the
+    maintainer signed off on including it anyway because the typical mxlrcgo-svc
+    deployment is a LAN box where a
+    real cert is overkill; an operator who wants encryption-in-transit without a
+    CA gets it with one flag.
+  - Deferred to a follow-up issue: ACME autocert (the
+    `golang.org/x/crypto/acme/autocert` path, copied almost verbatim from
+    stillwater's `cert_manager.go`). It is marked experimental because it needs a
+    public domain, reachable port 80, and end-to-end validation we cannot do in
+    a unit test. The `CertManager` interface is introduced in v1 so this lands
+    later without a listener rewrite.
+
+**Required vs optional.** TLS is optional and off by default, preserving today's
+plain-HTTP behavior. Most deployments front the daemon with a reverse proxy that
+already terminates TLS; keeping daemon TLS opt-in means those operators avoid
+double-encryption (proxy TLS plus daemon TLS) simply by not enabling it. The
+design strongly recommends TLS (or a TLS-terminating proxy) for any non-loopback
+exposure, and the `Secure` cookie flag is set automatically when the effective
+connection is TLS so the session cookie is never sent in cleartext on an HTTPS
+deployment.
+
+## Decision B (resolved constraint, restated)
+
+Maintainer-confirmed 2026-06-14 on issue #204: the secrets-at-rest crypto stays
+decoupled from the #204 login. #204 auth is session login (Argon2id hash) + TLS,
+gating who can reach the UI. The onboarding form enters secrets through the
+existing `secrets.Set()` path; it introduces no new crypto.
+
+Rationale (short form; full thread on #204): the earlier "dual-wrap envelope"
+idea (wrap a data key under both an Argon2id key from the admin password and the
+env/key-file master key, so login verification "falls out free") was reconsidered
+and rejected. Because `serve` is a headless daemon that must auto-decrypt secrets
+at boot, the data key must be wrapped under the machine-available master key
+regardless, so an attacker with the env key (the realistic at-rest threat: a
+stolen `/config` volume plus env file) unwraps without the password. Password
+dual-wrap therefore adds no at-rest confidentiality over env-key-only, while
+adding complexity (rewrap-on-password-change, a migration of #229's
+direct-encrypted rows) and a second offline-crack surface. A standard Argon2id
+login hash plus the already-shipped env-key secrets is both simpler and no weaker.
+Separately, the real onboarding-friction concern (a mandatory `MXLRC_MASTER_KEY`
+in Docker) is fixed under #238 (auto key file as the zero-setup default), not by
+binding secrets to the password.
+
+Consequence for this design: #204 and #229 stay in separate layers. #204 never
+reads, writes, or re-encrypts secret ciphertext; it only calls `secrets.Set` from
+onboarding and otherwise concerns itself with sessions, login, and TLS.
+
+## Open questions resolved (with recommendations)
+
+1. Session model: cookie + server-side SQLite session store (not stateless signed
+   cookie). Recommended for revocability and restart durability; aligns with the
+   repo's SQLite-everywhere pattern. Resolved.
+2. Password hashing: Argon2id. RESOLVED at sign-off (S1); chosen over PBKDF2 reuse
+   and bcrypt. See Area 1.
+3. Session token at rest: store SHA-256 of the token, not the raw token.
+   Resolved (improves on stillwater).
+4. Lockout/rate-limiting: in-memory per-IP exponential backoff + hard lockout.
+   Resolved; specific thresholds (10 failures / 15 min) are tunable defaults, not
+   sign-off items.
+5. Trusted-network default: closed (empty). Resolved.
+6. XFF handling: ignore unless `RemoteAddr` is a configured trusted proxy, then
+   walk right-to-left. Resolved.
+7. Bypass vs webhook key: bypass never weakens the API key. Resolved.
+8. `/metrics` exposure under the new model: gated by the trusted-network allowlist
+   (loopback implicitly trusted). RESOLVED at sign-off (S3 = the stricter option);
+   no session or API key required, but only trusted IPs can scrape. See Area 2.
+9. Onboarding location: in `internal/web`, extends #210; only write surface in
+   v1. Resolved.
+10. Pre-onboarding posture: web UI redirects to `/setup`; `/setup` loopback/trusted
+    only; webhook+health unaffected; no default admin. Resolved.
+11. TLS modes: BYO (v1) + self-signed bootstrap (v1; RESOLVED at sign-off, S2 =
+    include) + ACME (deferred, experimental). Resolved.
+12. TLS required vs optional: optional, off by default; recommended for direct
+    exposure; auto-`Secure` cookie when TLS. Resolved.
+
+### Items resolved at sign-off (maintainer, 2026-06-15)
+
+- S1. Password hashing algorithm: **Argon2id** (over PBKDF2 reuse and bcrypt).
+  Accepts a direct `golang.org/x/crypto` dependency; a deliberate upgrade over
+  stillwater's bcrypt.
+- S2. Self-signed TLS bootstrap: **include in v1** (alongside BYO; ACME deferred).
+  Goes one step beyond stillwater, which is BYO + ACME only.
+- S3. `/metrics` exposure: **gate behind the trusted-network allowlist** (the
+  stricter option, consistent with stillwater keeping observability off the public
+  port). Loopback is implicitly trusted so same-host scraping needs no config; no
+  session or API key required for trusted IPs.
+
+All three sign-off items are now resolved (2026-06-15); every other question above
+was resolved in design. The implementer proceeds on the design as written.
+
+## Decomposition (implementation lanes)
+
+Land as small, dependency-ordered PRs, each with its own tests. A separate
+implementation issue (drafted alongside this doc) tracks these and references this
+document; no code lands before that issue exists (repo design-doc rule).
+
+1. Schema + `internal/webauth` core: migrations for `users` and `sessions`;
+   Argon2id hashing; user store; session store (hashed token); `Service` with
+   Setup/Login/ValidateSession/Logout/CleanExpiredSessions/HasUsers. Pure unit
+   tests against real in-memory SQLite. No HTTP yet.
+2. Client-IP + trusted-network primitive: config parsing/validation for
+   `[server.trusted_networks]`, the `clientIP` helper, and the allowlist matcher
+   (loopback implicitly trusted). Wire the `/metrics` gate (S3) onto this primitive
+   so a non-trusted IP is refused. Heavily unit-tested for spoofing.
+3. Web auth middleware + login/logout endpoints: `RequireSession`, `/login`
+   (GET/POST), `/logout`, the rate limiter, and wiring the middleware around the
+   #210 UI routes. Cookie flags + auto-`Secure`.
+4. Onboarding: `/setup` (GET/POST), first-run gating, `secrets.Set` writes, the
+   migration/posture behavior for existing deployments.
+5. TLS BYO + optional HTTP->HTTPS redirect + the `CertManager` interface seam +
+   self-signed bootstrap (S2 = in v1). Listener wiring in `runServe`.
+6. (Follow-up issue) ACME autocert behind `CertManager`, experimental.
+
+Background session sweeper hangs off the existing scheduler loop in `runServe`
+(alongside `runScheduler`/`runWorkerLoop`), reusing the established goroutine +
+context-cancel pattern.
+
+## Testing
+
+- `internal/webauth`: Argon2id hash/verify round-trip, wrong-password reject,
+  missing-user constant-time path, session create/validate/expire/revoke, expired
+  cleanup. Real in-memory SQLite (`file::memory:?cache=shared`), not mocks (repo
+  rule for stateful features).
+- Trusted-network: table-driven `clientIP` tests (no proxies, trusted single,
+  trusted chain, forged leftmost, IPv6, malformed XFF) and CIDR-match tests;
+  startup-validation rejects bad CIDRs.
+- Middleware/endpoints: login success/failure, lockout/backoff, redirect-vs-401
+  by Accept header, cookie attributes (HttpOnly/SameSite/Secure-with-TLS),
+  trusted-network bypass, logout revocation. Live-handler tests where feasible
+  (strongest evidence), mirroring #210's live redaction test.
+- `/metrics` gate (S3): reachable from loopback with an empty allowlist; reachable
+  from an in-allowlist IP; refused (403/404) from a non-trusted IP; spoofed XFF
+  cannot forge a trusted source. No cookie or API key required for trusted IPs.
+- Onboarding: first-run redirect to `/setup`, loopback/trusted gating, race-safe
+  double-setup rejection, `secrets.Set` is called with the right names, post-setup
+  `/setup` is closed, webhook/health unaffected before onboarding.
+- TLS: BYO cert serves HTTPS (httptest TLS server or a generated test cert),
+  self-signed generation+persistence+reuse+regeneration, redirect listener 301s,
+  cookie `Secure` flips under TLS. Use a temp cert fixture; do not require a real
+  CA.
+- Rendered evidence for any UI (binding UI/UX rule): the login and setup pages
+  must be verified against the live binary at branch HEAD (computed styles match
+  the #210 tokens, both fonts load, no secret leakage), not from source reads.
+- Patch coverage at the repo gate (`make gate`); generated `*_templ.go` excluded
+  from patch coverage per #210's `codecov.yml`.
+
+## Acceptance criteria (design phase)
+
+- [x] Design doc covering auth model, trusted-network exception, onboarding flow,
+      and TLS, with stillwater referenced where applicable.
+- [x] Decision B stated as a resolved constraint with rationale and a cross-ref
+      to the #204 comment.
+- [x] Each open #204 design question has a recommended answer.
+- [x] Maintainer sign-off on S1-S3 (Argon2id / include self-sign / gate
+      `/metrics`), folded into the doc 2026-06-15.
+- [ ] A separate implementation issue is filed referencing this doc before any
+      code lands (draft body prepared alongside this doc).


### PR DESCRIPTION
## Summary

Design-of-record for issue #204: authenticated web access, first-run onboarding, and TLS for the serve-mode web surface. Design-only (docs); implementation is tracked in a separate issue referencing this doc.

Doc: `docs/design/2026-06-14-204-auth-web-tls.md`

Closes #204 (design phase). Implementation tracked separately.

## What it lands

- **Authentication:** session login in a new `internal/webauth` package, distinct from the existing API-key auth. Argon2id password hashing (OWASP params); session token stored SHA-256 at rest; per-IP backoff + lockout; username-enumeration-safe verify.
- **Trusted-network exception:** `[server.trusted_networks]` CIDR allowlist, default CLOSED, with `trusted_proxy` / `X-Forwarded-For` handling (proxy-aware, resolves the real client IP).
- **Onboarding:** first-run `/setup` flow extending #210; writes secrets via the existing `secrets.Set()` path (no new crypto; #238's auto-key means no master-key prompt). Existing webhook-key deployments keep working.
- **TLS:** self-signed bootstrap + BYO cert in v1, optional HTTP->HTTPS redirect, off by default; ACME autocert deferred to a follow-up.
- **Decision B (resolved):** secrets-at-rest crypto stays decoupled from the login.
- **/metrics:** gated behind the trusted-network allowlist (access-control only; loopback implicitly trusted for zero-config same-host scraping). Behavior change from today's open `/metrics` (#212) - documented as a migration note.

## Maintainer sign-offs (2026-06-15)

- S1 password hashing = **Argon2id** (a step beyond stillwater's bcrypt).
- S2 TLS = **include self-signed bootstrap in v1** (beyond stillwater's BYO+ACME).
- S3 `/metrics` = **gate behind the trusted-network allowlist** (stricter than open; stillwater keeps observability off the public port entirely).

## Notes

- Docs-only; no code or behavior change in this PR. `norabbit` applied (design doc, no CR slot needed).
- Stillwater referenced for the TLS/cert and login patterns; divergences (Argon2id over bcrypt, hashed session token, lockout, self-sign) are deliberate and noted in the doc.
