### PR TITLE
feat(webauth): session-auth core - Argon2id, user/session stores, migrations 019/020

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/rjeczalik/notify v0.9.3
 	github.com/valyala/fastjson v1.6.10
+	golang.org/x/crypto v0.51.0
 	golang.org/x/text v0.38.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.52.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=

--- a/internal/db/migrations/019_users.sql
+++ b/internal/db/migrations/019_users.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Web-UI admin credentials (issue #204, lane 1). v1 is single-admin, but this is
+-- a table (not a singleton row) so multi-user can grow later without a migration.
+-- password_hash is an Argon2id PHC string ($argon2id$v=19$...); the password is
+-- never stored or logged in plaintext. username is case-insensitive (COLLATE
+-- NOCASE) so login does not depend on the exact case the admin first typed.
+CREATE TABLE users (
+    id            TEXT PRIMARY KEY,
+    username      TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    password_hash TEXT NOT NULL,
+    created_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    -- NOTE: there is no AFTER UPDATE trigger maintaining updated_at. A future
+    -- password-rotation/profile-edit lane MUST set updated_at explicitly when it
+    -- mutates a row; today nothing updates users after the initial insert.
+    updated_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS users;
+-- +goose StatementEnd

--- a/internal/db/migrations/020_sessions.sql
+++ b/internal/db/migrations/020_sessions.sql
@@ -6,10 +6,10 @@
 -- already takes for API keys). Lookup hashes the cookie value and selects by
 -- token_hash (the primary key). Deleting a user cascades to its sessions.
 CREATE TABLE sessions (
-    token_hash TEXT PRIMARY KEY,
+    token_hash TEXT PRIMARY KEY CHECK (length(token_hash) = 64),
     user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    expires_at DATETIME NOT NULL
+    expires_at DATETIME NOT NULL CHECK (expires_at > created_at)
 );
 -- +goose StatementEnd
 -- +goose StatementBegin
@@ -17,8 +17,14 @@ CREATE TABLE sessions (
 -- and for skipping expired rows on lookup. token_hash is already indexed as the PK.
 CREATE INDEX idx_sessions_expires_at ON sessions (expires_at);
 -- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX idx_sessions_user_id ON sessions (user_id);
+-- +goose StatementEnd
 
 -- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_sessions_user_id;
+-- +goose StatementEnd
 -- +goose StatementBegin
 DROP INDEX IF EXISTS idx_sessions_expires_at;
 -- +goose StatementEnd

--- a/internal/db/migrations/020_sessions.sql
+++ b/internal/db/migrations/020_sessions.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Server-side web session store (issue #204, lane 1). The raw session token is a
+-- bearer credential and is NEVER stored: token_hash is the SHA-256 hex of the raw
+-- token, so a stolen database yields no usable tokens (same posture the repo
+-- already takes for API keys). Lookup hashes the cookie value and selects by
+-- token_hash (the primary key). Deleting a user cascades to its sessions.
+CREATE TABLE sessions (
+    token_hash TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    expires_at DATETIME NOT NULL
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+-- Index for the expiry sweep (CleanExpiredSessions deletes WHERE expires_at <= now)
+-- and for skipping expired rows on lookup. token_hash is already indexed as the PK.
+CREATE INDEX idx_sessions_expires_at ON sessions (expires_at);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_sessions_expires_at;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS sessions;
+-- +goose StatementEnd

--- a/internal/webauth/errors_test.go
+++ b/internal/webauth/errors_test.go
@@ -1,0 +1,171 @@
+package webauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// errReader is an io.Reader that always fails, to exercise token/id generation
+// error paths.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom: rand failure") }
+
+func TestUserStoreCreateUserRandFailure(t *testing.T) {
+	store := NewSQLUserStore(newTestDB(t))
+	store.rand = errReader{}
+	if _, err := store.CreateUser(context.Background(), "admin", "$argon2id$hash"); err == nil {
+		t.Fatal("CreateUser should fail when id generation fails")
+	}
+}
+
+func TestSessionStoreCreateSessionRandFailure(t *testing.T) {
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+	store.rand = errReader{}
+	if _, err := store.CreateSession(context.Background(), userID, time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("CreateSession should fail when token generation fails")
+	}
+}
+
+func TestSessionStoreCreateSessionEmptyUser(t *testing.T) {
+	store := NewSQLSessionStore(newTestDB(t))
+	if _, err := store.CreateSession(context.Background(), "", time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("CreateSession should reject an empty user id")
+	}
+}
+
+func TestIsUniqueViolationNonSQLite(t *testing.T) {
+	if isUniqueViolation(errors.New("not a sqlite error")) {
+		t.Fatal("isUniqueViolation should be false for a non-sqlite error")
+	}
+}
+
+// failingUserStore and failingSessionStore return a sentinel error from every
+// method, to verify the Service propagates store errors rather than swallowing
+// them.
+var errStore = errors.New("store is down")
+
+type failingUserStore struct{}
+
+func (failingUserStore) CreateUser(context.Context, string, string) (User, error) {
+	return User{}, errStore
+}
+func (failingUserStore) CreateFirstUser(context.Context, string, string) (User, error) {
+	return User{}, errStore
+}
+func (failingUserStore) GetByUsername(context.Context, string) (User, bool, error) {
+	return User{}, false, errStore
+}
+func (failingUserStore) GetByID(context.Context, string) (User, bool, error) {
+	return User{}, false, errStore
+}
+func (failingUserStore) HasUsers(context.Context) (bool, error) { return false, errStore }
+
+type failingSessionStore struct{}
+
+func (failingSessionStore) CreateSession(context.Context, string, time.Time) (string, error) {
+	return "", errStore
+}
+func (failingSessionStore) GetSessionByToken(context.Context, string) (Session, bool, error) {
+	return Session{}, false, errStore
+}
+func (failingSessionStore) DeleteSession(context.Context, string) error { return errStore }
+func (failingSessionStore) CleanExpiredSessions(context.Context) (int64, error) {
+	return 0, errStore
+}
+
+func TestServicePropagatesStoreErrors(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(failingUserStore{}, failingSessionStore{})
+
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); !errors.Is(err, errStore) {
+		t.Fatalf("Setup error = %v, want errStore", err)
+	}
+	if _, err := svc.Login(ctx, "admin", "supersecret"); !errors.Is(err, errStore) {
+		t.Fatalf("Login error = %v, want errStore", err)
+	}
+	if _, err := svc.ValidateSession(ctx, "token"); !errors.Is(err, errStore) {
+		t.Fatalf("ValidateSession error = %v, want errStore", err)
+	}
+	if _, err := svc.CleanExpiredSessions(ctx); !errors.Is(err, errStore) {
+		t.Fatalf("CleanExpiredSessions error = %v, want errStore", err)
+	}
+	if _, err := svc.HasUsers(ctx); !errors.Is(err, errStore) {
+		t.Fatalf("HasUsers error = %v, want errStore", err)
+	}
+	if err := svc.Logout(ctx, "token"); !errors.Is(err, errStore) {
+		t.Fatalf("Logout error = %v, want errStore", err)
+	}
+}
+
+// userOnlyFailSession lets Login reach CreateSession (good creds) but then fails
+// at the session layer, covering Login's CreateSession error branch.
+type okUserStore struct{ user User }
+
+func (s okUserStore) CreateUser(context.Context, string, string) (User, error) { return s.user, nil }
+func (s okUserStore) CreateFirstUser(context.Context, string, string) (User, error) {
+	return s.user, nil
+}
+func (s okUserStore) GetByUsername(context.Context, string) (User, bool, error) {
+	return s.user, true, nil
+}
+func (s okUserStore) GetByID(context.Context, string) (User, bool, error) { return s.user, true, nil }
+func (s okUserStore) HasUsers(context.Context) (bool, error)              { return true, nil }
+
+func TestServiceLoginSessionCreateError(t *testing.T) {
+	ctx := context.Background()
+	hash, err := HashPassword("supersecret")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	svc := NewService(okUserStore{user: User{ID: "u1", Username: "admin", PasswordHash: hash}}, failingSessionStore{})
+	if _, err := svc.Login(ctx, "admin", "supersecret"); !errors.Is(err, errStore) {
+		t.Fatalf("Login error = %v, want errStore from CreateSession", err)
+	}
+}
+
+func TestStoresReturnErrorsOnClosedDB(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userStore := NewSQLUserStore(sqlDB)
+	sessStore := NewSQLSessionStore(sqlDB)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if _, err := userStore.HasUsers(ctx); err == nil {
+		t.Fatal("HasUsers should error on a closed db")
+	}
+	if _, _, err := userStore.GetByUsername(ctx, "admin"); err == nil {
+		t.Fatal("GetByUsername should error on a closed db")
+	}
+	if _, err := userStore.CreateUser(ctx, "admin", "$argon2id$hash"); err == nil {
+		t.Fatal("CreateUser should error on a closed db")
+	}
+	if _, _, err := sessStore.GetSessionByToken(ctx, "tok"); err == nil {
+		t.Fatal("GetSessionByToken should error on a closed db")
+	}
+	if _, err := sessStore.CreateSession(ctx, "u1", time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("CreateSession should error on a closed db")
+	}
+	if err := sessStore.DeleteSession(ctx, "tok"); err == nil {
+		t.Fatal("DeleteSession should error on a closed db")
+	}
+	if _, err := sessStore.CleanExpiredSessions(ctx); err == nil {
+		t.Fatal("CleanExpiredSessions should error on a closed db")
+	}
+}
+
+func TestServiceLoginUnparsableStoredHash(t *testing.T) {
+	ctx := context.Background()
+	// A user whose stored hash is corrupt: Login must return ErrInvalidCredentials
+	// (not leak the parse error) after logging it.
+	svc := NewService(okUserStore{user: User{ID: "u1", Username: "admin", PasswordHash: "not-a-phc-string"}}, failingSessionStore{})
+	if _, err := svc.Login(ctx, "admin", "supersecret"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("Login error = %v, want ErrInvalidCredentials", err)
+	}
+}

--- a/internal/webauth/helpers_test.go
+++ b/internal/webauth/helpers_test.go
@@ -1,0 +1,42 @@
+package webauth
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+)
+
+// newTestDB opens a migrated SQLite database in a temp file (real SQLite, no
+// mocks, per repo convention for stateful features).
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "webauth.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+// fakeClock is a manually advanced time source for deterministic expiry tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}

--- a/internal/webauth/password.go
+++ b/internal/webauth/password.go
@@ -32,6 +32,14 @@ const (
 	argonKeyLen  uint32 = 32
 )
 
+// Safe upper bounds on decoded Argon2id parameters. A hostile or corrupt PHC
+// string with extreme values would exhaust memory or CPU before verify returns.
+const (
+	maxArgonMemoryKiB uint32 = 8 * 1024 * 1024 // 8 GiB
+	maxArgonTime      uint32 = 100
+	maxArgonThreads   uint8  = 64
+)
+
 var (
 	// ErrInvalidHash is returned when an encoded hash is not a well-formed
 	// Argon2id PHC string.
@@ -67,6 +75,9 @@ func VerifyPassword(encoded, password string) (bool, error) {
 	memory, time, threads, salt, key, err := decodeHash(encoded)
 	if err != nil {
 		return false, err
+	}
+	if memory > maxArgonMemoryKiB || time > maxArgonTime || threads > maxArgonThreads {
+		return false, fmt.Errorf("webauth: argon2 parameters exceed safe bounds")
 	}
 	//nolint:gosec // reason: key length is bounded by decodeHash (non-empty, base64-decoded from our own PHC string whose key is argonKeyLen=32 bytes); no int->uint32 overflow is possible.
 	computed := argon2.IDKey([]byte(password), salt, time, memory, threads, uint32(len(key)))

--- a/internal/webauth/password.go
+++ b/internal/webauth/password.go
@@ -1,0 +1,119 @@
+// Package webauth owns browser-based authentication for the serve-mode web UI:
+// Argon2id password hashing, an admin user store, a server-side session store
+// (raw tokens are hashed at rest), and a Service tying them together. It is kept
+// separate from internal/auth (the stateless, in-memory API-key path) because the
+// two have different storage, lifecycle, and threat models.
+//
+// This file is lane 1 of issue #204 (see docs/design/2026-06-14-204-auth-web-tls.md):
+// the storage and service core only. No HTTP handlers, middleware, or server
+// wiring live here; those land in later lanes.
+package webauth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Argon2id parameters (OWASP-recommended baseline; sign-off item S1 chose
+// Argon2id over PBKDF2 reuse and bcrypt). They are encoded into every PHC string
+// so the parameters and salt travel with the hash and can be tuned later without
+// a migration. memory is in KiB.
+const (
+	argonMemory  uint32 = 64 * 1024 // 64 MiB
+	argonTime    uint32 = 1
+	argonThreads uint8  = 4
+	argonSaltLen        = 16
+	argonKeyLen  uint32 = 32
+)
+
+var (
+	// ErrInvalidHash is returned when an encoded hash is not a well-formed
+	// Argon2id PHC string.
+	ErrInvalidHash = errors.New("webauth: invalid password hash format")
+	// ErrIncompatibleVersion is returned when the encoded hash was produced by a
+	// different Argon2 version than this build understands.
+	ErrIncompatibleVersion = errors.New("webauth: incompatible argon2 version")
+)
+
+// dummyHash is a syntactically valid Argon2id PHC string over a zero salt and
+// key. It is used by the Service to run a verify against a non-existent user so
+// the missing-user and wrong-password paths cost the same time (no username
+// enumeration oracle). Only its m/t/p fields drive the recompute cost, so a
+// constant value is sufficient and cannot fail to construct.
+var dummyHash = encodeHash(make([]byte, argonSaltLen), make([]byte, int(argonKeyLen)))
+
+// HashPassword returns an Argon2id PHC-encoded hash of password using a fresh
+// 16-byte random salt and the package parameters.
+func HashPassword(password string) (string, error) {
+	salt := make([]byte, argonSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("webauth: generate salt: %w", err)
+	}
+	key := argon2.IDKey([]byte(password), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return encodeHash(salt, key), nil
+}
+
+// VerifyPassword reports whether password matches the Argon2id PHC-encoded hash.
+// The hash compare is constant-time. A malformed encoded hash returns an error
+// (ErrInvalidHash / ErrIncompatibleVersion), not a false negative, so callers can
+// distinguish a wrong password from a corrupt record.
+func VerifyPassword(encoded, password string) (bool, error) {
+	memory, time, threads, salt, key, err := decodeHash(encoded)
+	if err != nil {
+		return false, err
+	}
+	//nolint:gosec // reason: key length is bounded by decodeHash (non-empty, base64-decoded from our own PHC string whose key is argonKeyLen=32 bytes); no int->uint32 overflow is possible.
+	computed := argon2.IDKey([]byte(password), salt, time, memory, threads, uint32(len(key)))
+	return subtle.ConstantTimeCompare(computed, key) == 1, nil
+}
+
+// encodeHash renders salt and key as a standard Argon2id PHC string:
+// $argon2id$v=19$m=<KiB>,t=<iters>,p=<lanes>$<b64salt>$<b64key>. The base64 is
+// raw (unpadded) standard encoding, per the PHC convention.
+func encodeHash(salt, key []byte) string {
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, argonMemory, argonTime, argonThreads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(key),
+	)
+}
+
+// decodeHash parses an Argon2id PHC string into its parameters, salt, and key.
+func decodeHash(encoded string) (memory, time uint32, threads uint8, salt, key []byte, err error) {
+	parts := strings.Split(encoded, "$")
+	// Leading "$" yields an empty first element: ["", "argon2id", "v=..", "m=..", salt, key].
+	if len(parts) != 6 || parts[0] != "" || parts[1] != "argon2id" {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+	if version != argon2.Version {
+		return 0, 0, 0, nil, nil, ErrIncompatibleVersion
+	}
+
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+
+	salt, err = base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+	key, err = base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+	if len(salt) == 0 || len(key) == 0 {
+		return 0, 0, 0, nil, nil, ErrInvalidHash
+	}
+	return memory, time, threads, salt, key, nil
+}

--- a/internal/webauth/password_test.go
+++ b/internal/webauth/password_test.go
@@ -103,6 +103,19 @@ func TestVerifyPasswordMalformed(t *testing.T) {
 	}
 }
 
+func TestVerifyPasswordOversizedParamsRejected(t *testing.T) {
+	// A PHC string with m= exceeding the safe bound must be rejected before
+	// argon2.IDKey is called; otherwise a hostile hash could exhaust memory.
+	oversized := "$argon2id$v=19$m=9999999,t=1,p=4$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	ok, err := VerifyPassword(oversized, "any")
+	if ok {
+		t.Fatal("VerifyPassword returned true for an oversized-parameter hash")
+	}
+	if err == nil {
+		t.Fatal("VerifyPassword returned nil error for an oversized-parameter hash")
+	}
+}
+
 func TestVerifyPasswordIncompatibleVersion(t *testing.T) {
 	// A PHC string with a version other than the one this build uses.
 	encoded := "$argon2id$v=18$m=65536,t=1,p=4$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"

--- a/internal/webauth/password_test.go
+++ b/internal/webauth/password_test.go
@@ -1,0 +1,119 @@
+package webauth
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/argon2"
+)
+
+func TestHashPasswordRoundTrip(t *testing.T) {
+	encoded, err := HashPassword("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	ok, err := VerifyPassword(encoded, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("VerifyPassword: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyPassword returned false for the correct password")
+	}
+}
+
+func TestVerifyPasswordWrongPassword(t *testing.T) {
+	encoded, err := HashPassword("the right password")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	ok, err := VerifyPassword(encoded, "the wrong password")
+	if err != nil {
+		t.Fatalf("VerifyPassword: %v", err)
+	}
+	if ok {
+		t.Fatal("VerifyPassword returned true for a wrong password")
+	}
+}
+
+func TestHashPasswordEncodingFormat(t *testing.T) {
+	encoded, err := HashPassword("hunter2hunter2")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	const wantPrefix = "$argon2id$v=19$m=65536,t=1,p=4$"
+	if !strings.HasPrefix(encoded, wantPrefix) {
+		t.Fatalf("hash prefix = %q, want prefix %q", encoded, wantPrefix)
+	}
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 6 {
+		t.Fatalf("hash has %d $-parts, want 6: %q", len(parts), encoded)
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		t.Fatalf("decode salt: %v", err)
+	}
+	if len(salt) != argonSaltLen {
+		t.Fatalf("salt length = %d, want %d", len(salt), argonSaltLen)
+	}
+	key, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	if len(key) != int(argonKeyLen) {
+		t.Fatalf("key length = %d, want %d", len(key), argonKeyLen)
+	}
+}
+
+func TestHashPasswordUsesRandomSalt(t *testing.T) {
+	a, err := HashPassword("same password")
+	if err != nil {
+		t.Fatalf("HashPassword a: %v", err)
+	}
+	b, err := HashPassword("same password")
+	if err != nil {
+		t.Fatalf("HashPassword b: %v", err)
+	}
+	if a == b {
+		t.Fatal("two hashes of the same password are identical; salt is not random")
+	}
+}
+
+func TestVerifyPasswordMalformed(t *testing.T) {
+	cases := map[string]string{
+		"empty":            "",
+		"not phc":          "plaintext",
+		"wrong algorithm":  "$argon2i$v=19$m=65536,t=1,p=4$AAAA$AAAA",
+		"too few fields":   "$argon2id$v=19$m=65536,t=1,p=4$AAAA",
+		"bad params":       "$argon2id$v=19$m=foo,t=1,p=4$AAAA$AAAA",
+		"bad salt base64":  "$argon2id$v=19$m=65536,t=1,p=4$!!!!$AAAA",
+		"empty salt + key": "$argon2id$v=19$m=65536,t=1,p=4$$",
+	}
+	for name, encoded := range cases {
+		t.Run(name, func(t *testing.T) {
+			ok, err := VerifyPassword(encoded, "whatever")
+			if ok {
+				t.Fatal("VerifyPassword returned true for a malformed hash")
+			}
+			if !errors.Is(err, ErrInvalidHash) {
+				t.Fatalf("error = %v, want ErrInvalidHash", err)
+			}
+		})
+	}
+}
+
+func TestVerifyPasswordIncompatibleVersion(t *testing.T) {
+	// A PHC string with a version other than the one this build uses.
+	encoded := "$argon2id$v=18$m=65536,t=1,p=4$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	if argon2.Version == 18 {
+		t.Skip("argon2.Version unexpectedly 18")
+	}
+	ok, err := VerifyPassword(encoded, "whatever")
+	if ok {
+		t.Fatal("VerifyPassword returned true for an incompatible version")
+	}
+	if !errors.Is(err, ErrIncompatibleVersion) {
+		t.Fatalf("error = %v, want ErrIncompatibleVersion", err)
+	}
+}

--- a/internal/webauth/service.go
+++ b/internal/webauth/service.go
@@ -64,6 +64,9 @@ func WithClock(now func() time.Time) Option {
 
 // NewService returns a Service backed by the given stores.
 func NewService(users UserStore, sessions SessionStore, opts ...Option) *Service {
+	if users == nil || sessions == nil {
+		panic("webauth: NewService: users and sessions must not be nil")
+	}
 	s := &Service{
 		users:      users,
 		sessions:   sessions,
@@ -90,16 +93,20 @@ func (s *Service) Setup(ctx context.Context, username, password string) (User, e
 	}
 	exists, err := s.users.HasUsers(ctx)
 	if err != nil {
-		return User{}, err
+		return User{}, fmt.Errorf("webauth: setup: %w", err)
 	}
 	if exists {
 		return User{}, ErrUserExists
 	}
 	hash, err := HashPassword(password)
 	if err != nil {
-		return User{}, err
+		return User{}, fmt.Errorf("webauth: setup: %w", err)
 	}
-	return s.users.CreateFirstUser(ctx, username, hash)
+	user, err := s.users.CreateFirstUser(ctx, username, hash)
+	if err != nil {
+		return User{}, fmt.Errorf("webauth: setup: %w", err)
+	}
+	return user, nil
 }
 
 // Login verifies credentials and, on success, creates a session and returns its
@@ -109,7 +116,7 @@ func (s *Service) Setup(ctx context.Context, username, password string) (User, e
 func (s *Service) Login(ctx context.Context, username, password string) (string, error) {
 	user, ok, err := s.users.GetByUsername(ctx, username)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("webauth: login: %w", err)
 	}
 	if !ok {
 		// Spend comparable time so a missing user is indistinguishable from a
@@ -130,7 +137,7 @@ func (s *Service) Login(ctx context.Context, username, password string) (string,
 	expiresAt := s.now().Add(s.sessionTTL)
 	token, err := s.sessions.CreateSession(ctx, user.ID, expiresAt)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("webauth: login: %w", err)
 	}
 	return token, nil
 }
@@ -143,14 +150,14 @@ func (s *Service) ValidateSession(ctx context.Context, rawToken string) (*User, 
 	}
 	sess, ok, err := s.sessions.GetSessionByToken(ctx, rawToken)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("webauth: validate session: %w", err)
 	}
 	if !ok {
 		return nil, ErrInvalidSession
 	}
 	user, ok, err := s.users.GetByID(ctx, sess.UserID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("webauth: validate session: %w", err)
 	}
 	if !ok {
 		// Session references a user that no longer exists; treat as invalid.
@@ -165,16 +172,27 @@ func (s *Service) Logout(ctx context.Context, rawToken string) error {
 	if rawToken == "" {
 		return nil
 	}
-	return s.sessions.DeleteSession(ctx, rawToken)
+	if err := s.sessions.DeleteSession(ctx, rawToken); err != nil {
+		return fmt.Errorf("webauth: logout: %w", err)
+	}
+	return nil
 }
 
 // CleanExpiredSessions deletes expired sessions and returns the count removed.
 // Intended to be called periodically by a background sweeper (a later lane).
 func (s *Service) CleanExpiredSessions(ctx context.Context) (int64, error) {
-	return s.sessions.CleanExpiredSessions(ctx)
+	n, err := s.sessions.CleanExpiredSessions(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("webauth: clean expired sessions: %w", err)
+	}
+	return n, nil
 }
 
 // HasUsers reports whether an admin account exists (first-run detection).
 func (s *Service) HasUsers(ctx context.Context) (bool, error) {
-	return s.users.HasUsers(ctx)
+	has, err := s.users.HasUsers(ctx)
+	if err != nil {
+		return false, fmt.Errorf("webauth: has users: %w", err)
+	}
+	return has, nil
 }

--- a/internal/webauth/service.go
+++ b/internal/webauth/service.go
@@ -1,0 +1,180 @@
+package webauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// DefaultSessionTTL is how long a new session stays valid (design default: 7 days).
+const DefaultSessionTTL = 7 * 24 * time.Hour
+
+// MinPasswordLength is the minimum admin password length enforced at the service
+// boundary. The onboarding UI (a later lane) also checks length; enforcing it
+// here keeps the core safe-by-default regardless of caller.
+const MinPasswordLength = 8
+
+var (
+	// ErrInvalidCredentials is returned by Login for any failure (unknown user or
+	// wrong password). It is deliberately identical for both so the caller cannot
+	// distinguish them and enumerate usernames.
+	ErrInvalidCredentials = errors.New("webauth: invalid credentials")
+	// ErrInvalidSession is returned by ValidateSession for an unknown, expired, or
+	// orphaned session token.
+	ErrInvalidSession = errors.New("webauth: invalid session")
+	// ErrPasswordTooShort is returned by Setup when the password is shorter than
+	// MinPasswordLength.
+	ErrPasswordTooShort = fmt.Errorf("webauth: password must be at least %d characters", MinPasswordLength)
+)
+
+// Service ties the user and session stores together into the browser-auth core:
+// first-run setup, login, session validation, logout, and expiry cleanup. It is
+// designed to be wrapped (e.g. by a per-IP rate limiter in a later lane); it does
+// not implement lockout itself.
+type Service struct {
+	users      UserStore
+	sessions   SessionStore
+	sessionTTL time.Duration
+	now        func() time.Time
+}
+
+// Option customizes a Service.
+type Option func(*Service)
+
+// WithSessionTTL overrides the session lifetime (default DefaultSessionTTL).
+func WithSessionTTL(ttl time.Duration) Option {
+	return func(s *Service) {
+		if ttl > 0 {
+			s.sessionTTL = ttl
+		}
+	}
+}
+
+// WithClock overrides the time source (for tests).
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// NewService returns a Service backed by the given stores.
+func NewService(users UserStore, sessions SessionStore, opts ...Option) *Service {
+	s := &Service{
+		users:      users,
+		sessions:   sessions,
+		sessionTTL: DefaultSessionTTL,
+		now:        time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Setup creates the first admin user. It rejects with ErrUserExists if any user
+// already exists, so it can be called at most once. Atomicity is guaranteed by
+// CreateFirstUser (a single conditional insert), not by the check below: the
+// HasUsers call is only a fast path that avoids an expensive Argon2id hash when
+// an admin already exists, and is safe to lose a race on.
+func (s *Service) Setup(ctx context.Context, username, password string) (User, error) {
+	if strings.TrimSpace(username) == "" {
+		return User{}, fmt.Errorf("webauth: username must not be empty")
+	}
+	if len(password) < MinPasswordLength {
+		return User{}, ErrPasswordTooShort
+	}
+	exists, err := s.users.HasUsers(ctx)
+	if err != nil {
+		return User{}, err
+	}
+	if exists {
+		return User{}, ErrUserExists
+	}
+	hash, err := HashPassword(password)
+	if err != nil {
+		return User{}, err
+	}
+	return s.users.CreateFirstUser(ctx, username, hash)
+}
+
+// Login verifies credentials and, on success, creates a session and returns its
+// raw token. It is constant-time and enumeration-safe: an unknown username still
+// runs an Argon2id verify against a dummy hash, and both the unknown-user and
+// wrong-password paths return the identical ErrInvalidCredentials.
+func (s *Service) Login(ctx context.Context, username, password string) (string, error) {
+	user, ok, err := s.users.GetByUsername(ctx, username)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		// Spend comparable time so a missing user is indistinguishable from a
+		// wrong password by timing. The result is intentionally discarded.
+		_, _ = VerifyPassword(dummyHash, password)
+		return "", ErrInvalidCredentials
+	}
+	valid, err := VerifyPassword(user.PasswordHash, password)
+	if err != nil {
+		// A stored hash we cannot parse is a server-side defect, not a credential
+		// problem; log it but do not leak detail to the caller.
+		slog.Error("webauth: stored password hash is unparsable", "user_id", user.ID, "error", err)
+		return "", ErrInvalidCredentials
+	}
+	if !valid {
+		return "", ErrInvalidCredentials
+	}
+	expiresAt := s.now().Add(s.sessionTTL)
+	token, err := s.sessions.CreateSession(ctx, user.ID, expiresAt)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// ValidateSession resolves a raw session token to its owning user. It returns
+// ErrInvalidSession for an unknown, expired, or orphaned token.
+func (s *Service) ValidateSession(ctx context.Context, rawToken string) (*User, error) {
+	if rawToken == "" {
+		return nil, ErrInvalidSession
+	}
+	sess, ok, err := s.sessions.GetSessionByToken(ctx, rawToken)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrInvalidSession
+	}
+	user, ok, err := s.users.GetByID(ctx, sess.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		// Session references a user that no longer exists; treat as invalid.
+		return nil, ErrInvalidSession
+	}
+	return &user, nil
+}
+
+// Logout revokes the session for rawToken by deleting it. Logging out an unknown
+// token is a no-op (no error), so a double-logout is harmless.
+func (s *Service) Logout(ctx context.Context, rawToken string) error {
+	if rawToken == "" {
+		return nil
+	}
+	return s.sessions.DeleteSession(ctx, rawToken)
+}
+
+// CleanExpiredSessions deletes expired sessions and returns the count removed.
+// Intended to be called periodically by a background sweeper (a later lane).
+func (s *Service) CleanExpiredSessions(ctx context.Context) (int64, error) {
+	return s.sessions.CleanExpiredSessions(ctx)
+}
+
+// HasUsers reports whether an admin account exists (first-run detection).
+func (s *Service) HasUsers(ctx context.Context) (bool, error) {
+	return s.users.HasUsers(ctx)
+}

--- a/internal/webauth/service_test.go
+++ b/internal/webauth/service_test.go
@@ -17,6 +17,32 @@ func newTestService(t *testing.T) (*Service, *sql.DB) {
 	return svc, sqlDB
 }
 
+func TestNewServicePanicsOnNilStore(t *testing.T) {
+	sqlDB := newTestDB(t)
+	us := NewSQLUserStore(sqlDB)
+	ss := NewSQLSessionStore(sqlDB)
+
+	cases := []struct {
+		name     string
+		users    UserStore
+		sessions SessionStore
+	}{
+		{"nil users", nil, ss},
+		{"nil sessions", us, nil},
+		{"both nil", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("NewService did not panic on nil store")
+				}
+			}()
+			NewService(tc.users, tc.sessions)
+		})
+	}
+}
+
 func TestServiceSetupCreatesAdmin(t *testing.T) {
 	ctx := context.Background()
 	svc, _ := newTestService(t)
@@ -219,7 +245,7 @@ func TestServiceLogout(t *testing.T) {
 func TestServiceSessionExpiry(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := newTestDB(t)
-	clock := &fakeClock{t: time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)}
+	clock := &fakeClock{t: time.Now()}
 
 	sessStore := NewSQLSessionStore(sqlDB)
 	sessStore.now = clock.Now // white-box: drive the store's expiry checks off the fake clock

--- a/internal/webauth/service_test.go
+++ b/internal/webauth/service_test.go
@@ -1,0 +1,276 @@
+package webauth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	sqlDB := newTestDB(t)
+	svc := NewService(NewSQLUserStore(sqlDB), NewSQLSessionStore(sqlDB))
+	return svc, sqlDB
+}
+
+func TestServiceSetupCreatesAdmin(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+
+	has, err := svc.HasUsers(ctx)
+	if err != nil || has {
+		t.Fatalf("HasUsers before setup = (%v, %v), want (false, nil)", has, err)
+	}
+
+	user, err := svc.Setup(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if user.ID == "" || user.Username != "admin" {
+		t.Fatalf("Setup returned %+v", user)
+	}
+	if user.PasswordHash == "supersecret" {
+		t.Fatal("Setup stored the password in plaintext")
+	}
+
+	has, err = svc.HasUsers(ctx)
+	if err != nil || !has {
+		t.Fatalf("HasUsers after setup = (%v, %v), want (true, nil)", has, err)
+	}
+}
+
+func TestServiceSetupRejectsSecond(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("first Setup: %v", err)
+	}
+	_, err := svc.Setup(ctx, "other", "anothersecret")
+	if !errors.Is(err, ErrUserExists) {
+		t.Fatalf("second Setup error = %v, want ErrUserExists", err)
+	}
+}
+
+func TestServiceSetupConcurrentSingleAdmin(t *testing.T) {
+	ctx := context.Background()
+	svc, sqlDB := newTestService(t)
+
+	// Fire many first-run setups at once, each with a DISTINCT username (the case
+	// the username UNIQUE constraint does NOT catch). Exactly one must win; the
+	// rest must be rejected. On the pre-fix HasUsers+CreateUser code this created
+	// multiple admins (TOCTOU privilege escalation); the atomic CreateFirstUser
+	// closes that window.
+	const n = 12
+	var wg sync.WaitGroup
+	results := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := svc.Setup(ctx, fmt.Sprintf("admin%d", i), "supersecret")
+			results[i] = err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrUserExists):
+		default:
+			t.Fatalf("unexpected concurrent Setup error: %v", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("concurrent Setup produced %d admins, want exactly 1", successes)
+	}
+
+	var count int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("users table has %d rows after concurrent setup, want 1", count)
+	}
+}
+
+func TestServiceSetupValidation(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+
+	if _, err := svc.Setup(ctx, "admin", "short"); !errors.Is(err, ErrPasswordTooShort) {
+		t.Fatalf("short password error = %v, want ErrPasswordTooShort", err)
+	}
+	if _, err := svc.Setup(ctx, "  ", "supersecret"); err == nil {
+		t.Fatal("blank username should be rejected")
+	}
+}
+
+func TestServiceLoginSuccess(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+
+	admin, err := svc.Setup(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	token, err := svc.Login(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if token == "" {
+		t.Fatal("Login returned an empty token")
+	}
+
+	user, err := svc.ValidateSession(ctx, token)
+	if err != nil {
+		t.Fatalf("ValidateSession: %v", err)
+	}
+	if user == nil || user.ID != admin.ID {
+		t.Fatalf("ValidateSession returned %+v, want id %q", user, admin.ID)
+	}
+}
+
+func TestServiceLoginCaseInsensitiveUsername(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+	if _, err := svc.Setup(ctx, "Admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if _, err := svc.Login(ctx, "ADMIN", "supersecret"); err != nil {
+		t.Fatalf("Login with different-case username: %v", err)
+	}
+}
+
+func TestServiceLoginWrongPassword(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	_, err := svc.Login(ctx, "admin", "wrongpassword")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("Login wrong password error = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestServiceLoginUnknownUser(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	// Unknown user returns the SAME error as a wrong password (enumeration-safe).
+	_, err := svc.Login(ctx, "ghost", "supersecret")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("Login unknown user error = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestServiceValidateSessionInvalid(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+
+	if _, err := svc.ValidateSession(ctx, ""); !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("ValidateSession(empty) error = %v, want ErrInvalidSession", err)
+	}
+	if _, err := svc.ValidateSession(ctx, "bogus-token"); !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("ValidateSession(bogus) error = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestServiceLogout(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newTestService(t)
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	token, err := svc.Login(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	if err := svc.Logout(ctx, token); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if _, err := svc.ValidateSession(ctx, token); !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("session still valid after logout: %v", err)
+	}
+	// Logging out an already-cleared token is a no-op.
+	if err := svc.Logout(ctx, token); err != nil {
+		t.Fatalf("double Logout: %v", err)
+	}
+	if err := svc.Logout(ctx, ""); err != nil {
+		t.Fatalf("Logout(empty): %v", err)
+	}
+}
+
+func TestServiceSessionExpiry(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	clock := &fakeClock{t: time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)}
+
+	sessStore := NewSQLSessionStore(sqlDB)
+	sessStore.now = clock.Now // white-box: drive the store's expiry checks off the fake clock
+	svc := NewService(NewSQLUserStore(sqlDB), sessStore,
+		WithClock(clock.Now), WithSessionTTL(time.Hour))
+
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	token, err := svc.Login(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Still valid within the TTL window.
+	if _, err := svc.ValidateSession(ctx, token); err != nil {
+		t.Fatalf("ValidateSession within TTL: %v", err)
+	}
+
+	// Advance past the TTL: the session must be rejected.
+	clock.Advance(2 * time.Hour)
+	if _, err := svc.ValidateSession(ctx, token); !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expired session error = %v, want ErrInvalidSession", err)
+	}
+
+	// And the sweeper removes it.
+	removed, err := svc.CleanExpiredSessions(ctx)
+	if err != nil {
+		t.Fatalf("CleanExpiredSessions: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("CleanExpiredSessions removed %d, want 1", removed)
+	}
+}
+
+func TestServiceValidateSessionOrphanedUser(t *testing.T) {
+	ctx := context.Background()
+	svc, sqlDB := newTestService(t)
+	if _, err := svc.Setup(ctx, "admin", "supersecret"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	token, err := svc.Login(ctx, "admin", "supersecret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	// Deleting the user cascades to its sessions (ON DELETE CASCADE); the token
+	// must then be invalid rather than resolving to a missing user.
+	if _, err := sqlDB.ExecContext(ctx, `DELETE FROM users`); err != nil {
+		t.Fatalf("delete users: %v", err)
+	}
+	if _, err := svc.ValidateSession(ctx, token); !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("orphaned session error = %v, want ErrInvalidSession", err)
+	}
+}

--- a/internal/webauth/session_store.go
+++ b/internal/webauth/session_store.go
@@ -21,10 +21,10 @@ const sessionTokenBytes = 32
 // raw token; the raw token itself is returned to the caller only at creation and
 // is never persisted.
 type Session struct {
-	TokenHash string
-	UserID    string
-	CreatedAt time.Time
-	ExpiresAt time.Time
+	TokenHash string    `json:"-"`
+	UserID    string    `json:"user_id,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
 }
 
 // SessionStore persists login sessions keyed by the SHA-256 of the raw token.

--- a/internal/webauth/session_store.go
+++ b/internal/webauth/session_store.go
@@ -1,0 +1,146 @@
+package webauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// sessionTokenBytes is the entropy of a raw session token before base64url
+// encoding (256 bits, matching the API-key generator).
+const sessionTokenBytes = 32
+
+// Session is a server-side login session. TokenHash is the SHA-256 hex of the
+// raw token; the raw token itself is returned to the caller only at creation and
+// is never persisted.
+type Session struct {
+	TokenHash string
+	UserID    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// SessionStore persists login sessions keyed by the SHA-256 of the raw token.
+type SessionStore interface {
+	// CreateSession mints a raw token, stores only its SHA-256, and returns the
+	// raw token to the caller (the only time it exists outside the browser).
+	CreateSession(ctx context.Context, userID string, expiresAt time.Time) (rawToken string, err error)
+	// GetSessionByToken resolves rawToken via its SHA-256 and returns the session
+	// only if it has not expired. ok is false for unknown or expired tokens.
+	GetSessionByToken(ctx context.Context, rawToken string) (session Session, ok bool, err error)
+	// DeleteSession removes the session for rawToken. Deleting an unknown token is
+	// a no-op (used for logout).
+	DeleteSession(ctx context.Context, rawToken string) error
+	// CleanExpiredSessions deletes every session whose expires_at is at or before
+	// now and returns the number removed.
+	CleanExpiredSessions(ctx context.Context) (int64, error)
+}
+
+// SQLSessionStore persists sessions in the SQLite `sessions` table.
+type SQLSessionStore struct {
+	db   *sql.DB
+	rand io.Reader
+	now  func() time.Time
+}
+
+// NewSQLSessionStore returns a SQL-backed session store.
+func NewSQLSessionStore(db *sql.DB) *SQLSessionStore {
+	return &SQLSessionStore{db: db, rand: rand.Reader, now: time.Now}
+}
+
+// CreateSession generates a 32-byte base64url token, persists its SHA-256 hash
+// with the given expiry, and returns the raw token.
+func (s *SQLSessionStore) CreateSession(ctx context.Context, userID string, expiresAt time.Time) (string, error) {
+	if userID == "" {
+		return "", fmt.Errorf("webauth: session user id must not be empty")
+	}
+	raw, err := s.newToken()
+	if err != nil {
+		return "", err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO sessions (token_hash, user_id, expires_at) VALUES (?, ?, ?)`,
+		hashToken(raw), userID, formatTime(expiresAt),
+	)
+	if err != nil {
+		return "", fmt.Errorf("webauth: create session: %w", err)
+	}
+	return raw, nil
+}
+
+// GetSessionByToken returns the unexpired session for rawToken, or ok=false.
+func (s *SQLSessionStore) GetSessionByToken(ctx context.Context, rawToken string) (Session, bool, error) {
+	var (
+		sess                 Session
+		createdAt, expiresAt string
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT token_hash, user_id, created_at, expires_at
+		 FROM sessions WHERE token_hash = ? AND expires_at > ?`,
+		hashToken(rawToken), formatTime(s.now()),
+	).Scan(&sess.TokenHash, &sess.UserID, &createdAt, &expiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Session{}, false, nil
+	}
+	if err != nil {
+		return Session{}, false, fmt.Errorf("webauth: get session: %w", err)
+	}
+	if sess.CreatedAt, err = parseTime(createdAt); err != nil {
+		return Session{}, false, err
+	}
+	if sess.ExpiresAt, err = parseTime(expiresAt); err != nil {
+		return Session{}, false, err
+	}
+	return sess, true, nil
+}
+
+// DeleteSession removes the session for rawToken (no-op if absent).
+func (s *SQLSessionStore) DeleteSession(ctx context.Context, rawToken string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE token_hash = ?`, hashToken(rawToken),
+	); err != nil {
+		return fmt.Errorf("webauth: delete session: %w", err)
+	}
+	return nil
+}
+
+// CleanExpiredSessions deletes sessions whose expiry is at or before now.
+func (s *SQLSessionStore) CleanExpiredSessions(ctx context.Context) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE expires_at <= ?`, formatTime(s.now()),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("webauth: clean expired sessions: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("webauth: clean expired sessions rows: %w", err)
+	}
+	return n, nil
+}
+
+func (s *SQLSessionStore) newToken() (string, error) {
+	b := make([]byte, sessionTokenBytes)
+	if _, err := io.ReadFull(s.rand, b); err != nil {
+		return "", fmt.Errorf("webauth: generate session token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// hashToken returns the lowercase SHA-256 hex of a raw token. This is the value
+// stored at rest and used for lookup, so the raw bearer token never touches disk.
+func hashToken(rawToken string) string {
+	sum := sha256.Sum256([]byte(rawToken))
+	return hex.EncodeToString(sum[:])
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/webauth/session_store_test.go
+++ b/internal/webauth/session_store_test.go
@@ -88,11 +88,15 @@ func TestSessionStoreExpired(t *testing.T) {
 	userID := newUserForSession(t, sqlDB)
 	store := NewSQLSessionStore(sqlDB)
 
-	// Expiry already in the past: GetSessionByToken must treat it as gone.
-	raw, err := store.CreateSession(ctx, userID, time.Now().Add(-time.Minute))
+	// Create a session that expires in 1 minute (valid at insert time; the
+	// CHECK constraint requires expires_at > created_at, so we cannot insert
+	// a session whose expiry is already in the past).
+	raw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
+	// Advance the store clock past the expiry; GetSessionByToken must treat it as gone.
+	store.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
 	if _, ok, err := store.GetSessionByToken(ctx, raw); err != nil || ok {
 		t.Fatalf("GetSessionByToken(expired) = (ok=%v, err=%v), want (false, nil)", ok, err)
 	}
@@ -126,14 +130,18 @@ func TestSessionStoreCleanExpired(t *testing.T) {
 	userID := newUserForSession(t, sqlDB)
 	store := NewSQLSessionStore(sqlDB)
 
-	validRaw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+	// Both sessions must be inserted with expires_at > created_at (CHECK constraint).
+	// Use a short-lived session (1 minute) and a long-lived one (2 hours); then
+	// advance the store clock to 90 minutes so only the short-lived one is swept.
+	validRaw, err := store.CreateSession(ctx, userID, time.Now().Add(2*time.Hour))
 	if err != nil {
 		t.Fatalf("CreateSession valid: %v", err)
 	}
-	if _, err := store.CreateSession(ctx, userID, time.Now().Add(-time.Hour)); err != nil {
-		t.Fatalf("CreateSession expired: %v", err)
+	if _, err := store.CreateSession(ctx, userID, time.Now().Add(time.Minute)); err != nil {
+		t.Fatalf("CreateSession short-lived: %v", err)
 	}
 
+	store.now = func() time.Time { return time.Now().Add(90 * time.Minute) }
 	removed, err := store.CleanExpiredSessions(ctx)
 	if err != nil {
 		t.Fatalf("CleanExpiredSessions: %v", err)
@@ -142,7 +150,8 @@ func TestSessionStoreCleanExpired(t *testing.T) {
 		t.Fatalf("CleanExpiredSessions removed %d, want 1", removed)
 	}
 
-	// The valid session survives the sweep.
+	// Reset clock to real time; the 2-hour session is still valid.
+	store.now = time.Now
 	if _, ok, err := store.GetSessionByToken(ctx, validRaw); err != nil || !ok {
 		t.Fatalf("valid session removed by sweep (ok=%v, err=%v)", ok, err)
 	}

--- a/internal/webauth/session_store_test.go
+++ b/internal/webauth/session_store_test.go
@@ -1,0 +1,175 @@
+package webauth
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newUserForSession creates a user row so session FKs resolve, returning its id.
+func newUserForSession(t *testing.T, sqlDB *sql.DB) string {
+	t.Helper()
+	u, err := NewSQLUserStore(sqlDB).CreateUser(context.Background(), "admin", "$argon2id$hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u.ID
+}
+
+func TestSessionStoreCreateStoresHashNotRawToken(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	raw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("CreateSession returned an empty raw token")
+	}
+
+	// The DB must hold the SHA-256 hash, never the raw bearer token.
+	var stored string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT token_hash FROM sessions`).Scan(&stored); err != nil {
+		t.Fatalf("read token_hash: %v", err)
+	}
+	if stored == raw {
+		t.Fatal("sessions table stored the RAW token, not its hash")
+	}
+	if stored != hashToken(raw) {
+		t.Fatalf("stored token_hash = %q, want sha256 hex of raw token", stored)
+	}
+	if len(stored) != 64 {
+		t.Fatalf("token_hash length = %d, want 64 hex chars", len(stored))
+	}
+	if strings.Contains(stored, raw) {
+		t.Fatal("raw token leaked into the stored hash")
+	}
+}
+
+func TestSessionStoreGetByToken(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	raw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	sess, ok, err := store.GetSessionByToken(ctx, raw)
+	if err != nil {
+		t.Fatalf("GetSessionByToken: %v", err)
+	}
+	if !ok {
+		t.Fatal("GetSessionByToken found nothing for a valid token")
+	}
+	if sess.UserID != userID {
+		t.Fatalf("session user id = %q, want %q", sess.UserID, userID)
+	}
+	if sess.TokenHash != hashToken(raw) {
+		t.Fatal("session token hash mismatch")
+	}
+
+	// Unknown token resolves to ok=false, not an error.
+	if _, ok, err := store.GetSessionByToken(ctx, "not-a-real-token"); err != nil || ok {
+		t.Fatalf("GetSessionByToken(unknown) = (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+}
+
+func TestSessionStoreExpired(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	// Expiry already in the past: GetSessionByToken must treat it as gone.
+	raw, err := store.CreateSession(ctx, userID, time.Now().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, ok, err := store.GetSessionByToken(ctx, raw); err != nil || ok {
+		t.Fatalf("GetSessionByToken(expired) = (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+}
+
+func TestSessionStoreDelete(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	raw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := store.DeleteSession(ctx, raw); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, ok, err := store.GetSessionByToken(ctx, raw); err != nil || ok {
+		t.Fatalf("session still present after delete (ok=%v, err=%v)", ok, err)
+	}
+	// Deleting an unknown token is a no-op, not an error.
+	if err := store.DeleteSession(ctx, "unknown"); err != nil {
+		t.Fatalf("DeleteSession(unknown): %v", err)
+	}
+}
+
+func TestSessionStoreCleanExpired(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	validRaw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession valid: %v", err)
+	}
+	if _, err := store.CreateSession(ctx, userID, time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("CreateSession expired: %v", err)
+	}
+
+	removed, err := store.CleanExpiredSessions(ctx)
+	if err != nil {
+		t.Fatalf("CleanExpiredSessions: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("CleanExpiredSessions removed %d, want 1", removed)
+	}
+
+	// The valid session survives the sweep.
+	if _, ok, err := store.GetSessionByToken(ctx, validRaw); err != nil || !ok {
+		t.Fatalf("valid session removed by sweep (ok=%v, err=%v)", ok, err)
+	}
+	var count int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM sessions`).Scan(&count); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("sessions remaining = %d, want 1", count)
+	}
+}
+
+func TestSessionStoreTokensAreUnique(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := newTestDB(t)
+	userID := newUserForSession(t, sqlDB)
+	store := NewSQLSessionStore(sqlDB)
+
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		raw, err := store.CreateSession(ctx, userID, time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSession #%d: %v", i, err)
+		}
+		if seen[raw] {
+			t.Fatalf("duplicate raw token generated: %q", raw)
+		}
+		seen[raw] = true
+	}
+}

--- a/internal/webauth/user_store.go
+++ b/internal/webauth/user_store.go
@@ -24,11 +24,11 @@ var ErrUserExists = errors.New("webauth: user already exists")
 // User is a web-UI admin account. PasswordHash is an Argon2id PHC string; the
 // plaintext password is never held here.
 type User struct {
-	ID           string
-	Username     string
-	PasswordHash string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID           string    `json:"id"`
+	Username     string    `json:"username"`
+	PasswordHash string    `json:"-"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // UserStore persists admin accounts. Implementations are storage-swappable

--- a/internal/webauth/user_store.go
+++ b/internal/webauth/user_store.go
@@ -1,0 +1,214 @@
+package webauth
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// userIDBytes is the length of the random user id before hex-encoding.
+const userIDBytes = 16
+
+// ErrUserExists is returned when creating a user whose username is already taken
+// (the username UNIQUE constraint fired).
+var ErrUserExists = errors.New("webauth: user already exists")
+
+// User is a web-UI admin account. PasswordHash is an Argon2id PHC string; the
+// plaintext password is never held here.
+type User struct {
+	ID           string
+	Username     string
+	PasswordHash string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// UserStore persists admin accounts. Implementations are storage-swappable
+// (repository-over-interface, mirroring internal/cache and internal/secrets).
+type UserStore interface {
+	// CreateUser inserts a new user with the given username and Argon2id hash and
+	// returns the stored row. It returns ErrUserExists if the username is taken.
+	CreateUser(ctx context.Context, username, passwordHash string) (User, error)
+	// CreateFirstUser atomically inserts the first admin: the insert succeeds only
+	// when the users table is empty. It returns ErrUserExists if any user already
+	// exists, closing the check-then-insert race that a HasUsers+CreateUser pair
+	// would leave open (two concurrent first-run setups with different usernames).
+	CreateFirstUser(ctx context.Context, username, passwordHash string) (User, error)
+	// GetByUsername returns the user for username (case-insensitive). ok is false
+	// when no such user exists; that is not an error.
+	GetByUsername(ctx context.Context, username string) (user User, ok bool, err error)
+	// GetByID returns the user for id. ok is false when no such user exists.
+	GetByID(ctx context.Context, id string) (user User, ok bool, err error)
+	// HasUsers reports whether any user exists (used for first-run detection).
+	HasUsers(ctx context.Context) (bool, error)
+}
+
+// SQLUserStore persists users in the SQLite `users` table.
+type SQLUserStore struct {
+	db   *sql.DB
+	rand io.Reader
+}
+
+// NewSQLUserStore returns a SQL-backed user store.
+func NewSQLUserStore(db *sql.DB) *SQLUserStore {
+	return &SQLUserStore{db: db, rand: rand.Reader}
+}
+
+// CreateUser inserts a user with a fresh random id. A username collision (the
+// UNIQUE constraint) is reported as ErrUserExists.
+func (s *SQLUserStore) CreateUser(ctx context.Context, username, passwordHash string) (User, error) {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return User{}, fmt.Errorf("webauth: username must not be empty")
+	}
+	if passwordHash == "" {
+		return User{}, fmt.Errorf("webauth: password hash must not be empty")
+	}
+	id, err := s.newID()
+	if err != nil {
+		return User{}, err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)`,
+		id, username, passwordHash,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return User{}, ErrUserExists
+		}
+		return User{}, fmt.Errorf("webauth: create user: %w", err)
+	}
+	return s.requireByID(ctx, id)
+}
+
+// CreateFirstUser inserts the admin only if no user exists yet, in a single
+// atomic statement (INSERT ... SELECT ... WHERE NOT EXISTS). Because the check
+// and the insert happen in one Exec, two concurrent first-run setups cannot both
+// succeed: the second sees a non-empty table, inserts zero rows, and gets
+// ErrUserExists. This is the authoritative guard against multi-admin creation.
+func (s *SQLUserStore) CreateFirstUser(ctx context.Context, username, passwordHash string) (User, error) {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return User{}, fmt.Errorf("webauth: username must not be empty")
+	}
+	if passwordHash == "" {
+		return User{}, fmt.Errorf("webauth: password hash must not be empty")
+	}
+	id, err := s.newID()
+	if err != nil {
+		return User{}, err
+	}
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO users (id, username, password_hash)
+		 SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM users)`,
+		id, username, passwordHash,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return User{}, ErrUserExists
+		}
+		return User{}, fmt.Errorf("webauth: create first user: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return User{}, fmt.Errorf("webauth: create first user rows: %w", err)
+	}
+	if n == 0 {
+		return User{}, ErrUserExists
+	}
+	return s.requireByID(ctx, id)
+}
+
+// GetByUsername returns the user for username (case-insensitive via COLLATE NOCASE).
+func (s *SQLUserStore) GetByUsername(ctx context.Context, username string) (User, bool, error) {
+	return s.scanOne(ctx,
+		`SELECT id, username, password_hash, created_at, updated_at FROM users WHERE username = ?`,
+		strings.TrimSpace(username),
+	)
+}
+
+// GetByID returns the user for id.
+func (s *SQLUserStore) GetByID(ctx context.Context, id string) (User, bool, error) {
+	return s.scanOne(ctx,
+		`SELECT id, username, password_hash, created_at, updated_at FROM users WHERE id = ?`,
+		id,
+	)
+}
+
+// HasUsers reports whether the users table holds at least one row.
+func (s *SQLUserStore) HasUsers(ctx context.Context) (bool, error) {
+	var exists int
+	err := s.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM users)`).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("webauth: has users: %w", err)
+	}
+	return exists == 1, nil
+}
+
+func (s *SQLUserStore) requireByID(ctx context.Context, id string) (User, error) {
+	user, ok, err := s.GetByID(ctx, id)
+	if err != nil {
+		return User{}, err
+	}
+	if !ok {
+		return User{}, fmt.Errorf("webauth: created user %q not found on read-back", id)
+	}
+	return user, nil
+}
+
+func (s *SQLUserStore) scanOne(ctx context.Context, query string, arg string) (User, bool, error) {
+	var (
+		u                    User
+		createdAt, updatedAt string
+	)
+	err := s.db.QueryRowContext(ctx, query, arg).
+		Scan(&u.ID, &u.Username, &u.PasswordHash, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return User{}, false, nil
+	}
+	if err != nil {
+		return User{}, false, fmt.Errorf("webauth: get user: %w", err)
+	}
+	if u.CreatedAt, err = parseTime(createdAt); err != nil {
+		return User{}, false, err
+	}
+	if u.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return User{}, false, err
+	}
+	return u, true, nil
+}
+
+func (s *SQLUserStore) newID() (string, error) {
+	b := make([]byte, userIDBytes)
+	if _, err := io.ReadFull(s.rand, b); err != nil {
+		return "", fmt.Errorf("webauth: generate user id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// isUniqueViolation reports whether err is a SQLite constraint violation
+// (extended result codes carry SQLITE_CONSTRAINT == 19 in the low byte). It is
+// used to map a username collision onto ErrUserExists.
+func isUniqueViolation(err error) bool {
+	var serr *sqlite.Error
+	if errors.As(err, &serr) {
+		return serr.Code()&0xff == 19 // SQLITE_CONSTRAINT
+	}
+	return false
+}
+
+func parseTime(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("webauth: parse time %q: %w", s, err)
+	}
+	return t, nil
+}

--- a/internal/webauth/user_store_test.go
+++ b/internal/webauth/user_store_test.go
@@ -1,0 +1,147 @@
+package webauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestUserStoreCreateAndGet(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	created, err := store.CreateUser(ctx, "Admin", "$argon2id$hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created user has empty id")
+	}
+	if created.Username != "Admin" {
+		t.Fatalf("username = %q, want %q", created.Username, "Admin")
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatal("created/updated timestamps not populated")
+	}
+
+	// GetByUsername is case-insensitive (COLLATE NOCASE).
+	got, ok, err := store.GetByUsername(ctx, "ADMIN")
+	if err != nil {
+		t.Fatalf("GetByUsername: %v", err)
+	}
+	if !ok {
+		t.Fatal("GetByUsername (different case) found nothing")
+	}
+	if got.ID != created.ID || got.PasswordHash != "$argon2id$hash" {
+		t.Fatalf("GetByUsername returned %+v, want id %q", got, created.ID)
+	}
+
+	gotByID, ok, err := store.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !ok || gotByID.Username != "Admin" {
+		t.Fatalf("GetByID returned (%+v, %v)", gotByID, ok)
+	}
+}
+
+func TestUserStoreHasUsers(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	has, err := store.HasUsers(ctx)
+	if err != nil {
+		t.Fatalf("HasUsers: %v", err)
+	}
+	if has {
+		t.Fatal("HasUsers true on an empty table")
+	}
+
+	if _, err := store.CreateUser(ctx, "admin", "$argon2id$hash"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	has, err = store.HasUsers(ctx)
+	if err != nil {
+		t.Fatalf("HasUsers: %v", err)
+	}
+	if !has {
+		t.Fatal("HasUsers false after a user was created")
+	}
+}
+
+func TestUserStoreDuplicateUsername(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	if _, err := store.CreateUser(ctx, "admin", "$argon2id$hash"); err != nil {
+		t.Fatalf("first CreateUser: %v", err)
+	}
+	// Same username in a different case must collide (COLLATE NOCASE unique).
+	_, err := store.CreateUser(ctx, "ADMIN", "$argon2id$other")
+	if !errors.Is(err, ErrUserExists) {
+		t.Fatalf("duplicate CreateUser error = %v, want ErrUserExists", err)
+	}
+}
+
+func TestUserStoreCreateFirstUser(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	first, err := store.CreateFirstUser(ctx, "admin", "$argon2id$hash")
+	if err != nil {
+		t.Fatalf("CreateFirstUser (empty table): %v", err)
+	}
+	if first.ID == "" || first.Username != "admin" {
+		t.Fatalf("CreateFirstUser returned %+v", first)
+	}
+
+	// A second attempt, even with a different username, must be rejected because a
+	// user already exists.
+	if _, err := store.CreateFirstUser(ctx, "intruder", "$argon2id$other"); !errors.Is(err, ErrUserExists) {
+		t.Fatalf("second CreateFirstUser error = %v, want ErrUserExists", err)
+	}
+
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("users table has %d rows, want 1", count)
+	}
+}
+
+func TestUserStoreCreateFirstUserRejectsEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	if _, err := store.CreateFirstUser(ctx, "  ", "$argon2id$hash"); err == nil {
+		t.Fatal("CreateFirstUser with blank username should error")
+	}
+	if _, err := store.CreateFirstUser(ctx, "admin", ""); err == nil {
+		t.Fatal("CreateFirstUser with empty password hash should error")
+	}
+}
+
+func TestUserStoreGetMissing(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	if _, ok, err := store.GetByUsername(ctx, "nobody"); err != nil || ok {
+		t.Fatalf("GetByUsername(missing) = (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+	if _, ok, err := store.GetByID(ctx, "deadbeef"); err != nil || ok {
+		t.Fatalf("GetByID(missing) = (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+}
+
+func TestUserStoreRejectsEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := NewSQLUserStore(newTestDB(t))
+
+	if _, err := store.CreateUser(ctx, "  ", "$argon2id$hash"); err == nil {
+		t.Fatal("CreateUser with blank username should error")
+	}
+	if _, err := store.CreateUser(ctx, "admin", ""); err == nil {
+		t.Fatal("CreateUser with empty password hash should error")
+	}
+}


### PR DESCRIPTION
## Summary

Lane 1 of #241 (authenticated web access): the `internal/webauth` session-auth core, with no HTTP surface yet - the foundation lanes 3/4 (login middleware, onboarding) build on. Implements the design of record `docs/design/2026-06-14-204-auth-web-tls.md`.

- **Argon2id** password hashing (sign-off S1): m=64MiB, t=1, p=4, 16B salt, 32B key (matches the design exactly, exceeds OWASP baseline); salt from `crypto/rand`, standard PHC encoded format with version+param validation.
- **Constant-time, enumeration-safe verification**: `subtle.ConstantTimeCompare`; an unknown user runs a dummy Argon2id verify so unknown-vs-wrong-password are indistinguishable by timing or error.
- **Session store**: 256-bit `crypto/rand` tokens; the raw token is returned to the caller and **never persisted** - only `SHA-256(token)` is stored, and lookup/delete is by hash.
- **Stores + Service**: user store, session store, and `Service` (Setup / Login / ValidateSession / Logout / CleanExpiredSessions / HasUsers). First-admin creation is race-safe via an atomic `INSERT ... WHERE NOT EXISTS`.
- **Migrations 019/020**: `users` (NOCASE-unique username) and `sessions` (FK `ON DELETE CASCADE`, index on `expires_at`); both reversible. FK enforcement is real (`PRAGMA foreign_keys=ON`).
- Unit tests against real in-memory SQLite (no mocks), asserting the security properties: hash-not-raw stored, dummy-verify path, FK cascade, and a 12-goroutine concurrent-setup test.

**Size override:** ~1640 hand-written LOC / 13 files, over the 800/10 PR-size gate. Overridden because lane 1 is a cohesive, atomic foundation - the Service, user store, session store, and migrations are mutually dependent and cannot compile/test if split - and ~810 of those LOC are tests.

## Linked issue

Part of #241 (one of the dependency-ordered lanes; the issue stays open until the remaining lanes land).

## Test plan

- [x] `make gate` green (build, `go vet`, race tests across 33 packages, golangci-lint 0 issues, actionlint, govulncheck clean)
- [x] Patch coverage 83.78% (279/333 lines), above the 70% floor
- [x] Adversarial security review: SHIP-READY (no CRITICAL/MAJOR; Argon2id params, timing/enumeration safety, token-at-rest, parameterized SQL, FK cascade, TOCTOU all verified)
- [ ] Reviewer follow-up

## Notes (non-blocking nits from internal review, for reviewer awareness)

- `isUniqueViolation` maps any `SQLITE_CONSTRAINT` to `ErrUserExists`; only the username unique constraint can fire in practice today, but this is a latent fragility if more constraints are added.
- `dummyHash` should track the strongest deployed Argon2id params if a future lane adds per-hash param upgrades.
- An optional max-password-length cap could bound Argon2id input cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added web-based admin authentication system with secure login and logout functionality
  * Implemented session management with configurable expiration and automatic cleanup
  * Added admin user provisioning on initial setup
  * Introduced Argon2id-based password hashing for secure credential storage
  * Added enumeration-safe session validation and authentication checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->