### PR TITLE
chore(ci): parity hardening - Go build caching + golangci-lint v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,13 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
-          version: v2.11.4
+          version: v2.12.2
+          cache-invalidation-interval: 1
 
   test:
     name: Test
@@ -93,6 +95,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Run tests
         run: go test -v -race -count=1 -coverprofile=coverage.out ./...
@@ -123,6 +126,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Install Tailwind standalone CLI (v4.2.0)
         run: |
@@ -160,6 +164,10 @@ jobs:
           severity-cutoff: high
           fail-build: true
 
+  # Per-package coverage-floor CI enforcement is deferred: Codecov handles patch
+  # coverage for PR gates, and scripts/coverage-floor.sh remains available for
+  # local use. A CI job can be promoted here when the repo matures and a stable
+  # per-package floor baseline has been established.
   coverage-upload:
     name: Upload Coverage
     runs-on: ubuntu-latest
@@ -212,6 +220,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Build binary
         if: ${{ matrix.skip != 'true' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
 


### PR DESCRIPTION
## Summary

CI parity hardening cherry-picked from `sydlexius/stillwater` (both repos are pure-Go/no-CGO). Three items from #254:

1. **Go build/module caching** - added `cache: true` to **all 4** `actions/setup-go` steps (lint, test, the templ+Tailwind `ui-check` job, and build-matrix). The module + build cache is keyed on `go.sum`; a pure wall-clock win on every PR. (The issue's plan listed 3 steps; the `ui-check` job was the 4th and is included.)
2. **golangci-lint currency** - bumped `v2.11.4` -> `v2.12.2` in both `ci.yml` and `.pre-commit-config.yaml`, with `cache-invalidation-interval: 1` on the action. `make sync-tool-versions` confirms the pins agree. Per CLAUDE.md, a lint-pin bump is a probe: running golangci-lint v2.12.2 locally reported **0 issues** - no analyzer-regression findings, no new `//nolint` needed.
3. **Coverage floor (Item 3)** - **deferred** (documented in `ci.yml`): Codecov already gates patch coverage; `scripts/coverage-floor.sh` stays available locally and can be promoted to CI when the repo matures.

## Linked issue

Closes #254

## Test plan

- [x] `actionlint .github/workflows/ci.yml` clean
- [x] `make sync-tool-versions` passes (pins agree)
- [x] `make gate` green (build, race tests, golangci-lint 0 issues, govulncheck, actionlint)
- [x] golangci-lint **v2.12.2** probe run locally: 0 issues
- [ ] CI is the authoritative v2.12.2 probe - confirm no analyzer-regression findings on this PR's run

## Notes

Additive CI config only; no application code changed. The diff is limited to `.github/workflows/ci.yml` and `.pre-commit-config.yaml`.