### PR TITLE
chore(secrets): use explicit _ = Close() over //nolint:errcheck

### DIFF
--- a/internal/commands/secrets_cmd.go
+++ b/internal/commands/secrets_cmd.go
@@ -33,7 +33,7 @@ func runSecrets(ctx context.Context, out io.Writer, args SecretsCmd) int {
 		slog.Error("failed to open database", "error", err)
 		return 1
 	}
-	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+	defer func() { _ = sqlDB.Close() }()
 
 	store, err := resolveSecretStore(cfg, sqlDB)
 	if err != nil {

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -114,7 +114,7 @@ func (s *SQLStore) List(ctx context.Context) ([]SecretInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("secrets: list: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+	defer func() { _ = rows.Close() }()
 	var out []SecretInfo
 	for rows.Next() {
 		var info SecretInfo


### PR DESCRIPTION
## Summary

Adopts the explicit `defer func() { _ = X.Close() }()` discard idiom in place of `defer X.Close() //nolint:errcheck` across the secrets-package close sites, so the package is consistent and carries no `//nolint` suppressions for these closes (errcheck is satisfied by the explicit discard).

- `internal/secrets/store.go:117` - `rows.Close()` (read-only query)
- `internal/commands/secrets_cmd.go:36` - `sqlDB.Close()` (best-effort close on shutdown)

A grep confirms no `.Close() //nolint:errcheck` remains in those files.

## Linked issue

Closes #236

## Test plan

- [x] `make gate` green (build, `go vet`, race tests, golangci-lint **0 issues**, govulncheck, actionlint)
- [x] No behavior change (functionally identical to the prior `//nolint:errcheck` form)

## Notes

Pure idiomatic cleanup, no behavioral change - `norabbit` candidate.