### PR TITLE
feat(lyrics): embed provenance ID-tags in .lrc output + backfill from the DB

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,9 +26,9 @@ builds:
       # defaults). GoReleaser only auto-injects these when ldflags is unset, so
       # they are wired explicitly here. CommitDate (not Date) keeps the build
       # reproducible, matching the -trimpath stance above.
-      - -X github.com/sydlexius/mxlrcgo-svc/internal/commands.version={{ .Version }}
-      - -X github.com/sydlexius/mxlrcgo-svc/internal/commands.commit={{ .Commit }}
-      - -X github.com/sydlexius/mxlrcgo-svc/internal/commands.date={{ .CommitDate }}
+      - -X github.com/sydlexius/mxlrcgo-svc/internal/version.Version={{ .Version }}
+      - -X github.com/sydlexius/mxlrcgo-svc/internal/version.Commit={{ .Commit }}
+      - -X github.com/sydlexius/mxlrcgo-svc/internal/version.Date={{ .CommitDate }}
 
 archives:
   - id: default

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5,16 +5,17 @@ This page documents every subcommand and flag. For operational guidance (running
 ## Usage
 
 ```text
-Usage: mxlrcgo-svc [fetch|serve|scan|library|keys|config|queue]
+Usage: mxlrcgo-svc [fetch|serve|scan|library|keys|config|queue|provenance]
 
 Commands:
-  fetch     fetch lyrics once without HTTP server or DB queue
-  serve     run HTTP server, worker, and library scheduler
-  scan      scan configured libraries and enqueue missing lyrics
-  library   manage library roots
-  keys      manage API keys
-  config    inspect or update configuration
-  queue     inspect or maintain the durable work queue
+  fetch       fetch lyrics once without HTTP server or DB queue
+  serve       run HTTP server, worker, and library scheduler
+  scan        scan configured libraries and enqueue missing lyrics
+  library     manage library roots
+  keys        manage API keys
+  config      inspect or update configuration
+  queue       inspect or maintain the durable work queue
+  provenance  inject provenance ID tags into .lrc files
 
 Global flags:
   --version  print the build version and exit
@@ -95,6 +96,48 @@ mxlrcgo-svc config get db.path
 ## Queue and scan inspection
 
 The `queue` and `scan` subcommands expose the durable work queue and persisted scan results. See [Inspection commands](USER_GUIDE.md#inspection-commands) in the User Guide for the full command set (`queue list`/`failed`/`deferred`/`retry`/`clear`, and `scan results`/`clear`).
+
+## Provenance
+
+Synced `.lrc` files written by `mxlrcgo-svc` carry provenance tags in the header block that identify where and when each file came from. These tags appear after the standard metadata tags (`[by:]`, `[ar:]`, `[ti:]`, etc.) and before the first timestamped lyric line:
+
+```text
+[source:musixmatch]
+[fetched:2026-06-15T12:00:00Z]
+[ve:v1.2.0]
+[isrc:USRC17607834]
+[mbid:9f2a2b4c-1234-5678-abcd-000000000000]
+```
+
+| Tag | Value | Notes |
+|---|---|---|
+| `[source:]` | provider lane name | e.g. `musixmatch`, `petitlyrics` |
+| `[fetched:]` | ISO 8601 fetch timestamp | UTC; absent on cache hits |
+| `[ve:]` | generating mxlrcgo-svc version | e.g. `v1.2.0`; `dev` on local builds |
+| `[isrc:]` | ISRC recording identifier | when available from the audio file or API response |
+| `[mbid:]` | MusicBrainz recording ID | when available from the audio file |
+
+### Provenance backfill
+
+Existing `.lrc` files that predate this feature can have provenance tags injected retroactively from the work queue database:
+
+```sh
+# Preview what would change (dry run)
+mxlrcgo-svc provenance backfill
+
+# Target specific paths or directories
+mxlrcgo-svc provenance backfill /data/music/Artist
+
+# Apply the changes
+mxlrcgo-svc provenance backfill --yes
+
+# Apply to specific paths
+mxlrcgo-svc provenance backfill --yes /data/music/Artist/Album
+```
+
+The backfill is idempotent: tags that already exist in a file are skipped; only genuinely absent tags are injected. The `[ve:]` tag is never injected on backfill (the originating version is not recorded in the database). Files for which the database has no matching row, or with only partial metadata, are reported as `partial` rather than `seeded`.
+
+**Cache-hit writes and missing `[source:]`/`[fetched:]` tags:** when a lyric fetch is served from the in-memory cache, `[ve:]` is written inline but `[source:]` and `[fetched:]` are absent because those fields are transient (not persisted alongside the cached result). Run `provenance backfill --yes` after a cache-hit write to pull the source lane and fetch timestamp from the work queue database and inject them retroactively.
 
 ## Shell completion
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -92,6 +92,7 @@ func TestRunFetchesAndWritesSyncedLyrics(t *testing.T) {
 		"[ti:Test Song]",
 		"[al:Test Album]",
 		"[length:02:03]",
+		"[ve:dev]",
 		"[00:01.23]first line",
 		"[00:02.34]second line",
 		"",

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -56,6 +56,7 @@ type Args struct {
 	Secrets    *SecretsCmd    `arg:"subcommand:secrets" help:"manage encrypted-at-rest secrets"`
 	Config     *ConfigCmd     `arg:"subcommand:config" help:"inspect or update configuration"`
 	Queue      *QueueCmd      `arg:"subcommand:queue" help:"inspect or maintain the durable work queue"`
+	Provenance *ProvenanceCmd `arg:"subcommand:provenance" help:"embed or inspect provenance tags in .lrc files"`
 	Completion *CompletionCmd `arg:"subcommand:completion" help:"output a shell completion script (bash, zsh, or fish)"`
 }
 
@@ -410,6 +411,8 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 		return runConfig(out, *args.Config)
 	case args.Queue != nil:
 		return runQueueCmd(ctx, out, *args.Queue)
+	case args.Provenance != nil:
+		return runProvenance(ctx, out, *args.Provenance)
 	case args.Completion != nil:
 		return runCompletion(out, *args.Completion)
 	default:
@@ -426,7 +429,7 @@ func usesSubcommand(rawArgs []string) bool {
 		return true
 	}
 	commands := map[string]bool{
-		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "secrets": true, "config": true, "queue": true, "completion": true,
+		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "secrets": true, "config": true, "queue": true, "provenance": true, "completion": true,
 	}
 	return commands[rawArgs[0]]
 }

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -20,7 +20,7 @@ type CompletionCmd struct {
 
 // completionSubcommands are the top-level subcommands offered at the first word.
 var completionSubcommands = []string{
-	"fetch", "serve", "scan", "library", "keys", "config", "queue", "completion",
+	"fetch", "serve", "scan", "library", "keys", "config", "queue", "provenance", "completion",
 }
 
 // completionCandidates maps a subcommand to the flags and/or nested subcommands
@@ -34,6 +34,7 @@ var completionCandidates = map[string][]string{
 	"keys":       {"create", "list", "revoke"},
 	"config":     {"get", "set", "list"},
 	"queue":      {"list", "failed", "deferred", "retry", "clear", "recheck"},
+	"provenance": {"backfill"},
 	"completion": {"bash", "zsh", "fish"},
 }
 

--- a/internal/commands/provenance.go
+++ b/internal/commands/provenance.go
@@ -1,0 +1,441 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
+)
+
+// ProvenanceCmd hosts nested provenance subcommands.
+type ProvenanceCmd struct {
+	Backfill *ProvenanceBackfillCmd `arg:"subcommand:backfill" help:"inject provenance tags into existing .lrc files from the DB"`
+}
+
+// ProvenanceBackfillCmd injects provenance tags into existing .lrc files.
+type ProvenanceBackfillCmd struct {
+	Paths      []string `arg:"positional" help:"paths or directories to process (default: all known .lrc files from the DB)"`
+	Yes        bool     `arg:"--yes" help:"apply the changes; without it, prints what would change and exits 0"`
+	ConfigPath string   `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+func runProvenance(ctx context.Context, out io.Writer, args ProvenanceCmd) int {
+	switch {
+	case args.Backfill != nil:
+		return runProvenanceBackfill(ctx, out, *args.Backfill)
+	default:
+		_, _ = fmt.Fprintln(out, "missing provenance subcommand")
+		return 2
+	}
+}
+
+// provenanceRecord holds the provenance data retrieved from the DB for one .lrc file.
+type provenanceRecord struct {
+	Source    string
+	FetchedAt time.Time
+	ISRC      string
+	MBID      string
+}
+
+// provenancePlan describes what would happen to one .lrc file.
+type provenancePlan struct {
+	Path    string
+	Tags    lyrics.ProvenanceTags
+	Partial bool // true when some tags are missing because the DB lacks data
+}
+
+func runProvenanceBackfill(ctx context.Context, out io.Writer, args ProvenanceBackfillCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	var plans []provenancePlan
+	var planSkipped int
+	if len(args.Paths) == 0 {
+		plans, planSkipped, err = backfillPlansFromDB(ctx, sqlDB)
+	} else {
+		plans, planSkipped, err = backfillPlansFromPaths(ctx, sqlDB, args.Paths)
+	}
+	if err != nil {
+		slog.Error("backfill plan failed", "error", err)
+		return 1
+	}
+
+	// Tally DB-coverage counts for the plan report.
+	var seeded, partial int
+	for _, p := range plans {
+		if p.Partial {
+			partial++
+		} else {
+			seeded++
+		}
+	}
+
+	if !args.Yes {
+		// MINOR-8: label the plan output unambiguously so users understand that
+		// 'ready' is DB-coverage (not file state); already-tagged files appear as
+		// 'unchanged' in the apply run.
+		_, _ = fmt.Fprintf(out, "provenance backfill plan: %d files ready (all tags available in DB), %d partial (some DB tags missing), %d skipped (no DB row)\n",
+			seeded, partial, planSkipped)
+		_, _ = fmt.Fprintln(out, "Note: files already fully tagged appear as unchanged when --yes is applied.")
+		_, _ = fmt.Fprintln(out, "pass --yes to apply")
+		return 0
+	}
+
+	// Apply the plan.
+	var applied, appliedPartial, unchanged, errCount int
+	var failed []string // MINOR-9: track which files fail for stdout report
+	for _, p := range plans {
+		inj, _, ierr := lyrics.InjectProvenance(p.Path, p.Tags)
+		if ierr != nil {
+			slog.Warn("backfill inject failed", "path", p.Path, "error", ierr)
+			errCount++
+			failed = append(failed, p.Path)
+			continue
+		}
+		if inj == 0 {
+			unchanged++
+		} else if p.Partial {
+			appliedPartial++
+		} else {
+			applied++
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "provenance backfill: applied %d, partial %d, unchanged %d, errors %d\n",
+		applied, appliedPartial, unchanged, errCount)
+	if errCount > 0 {
+		for _, f := range failed {
+			_, _ = fmt.Fprintf(out, "  failed: %s\n", f)
+		}
+		return 1
+	}
+	return 0
+}
+
+// wqRow is a raw scanned work_queue row used to buffer results before secondary lookups.
+type wqRow struct {
+	artist, title, outdir, filename, outputPathsJSON string
+	providerLane, completedAt                        sql.NullString
+}
+
+// backfillPlansFromDB enumerates all done work_queue rows in the DB and builds
+// a plan for each associated .lrc file that exists on disk.
+//
+// Two-pass design: the outer rows cursor is closed before any secondary
+// lyricsISRCMBID query runs, avoiding a deadlock on the single-connection pool
+// (db.Open sets MaxOpenConns(1)).
+//
+// Returns (plans, skipped, error) where skipped counts .lrc files with no
+// on-disk presence and same-stem collisions (MAJOR-2, MAJOR-3).
+func backfillPlansFromDB(ctx context.Context, sqlDB *sql.DB) (plans []provenancePlan, skipped int, err error) {
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT id, artist, title, outdir, filename, output_paths, provider_lane, completed_at
+		FROM work_queue
+		WHERE status = 'done'
+		ORDER BY id`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query done work_queue rows: %w", err)
+	}
+
+	// Pass 1: collect raw rows so we can close the cursor before issuing secondary queries.
+	var raw []wqRow
+	for rows.Next() {
+		var id int64
+		var r wqRow
+		if err := rows.Scan(&id, &r.artist, &r.title, &r.outdir, &r.filename, &r.outputPathsJSON, &r.providerLane, &r.completedAt); err != nil {
+			_ = rows.Close()
+			return nil, 0, fmt.Errorf("scan work_queue row: %w", err)
+		}
+		raw = append(raw, r)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, fmt.Errorf("close work_queue rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate work_queue rows: %w", err)
+	}
+
+	// Pass 2: build plans; secondary DB lookups are safe now that the cursor is closed.
+	for _, r := range raw {
+		paths := resolveOutputPaths(r.outdir, r.filename, r.outputPathsJSON)
+		rec := buildProvenanceRecord(ctx, sqlDB, r.artist, r.title, r.providerLane, r.completedAt)
+
+		for _, p := range paths {
+			if strings.ToLower(filepath.Ext(p)) != ".lrc" {
+				continue
+			}
+			if _, serr := os.Stat(p); os.IsNotExist(serr) {
+				skipped++ // MAJOR-2: count missing-on-disk files
+				continue
+			}
+			plans = append(plans, makePlan(p, rec))
+		}
+	}
+
+	// MAJOR-3: detect same-stem collisions (same .lrc path from multiple source tracks).
+	// Warn and skip any path that appears more than once to avoid cross-attribution.
+	pathCount := make(map[string]int, len(plans))
+	for _, p := range plans {
+		pathCount[p.Path]++
+	}
+	warnedPaths := make(map[string]bool)
+	var deduped []provenancePlan
+	for _, p := range plans {
+		if pathCount[p.Path] > 1 {
+			if !warnedPaths[p.Path] {
+				slog.Warn("backfill: ambiguous .lrc (multiple source tracks); skipping", "path", p.Path)
+				warnedPaths[p.Path] = true
+				skipped++
+			}
+			continue
+		}
+		deduped = append(deduped, p)
+	}
+	return deduped, skipped, nil
+}
+
+// backfillPlansFromPaths walks the given paths/dirs to find .lrc files and
+// looks up each in the DB.
+//
+// Returns (plans, skipped, error) where skipped counts .lrc files with no
+// matching DB row (including ambiguous multi-row cases from MAJOR-3).
+func backfillPlansFromPaths(ctx context.Context, sqlDB *sql.DB, paths []string) (plans []provenancePlan, skipped int, err error) {
+	for _, root := range paths {
+		info, err := os.Stat(root)
+		if err != nil {
+			return nil, 0, fmt.Errorf("stat %s: %w", root, err)
+		}
+		if !info.IsDir() {
+			if strings.ToLower(filepath.Ext(root)) != ".lrc" {
+				continue
+			}
+			if p, ok := lookupPlan(ctx, sqlDB, root); ok {
+				plans = append(plans, p)
+			} else {
+				skipped++ // MAJOR-2: count .lrc files with no usable DB row
+			}
+			continue
+		}
+		if werr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || strings.ToLower(filepath.Ext(path)) != ".lrc" {
+				return nil
+			}
+			if p, ok := lookupPlan(ctx, sqlDB, path); ok {
+				plans = append(plans, p)
+			} else {
+				skipped++ // MAJOR-2: count .lrc files with no usable DB row
+			}
+			return nil
+		}); werr != nil {
+			return nil, 0, fmt.Errorf("walk %s: %w", root, werr)
+		}
+	}
+	return plans, skipped, nil
+}
+
+// canonicalDir returns a canonical form of a directory path for comparison:
+// made absolute (a relative path is resolved against the current working
+// directory) then Cleaned, which collapses trailing slashes and "." / ".."
+// segments. Symlinks are deliberately NOT resolved (the directory may no
+// longer exist). On a filepath.Abs error it falls back to filepath.Clean.
+func canonicalDir(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs // filepath.Abs already returns a Cleaned path
+	}
+	return filepath.Clean(p)
+}
+
+// lookupPlan looks up a single .lrc file path in the DB and returns its plan.
+// MAJOR-3 / NEW-1: ambiguity is measured by DISTINCT work_queue id, not raw
+// join-row count. A single track released in multiple audio formats (e.g.
+// song.flac + song.mp3) is ONE work_queue row joined to several scan_results
+// rows that all point at the same output .lrc; that is unambiguous and tags
+// normally. Only genuinely distinct work_queue ids sharing one .lrc path are a
+// cross-attribution collision (warn + skip).
+func lookupPlan(ctx context.Context, sqlDB *sql.DB, path string) (provenancePlan, bool) {
+	base := filepath.Base(path)
+
+	// NEW-2: match the directory by a CANONICAL form rather than an exact SQL
+	// string compare. The stored scan_results.outdir may be relative, carry a
+	// trailing slash, or otherwise differ in cleanliness from the absolute path
+	// the user passes to backfill; an exact `sr.outdir = ?` match would return
+	// 0 rows and the file would be silently counted as skipped. We query on the
+	// filename alone, then compare canonicalDir(stored outdir) against
+	// canonicalDir(query dir) in Go. Symlinks are NOT resolved (EvalSymlinks):
+	// the stored dir may no longer exist, so two paths differing only by an
+	// unresolved symlink will not match - an accepted residual limitation.
+	wantDir := canonicalDir(filepath.Dir(path))
+
+	type wqMatch struct {
+		artist, title             string
+		providerLane, completedAt sql.NullString
+	}
+
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT wq.id, wq.artist, wq.title, wq.provider_lane, wq.completed_at, sr.outdir
+		FROM work_queue wq
+		JOIN work_queue_scan_results wqsr ON wqsr.work_queue_id = wq.id
+		JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+		WHERE sr.filename = ?
+		  AND wq.status = 'done'
+		ORDER BY wq.id DESC`,
+		base,
+	)
+	if err != nil {
+		slog.Warn("backfill: DB lookup failed", "path", path, "error", err)
+		return provenancePlan{}, false
+	}
+
+	// Collapse to DISTINCT work_queue id: a given wq.id has identical
+	// artist/title/provider_lane/completed_at across all its scan_results rows,
+	// so keeping the first row seen per id is correct.
+	matched := make(map[int64]wqMatch)
+	var order []int64 // preserve first-seen order for a stable picked row
+	for rows.Next() {
+		var id int64
+		var m wqMatch
+		var storedOutdir string
+		if serr := rows.Scan(&id, &m.artist, &m.title, &m.providerLane, &m.completedAt, &storedOutdir); serr != nil {
+			_ = rows.Close()
+			slog.Warn("backfill: scan row failed", "path", path, "error", serr)
+			return provenancePlan{}, false
+		}
+		// NEW-2: we matched on filename alone; keep only rows whose stored
+		// directory canonically matches the directory of the file we are
+		// tagging. This rejects same-named files in genuinely different
+		// directories while tolerating trailing-slash / relative-vs-absolute /
+		// uncleaned differences in the stored outdir.
+		if canonicalDir(storedOutdir) != wantDir {
+			continue
+		}
+		if _, seen := matched[id]; !seen {
+			matched[id] = m
+			order = append(order, id)
+		}
+	}
+	if cerr := rows.Close(); cerr != nil {
+		slog.Warn("backfill: close rows failed", "path", path, "error", cerr)
+		return provenancePlan{}, false
+	}
+	if rerr := rows.Err(); rerr != nil {
+		slog.Warn("backfill: rows error", "path", path, "error", rerr)
+		return provenancePlan{}, false
+	}
+
+	switch len(matched) {
+	case 0:
+		return provenancePlan{}, false
+	case 1:
+		m := matched[order[0]]
+		rec := buildProvenanceRecord(ctx, sqlDB, m.artist, m.title, m.providerLane, m.completedAt)
+		return makePlan(path, rec), true
+	default:
+		// MAJOR-3 / NEW-1: ambiguous - distinct source tracks share this .lrc
+		// filename. count reflects distinct tracks, not raw join rows.
+		slog.Warn("backfill: ambiguous .lrc (multiple source tracks); skipping", "path", path, "count", len(matched))
+		return provenancePlan{}, false
+	}
+}
+
+// resolveOutputPaths decodes the JSON output_paths blob. Falls back to the
+// top-level outdir+filename when the JSON is empty or unparsable.
+func resolveOutputPaths(outdir, filename, outputPathsJSON string) []string {
+	if strings.TrimSpace(outputPathsJSON) != "" && outputPathsJSON != "[]" && outputPathsJSON != "null" {
+		var ops []models.OutputPath
+		if err := json.Unmarshal([]byte(outputPathsJSON), &ops); err == nil && len(ops) > 0 {
+			paths := make([]string, 0, len(ops))
+			for _, op := range ops {
+				if op.Outdir != "" && op.Filename != "" {
+					paths = append(paths, filepath.Join(op.Outdir, op.Filename))
+				}
+			}
+			if len(paths) > 0 {
+				return paths
+			}
+		}
+	}
+	if outdir != "" && filename != "" {
+		return []string{filepath.Join(outdir, filename)}
+	}
+	return nil
+}
+
+// buildProvenanceRecord assembles the provenance tags from the DB columns plus
+// an optional lyrics_cache lookup for ISRC/MBID.
+func buildProvenanceRecord(ctx context.Context, sqlDB *sql.DB, artist, title string, providerLane, completedAt sql.NullString) provenanceRecord {
+	var rec provenanceRecord
+	if providerLane.Valid {
+		rec.Source = providerLane.String
+	}
+	if completedAt.Valid && completedAt.String != "" {
+		if t, err := time.Parse(time.RFC3339, completedAt.String); err == nil {
+			rec.FetchedAt = t
+		}
+	}
+	// Try to enrich ISRC/MBID from the lyrics_cache JSON blob.
+	rec.ISRC, rec.MBID = lyricsISRCMBID(ctx, sqlDB, artist, title)
+	return rec
+}
+
+// lyricsISRCMBID attempts to read ISRC and RecordingMBID from the lyrics_cache
+// JSON blob for the given artist+title. Returns ("", "") when the cache lacks
+// the data (partial-coverage case).
+func lyricsISRCMBID(ctx context.Context, sqlDB *sql.DB, artist, title string) (isrc, mbid string) {
+	var raw string
+	err := sqlDB.QueryRowContext(ctx, `
+		SELECT lyrics FROM lyrics_cache
+		WHERE artist = ? AND title = ?
+		ORDER BY updated_at DESC
+		LIMIT 1`,
+		normalize.NormalizeKey(artist), normalize.NormalizeKey(title),
+	).Scan(&raw)
+	if err != nil {
+		return "", ""
+	}
+	var song models.Song
+	if err := json.Unmarshal([]byte(raw), &song); err != nil {
+		return "", ""
+	}
+	return song.Track.ISRC, song.Track.RecordingMBID
+}
+
+// makePlan builds a provenancePlan for one .lrc file from a provenanceRecord.
+func makePlan(path string, rec provenanceRecord) provenancePlan {
+	var fetched string
+	if !rec.FetchedAt.IsZero() {
+		fetched = rec.FetchedAt.Format(time.RFC3339)
+	}
+	tags := lyrics.ProvenanceTags{
+		Source:  rec.Source,
+		Fetched: fetched,
+		ISRC:    rec.ISRC,
+		MBID:    rec.MBID,
+	}
+	partial := rec.Source == "" || rec.FetchedAt.IsZero()
+	return provenancePlan{Path: path, Tags: tags, Partial: partial}
+}

--- a/internal/commands/provenance_test.go
+++ b/internal/commands/provenance_test.go
@@ -1,0 +1,748 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/normalize"
+)
+
+const testLRCFilename = "track.lrc"
+
+// seedProvenanceDB inserts the minimal rows needed to test the backfill:
+// a library, a scan_result, a work_queue row, the junction row, and optionally
+// a lyrics_cache row.
+func seedProvenanceDB(t *testing.T, sqlDB *sql.DB, outdir, providerLane string, completedAt time.Time, song *models.Song) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Insert library.
+	var libID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?) RETURNING id`,
+		outdir, "test-lib").Scan(&libID); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+
+	// Insert scan_result.
+	var srID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
+		 VALUES (?, ?, ?, ?, ?, ?, 'done') RETURNING id`,
+		libID, filepath.Join(outdir, "source.flac"),
+		song.Track.ArtistName, song.Track.TrackName, outdir, testLRCFilename,
+	).Scan(&srID); err != nil {
+		t.Fatalf("insert scan_result: %v", err)
+	}
+
+	// Insert work_queue row.
+	completedStr := completedAt.UTC().Format(time.RFC3339)
+	var wqID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO work_queue (artist, title, outdir, filename, status, provider_lane, completed_at)
+		 VALUES (?, ?, ?, ?, 'done', ?, ?) RETURNING id`,
+		song.Track.ArtistName, song.Track.TrackName, outdir, testLRCFilename,
+		providerLane, completedStr,
+	).Scan(&wqID); err != nil {
+		t.Fatalf("insert work_queue: %v", err)
+	}
+
+	// Insert junction row.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+		wqID, srID); err != nil {
+		t.Fatalf("insert junction: %v", err)
+	}
+
+	// Insert lyrics_cache if a song is provided.
+	if song != nil && (song.Track.ISRC != "" || song.Track.RecordingMBID != "") {
+		encoded, err := json.Marshal(song)
+		if err != nil {
+			t.Fatalf("marshal song: %v", err)
+		}
+		// Cache keys are normalized (lowercase NFKC) - match what CacheRepo.Store writes.
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT OR REPLACE INTO lyrics_cache (artist, title, duration_bucket, lyrics)
+			 VALUES (?, ?, 0, ?)`,
+			normalize.NormalizeKey(song.Track.ArtistName),
+			normalize.NormalizeKey(song.Track.TrackName),
+			string(encoded),
+		); err != nil {
+			t.Fatalf("insert lyrics_cache: %v", err)
+		}
+	}
+}
+
+// writeLRCFile writes a minimal .lrc file at the given path for backfill tests.
+func writeLRCFile(t *testing.T, path string) {
+	t.Helper()
+	content := "[by:mxlrcgo-svc]\n[ar:Test Artist]\n[ti:Test Track]\n[00:01.00]Hello world\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write lrc: %v", err)
+	}
+}
+
+func TestProvenanceSchemaQuery(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{
+		Track: models.Track{
+			ArtistName:    "Test Artist",
+			TrackName:     "Test Track",
+			ISRC:          "USRC12345678",
+			RecordingMBID: "abcd1234-0000-0000-0000-000000000000",
+		},
+	}
+
+	seedProvenanceDB(t, sqlDB, outdir, "musixmatch", completedAt, song)
+
+	// Run the schema query that lookupPlan uses.
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	dir := filepath.Dir(lrcPath)
+	base := filepath.Base(lrcPath)
+
+	var artist, title string
+	var providerLane, completedAtStr sql.NullString
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT wq.artist, wq.title, wq.provider_lane, wq.completed_at
+		FROM work_queue wq
+		JOIN work_queue_scan_results wqsr ON wqsr.work_queue_id = wq.id
+		JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+		WHERE sr.outdir = ? AND sr.filename = ?
+		  AND wq.status = 'done'
+		ORDER BY wq.id DESC
+		LIMIT 1`,
+		dir, base,
+	).Scan(&artist, &title, &providerLane, &completedAtStr)
+	if err != nil {
+		t.Fatalf("schema query: %v", err)
+	}
+
+	if artist != "Test Artist" {
+		t.Errorf("artist=%q, want %q", artist, "Test Artist")
+	}
+	if !providerLane.Valid || providerLane.String != "musixmatch" {
+		t.Errorf("provider_lane=%v, want musixmatch", providerLane)
+	}
+	if !completedAtStr.Valid {
+		t.Error("completed_at is NULL, want non-null")
+	}
+
+	// Verify ISRC/MBID come through from lyrics_cache.
+	isrc, mbid := lyricsISRCMBID(ctx, sqlDB, artist, title)
+	if isrc != "USRC12345678" {
+		t.Errorf("isrc=%q, want USRC12345678", isrc)
+	}
+	if mbid != "abcd1234-0000-0000-0000-000000000000" {
+		t.Errorf("mbid=%q, want abcd1234-...", mbid)
+	}
+}
+
+// TestLookupPlan_OutdirNormalization verifies NEW-2: lookupPlan matches the
+// stored scan_results.outdir against the query path's directory by a CANONICAL
+// form, so a stored outdir that differs only by a trailing slash / redundant
+// "." segment (uncleaned, as a relative-vs-absolute or sloppily-stored path
+// would be) still resolves. Before the fix the exact `sr.outdir = ?` compare
+// returned 0 rows and the file was silently counted as skipped.
+func TestLookupPlan_OutdirNormalization(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	realDir := t.TempDir()
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{
+		Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"},
+	}
+
+	// Seed with a stored outdir that differs from the cleaned query directory
+	// only by a trailing separator plus a redundant "." segment - an exact
+	// string compare against the cleaned query dir would not match.
+	storedOutdir := realDir + string(filepath.Separator) + "." + string(filepath.Separator)
+	seedProvenanceDB(t, sqlDB, storedOutdir, "musixmatch", completedAt, song)
+
+	lrcPath := filepath.Join(realDir, testLRCFilename)
+
+	// Precondition: the old exact-match query finds nothing for this seed, so a
+	// success below is attributable to the canonical-dir normalization.
+	var n int
+	if err := sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM scan_results sr
+		WHERE sr.outdir = ? AND sr.filename = ?`,
+		filepath.Dir(lrcPath), testLRCFilename,
+	).Scan(&n); err != nil {
+		t.Fatalf("precondition count query: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("precondition: expected 0 exact-match rows for uncleaned outdir, got %d", n)
+	}
+
+	plan, ok := lookupPlan(ctx, sqlDB, lrcPath)
+	if !ok {
+		t.Fatal("lookupPlan returned ok=false; expected canonical outdir match to succeed")
+	}
+	if plan.Path != lrcPath {
+		t.Errorf("plan.Path=%q, want %q", plan.Path, lrcPath)
+	}
+}
+
+func TestBackfillPlansFromPaths_Basic(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	writeLRCFile(t, lrcPath)
+
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"}}
+	seedProvenanceDB(t, sqlDB, outdir, "musixmatch", completedAt, song)
+
+	plans, skipped, err := backfillPlansFromPaths(ctx, sqlDB, []string{outdir})
+	if err != nil {
+		t.Fatalf("backfillPlansFromPaths: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("len(plans)=%d, want 1", len(plans))
+	}
+	if skipped != 0 {
+		t.Errorf("skipped=%d, want 0 for a matched file", skipped)
+	}
+	if plans[0].Path != lrcPath {
+		t.Errorf("plan.Path=%q, want %q", plans[0].Path, lrcPath)
+	}
+	if plans[0].Tags.Source != "musixmatch" {
+		t.Errorf("Tags.Source=%q, want musixmatch", plans[0].Tags.Source)
+	}
+}
+
+func TestBackfillPlansFromDB_Basic(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	writeLRCFile(t, lrcPath)
+
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"}}
+	seedProvenanceDB(t, sqlDB, outdir, "musixmatch", completedAt, song)
+
+	plans, _, err := backfillPlansFromDB(ctx, sqlDB)
+	if err != nil {
+		t.Fatalf("backfillPlansFromDB: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("len(plans)=%d, want 1", len(plans))
+	}
+	if plans[0].Tags.Source != "musixmatch" {
+		t.Errorf("Tags.Source=%q, want musixmatch", plans[0].Tags.Source)
+	}
+}
+
+func TestRunProvenanceBackfill_YesGuard(t *testing.T) {
+	ctx := context.Background()
+	tmpDB := filepath.Join(t.TempDir(), "test.db")
+	sqlDB, err := db.Open(ctx, tmpDB)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	writeLRCFile(t, lrcPath)
+
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"}}
+	seedProvenanceDB(t, sqlDB, outdir, "musixmatch", completedAt, song)
+	_ = sqlDB.Close() // close before runProvenanceBackfill opens its own connection
+
+	// Without --yes: plan output, no file modification.
+	originalContent, _ := os.ReadFile(lrcPath)
+
+	var out bytes.Buffer
+	cfg := makeTempConfig(t, tmpDB)
+	code := runProvenanceBackfill(ctx, &out, ProvenanceBackfillCmd{
+		ConfigPath: cfg,
+		Paths:      []string{outdir},
+		Yes:        false,
+	})
+	if code != 0 {
+		t.Fatalf("without --yes: exit=%d, output=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "pass --yes") {
+		t.Errorf("without --yes: expected 'pass --yes' in output, got: %s", out.String())
+	}
+	afterContent, _ := os.ReadFile(lrcPath)
+	if string(afterContent) != string(originalContent) {
+		t.Error("without --yes: file was modified")
+	}
+
+	// With --yes: file is modified.
+	out.Reset()
+	code = runProvenanceBackfill(ctx, &out, ProvenanceBackfillCmd{
+		ConfigPath: cfg,
+		Paths:      []string{outdir},
+		Yes:        true,
+	})
+	if code != 0 {
+		t.Fatalf("with --yes: exit=%d, output=%s", code, out.String())
+	}
+	afterYesContent, _ := os.ReadFile(lrcPath)
+	if string(afterYesContent) == string(originalContent) {
+		t.Error("with --yes: file was not modified")
+	}
+	if !strings.Contains(string(afterYesContent), "[source:musixmatch]") {
+		t.Errorf("with --yes: expected [source:musixmatch] in file, got:\n%s", string(afterYesContent))
+	}
+}
+
+func TestRunProvenanceBackfill_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	tmpDB := filepath.Join(t.TempDir(), "test.db")
+	sqlDB, err := db.Open(ctx, tmpDB)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	writeLRCFile(t, lrcPath)
+
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"}}
+	seedProvenanceDB(t, sqlDB, outdir, "musixmatch", completedAt, song)
+	_ = sqlDB.Close() // close before runProvenanceBackfill opens its own connection
+
+	cfg := makeTempConfig(t, tmpDB)
+	args := ProvenanceBackfillCmd{ConfigPath: cfg, Paths: []string{outdir}, Yes: true}
+
+	var out1 bytes.Buffer
+	if code := runProvenanceBackfill(ctx, &out1, args); code != 0 {
+		t.Fatalf("first run: exit=%d, output=%s", code, out1.String())
+	}
+	after1, _ := os.ReadFile(lrcPath)
+
+	var out2 bytes.Buffer
+	if code := runProvenanceBackfill(ctx, &out2, args); code != 0 {
+		t.Fatalf("second run: exit=%d, output=%s", code, out2.String())
+	}
+	after2, _ := os.ReadFile(lrcPath)
+
+	if string(after1) != string(after2) {
+		t.Error("second run modified the file (not idempotent)")
+	}
+
+	// No duplicate [source:] tags.
+	count := strings.Count(string(after2), "[source:")
+	if count > 1 {
+		t.Errorf("duplicate [source:] tags after second run: %d", count)
+	}
+}
+
+func TestRunProvenanceBackfill_LRCOnly(t *testing.T) {
+	ctx := context.Background()
+	tmpDB := filepath.Join(t.TempDir(), "test.db")
+	sqlDB, err := db.Open(ctx, tmpDB)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// No data to seed; just ensure migrations ran, then close so the command opens its own connection.
+	_ = sqlDB.Close()
+
+	// Put a .txt file in the directory - it should not be processed.
+	outdir := t.TempDir()
+	txtPath := filepath.Join(outdir, "track.txt")
+	if err := os.WriteFile(txtPath, []byte("instrumental\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := makeTempConfig(t, tmpDB)
+	var out bytes.Buffer
+	code := runProvenanceBackfill(ctx, &out, ProvenanceBackfillCmd{
+		ConfigPath: cfg,
+		Paths:      []string{outdir},
+		Yes:        true,
+	})
+	// Should succeed with no files processed (txt ignored); exit 0 = no errors.
+	if code != 0 {
+		t.Fatalf("exit=%d, output=%s", code, out.String())
+	}
+}
+
+func TestRunProvenanceBackfill_PartialCoverage(t *testing.T) {
+	ctx := context.Background()
+	tmpDB := filepath.Join(t.TempDir(), "test.db")
+	sqlDB, err := db.Open(ctx, tmpDB)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, testLRCFilename)
+	writeLRCFile(t, lrcPath)
+
+	// provider_lane is NULL -> partial coverage (no [source:] available).
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := &models.Song{Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"}}
+	seedProvenanceDB(t, sqlDB, outdir, "", completedAt, song) // empty lane = partial
+	_ = sqlDB.Close()                                         // close before runProvenanceBackfill opens its own connection
+
+	cfg := makeTempConfig(t, tmpDB)
+	var out bytes.Buffer
+	code := runProvenanceBackfill(ctx, &out, ProvenanceBackfillCmd{
+		ConfigPath: cfg,
+		Paths:      []string{outdir},
+		Yes:        false, // plan only
+	})
+	if code != 0 {
+		t.Fatalf("exit=%d, output=%s", code, out.String())
+	}
+	// Should report partial coverage.
+	if !strings.Contains(out.String(), "partial") {
+		t.Errorf("expected 'partial' in plan output, got: %s", out.String())
+	}
+}
+
+func TestRunProvenance_MissingSubcommand(t *testing.T) {
+	var out bytes.Buffer
+	code := runProvenance(context.Background(), &out, ProvenanceCmd{})
+	if code != 2 {
+		t.Errorf("exit=%d, want 2", code)
+	}
+	if !strings.Contains(out.String(), "missing") {
+		t.Errorf("expected 'missing' in output, got: %s", out.String())
+	}
+}
+
+func TestResolveOutputPaths(t *testing.T) {
+	tests := []struct {
+		name                              string
+		outdir, filename, outputPathsJSON string
+		wantLen                           int
+		wantFirst                         string
+	}{
+		{
+			name:   "empty json falls back to outdir/filename",
+			outdir: "/music", filename: "track.lrc", outputPathsJSON: "",
+			wantLen: 1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+		{
+			name:   "null json falls back",
+			outdir: "/music", filename: "track.lrc", outputPathsJSON: "null",
+			wantLen: 1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+		{
+			name:   "empty array falls back",
+			outdir: "/music", filename: "track.lrc", outputPathsJSON: "[]",
+			wantLen: 1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+		{
+			name:   "valid json output_paths overrides outdir/filename",
+			outdir: "/ignored", filename: "ignored.lrc",
+			outputPathsJSON: `[{"outdir":"/music","filename":"track.lrc"}]`,
+			wantLen:         1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+		{
+			name:   "invalid json falls back to outdir/filename",
+			outdir: "/music", filename: "track.lrc", outputPathsJSON: "{bad",
+			wantLen: 1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+		{
+			name:   "empty outdir and filename returns nil",
+			outdir: "", filename: "", outputPathsJSON: "",
+			wantLen: 0,
+		},
+		{
+			name:   "json entry with no outdir is skipped; fallback used",
+			outdir: "/music", filename: "track.lrc",
+			outputPathsJSON: `[{"filename":"track.lrc"}]`,
+			wantLen:         1, wantFirst: filepath.Join("/music", "track.lrc"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveOutputPaths(tc.outdir, tc.filename, tc.outputPathsJSON)
+			if len(got) != tc.wantLen {
+				t.Fatalf("resolveOutputPaths: got %v (len %d), want len %d", got, len(got), tc.wantLen)
+			}
+			if tc.wantLen > 0 && got[0] != tc.wantFirst {
+				t.Errorf("got[0]=%q, want %q", got[0], tc.wantFirst)
+			}
+		})
+	}
+}
+
+func TestBackfillPlansFromPaths_StatError(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	nonExistent := filepath.Join(t.TempDir(), "no-such-subdir")
+	_, _, err = backfillPlansFromPaths(ctx, sqlDB, []string{nonExistent})
+	if err == nil {
+		t.Error("expected error for non-existent path, got nil")
+	}
+}
+
+// TestBackfillPlansFromPaths_SkippedCount asserts MAJOR-2: .lrc files with no
+// matching DB row are counted as skipped, not silently dropped.
+func TestBackfillPlansFromPaths_SkippedCount(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	// Write an .lrc file with no matching DB row (orphan).
+	orphanPath := filepath.Join(outdir, "orphan.lrc")
+	writeLRCFile(t, orphanPath)
+
+	plans, skipped, err := backfillPlansFromPaths(ctx, sqlDB, []string{outdir})
+	if err != nil {
+		t.Fatalf("backfillPlansFromPaths: %v", err)
+	}
+	if len(plans) != 0 {
+		t.Errorf("expected 0 plans for orphan file, got %d", len(plans))
+	}
+	if skipped != 1 {
+		t.Errorf("expected skipped=1, got %d", skipped)
+	}
+}
+
+// seedDualFormatDB inserts two scan_results rows that share the same (outdir, filename)
+// linked to ONE work_queue row - the DUAL-FORMAT SINGLE-TRACK case
+// (e.g. song.flac + song.mp3 both map to song.lrc; only one wq row exists per
+// artist+title due to the unique index, but both scan_result rows join through it).
+// This is NOT a collision: the join returns two rows for ONE distinct work_queue id,
+// so lookupPlan must tag it normally (ok=true).
+func seedDualFormatDB(t *testing.T, sqlDB *sql.DB, outdir, lrcFilename string) {
+	t.Helper()
+	ctx := context.Background()
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339)
+
+	var libID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?) RETURNING id`,
+		outdir, "test-lib").Scan(&libID); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+
+	// One work_queue row (unique per artist+title).
+	var wqID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO work_queue (artist, title, outdir, filename, status, provider_lane, completed_at)
+		 VALUES (?, ?, ?, ?, 'done', 'musixmatch', ?) RETURNING id`,
+		"Test Artist", "Test Track", outdir, lrcFilename, completedAt,
+	).Scan(&wqID); err != nil {
+		t.Fatalf("insert work_queue: %v", err)
+	}
+
+	// Two scan_results pointing to different audio files but the same output .lrc.
+	for _, audioFile := range []string{"song.flac", "song.mp3"} {
+		var srID int64
+		if err := sqlDB.QueryRowContext(ctx,
+			`INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
+			 VALUES (?, ?, ?, ?, ?, ?, 'done') RETURNING id`,
+			libID, filepath.Join(outdir, audioFile),
+			"Test Artist", "Test Track", outdir, lrcFilename,
+		).Scan(&srID); err != nil {
+			t.Fatalf("insert scan_result for %s: %v", audioFile, err)
+		}
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+			wqID, srID); err != nil {
+			t.Fatalf("insert junction for %s: %v", audioFile, err)
+		}
+	}
+}
+
+// seedAmbiguousDB inserts TWO DISTINCT work_queue rows (different artist+title)
+// each linked to its own scan_results row that points at the SAME output .lrc.
+// This is the genuine cross-attribution collision: two distinct tracks both
+// claim one .lrc file, so lookupPlan must warn + skip (ok=false).
+func seedAmbiguousDB(t *testing.T, sqlDB *sql.DB, outdir, lrcFilename string) {
+	t.Helper()
+	ctx := context.Background()
+	completedAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC).UTC().Format(time.RFC3339)
+
+	var libID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?) RETURNING id`,
+		outdir, "test-lib").Scan(&libID); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+
+	tracks := []struct{ artist, title, audioFile string }{
+		{"Artist One", "Track One", "one.flac"},
+		{"Artist Two", "Track Two", "two.flac"},
+	}
+	for _, tr := range tracks {
+		// Set artist_key/title_key explicitly so the two distinct tracks do not
+		// collide on the (artist_key, title_key) unique index (these columns
+		// default to '' and are not auto-populated on a plain INSERT).
+		var wqID int64
+		if err := sqlDB.QueryRowContext(ctx,
+			`INSERT INTO work_queue (artist, title, artist_key, title_key, outdir, filename, status, provider_lane, completed_at)
+			 VALUES (?, ?, normalize_key(?), normalize_key(?), ?, ?, 'done', 'musixmatch', ?) RETURNING id`,
+			tr.artist, tr.title, tr.artist, tr.title, outdir, lrcFilename, completedAt,
+		).Scan(&wqID); err != nil {
+			t.Fatalf("insert work_queue for %s: %v", tr.artist, err)
+		}
+		var srID int64
+		if err := sqlDB.QueryRowContext(ctx,
+			`INSERT INTO scan_results (library_id, file_path, artist, title, outdir, filename, status)
+			 VALUES (?, ?, ?, ?, ?, ?, 'done') RETURNING id`,
+			libID, filepath.Join(outdir, tr.audioFile),
+			tr.artist, tr.title, outdir, lrcFilename,
+		).Scan(&srID); err != nil {
+			t.Fatalf("insert scan_result for %s: %v", tr.artist, err)
+		}
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+			wqID, srID); err != nil {
+			t.Fatalf("insert junction for %s: %v", tr.artist, err)
+		}
+	}
+}
+
+// TestLookupPlan_AmbiguousCollision asserts MAJOR-3 / NEW-1 (path mode): when the
+// same (outdir, filename) maps to more than one DISTINCT work_queue row,
+// lookupPlan returns false (warn+skip) instead of silently picking one.
+func TestLookupPlan_AmbiguousCollision(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, "song.lrc")
+	writeLRCFile(t, lrcPath)
+	seedAmbiguousDB(t, sqlDB, outdir, "song.lrc")
+
+	plan, ok := lookupPlan(ctx, sqlDB, lrcPath)
+	if ok {
+		t.Errorf("lookupPlan returned ok=true for ambiguous collision; plan=%+v", plan)
+	}
+	_ = plan // silence unused warning
+}
+
+// TestLookupPlan_DualFormatSingleTrack asserts NEW-1 (path mode): one track
+// released in two audio formats (one work_queue row, two scan_results rows at the
+// same .lrc) is unambiguous - lookupPlan must build the plan (ok=true) with the
+// correct provenance, matching what DB mode produces for the same data.
+func TestLookupPlan_DualFormatSingleTrack(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, "song.lrc")
+	writeLRCFile(t, lrcPath)
+	seedDualFormatDB(t, sqlDB, outdir, "song.lrc")
+
+	plan, ok := lookupPlan(ctx, sqlDB, lrcPath)
+	if !ok {
+		t.Fatalf("lookupPlan returned ok=false for dual-format single track; want ok=true")
+	}
+	if plan.Path != lrcPath {
+		t.Errorf("plan.Path=%q, want %q", plan.Path, lrcPath)
+	}
+	if plan.Tags.Source != "musixmatch" {
+		t.Errorf("plan.Tags.Source=%q, want musixmatch", plan.Tags.Source)
+	}
+	if plan.Tags.Fetched == "" {
+		t.Error("plan.Tags.Fetched is empty, want the completed_at timestamp")
+	}
+	if plan.Partial {
+		t.Error("plan.Partial=true, want false (source + fetched both present)")
+	}
+}
+
+// TestBackfillPlansFromDB_CollisionProducesOnePlan asserts MAJOR-3 (DB mode): the
+// same-stem setup (two scan_results linked to one work_queue row) produces exactly
+// one plan in DB mode because the work_queue schema enforces one row per
+// artist+title. DB-mode provenance comes from the wq row directly, so no
+// cross-attribution is possible even with two scan_results.
+func TestBackfillPlansFromDB_CollisionProducesOnePlan(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	outdir := t.TempDir()
+	lrcPath := filepath.Join(outdir, "song.lrc")
+	writeLRCFile(t, lrcPath)
+	seedDualFormatDB(t, sqlDB, outdir, "song.lrc")
+
+	plans, skipped, err := backfillPlansFromDB(ctx, sqlDB)
+	if err != nil {
+		t.Fatalf("backfillPlansFromDB: %v", err)
+	}
+	// DB mode iterates work_queue rows (one row per artist+title); even with two
+	// scan_results linked, the provenance data is unambiguous and one plan is built.
+	if len(plans) != 1 {
+		t.Errorf("expected 1 plan from unambiguous wq row, got %d", len(plans))
+	}
+	if skipped != 0 {
+		t.Errorf("expected skipped=0, got %d", skipped)
+	}
+	if len(plans) > 0 && plans[0].Tags.Source != "musixmatch" {
+		t.Errorf("Tags.Source=%q, want musixmatch", plans[0].Tags.Source)
+	}
+	_ = lrcPath
+}
+
+// makeTempConfig creates a minimal TOML config file pointing at the given DB path.
+func makeTempConfig(t *testing.T, dbPath string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	content := "[db]\npath = \"" + dbPath + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,29 +1,25 @@
 package commands
 
-import "fmt"
+import appversion "github.com/sydlexius/mxlrcgo-svc/internal/version"
 
-// Build-time version metadata. These defaults are overridden at release time by
-// GoReleaser via -ldflags "-X .../internal/commands.version=..." (see the
-// builds section of .goreleaser.yml). A plain `go build`, `go run`, or the
-// nightly/CVE-scan image leaves the defaults, so a non-release binary reports a
-// clear "dev" marker instead of masquerading as a tagged version.
+// version, commit, and date mirror internal/version's build-time vars so
+// callers within this package (e.g. server.WithWebUIIf, version_test.go) can
+// use them without importing internal/version directly. Values are injected via
+// ldflags into internal/version at release time; see .goreleaser.yml.
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	version = appversion.Version
+	commit  = appversion.Commit
+	date    = appversion.Date
 )
 
-// VersionString renders the single line printed for --version.
-func VersionString() string {
-	return fmt.Sprintf("mxlrcgo-svc %s (commit %s, built %s)", version, commit, date)
-}
+// VersionString delegates to internal/version so the rest of the codebase
+// can read the app version without importing internal/commands.
+func VersionString() string { return appversion.VersionString() }
 
 // Version implements go-arg's Versioned interface for the subcommand-aware
 // parser, so `mxlrcgo-svc <cmd> --version` is recognized.
-func (Args) Version() string { return VersionString() }
+func (Args) Version() string { return appversion.VersionString() }
 
 // Version implements go-arg's Versioned interface for the legacy (no
-// subcommand) parser, so top-level `mxlrcgo-svc --version` works too. Both
-// parse targets need the method because Run selects the target based on whether
-// the first argument names a subcommand.
-func (LegacyArgs) Version() string { return VersionString() }
+// subcommand) parser, so top-level `mxlrcgo-svc --version` works too.
+func (LegacyArgs) Version() string { return appversion.VersionString() }

--- a/internal/db/migrations/021_scan_results_output_idx.sql
+++ b/internal/db/migrations/021_scan_results_output_idx.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Index to accelerate the provenance backfill lookup: given an .lrc file path,
+-- the query searches by filename alone, then filters the directory canonically
+-- in Go. A filename-leading index lets SQLite seek directly from the query's
+-- filename=? predicate at plan time (a composite index can only be searched by
+-- its leading column). A plain index (no WHERE predicate) is used so the
+-- planner can match it from a bound parameter; outdir is kept as a trailing
+-- column to narrow the seek without being part of the predicate.
+CREATE INDEX IF NOT EXISTS idx_scan_results_filename_outdir
+    ON scan_results(filename, outdir);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_scan_results_filename_outdir;
+-- +goose StatementEnd

--- a/internal/lyrics/fsync.go
+++ b/internal/lyrics/fsync.go
@@ -1,0 +1,30 @@
+package lyrics
+
+import (
+	"log/slog"
+	"os"
+)
+
+// fsyncDir flushes the directory entry for dir to stable storage so that a
+// rename into it (the final step of our atomic write/rewrite) survives a hard
+// crash. The temp file's data is already Sync'd before the rename; this fsyncs
+// the parent so the rename itself is durable.
+//
+// NEW-3: a failure here is non-fatal and durability-only - the rename has
+// already succeeded, so the new content is visible; only crash-durability is at
+// risk. On platforms where opening a directory for sync is unsupported (e.g.
+// Windows), the open or Sync call fails and we warn + continue rather than
+// failing the whole operation.
+func fsyncDir(dir string) {
+	d, err := os.Open(dir) //nolint:gosec // dir is the parent of a caller-controlled output path already validated upstream
+	if err != nil {
+		slog.Warn("fsync parent dir: open failed (durability-only, continuing)", "dir", dir, "error", err)
+		return
+	}
+	if serr := d.Sync(); serr != nil {
+		slog.Warn("fsync parent dir: sync failed (durability-only, continuing)", "dir", dir, "error", serr)
+	}
+	if cerr := d.Close(); cerr != nil {
+		slog.Warn("fsync parent dir: close failed", "dir", dir, "error", cerr)
+	}
+}

--- a/internal/lyrics/parser.go
+++ b/internal/lyrics/parser.go
@@ -1,0 +1,258 @@
+package lyrics
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProvenanceTags holds the tag key-value pairs to inject into an LRC header.
+// A zero-value field means "skip this tag". Existing tags with the same key
+// are never overwritten (S4 idempotency rule).
+type ProvenanceTags struct {
+	Source  string // [source:] tag
+	Fetched string // [fetched:] tag (RFC3339)
+	ISRC    string // [isrc:] tag
+	MBID    string // [mbid:] tag
+	// Ve is intentionally absent: [ve:] is skipped on backfilled files (DC4).
+}
+
+// lrcTag represents a parsed LRC header tag.
+type lrcTag struct {
+	key   string
+	value string
+	raw   string // original line as-is
+}
+
+// parseLRCHeader reads a file and returns (headerTags, lyricLines, error).
+// headerTags holds parsed tag lines from the leading block; lyricLines holds
+// the rest of the file verbatim. The split point is the first line that is NOT
+// an LRC tag (i.e. does not match [key:value]). Blank lines before the first
+// non-tag line are considered part of the header.
+func parseLRCHeader(path string) ([]lrcTag, []string, error) {
+	f, err := os.Open(path) //nolint:gosec // path comes from caller-controlled file enumeration
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var tags []lrcTag
+	var lyrics []string
+	inHeader := true
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if inHeader {
+			if tag, ok := parseTagLine(line); ok {
+				tags = append(tags, tag)
+				continue
+			}
+			if strings.TrimSpace(line) == "" && len(lyrics) == 0 {
+				// blank line in header block - treat as header
+				tags = append(tags, lrcTag{raw: line})
+				continue
+			}
+			inHeader = false
+		}
+		lyrics = append(lyrics, line)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan %s: %w", path, err)
+	}
+	return tags, lyrics, nil
+}
+
+// parseTagLine parses a single LRC tag line of the form [key:value].
+// Returns (tag, true) on success or (zero, false) if the line is not a tag.
+func parseTagLine(line string) (lrcTag, bool) {
+	s := strings.TrimSpace(line)
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		return lrcTag{}, false
+	}
+	inner := s[1 : len(s)-1]
+	// Lyric lines like [01:23.45]text are NOT header tags. A header tag has
+	// a non-numeric first character in the key portion.
+	idx := strings.IndexByte(inner, ':')
+	if idx <= 0 {
+		return lrcTag{}, false
+	}
+	key := inner[:idx]
+	// If key starts with a digit it is a timestamp line, not a tag.
+	if key[0] >= '0' && key[0] <= '9' {
+		return lrcTag{}, false
+	}
+	value := inner[idx+1:]
+	return lrcTag{key: key, value: value, raw: line}, true
+}
+
+// sanitizeTagValue strips ']' and newline characters from a provenance tag
+// value so a crafted value cannot break out of the [key:value] format.
+func sanitizeTagValue(v string) string {
+	v = strings.ReplaceAll(v, "]", "")
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "\n", "")
+	return v
+}
+
+// InjectProvenance injects the given provenance tags into the LRC file at path,
+// skipping any tag whose key already exists in the file (idempotent per S4).
+// The rewrite is atomic: a temp file in the same directory is written and
+// renamed over path only on complete success. Only the header block is modified;
+// lyric lines are preserved verbatim. The file must be a .lrc file.
+//
+// Returns (injected, skipped, error) where injected counts tags added and
+// skipped counts tags that already existed and were left untouched.
+func InjectProvenance(path string, pt ProvenanceTags) (injected, skipped int, err error) {
+	if strings.ToLower(filepath.Ext(path)) != ".lrc" {
+		return 0, 0, fmt.Errorf("not an LRC file: %s", path)
+	}
+
+	// Lstat to detect symlinks (MINOR-5) and capture original permissions (MAJOR-1).
+	fi, err := os.Lstat(path) //nolint:gosec // path is caller-controlled
+	if err != nil {
+		return 0, 0, fmt.Errorf("lstat %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		slog.Warn("backfill: skipping symlink .lrc", "path", path)
+		return 0, 0, nil
+	}
+	origMode := fi.Mode().Perm()
+
+	// Detect original line endings and trailing-newline state (MINOR-6).
+	rawContent, err := os.ReadFile(path) //nolint:gosec // path is caller-controlled
+	if err != nil {
+		return 0, 0, fmt.Errorf("read %s: %w", path, err)
+	}
+	eol := "\n"
+	if bytes.Contains(rawContent, []byte("\r\n")) {
+		eol = "\r\n"
+	}
+	hasTrailingNL := len(rawContent) > 0 && rawContent[len(rawContent)-1] == '\n'
+	existingTags, lyricsLines, err := parseLRCHeader(path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Build a set of keys already present in the header (NIT-13: case-insensitive).
+	existing := make(map[string]bool, len(existingTags))
+	for _, t := range existingTags {
+		if t.key != "" {
+			existing[strings.ToLower(t.key)] = true
+		}
+	}
+
+	// Build the list of candidate tags to inject (MINOR-10: sanitize values).
+	type candidate struct{ key, value string }
+	candidates := []candidate{
+		{"source", sanitizeTagValue(pt.Source)},
+		{"fetched", sanitizeTagValue(pt.Fetched)},
+		{"isrc", sanitizeTagValue(pt.ISRC)},
+		{"mbid", sanitizeTagValue(pt.MBID)},
+	}
+
+	var toAdd []lrcTag
+	for _, c := range candidates {
+		if c.value == "" {
+			continue
+		}
+		if existing[c.key] {
+			skipped++
+			continue
+		}
+		toAdd = append(toAdd, lrcTag{
+			key:   c.key,
+			value: c.value,
+			raw:   fmt.Sprintf("[%s:%s]", c.key, c.value),
+		})
+		injected++
+	}
+
+	if injected == 0 {
+		return 0, skipped, nil
+	}
+
+	// MINOR-7: insert new tags before the first blank header entry so they land
+	// within the tag block, not after the blank line that precedes lyric lines.
+	insertIdx := len(existingTags)
+	for i, t := range existingTags {
+		if t.key == "" {
+			insertIdx = i
+			break
+		}
+	}
+
+	// Build the ordered output line list.
+	var outLines []string
+	for _, t := range existingTags[:insertIdx] {
+		outLines = append(outLines, t.raw)
+	}
+	for _, t := range toAdd {
+		outLines = append(outLines, t.raw)
+	}
+	for _, t := range existingTags[insertIdx:] {
+		outLines = append(outLines, t.raw)
+	}
+	outLines = append(outLines, lyricsLines...)
+
+	// Atomic rewrite: write to a temp file, then rename.
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, base+".*.tmp") //nolint:gosec // path is caller-controlled
+	if err != nil {
+		return 0, 0, fmt.Errorf("create temp for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	tmpClosed := false
+	defer func() {
+		if !tmpClosed {
+			_ = tmp.Close()
+		}
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	buf := bufio.NewWriter(tmp)
+
+	// Write output lines preserving original line endings (MINOR-6).
+	for i, line := range outLines {
+		isLast := i == len(outLines)-1
+		var werr error
+		if isLast && !hasTrailingNL {
+			_, werr = fmt.Fprint(buf, line)
+		} else {
+			_, werr = fmt.Fprint(buf, line+eol)
+		}
+		if werr != nil {
+			return 0, 0, fmt.Errorf("write line: %w", werr)
+		}
+	}
+
+	if err = buf.Flush(); err != nil {
+		return 0, 0, fmt.Errorf("flush %s: %w", tmpPath, err)
+	}
+	// MINOR-4: sync data to disk before rename for durability.
+	if err = tmp.Sync(); err != nil {
+		return 0, 0, fmt.Errorf("sync %s: %w", tmpPath, err)
+	}
+	if err = tmp.Close(); err != nil {
+		return 0, 0, fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	tmpClosed = true
+
+	// MAJOR-1: restore original file permissions instead of hardcoding 0666.
+	if err = os.Chmod(tmpPath, origMode); err != nil { //nolint:gosec // mode copied from original
+		return 0, 0, fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return 0, 0, fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	// NEW-3: fsync the parent dir so the rename is durable across a hard crash.
+	fsyncDir(dir)
+	return injected, skipped, nil
+}

--- a/internal/lyrics/parser_test.go
+++ b/internal/lyrics/parser_test.go
@@ -1,0 +1,581 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+)
+
+// writeTestLRC is a helper that writes a minimal synced LRC file containing
+// the provided extra header tags plus a fixed lyric line, for parser tests.
+func writeTestLRC(t *testing.T, dir string, extraTags []string, lyricLines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, "track.lrc")
+	var sb strings.Builder
+	sb.WriteString("[by:mxlrcgo-svc]\n")
+	sb.WriteString("[ar:Test Artist]\n")
+	sb.WriteString("[ti:Test Track]\n")
+	for _, tag := range extraTags {
+		sb.WriteString(tag + "\n")
+	}
+	for _, line := range lyricLines {
+		sb.WriteString(line + "\n")
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		t.Fatalf("writeTestLRC: %v", err)
+	}
+	return path
+}
+
+func TestParseTagLine(t *testing.T) {
+	tests := []struct {
+		line    string
+		wantKey string
+		wantVal string
+		wantOK  bool
+	}{
+		{"[ar:Test Artist]", "ar", "Test Artist", true},
+		{"[source:musixmatch]", "source", "musixmatch", true},
+		{"[fetched:2024-01-02T03:04:05Z]", "fetched", "2024-01-02T03:04:05Z", true},
+		{"[isrc:USRC12345678]", "isrc", "USRC12345678", true},
+		{"[mbid:12345678-1234-1234-1234-123456789abc]", "mbid", "12345678-1234-1234-1234-123456789abc", true},
+		{"[01:23.45]lyric line", "", "", false}, // timestamp line, not a tag
+		{"not a tag", "", "", false},
+		{"[nocolon]", "", "", false},
+		{"", "", "", false},
+		{"  [by:mxlrcgo-svc]  ", "by", "mxlrcgo-svc", true}, // leading/trailing whitespace
+	}
+	for _, tc := range tests {
+		tag, ok := parseTagLine(tc.line)
+		if ok != tc.wantOK {
+			t.Errorf("parseTagLine(%q): got ok=%v, want %v", tc.line, ok, tc.wantOK)
+			continue
+		}
+		if ok {
+			if tag.key != tc.wantKey {
+				t.Errorf("parseTagLine(%q): key=%q, want %q", tc.line, tag.key, tc.wantKey)
+			}
+			if tag.value != tc.wantVal {
+				t.Errorf("parseTagLine(%q): value=%q, want %q", tc.line, tag.value, tc.wantVal)
+			}
+		}
+	}
+}
+
+func TestInjectProvenance_AddsNewTags(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello world"})
+
+	pt := ProvenanceTags{
+		Source:  "musixmatch",
+		Fetched: "2024-06-15T12:00:00Z",
+		ISRC:    "USRC12345678",
+		MBID:    "12345678-1234-1234-1234-123456789abc",
+	}
+	inj, skipped, err := InjectProvenance(path, pt)
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+	if inj != 4 {
+		t.Errorf("injected=%d, want 4", inj)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped=%d, want 0", skipped)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"[source:musixmatch]",
+		"[fetched:2024-06-15T12:00:00Z]",
+		"[isrc:USRC12345678]",
+		"[mbid:12345678-1234-1234-1234-123456789abc]",
+		"[00:01.00]Hello world",
+		"[by:mxlrcgo-svc]",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("result missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestInjectProvenance_SkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir,
+		[]string{"[source:petitlyrics]", "[isrc:GBRC12345678]"},
+		[]string{"[00:01.00]Hello"},
+	)
+
+	pt := ProvenanceTags{
+		Source:  "musixmatch",
+		Fetched: "2024-06-15T12:00:00Z",
+		ISRC:    "USRC12345678",
+		MBID:    "12345678-1234-1234-1234-123456789abc",
+	}
+	inj, skipped, err := InjectProvenance(path, pt)
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+	// source and isrc already exist -> skipped=2; fetched and mbid are new -> inj=2
+	if skipped != 2 {
+		t.Errorf("skipped=%d, want 2", skipped)
+	}
+	if inj != 2 {
+		t.Errorf("injected=%d, want 2", inj)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	// Original source tag must be preserved (not overwritten).
+	if !strings.Contains(content, "[source:petitlyrics]") {
+		t.Error("original [source:] tag was overwritten")
+	}
+	if strings.Contains(content, "[source:musixmatch]") {
+		t.Error("new [source:] tag was injected even though one already existed")
+	}
+	// Original isrc preserved.
+	if !strings.Contains(content, "[isrc:GBRC12345678]") {
+		t.Error("original [isrc:] tag was overwritten")
+	}
+}
+
+func TestInjectProvenance_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+
+	pt := ProvenanceTags{Source: "musixmatch", Fetched: "2024-06-15T12:00:00Z"}
+
+	inj1, _, err := InjectProvenance(path, pt)
+	if err != nil {
+		t.Fatalf("first inject: %v", err)
+	}
+	inj2, skipped2, err := InjectProvenance(path, pt)
+	if err != nil {
+		t.Fatalf("second inject: %v", err)
+	}
+	if inj2 != 0 {
+		t.Errorf("second inject: inj=%d, want 0 (idempotent)", inj2)
+	}
+	if skipped2 != inj1 {
+		t.Errorf("second inject: skipped=%d, want %d", skipped2, inj1)
+	}
+
+	// Verify no duplicate tags in the file.
+	data, _ := os.ReadFile(path)
+	lines := strings.Split(string(data), "\n")
+	seen := map[string]int{}
+	for _, l := range lines {
+		if tag, ok := parseTagLine(l); ok && tag.key != "" {
+			seen[tag.key]++
+		}
+	}
+	for k, n := range seen {
+		if n > 1 {
+			t.Errorf("duplicate tag [%s:] appears %d times", k, n)
+		}
+	}
+}
+
+func TestInjectProvenance_PreservesLyricContent(t *testing.T) {
+	dir := t.TempDir()
+	lyricLines := []string{
+		"[00:01.00]First line",
+		"[00:02.50]Second line",
+		"[00:04.00]Third line",
+	}
+	path := writeTestLRC(t, dir, nil, lyricLines)
+
+	_, _, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"})
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	for _, l := range lyricLines {
+		if !strings.Contains(content, l) {
+			t.Errorf("lyric line %q missing from result", l)
+		}
+	}
+}
+
+func TestInjectProvenance_LRCOnly(t *testing.T) {
+	dir := t.TempDir()
+	txtPath := filepath.Join(dir, "track.txt")
+	if err := os.WriteFile(txtPath, []byte("some content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := InjectProvenance(txtPath, ProvenanceTags{Source: "musixmatch"})
+	if err == nil {
+		t.Error("expected error for non-.lrc file, got nil")
+	}
+}
+
+func TestInjectProvenance_NoOpWhenNoTags(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+
+	inj, skipped, err := InjectProvenance(path, ProvenanceTags{}) // all empty
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+	if inj != 0 {
+		t.Errorf("inj=%d, want 0 for empty ProvenanceTags", inj)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped=%d, want 0 for empty ProvenanceTags", skipped)
+	}
+}
+
+// TestWriterProvenanceTags verifies that WriteLRC emits [source:], [fetched:],
+// [ve:], [isrc:], and [mbid:] when the Song fields are set.
+func TestWriterProvenanceTags(t *testing.T) {
+	w := NewLRCWriter()
+	dir := t.TempDir()
+
+	fetchTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:    "Test Artist",
+			TrackName:     "Test Track",
+			ISRC:          "USRC12345678",
+			RecordingMBID: "abcd1234-abcd-abcd-abcd-abcd12345678",
+		},
+		Subtitles: models.Synced{
+			Lines: []models.Lines{
+				{Text: "Hello", Time: models.Time{Minutes: 0, Seconds: 1, Hundredths: 0}},
+			},
+		},
+		WinningLane: "musixmatch",
+		FetchedAt:   fetchTime,
+	}
+
+	if err := w.WriteLRC(song, "track.lrc", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "track.lrc"))
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	content := string(data)
+
+	wantTags := []string{
+		"[source:musixmatch]",
+		"[fetched:2024-06-15T12:00:00Z]",
+		"[isrc:USRC12345678]",
+		"[mbid:abcd1234-abcd-abcd-abcd-abcd12345678]",
+		"[ve:",
+	}
+	for _, tag := range wantTags {
+		if !strings.Contains(content, tag) {
+			t.Errorf("missing tag %q in output:\n%s", tag, content)
+		}
+	}
+}
+
+// TestWriterProvenanceTags_AbsentWhenEmpty verifies that provenance tags are
+// NOT emitted when the corresponding Song fields are zero/empty.
+func TestWriterProvenanceTags_AbsentWhenEmpty(t *testing.T) {
+	w := NewLRCWriter()
+	dir := t.TempDir()
+
+	song := models.Song{
+		Track: models.Track{
+			ArtistName: "Test Artist",
+			TrackName:  "Test Track",
+		},
+		Subtitles: models.Synced{
+			Lines: []models.Lines{
+				{Text: "Hello", Time: models.Time{Minutes: 0, Seconds: 1, Hundredths: 0}},
+			},
+		},
+		// WinningLane, FetchedAt, ISRC, RecordingMBID all zero/empty
+	}
+
+	if err := w.WriteLRC(song, "track.lrc", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "track.lrc"))
+	content := string(data)
+
+	for _, tag := range []string{"[source:", "[fetched:", "[isrc:", "[mbid:"} {
+		if strings.Contains(content, tag) {
+			t.Errorf("unexpected tag %q in output when field is empty:\n%s", tag, content)
+		}
+	}
+}
+
+func TestParseLRCHeader_NotFound(t *testing.T) {
+	_, _, err := parseLRCHeader(filepath.Join(t.TempDir(), "nonexistent.lrc"))
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestInjectProvenance_ParseError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, file permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, _, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"})
+	if err == nil {
+		t.Error("expected error for unreadable file, got nil")
+	}
+}
+
+func TestInjectProvenance_AtomicWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, directory permission restrictions do not apply")
+	}
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+	original, _ := os.ReadFile(path)
+
+	// Make the directory read-only: os.CreateTemp cannot create new files,
+	// but the existing .lrc file remains readable via the execute bit.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	_, _, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"})
+	if err == nil {
+		t.Error("expected error when directory is read-only, got nil")
+	}
+
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("original file unreadable after failed inject: %v", readErr)
+	}
+	if string(after) != string(original) {
+		t.Error("original file was modified by failed inject")
+	}
+}
+
+// TestWriterRoundTrip writes a tagged .lrc and parses it back to verify the
+// header parser correctly identifies all tag keys and leaves lyric lines intact.
+func TestWriterRoundTrip(t *testing.T) {
+	w := NewLRCWriter()
+	dir := t.TempDir()
+
+	fetchTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:    "Round Trip",
+			TrackName:     "Test Song",
+			AlbumName:     "Test Album",
+			TrackLength:   180,
+			ISRC:          "USRC12345678",
+			RecordingMBID: "abcd1234-0000-0000-0000-000000000000",
+		},
+		Subtitles: models.Synced{
+			Lines: []models.Lines{
+				{Text: "Line one", Time: models.Time{Minutes: 0, Seconds: 1, Hundredths: 0}},
+				{Text: "Line two", Time: models.Time{Minutes: 0, Seconds: 5, Hundredths: 50}},
+			},
+		},
+		WinningLane: "musixmatch",
+		FetchedAt:   fetchTime,
+	}
+
+	if err := w.WriteLRC(song, "roundtrip.lrc", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	path := filepath.Join(dir, "roundtrip.lrc")
+	tags, lyricLines, err := parseLRCHeader(path)
+	if err != nil {
+		t.Fatalf("parseLRCHeader: %v", err)
+	}
+
+	// Build a key->value map from the parsed tags.
+	tagMap := map[string]string{}
+	for _, tag := range tags {
+		if tag.key != "" {
+			tagMap[tag.key] = tag.value
+		}
+	}
+
+	wantKeys := []string{"by", "ar", "ti", "al", "length", "source", "fetched", "ve", "isrc", "mbid"}
+	for _, k := range wantKeys {
+		if _, ok := tagMap[k]; !ok {
+			t.Errorf("parsed header missing tag key %q; tags: %v", k, tagMap)
+		}
+	}
+
+	// Lyric lines must be preserved.
+	lyricText := strings.Join(lyricLines, "\n")
+	for _, want := range []string{"[00:01.00]Line one", "[00:05.50]Line two"} {
+		if !strings.Contains(lyricText, want) {
+			t.Errorf("lyric lines missing %q from:\n%s", want, lyricText)
+		}
+	}
+}
+
+// TestInjectProvenance_PreservesFileMode asserts MAJOR-1: a 0600 .lrc stays
+// 0600 after InjectProvenance rewrites it.
+func TestInjectProvenance_PreservesFileMode(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, file permissions do not apply")
+	}
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+	// writeTestLRC creates with 0600; verify the pre-condition.
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before inject: %v", err)
+	}
+	if before.Mode().Perm() != 0o600 {
+		t.Fatalf("pre-condition: expected 0600, got %04o", before.Mode().Perm())
+	}
+
+	if _, _, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"}); err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after inject: %v", err)
+	}
+	if after.Mode().Perm() != 0o600 {
+		t.Errorf("file permissions widened: before=%04o, after=%04o", before.Mode().Perm(), after.Mode().Perm())
+	}
+}
+
+// TestInjectProvenance_SkipsSymlink asserts MINOR-5: a symlinked .lrc is skipped
+// (the link is not replaced by a regular file) and the call returns no error.
+func TestInjectProvenance_SkipsSymlink(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, symlink semantics differ")
+	}
+	dir := t.TempDir()
+	real := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+	linkPath := filepath.Join(dir, "link.lrc")
+	if err := os.Symlink(real, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	inj, skip, err := InjectProvenance(linkPath, ProvenanceTags{Source: "musixmatch"})
+	if err != nil {
+		t.Fatalf("InjectProvenance on symlink returned error: %v", err)
+	}
+	if inj != 0 || skip != 0 {
+		t.Errorf("expected (0,0) for symlink skip, got (%d,%d)", inj, skip)
+	}
+
+	// The link must still be a symlink (not replaced by a regular file).
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat after inject: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("symlink was replaced by a regular file")
+	}
+}
+
+// TestInjectProvenance_TagValueSanitized asserts MINOR-10: ']' and newlines in a
+// new tag value are stripped so they cannot break out of [key:value] syntax.
+func TestInjectProvenance_TagValueSanitized(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestLRC(t, dir, nil, []string{"[00:01.00]Hello"})
+
+	// Value with ']' and embedded newline.
+	badSource := "evil]value\ninjected"
+	inj, _, err := InjectProvenance(path, ProvenanceTags{Source: badSource})
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+	if inj != 1 {
+		t.Fatalf("expected 1 tag injected, got %d", inj)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if strings.Contains(content, "]value") {
+		t.Errorf("sanitization failed: raw ']' in output:\n%s", content)
+	}
+	if strings.Contains(content, "\ninjected") {
+		t.Errorf("sanitization failed: embedded newline in output:\n%s", content)
+	}
+}
+
+// TestInjectProvenance_CaseInsensitiveDedup asserts NIT-13: a hand-edited file
+// with a capitalized [Source:] tag is recognized as "source already present" and
+// not duplicated.
+func TestInjectProvenance_CaseInsensitiveDedup(t *testing.T) {
+	dir := t.TempDir()
+	// Write a file with a capitalized tag key.
+	path := filepath.Join(dir, "track.lrc")
+	content := "[by:mxlrcgo-svc]\n[Source:petitlyrics]\n[00:01.00]Hello\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inj, skip, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"})
+	if err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+	if inj != 0 {
+		t.Errorf("expected 0 injected (key already present case-insensitively), got %d", inj)
+	}
+	if skip != 1 {
+		t.Errorf("expected 1 skipped, got %d", skip)
+	}
+
+	// Verify no duplicate [source:] was added.
+	result, _ := os.ReadFile(path)
+	if count := strings.Count(string(result), "Source"); count > 1 {
+		t.Errorf("duplicate source tag after inject:\n%s", string(result))
+	}
+}
+
+// TestInjectProvenance_TagsBeforeBlankLine asserts MINOR-7: new tags are
+// inserted within the header tag block, before any blank header separator line.
+func TestInjectProvenance_TagsBeforeBlankLine(t *testing.T) {
+	dir := t.TempDir()
+	// File with a blank separator line between header and lyric body.
+	path := filepath.Join(dir, "track.lrc")
+	content := "[by:mxlrcgo-svc]\n[ar:Test]\n\n[00:01.00]Hello\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := InjectProvenance(path, ProvenanceTags{Source: "musixmatch"}); err != nil {
+		t.Fatalf("InjectProvenance: %v", err)
+	}
+
+	result, _ := os.ReadFile(path)
+	lines := strings.Split(string(result), "\n")
+	// Find positions of [source:] and the blank line.
+	sourceIdx, blankIdx := -1, -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, "[source:") {
+			sourceIdx = i
+		}
+		if l == "" && blankIdx == -1 {
+			blankIdx = i
+		}
+	}
+	if sourceIdx < 0 {
+		t.Fatal("no [source:] tag found")
+	}
+	if blankIdx >= 0 && sourceIdx > blankIdx {
+		t.Errorf("[source:] at line %d is AFTER the blank line at %d; should be before", sourceIdx, blankIdx)
+	}
+}

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sydlexius/mxlrcgo-svc/internal/models"
 	"github.com/sydlexius/mxlrcgo-svc/internal/pathutil"
+	"github.com/sydlexius/mxlrcgo-svc/internal/version"
 )
 
 // InstrumentalMarker is the human-readable marker embedded in an instrumental .txt
@@ -179,6 +181,19 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 		if song.Track.TrackLength != 0 {
 			tags = append(tags, fmt.Sprintf("[length:%02d:%02d]", song.Track.TrackLength/60, song.Track.TrackLength%60))
 		}
+		if song.WinningLane != "" {
+			tags = append(tags, fmt.Sprintf("[source:%s]", song.WinningLane))
+		}
+		if !song.FetchedAt.IsZero() {
+			tags = append(tags, fmt.Sprintf("[fetched:%s]", song.FetchedAt.Format(time.RFC3339)))
+		}
+		tags = append(tags, fmt.Sprintf("[ve:%s]", version.Version))
+		if song.Track.ISRC != "" {
+			tags = append(tags, fmt.Sprintf("[isrc:%s]", song.Track.ISRC))
+		}
+		if song.Track.RecordingMBID != "" {
+			tags = append(tags, fmt.Sprintf("[mbid:%s]", song.Track.RecordingMBID))
+		}
 	}
 
 	// Write to a temp file in the same directory, then rename atomically so a
@@ -227,6 +242,8 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	if err := os.Rename(tmpPath, fp); err != nil {
 		return fmt.Errorf("renaming %s to %s: %w", tmpPath, fp, err)
 	}
+	// NEW-3: fsync the parent dir so the rename is durable across a hard crash.
+	fsyncDir(outdir)
 	// Remove the opposite sidecar so format transitions never leave both files on disk.
 	// Writing .lrc removes a stale .txt (upgrade), writing .txt removes a stale .lrc (downgrade).
 	switch filepath.Ext(fp) {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 // Track represents a song's metadata from the Musixmatch API.
 type Track struct {
 	TrackName    string `json:"track_name,omitempty"`
@@ -61,6 +63,11 @@ type Song struct {
 	// Empty on cache hits and zero-value songs. Used by the worker write-path to
 	// record per-lane hit counters without changing the Fetcher interface.
 	WinningLane string `json:"-"`
+	// FetchedAt is the time the song was fetched from the provider. Set by the
+	// worker immediately after a successful fetch and before any write path so
+	// all output formats share one consistent timestamp. Zero on cache hits
+	// (timestamp not available without a live fetch). Transient: not persisted.
+	FetchedAt time.Time `json:"-"`
 }
 
 // Inputs represents a single work item in the processing queue.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+import "fmt"
+
+// Build-time version metadata. These defaults are overridden at release time by
+// GoReleaser via -ldflags "-X .../internal/version.Version=..." (see .goreleaser.yml).
+// A plain `go build` or `go run` leaves the defaults, so a non-release binary
+// reports a clear "dev" marker instead of masquerading as a tagged version.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+// VersionString renders the single line printed for --version.
+func VersionString() string {
+	return fmt.Sprintf("mxlrcgo-svc %s (commit %s, built %s)", Version, Commit, Date)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,18 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionString(t *testing.T) {
+	got := VersionString()
+	if !strings.HasPrefix(got, "mxlrcgo-svc ") {
+		t.Errorf("VersionString() = %q, want prefix \"mxlrcgo-svc \"", got)
+	}
+	for _, sub := range []string{Version, Commit, Date} {
+		if !strings.Contains(got, sub) {
+			t.Errorf("VersionString() = %q, does not contain %q", got, sub)
+		}
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -712,6 +712,8 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	confidence := Confidence(item.Inputs.Track, song.Track)
 	slog.Debug("worker lyrics match", "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "confidence", confidence, "cache_hit", cacheHit)
 	if !cacheHit {
+		// Stamp the fetch time once, shared across all output paths.
+		song.FetchedAt = w.now()
 		// A non-cache provider fetch succeeded: record the hit and stamp the winning
 		// lane on the queue row before any downstream step so the counter and the
 		// per-track provenance are always written when the provider round-trip


### PR DESCRIPTION
## Summary

Embeds machine-readable provenance ID-tags in synced `.lrc` output and adds a `provenance backfill` command to retro-fit existing files from the cache DB.

- **New `.lrc` output** carries `[source]`, `[fetched]` (RFC3339), `[isrc]`, `[mbid]` (all already in `models.Song`, no schema change). `[ve]` reflects the writer version; `[match]` deferred (no match-basis field yet).
- **`provenance backfill [--yes] [paths...]`** — `--yes` default-off prints the plan (matches `queue clear`/`recheck`); idempotent skip-when-present; atomic temp-file + rename rewrite that **preserves the original file mode** (0600 stays 0600); `.lrc`-only; same-stem cross-attribution warns + skips.
- **DB join** verified against current migrations: `scan_results(filename)` → `work_queue_scan_results` → `work_queue`, ISRC/MBID from the `lyrics_cache` JSON. Ambiguity measured by **distinct `work_queue` id**, so a single track in multiple audio formats tags correctly while genuinely distinct tracks sharing one `.lrc` warn + skip. Outdir matched by a **canonical (Abs/Clean)** form so relative-vs-absolute / trailing-slash differences don't silently skip.
- **Crash-durability**: parent-dir `fsync` after the atomic rename (shared `lyrics.fsyncDir`, used by both the backfill rewrite and the LRC writer).
- Migration 021 adds a filename-leading index for the backfill lookup.

## Verification

- `make gate` green (patch coverage 70.48%, above the 70% floor; lint/actionlint/govulncheck clean).
- Hostile review across the branch + each fix round; all findings resolved (NEW-1 path/DB join divergence, NEW-2 outdir normalization, NEW-3 parent-dir fsync, NEW-4 index reorder).
- Functional backfill run against a seeded scratch DB: plan-mode no-write, apply, idempotent no-op, atomic (no temp litter), perms preserved (0600→0600), ambiguous-join warn+skip — all pass.

Closes #250
