### PR TITLE
feat(serve): TLS listener (BYO + self-signed bootstrap) + HTTP->HTTPS redirect (#241 lane 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ First run is interactive. With no admin yet, every UI page redirects to `/setup`
 
 For headless deployments (Docker), you can skip the interactive form by setting both `MXLRC_WEBAUTH_ADMIN_USER` and `MXLRC_WEBAUTH_ADMIN_PASSWORD` in the environment. On startup, if no admin exists yet, the daemon creates one from these values (password must be at least 8 characters). It is idempotent (an existing admin is never overwritten) and the password is never logged. Treat these as bootstrap-only credentials: after first run, sign in and rotate the password, then remove the variables from the environment.
 
+### TLS
+
+TLS for the serve listener is off by default (plain HTTP), so deployments behind a TLS-terminating reverse proxy avoid double-encryption by leaving it disabled. Enable it under `[server.tls]` in one of two ways:
+
+- **Bring-your-own certificate:** set `cert_file` and `key_file` (both required together). The listener terminates TLS itself with a TLS 1.2 minimum. Env: `MXLRC_TLS_CERT_FILE`, `MXLRC_TLS_KEY_FILE`.
+- **Self-signed bootstrap:** set `self_signed = true` (mutually exclusive with `cert_file`/`key_file`). An ECDSA P-256 certificate (CN `mxlrcgo-svc`, ~365-day validity) is generated and persisted `0600` under `<dir(db_path)>/tls/`, and regenerated when missing or expired. Browsers show an untrusted-certificate prompt; this is intended for a LAN box, not public exposure. Env: `MXLRC_TLS_SELF_SIGNED`.
+
+When TLS is on, the session cookie's `Secure` flag is set automatically. An optional `redirect_http` listen address (e.g. `":80"`, env `MXLRC_TLS_REDIRECT_HTTP`) runs a plain-HTTP listener that 301-redirects every request to the HTTPS address. A contradictory configuration (`self_signed` combined with a cert/key, or only one of `cert_file`/`key_file`) is a fatal startup error. ACME/Let's Encrypt is a planned follow-up.
+
 ## Credits
 
 - [Spicetify Lyrics Plus](https://github.com/spicetify/spicetify-cli/tree/master/CustomApps/lyrics-plus)

--- a/config.example.toml
+++ b/config.example.toml
@@ -136,6 +136,33 @@ addr = "127.0.0.1:3876"
 # lists would be skipped as a proxy hop and could never be the resolved client.
 # trusted_proxies = ["172.16.0.0/12"]
 
+# Optional TLS for the serve listener. Off by default (plain HTTP), so operators
+# fronting the daemon with a TLS-terminating reverse proxy avoid double-encryption
+# by leaving this disabled. Two modes:
+#
+#   1. Bring-your-own certificate: set cert_file AND key_file (both required
+#      together). The listener terminates TLS itself (MinVersion TLS 1.2).
+#   2. Self-signed bootstrap: set self_signed = true (mutually exclusive with
+#      cert_file/key_file). An ECDSA P-256 cert (CN=mxlrcgo-svc, ~365-day
+#      validity) is generated and persisted 0600 under <dir(db_path)>/tls/,
+#      regenerated when missing or expired. Browsers show an untrusted-cert
+#      prompt - fine for a LAN box, not for public exposure.
+#
+# When TLS is on, the session cookie's Secure flag is set automatically. A
+# contradictory combination (self_signed with cert/key, or only one of cert/key)
+# is a fatal startup error.
+# Env overrides: MXLRC_TLS_CERT_FILE, MXLRC_TLS_KEY_FILE, MXLRC_TLS_SELF_SIGNED,
+# MXLRC_TLS_REDIRECT_HTTP.
+[server.tls]
+# cert_file = "/config/tls/server.crt"
+# key_file  = "/config/tls/server.key"
+# self_signed = true
+#
+# Optional plain-HTTP listen address that 301-redirects every request to the
+# HTTPS address. Empty (the default) means no redirect listener. Only honored
+# when TLS is enabled.
+# redirect_http = ":80"
+
 [providers]
 # Active lyrics provider: "musixmatch" (default) or "petitlyrics".
 # petitlyrics has no public API; the adapter scrapes reverse-engineered

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
 	"github.com/sydlexius/mxlrcgo-svc/internal/server"
+	"github.com/sydlexius/mxlrcgo-svc/internal/servetls"
 	"github.com/sydlexius/mxlrcgo-svc/internal/trustnet"
 	"github.com/sydlexius/mxlrcgo-svc/internal/verification"
 	"github.com/sydlexius/mxlrcgo-svc/internal/watcher"
@@ -845,6 +846,18 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		return 1
 	}
 
+	// Optional TLS (#204, lane 5): build the certificate manager from
+	// [server.tls]. Returns nil when TLS is disabled (plain HTTP, the default).
+	// The self-signed bootstrap persists under <dir(db_path)>/tls/. Built before
+	// the run context so a bad cert/key or generation failure is a clean early
+	// return rather than a leaked listener.
+	certMgr, err := servetls.BuildCertManager(cfg.Server.TLS.CertFile, cfg.Server.TLS.KeyFile, cfg.Server.TLS.SelfSigned, filepath.Dir(cfg.DB.Path))
+	if err != nil {
+		_ = sqlDB.Close()
+		slog.Error("failed to initialize TLS", "error", err)
+		return 1
+	}
+
 	runCtx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -904,6 +917,9 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		WriteTimeout:      15 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
+	if certMgr != nil {
+		srv.TLSConfig = servetls.TLSConfig(certMgr)
+	}
 	go func() {
 		<-runCtx.Done()
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
@@ -912,11 +928,49 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 			slog.Warn("HTTP server shutdown failed", "error", err)
 		}
 	}()
-	slog.Info("starting HTTP server", "addr", addr)
+
+	// Optional plain-HTTP redirect listener (#204, lane 5): only when TLS is on
+	// and server.tls.redirect_http is set. Every request 301s to the HTTPS addr.
+	// Lifecycle mirrors the main server: graceful shutdown on context cancel.
+	var redirectSrv *http.Server
+	if certMgr != nil && cfg.Server.TLS.RedirectHTTP != "" {
+		redirectSrv = &http.Server{
+			Addr:              cfg.Server.TLS.RedirectHTTP,
+			Handler:           servetls.RedirectHandler(addr),
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			go func() {
+				<-runCtx.Done()
+				shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
+				defer shutdownCancel()
+				if err := redirectSrv.Shutdown(shutdownCtx); err != nil {
+					slog.Warn("HTTP redirect server shutdown failed", "error", err)
+				}
+			}()
+			slog.Info("starting HTTP->HTTPS redirect listener", "addr", redirectSrv.Addr, "target", addr)
+			if err := redirectSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("HTTP redirect server failed", "error", err)
+			}
+		}()
+	}
+
 	code := 0
-	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		slog.Error("HTTP server failed", "error", err)
-		code = 1
+	if certMgr != nil {
+		slog.Info("starting HTTPS server", "addr", addr)
+		// Empty cert/key paths: the certificate is supplied via TLSConfig.GetCertificate.
+		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("HTTPS server failed", "error", err)
+			code = 1
+		}
+	} else {
+		slog.Info("starting HTTP server", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("HTTP server failed", "error", err)
+			code = 1
+		}
 	}
 	cancel()
 	wg.Wait()

--- a/internal/commands/serve_tls_test.go
+++ b/internal/commands/serve_tls_test.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
+	"github.com/sydlexius/mxlrcgo-svc/internal/musixmatch"
+)
+
+// freePort returns a currently-free TCP address on loopback. There is a small
+// race between closing the probe listener and the server binding it, acceptable
+// for a local integration test.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("probe close: %v", err)
+	}
+	return addr
+}
+
+// TestRunServe_TLSSelfSignedServesHTTPS is the lane-5 integration test: runServe
+// with [server.tls].self_signed brings up an HTTPS listener that serves /healthz
+// over TLS (handler sees r.TLS), persists the self-signed pair under
+// <dir(db_path)>/tls/, and the optional redirect listener 301s plain HTTP to the
+// HTTPS address.
+func TestRunServe_TLSSelfSignedServesHTTPS(t *testing.T) {
+	// runServe -> initLogging -> logging.Init calls slog.SetDefault, mutating the
+	// process-global default logger. Snapshot and restore it so this test does not
+	// pollute others under -shuffle=on.
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MUSIXMATCH_TOKEN", "tok")
+	keyFile := filepath.Join(t.TempDir(), "test.key")
+	t.Setenv("MXLRC_SECRETS_KEY_FILE", keyFile)
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "serve.db")
+	httpsAddr := freePort(t)
+	redirectAddr := freePort(t)
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	var b strings.Builder
+	b.WriteString("[db]\npath = " + tomlString(dbPath) + "\n\n")
+	b.WriteString("[providers]\nprimary = \"musixmatch\"\n\n")
+	b.WriteString("[server]\naddr = " + tomlString(httpsAddr) + "\n\n")
+	b.WriteString("[server.tls]\nself_signed = true\nredirect_http = " + tomlString(redirectAddr) + "\n")
+	if err := os.WriteFile(cfgPath, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan int, 1)
+	var out bytes.Buffer
+	go func() {
+		done <- runServe(
+			ctx,
+			&out,
+			ServeCmd{ConfigPath: cfgPath},
+			func(string) musixmatch.Fetcher { return fakeFetcher{} },
+			func(...string) lyrics.Writer { return fakeWriter{} },
+		)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("runServe did not return after cancel")
+		}
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // G402: test trusts the locally generated self-signed cert.
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	// Poll the HTTPS health endpoint until the listener is up.
+	healthURL := "https://" + httpsAddr + "/healthz"
+	var resp *http.Response
+	var err error
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err = client.Get(healthURL)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("HTTPS health never came up: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthz status = %d; want 200", resp.StatusCode)
+	}
+	if resp.TLS == nil {
+		t.Error("response not served over TLS")
+	}
+
+	// The self-signed pair must be persisted under <dir(db_path)>/tls/.
+	if _, err := os.Stat(filepath.Join(dir, "tls", "cert.pem")); err != nil {
+		t.Errorf("self-signed cert not persisted: %v", err)
+	}
+
+	// The redirect listener 301s plain HTTP to the HTTPS address.
+	noRedirect := &http.Client{
+		Timeout: 2 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	var rresp *http.Response
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		rresp, err = noRedirect.Get("http://" + redirectAddr + "/config")
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("redirect listener never came up: %v", err)
+	}
+	defer func() { _ = rresp.Body.Close() }()
+	if rresp.StatusCode != http.StatusMovedPermanently {
+		t.Errorf("redirect status = %d; want 301", rresp.StatusCode)
+	}
+	loc := rresp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "https://") || !strings.HasSuffix(loc, "/config") {
+		t.Errorf("redirect Location = %q; want https://...:<port>/config", loc)
+	}
+}
+
+// TestRunServe_TLSBadCertFailsFast: a cert_file/key_file pointing at unreadable
+// PEM makes runServe fail before serving (exit 1).
+func TestRunServe_TLSBadCertFailsFast(t *testing.T) {
+	// runServe -> initLogging -> logging.Init calls slog.SetDefault, mutating the
+	// process-global default logger. Snapshot and restore it so this test does not
+	// pollute others under -shuffle=on.
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MUSIXMATCH_TOKEN", "tok")
+	keyFile := filepath.Join(t.TempDir(), "test.key")
+	t.Setenv("MXLRC_SECRETS_KEY_FILE", keyFile)
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "serve.db")
+	badCert := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(badCert, []byte("not pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	var b strings.Builder
+	b.WriteString("[db]\npath = " + tomlString(dbPath) + "\n\n")
+	b.WriteString("[providers]\nprimary = \"musixmatch\"\n\n")
+	b.WriteString("[server.tls]\ncert_file = " + tomlString(badCert) + "\nkey_file = " + tomlString(badCert) + "\n")
+	if err := os.WriteFile(cfgPath, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runServe(
+		context.Background(),
+		&out,
+		ServeCmd{ConfigPath: cfgPath},
+		func(string) musixmatch.Fetcher { return fakeFetcher{} },
+		func(...string) lyrics.Writer { return fakeWriter{} },
+	)
+	if code != 1 {
+		t.Fatalf("bad cert: exit code = %d, want 1", code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,43 @@ type ServerConfig struct {
 	// access (issue #204, Area 2): loopback-implicit access to GET /metrics and,
 	// once the login layer lands, the interactive-login bypass for the web UI.
 	TrustedNetworks TrustedNetworksConfig `toml:"trusted_networks"`
+	// TLS configures optional transport security for the serve listener (issue
+	// #204, Area 4). Off by default (plain HTTP), preserving pre-#204 behavior.
+	TLS TLSConfig `toml:"tls"`
+}
+
+// TLSConfig holds the optional TLS settings for the serve listener (issue #204,
+// Area 4). TLS is off by default. Two modes are supported: bring-your-own
+// certificate (CertFile + KeyFile, both required together) and a self-signed
+// bootstrap (SelfSigned, mutually exclusive with cert/key). Both are validated at
+// load (a contradictory combination is a fatal startup error). ACME autocert is a
+// deferred follow-up (lane 6); the listener wires a CertManager seam so it drops
+// in without a rewrite.
+type TLSConfig struct {
+	// CertFile is the PEM-encoded certificate path. With KeyFile set, the serve
+	// listener terminates TLS itself (MinVersion TLS 1.2). Override:
+	// MXLRC_TLS_CERT_FILE.
+	CertFile string `toml:"cert_file"`
+	// KeyFile is the PEM-encoded private key path. Required together with
+	// CertFile. Override: MXLRC_TLS_KEY_FILE.
+	KeyFile string `toml:"key_file"`
+	// SelfSigned generates and persists a self-signed certificate on first run
+	// (ECDSA P-256, CN=mxlrcgo-svc, ~365-day validity) under <dir(db_path)>/tls/,
+	// regenerating when missing or expired. Mutually exclusive with
+	// CertFile/KeyFile. Browsers show an untrusted-certificate prompt. Override:
+	// MXLRC_TLS_SELF_SIGNED.
+	SelfSigned bool `toml:"self_signed"`
+	// RedirectHTTP is an optional plain-HTTP listen address (e.g. ":80") whose
+	// every request 301-redirects to the HTTPS address. Empty (the default) means
+	// no redirect listener. Only honored when TLS is enabled. Override:
+	// MXLRC_TLS_REDIRECT_HTTP.
+	RedirectHTTP string `toml:"redirect_http"`
+}
+
+// Enabled reports whether TLS termination is configured (bring-your-own cert or
+// self-signed bootstrap). When false the serve listener stays plain HTTP.
+func (t TLSConfig) Enabled() bool {
+	return (t.CertFile != "" && t.KeyFile != "") || t.SelfSigned
 }
 
 // TrustedNetworksConfig holds the trusted-network allowlist for serve mode.
@@ -531,6 +568,9 @@ func LoadWithSources(path string) (Config, map[string]bool, error) {
 	if err := validateTrustedNetworks(cfg); err != nil {
 		return cfg, appliedEnv, err
 	}
+	if err := validateServerTLS(cfg); err != nil {
+		return cfg, appliedEnv, err
+	}
 	if cfg.DB.Path == "" {
 		return cfg, appliedEnv, fmt.Errorf("config: cannot determine DB path: set MXLRC_DB_PATH or XDG_DATA_HOME")
 	}
@@ -540,7 +580,7 @@ func LoadWithSources(path string) (Config, map[string]bool, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SECRETS_KEY_FILE, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_TRUSTED_CIDRS, MXLRC_TRUSTED_PROXIES, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SECRETS_KEY_FILE, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_TRUSTED_CIDRS, MXLRC_TRUSTED_PROXIES, MXLRC_TLS_CERT_FILE, MXLRC_TLS_KEY_FILE, MXLRC_TLS_SELF_SIGNED, MXLRC_TLS_REDIRECT_HTTP, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 //
 // applied (must be non-nil) records the dotted config field path for every
 // override that ACTUALLY took effect. Env values that are rejected (invalid
@@ -679,6 +719,27 @@ func applyEnvOverrides(cfg *Config, applied map[string]bool) {
 	if v := os.Getenv("MXLRC_TRUSTED_PROXIES"); v != "" {
 		cfg.Server.TrustedNetworks.TrustedProxies = splitCSV(v)
 		applied["server.trusted_networks.trusted_proxies"] = true
+	}
+	if v := os.Getenv("MXLRC_TLS_CERT_FILE"); v != "" {
+		cfg.Server.TLS.CertFile = v
+		applied["server.tls.cert_file"] = true
+	}
+	if v := os.Getenv("MXLRC_TLS_KEY_FILE"); v != "" {
+		cfg.Server.TLS.KeyFile = v
+		applied["server.tls.key_file"] = true
+	}
+	if v := os.Getenv("MXLRC_TLS_SELF_SIGNED"); v != "" {
+		selfSigned, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("env var is invalid; using current value", "var", "MXLRC_TLS_SELF_SIGNED", "value", v, "current", cfg.Server.TLS.SelfSigned) //nolint:gosec // G706: tainted env var passed as a structured slog field value (not a format string); no log-injection vector since slog escapes values
+		} else {
+			cfg.Server.TLS.SelfSigned = selfSigned
+			applied["server.tls.self_signed"] = true
+		}
+	}
+	if v := os.Getenv("MXLRC_TLS_REDIRECT_HTTP"); v != "" {
+		cfg.Server.TLS.RedirectHTTP = v
+		applied["server.tls.redirect_http"] = true
 	}
 	if v := os.Getenv("MXLRC_PROVIDER_PRIMARY"); v != "" {
 		cfg.Providers.Primary = v
@@ -1025,6 +1086,22 @@ func validateTrustedNetworks(cfg Config) error {
 	}
 	if _, err := trustnet.ParseCIDRs(cfg.Server.TrustedNetworks.TrustedProxies); err != nil {
 		return fmt.Errorf("config: server.trusted_networks.trusted_proxies: %w", err)
+	}
+	return nil
+}
+
+// validateServerTLS fails fast on a contradictory [server.tls] configuration
+// (issue #204, Area 4): self_signed cannot be combined with an explicit
+// cert_file/key_file, and cert_file and key_file must be supplied together.
+// Validation happens at load so a misconfiguration is a clear startup error
+// rather than a confusing listener failure.
+func validateServerTLS(cfg Config) error {
+	t := cfg.Server.TLS
+	if t.SelfSigned && (t.CertFile != "" || t.KeyFile != "") {
+		return fmt.Errorf("config: server.tls: self_signed is mutually exclusive with cert_file/key_file")
+	}
+	if (t.CertFile == "") != (t.KeyFile == "") {
+		return fmt.Errorf("config: server.tls: cert_file and key_file must be set together")
 	}
 	return nil
 }

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad_TLSFromFile(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+[server.tls]
+cert_file = "/etc/ssl/cert.pem"
+key_file = "/etc/ssl/key.pem"
+redirect_http = ":80"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Server.TLS.CertFile != "/etc/ssl/cert.pem" {
+		t.Errorf("cert_file = %q", cfg.Server.TLS.CertFile)
+	}
+	if cfg.Server.TLS.KeyFile != "/etc/ssl/key.pem" {
+		t.Errorf("key_file = %q", cfg.Server.TLS.KeyFile)
+	}
+	if cfg.Server.TLS.RedirectHTTP != ":80" {
+		t.Errorf("redirect_http = %q", cfg.Server.TLS.RedirectHTTP)
+	}
+	if !cfg.Server.TLS.Enabled() {
+		t.Error("Enabled() = false; want true with cert+key set")
+	}
+}
+
+func TestLoad_TLSDefaultDisabled(t *testing.T) {
+	isolateEnv(t)
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Server.TLS.Enabled() {
+		t.Error("TLS Enabled() = true; want false by default")
+	}
+	if cfg.Server.TLS.SelfSigned {
+		t.Error("self_signed defaults to true; want false")
+	}
+}
+
+func TestLoad_TLSSelfSignedFromFile(t *testing.T) {
+	isolateEnv(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[server.tls]\nself_signed = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if !cfg.Server.TLS.SelfSigned || !cfg.Server.TLS.Enabled() {
+		t.Errorf("self_signed=%v Enabled=%v; want both true", cfg.Server.TLS.SelfSigned, cfg.Server.TLS.Enabled())
+	}
+}
+
+func TestLoad_TLSEnvOverride(t *testing.T) {
+	isolateEnv(t)
+
+	t.Setenv("MXLRC_TLS_CERT_FILE", "/env/cert.pem")
+	t.Setenv("MXLRC_TLS_KEY_FILE", "/env/key.pem")
+	t.Setenv("MXLRC_TLS_REDIRECT_HTTP", ":8080")
+
+	cfg, applied, err := LoadWithSources(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithSources returned error: %v", err)
+	}
+	if cfg.Server.TLS.CertFile != "/env/cert.pem" || cfg.Server.TLS.KeyFile != "/env/key.pem" {
+		t.Errorf("env cert/key not applied: %+v", cfg.Server.TLS)
+	}
+	if cfg.Server.TLS.RedirectHTTP != ":8080" {
+		t.Errorf("redirect_http = %q; want :8080", cfg.Server.TLS.RedirectHTTP)
+	}
+	for _, k := range []string{"server.tls.cert_file", "server.tls.key_file", "server.tls.redirect_http"} {
+		if !applied[k] {
+			t.Errorf("expected %s marked applied", k)
+		}
+	}
+}
+
+func TestLoad_TLSSelfSignedEnvOverride(t *testing.T) {
+	isolateEnv(t)
+
+	t.Setenv("MXLRC_TLS_SELF_SIGNED", "true")
+	cfg, applied, err := LoadWithSources(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithSources returned error: %v", err)
+	}
+	if !cfg.Server.TLS.SelfSigned {
+		t.Error("MXLRC_TLS_SELF_SIGNED=true not applied")
+	}
+	if !applied["server.tls.self_signed"] {
+		t.Error("expected server.tls.self_signed marked applied")
+	}
+}
+
+func TestLoad_TLSSelfSignedInvalidEnvIgnored(t *testing.T) {
+	isolateEnv(t)
+
+	t.Setenv("MXLRC_TLS_SELF_SIGNED", "not-a-bool")
+	cfg, applied, err := LoadWithSources(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithSources returned error: %v", err)
+	}
+	if cfg.Server.TLS.SelfSigned {
+		t.Error("invalid bool should leave self_signed at its default (false)")
+	}
+	if applied["server.tls.self_signed"] {
+		t.Error("rejected env value must not be marked applied")
+	}
+}
+
+func TestLoad_TLSValidationFailsFast(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "self_signed with cert_file",
+			body: "[server.tls]\nself_signed = true\ncert_file = \"/c.pem\"\nkey_file = \"/k.pem\"\n",
+			want: "mutually exclusive",
+		},
+		{
+			name: "cert without key",
+			body: "[server.tls]\ncert_file = \"/c.pem\"\n",
+			want: "must be set together",
+		},
+		{
+			name: "key without cert",
+			body: "[server.tls]\nkey_file = \"/k.pem\"\n",
+			want: "must be set together",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("expected fail-fast error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q; want it to mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/servetls/redirect.go
+++ b/internal/servetls/redirect.go
@@ -1,0 +1,65 @@
+package servetls
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RedirectHandler returns a handler that 301-redirects every request to the HTTPS
+// scheme, preserving the request's host and path/query and substituting the TLS
+// listener's port. tlsAddr is the HTTPS listen address (e.g. ":443" or
+// "0.0.0.0:8443"); its port is used in the redirect target so a non-standard
+// HTTPS port is reached correctly. The standard https port (443) is omitted from
+// the target for a clean URL.
+func RedirectHandler(tlsAddr string) http.Handler {
+	tlsPort := portOf(tlsAddr)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := hostOnly(r.Host)
+		var authority string
+		if tlsPort != "" && tlsPort != "443" && tlsPort != "0" {
+			// net.JoinHostPort re-brackets an IPv6 literal so the target stays a
+			// valid URL (e.g. "::1" + "8443" -> "[::1]:8443").
+			authority = net.JoinHostPort(host, tlsPort)
+		} else {
+			authority = bracketHost(host)
+		}
+		target := "https://" + authority + r.URL.RequestURI()
+		//nolint:gosec // G710: not an open redirect. The target host is the client's own request Host (the host it connected to), only the scheme is forced to https and the port swapped to the TLS port; the path/query are preserved verbatim. This is the standard HTTP->HTTPS host-preserving redirect (same pattern as golang.org/x/crypto/acme/autocert.HTTPHandler). A client setting a different Host only redirects itself.
+		http.Redirect(w, r, target, http.StatusMovedPermanently)
+	})
+}
+
+// portOf returns the port component of a listen address, or "" if none is present.
+func portOf(addr string) string {
+	if _, port, err := net.SplitHostPort(addr); err == nil {
+		return port
+	}
+	return ""
+}
+
+// hostOnly strips an optional ":port" suffix from a request Host header,
+// returning the bare host without brackets. A bare host (no port) is returned
+// unchanged, except a bracketed IPv6 literal ("[::1]") is unbracketed so callers
+// can re-bracket it consistently via net.JoinHostPort / bracketHost.
+func hostOnly(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
+// bracketHost wraps an IPv6 literal in brackets so it is a valid URL authority.
+// A host already bracketed or without a colon is returned unchanged.
+func bracketHost(host string) string {
+	if strings.HasPrefix(host, "[") {
+		return host
+	}
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
+}

--- a/internal/servetls/redirect_test.go
+++ b/internal/servetls/redirect_test.go
@@ -1,0 +1,98 @@
+package servetls
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirectHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		tlsAddr  string
+		host     string
+		target   string // request-target (path?query)
+		wantLoc  string
+		wantCode int
+	}{
+		{
+			name:     "default https port omitted",
+			tlsAddr:  ":443",
+			host:     "example.com",
+			target:   "/config",
+			wantLoc:  "https://example.com/config",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "non-standard port preserved",
+			tlsAddr:  "0.0.0.0:8443",
+			host:     "example.com",
+			target:   "/reports?x=1",
+			wantLoc:  "https://example.com:8443/reports?x=1",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "request host port stripped, tls port substituted",
+			tlsAddr:  ":8443",
+			host:     "example.com:80",
+			target:   "/",
+			wantLoc:  "https://example.com:8443/",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "no port in tls addr yields no port in target",
+			tlsAddr:  "example.com",
+			host:     "example.com",
+			target:   "/x",
+			wantLoc:  "https://example.com/x",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "path and query preserved",
+			tlsAddr:  ":443",
+			host:     "host.local",
+			target:   "/a/b?c=d&e=f",
+			wantLoc:  "https://host.local/a/b?c=d&e=f",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "ipv6 literal host with port rebracketed",
+			tlsAddr:  ":8443",
+			host:     "[::1]:80",
+			target:   "/config",
+			wantLoc:  "https://[::1]:8443/config",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "bare ipv6 literal host stays bracketed",
+			tlsAddr:  ":443",
+			host:     "[::1]",
+			target:   "/config",
+			wantLoc:  "https://[::1]/config",
+			wantCode: http.StatusMovedPermanently,
+		},
+		{
+			name:     "ephemeral port zero omitted from redirect",
+			tlsAddr:  ":0",
+			host:     "example.com:80",
+			target:   "/setup",
+			wantLoc:  "https://example.com/setup",
+			wantCode: http.StatusMovedPermanently,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := RedirectHandler(tc.tlsAddr)
+			req := httptest.NewRequest(http.MethodGet, "http://"+tc.host+tc.target, nil)
+			req.Host = tc.host
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d; want %d", rec.Code, tc.wantCode)
+			}
+			if got := rec.Header().Get("Location"); got != tc.wantLoc {
+				t.Errorf("Location = %q; want %q", got, tc.wantLoc)
+			}
+		})
+	}
+}

--- a/internal/servetls/selfsigned.go
+++ b/internal/servetls/selfsigned.go
@@ -1,0 +1,167 @@
+package servetls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// selfSignedCommonName is the subject/issuer CN for the generated certificate.
+	selfSignedCommonName = "mxlrcgo-svc"
+	// selfSignedValidity is the certificate lifetime (~365 days).
+	selfSignedValidity = 365 * 24 * time.Hour
+	// selfSignedCertFile and selfSignedKeyFile are the on-disk PEM filenames.
+	selfSignedCertFile = "cert.pem"
+	selfSignedKeyFile  = "key.pem"
+	// keyFileMode and certFileMode are the persisted permissions. The private key
+	// is owner-only (0600); the certificate is public material but kept tight too.
+	keyFileMode  os.FileMode = 0o600
+	certFileMode os.FileMode = 0o600
+	dirMode      os.FileMode = 0o700
+)
+
+// selfSignedCertManager serves a self-signed certificate persisted under dir. The
+// certificate is loaded (or generated and persisted) once at construction;
+// regeneration happens only at startup when the stored pair is missing, unreadable,
+// or expired.
+type selfSignedCertManager struct {
+	cert *tls.Certificate
+}
+
+func newSelfSignedCertManager(dir string) (*selfSignedCertManager, error) {
+	cert, err := ensureSelfSignedCert(dir)
+	if err != nil {
+		return nil, err
+	}
+	slog.Warn("serving with a self-signed TLS certificate; browsers will show an untrusted-certificate prompt. Use a CA-issued cert (server.tls.cert_file/key_file) or a TLS-terminating reverse proxy for trusted access.",
+		"dir", dir, "common_name", selfSignedCommonName)
+	return &selfSignedCertManager{cert: cert}, nil
+}
+
+func (m *selfSignedCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return m.cert, nil
+}
+
+// ensureSelfSignedCert loads the persisted self-signed pair under dir, generating
+// and persisting a fresh one when the pair is missing, unreadable, or expired
+// (or expires within the renewal window). The private key is written 0600.
+func ensureSelfSignedCert(dir string) (*tls.Certificate, error) {
+	certPath := filepath.Join(dir, selfSignedCertFile)
+	keyPath := filepath.Join(dir, selfSignedKeyFile)
+
+	if cert, ok := loadValidCert(certPath, keyPath); ok {
+		slog.Info("reusing persisted self-signed TLS certificate", "cert", certPath)
+		return cert, nil
+	}
+
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return nil, fmt.Errorf("create TLS dir %s: %w", dir, err)
+	}
+	now := time.Now()
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	if err != nil {
+		return nil, err
+	}
+	// Write the key 0600 first (it is the secret); then the cert. WriteFile with
+	// an explicit mode does not chmod an existing file, so remove any stale file
+	// first to guarantee the mode on a regeneration over a wider-perm leftover.
+	if err := writeFileMode(keyPath, keyPEM, keyFileMode); err != nil {
+		return nil, fmt.Errorf("write TLS key %s: %w", keyPath, err)
+	}
+	if err := writeFileMode(certPath, certPEM, certFileMode); err != nil {
+		return nil, fmt.Errorf("write TLS cert %s: %w", certPath, err)
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated self-signed keypair: %w", err)
+	}
+	slog.Info("generated self-signed TLS certificate", "cert", certPath, "not_after", now.Add(selfSignedValidity).Format(time.RFC3339))
+	return &cert, nil
+}
+
+// loadValidCert loads the PEM pair and reports whether it is usable: it must
+// parse and not be expired (nor within the renewal window). Any failure returns
+// ok=false so the caller regenerates.
+func loadValidCert(certPath, keyPath string) (*tls.Certificate, bool) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, false
+	}
+	leaf := cert.Leaf
+	if leaf == nil {
+		// Go does not populate Leaf from LoadX509KeyPair; parse it to check expiry.
+		if len(cert.Certificate) == 0 {
+			return nil, false
+		}
+		parsed, perr := x509.ParseCertificate(cert.Certificate[0])
+		if perr != nil {
+			return nil, false
+		}
+		leaf = parsed
+	}
+	now := time.Now()
+	// Regenerate if already expired or within 30 days of expiry, so a long-running
+	// daemon rotates well before clients start failing handshakes.
+	if now.Before(leaf.NotBefore) || now.Add(30*24*time.Hour).After(leaf.NotAfter) {
+		return nil, false
+	}
+	return &cert, true
+}
+
+// generateSelfSignedCert builds an ECDSA P-256 self-signed certificate valid over
+// [notBefore, notAfter], returning the cert and key as PEM. CN=mxlrcgo-svc, with
+// loopback SANs so same-host HTTPS verifies against localhost/127.0.0.1/::1.
+func generateSelfSignedCert(notBefore, notAfter time.Time) (certPEM, keyPEM []byte, err error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate ECDSA key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate serial number: %w", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: selfSignedCommonName},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{selfSignedCommonName, "localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+// writeFileMode writes data to path with exactly the given mode, removing any
+// existing file first so a regeneration cannot inherit a wider permission from a
+// pre-existing file (os.WriteFile does not chmod an existing file).
+func writeFileMode(path string, data []byte, mode os.FileMode) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(path, data, mode)
+}

--- a/internal/servetls/selfsigned_test.go
+++ b/internal/servetls/selfsigned_test.go
@@ -1,0 +1,158 @@
+package servetls
+
+import (
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestGenerateSelfSignedCert(t *testing.T) {
+	now := time.Now()
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	if err != nil {
+		t.Fatalf("generateSelfSignedCert: %v", err)
+	}
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		t.Fatal("empty PEM output")
+	}
+	// The pair must parse and carry the expected subject + loopback SANs.
+	block := mustParseCert(t, certPEM)
+	if block.Subject.CommonName != selfSignedCommonName {
+		t.Errorf("CN = %q; want %q", block.Subject.CommonName, selfSignedCommonName)
+	}
+	if !blockHasDNS(block, "localhost") {
+		t.Errorf("missing localhost SAN; DNSNames=%v", block.DNSNames)
+	}
+	if block.PublicKeyAlgorithm != x509.ECDSA {
+		t.Errorf("public key algorithm = %v; want ECDSA", block.PublicKeyAlgorithm)
+	}
+}
+
+func TestEnsureSelfSignedCertGeneratesAndPersists(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	cert, err := ensureSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("ensureSelfSignedCert: %v", err)
+	}
+	if cert == nil || len(cert.Certificate) == 0 {
+		t.Fatal("nil/empty certificate")
+	}
+	certPath := filepath.Join(dir, selfSignedCertFile)
+	keyPath := filepath.Join(dir, selfSignedKeyFile)
+	if _, err := os.Stat(certPath); err != nil {
+		t.Fatalf("cert not persisted: %v", err)
+	}
+	assertMode0600(t, keyPath)
+	assertMode0600(t, certPath)
+}
+
+func TestEnsureSelfSignedCertReusesExisting(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	first, err := ensureSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	second, err := ensureSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	// Reuse means the same serial number (no regeneration).
+	if serialOf(t, first) != serialOf(t, second) {
+		t.Error("certificate was regenerated; expected reuse of the persisted pair")
+	}
+}
+
+func TestEnsureSelfSignedCertRegeneratesWhenExpired(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		t.Fatal(err)
+	}
+	// Write an already-expired pair.
+	past := time.Now().Add(-2 * selfSignedValidity)
+	certPEM, keyPEM, err := generateSelfSignedCert(past, past.Add(selfSignedValidity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath := filepath.Join(dir, selfSignedCertFile)
+	keyPath := filepath.Join(dir, selfSignedKeyFile)
+	if err := os.WriteFile(certPath, certPEM, certFileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, keyFileMode); err != nil {
+		t.Fatal(err)
+	}
+	expiredSerial := serialOfPEM(t, certPEM)
+
+	cert, err := ensureSelfSignedCert(dir)
+	if err != nil {
+		t.Fatalf("ensureSelfSignedCert: %v", err)
+	}
+	if serialOf(t, cert) == expiredSerial {
+		t.Error("expired certificate was reused; expected regeneration")
+	}
+	// The regenerated cert must be valid now.
+	leaf := mustLeaf(t, cert)
+	now := time.Now()
+	if now.Before(leaf.NotBefore) || now.After(leaf.NotAfter) {
+		t.Errorf("regenerated cert not valid now: NotBefore=%v NotAfter=%v", leaf.NotBefore, leaf.NotAfter)
+	}
+}
+
+func TestLoadValidCertRejectsMissing(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := loadValidCert(filepath.Join(dir, "nope.pem"), filepath.Join(dir, "nope.key")); ok {
+		t.Error("loadValidCert returned ok for missing files")
+	}
+}
+
+func TestNewSelfSignedCertManagerGetCertificate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	m, err := newSelfSignedCertManager(dir)
+	if err != nil {
+		t.Fatalf("newSelfSignedCertManager: %v", err)
+	}
+	cert, err := m.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if cert == nil || len(cert.Certificate) == 0 {
+		t.Fatal("nil/empty certificate from manager")
+	}
+}
+
+// --- helpers ---
+
+func mustParseCert(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+	c, err := certFromPEM(certPEM)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return c
+}
+
+func blockHasDNS(c *x509.Certificate, name string) bool {
+	for _, d := range c.DNSNames {
+		if d == name {
+			return true
+		}
+	}
+	return false
+}
+
+func assertMode0600(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not POSIX on Windows")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("%s mode = %o; want 600", path, perm)
+	}
+}

--- a/internal/servetls/servetls.go
+++ b/internal/servetls/servetls.go
@@ -1,0 +1,75 @@
+// Package servetls implements optional TLS for the serve-mode HTTP listener
+// (issue #204, Area 4). It provides two certificate sources behind one
+// CertManager seam: bring-your-own PEM files and a self-signed bootstrap that
+// generates and persists a certificate for LAN use. The seam exists so a future
+// ACME autocert path (lane 6) drops in without rewriting the listener.
+//
+// The security-relevant choices live here: TLS 1.2 minimum, self-signed keys
+// persisted 0600, and a clear operator warning that a self-signed certificate is
+// untrusted by browsers. The package never logs or persists secret material
+// beyond the private-key file it deliberately writes 0600.
+package servetls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+)
+
+// CertManager supplies the TLS certificate for the serve listener. Its single
+// method matches the signature of tls.Config.GetCertificate so an
+// autocert.Manager (the deferred ACME lane) is a drop-in implementation and the
+// listener never branches on TLS flavor.
+type CertManager interface {
+	// GetCertificate returns the certificate to present for a TLS handshake.
+	GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
+// BuildCertManager selects a CertManager from the resolved TLS settings, mirroring
+// the config precedence: an explicit cert_file+key_file pair (bring-your-own)
+// wins, else self_signed bootstraps a persisted certificate under <dbDir>/tls/,
+// else TLS is disabled and (nil, nil) is returned so the caller serves plain
+// HTTP. The caller is responsible for having validated that cert_file/key_file
+// are set together and that self_signed is not combined with them (see
+// config.validateServerTLS); this function trusts that contract and only acts on
+// it.
+func BuildCertManager(certFile, keyFile string, selfSigned bool, dbDir string) (CertManager, error) {
+	switch {
+	case certFile != "" && keyFile != "":
+		return newFileCertManager(certFile, keyFile)
+	case selfSigned:
+		return newSelfSignedCertManager(filepath.Join(dbDir, "tls"))
+	default:
+		return nil, nil
+	}
+}
+
+// TLSConfig builds the *tls.Config for the serve listener from a CertManager.
+// MinVersion is pinned to TLS 1.2 (no SSLv3/TLS 1.0/1.1). The certificate is
+// resolved per-handshake via the manager so a future rotating source (ACME)
+// needs no listener change.
+func TLSConfig(cm CertManager) *tls.Config {
+	return &tls.Config{
+		MinVersion:     tls.VersionTLS12,
+		GetCertificate: cm.GetCertificate,
+	}
+}
+
+// fileCertManager serves a bring-your-own certificate loaded once from PEM files
+// at startup. Loading at construction means a bad pair is a clean startup error
+// rather than a per-handshake failure.
+type fileCertManager struct {
+	cert *tls.Certificate
+}
+
+func newFileCertManager(certFile, keyFile string) (*fileCertManager, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load TLS keypair: %w", err)
+	}
+	return &fileCertManager{cert: &cert}, nil
+}
+
+func (m *fileCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return m.cert, nil
+}

--- a/internal/servetls/servetls_test.go
+++ b/internal/servetls/servetls_test.go
@@ -1,0 +1,212 @@
+package servetls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTLSConfigMinVersionAndCert(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	cm, err := newSelfSignedCertManager(dir)
+	if err != nil {
+		t.Fatalf("newSelfSignedCertManager: %v", err)
+	}
+	cfg := TLSConfig(cm)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %x; want TLS 1.2 (%x)", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if cfg.GetCertificate == nil {
+		t.Fatal("GetCertificate not wired")
+	}
+	got, err := cfg.GetCertificate(&tls.ClientHelloInfo{})
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if got == nil || len(got.Certificate) == 0 {
+		t.Fatal("nil/empty certificate")
+	}
+}
+
+func TestBuildCertManagerDisabled(t *testing.T) {
+	cm, err := BuildCertManager("", "", false, t.TempDir())
+	if err != nil {
+		t.Fatalf("BuildCertManager: %v", err)
+	}
+	if cm != nil {
+		t.Error("expected nil CertManager when TLS is disabled")
+	}
+}
+
+func TestBuildCertManagerSelfSigned(t *testing.T) {
+	dbDir := t.TempDir()
+	cm, err := BuildCertManager("", "", true, dbDir)
+	if err != nil {
+		t.Fatalf("BuildCertManager: %v", err)
+	}
+	if cm == nil {
+		t.Fatal("expected a CertManager for self_signed")
+	}
+	if _, ok := cm.(*selfSignedCertManager); !ok {
+		t.Errorf("got %T; want *selfSignedCertManager", cm)
+	}
+	// Persisted under <dbDir>/tls/.
+	if _, err := os.Stat(filepath.Join(dbDir, "tls", selfSignedCertFile)); err != nil {
+		t.Errorf("self-signed cert not persisted under dbDir/tls: %v", err)
+	}
+}
+
+func TestBuildCertManagerBYO(t *testing.T) {
+	certPath, keyPath := writeFixturePair(t)
+	cm, err := BuildCertManager(certPath, keyPath, false, t.TempDir())
+	if err != nil {
+		t.Fatalf("BuildCertManager: %v", err)
+	}
+	if _, ok := cm.(*fileCertManager); !ok {
+		t.Errorf("got %T; want *fileCertManager", cm)
+	}
+	cert, err := cm.GetCertificate(nil)
+	if err != nil || cert == nil {
+		t.Fatalf("GetCertificate: cert=%v err=%v", cert, err)
+	}
+}
+
+func TestBuildCertManagerBYOTakesPrecedenceOverSelfSigned(t *testing.T) {
+	certPath, keyPath := writeFixturePair(t)
+	cm, err := BuildCertManager(certPath, keyPath, true, t.TempDir())
+	if err != nil {
+		t.Fatalf("BuildCertManager: %v", err)
+	}
+	if _, ok := cm.(*fileCertManager); !ok {
+		t.Errorf("got %T; BYO cert/key must win over self_signed", cm)
+	}
+}
+
+func TestNewFileCertManagerBadFiles(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(bad, []byte("not a pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newFileCertManager(bad, bad); err == nil {
+		t.Error("expected error for invalid keypair")
+	}
+}
+
+// TestServeTLSEndToEnd is the strongest evidence for lane 5: a real http.Server
+// using the TLSConfig built from a CertManager serves HTTPS, and the handler sees
+// r.TLS != nil (the exact signal lane 3's secureRequest reads to flip the cookie
+// Secure flag). Covers both BYO and self-signed managers.
+func TestServeTLSEndToEnd(t *testing.T) {
+	byoCert, byoKey := writeFixturePair(t)
+	byo, err := newFileCertManager(byoCert, byoKey)
+	if err != nil {
+		t.Fatalf("newFileCertManager: %v", err)
+	}
+	selfsigned, err := newSelfSignedCertManager(filepath.Join(t.TempDir(), "tls"))
+	if err != nil {
+		t.Fatalf("newSelfSignedCertManager: %v", err)
+	}
+
+	for name, cm := range map[string]CertManager{"byo": byo, "self_signed": selfsigned} {
+		t.Run(name, func(t *testing.T) {
+			sawTLS := make(chan bool, 1)
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sawTLS <- (r.TLS != nil)
+				fmt.Fprintln(w, "ok")
+			})
+			srv := httptest.NewUnstartedServer(h)
+			srv.TLS = TLSConfig(cm)
+			srv.StartTLS()
+			defer srv.Close()
+
+			resp, err := srv.Client().Get(srv.URL)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d body=%q", resp.StatusCode, body)
+			}
+			if saw := <-sawTLS; !saw {
+				t.Error("handler did not see r.TLS (expected TLS connection)")
+			}
+			// MinVersion is enforced: a fresh handshake capped at TLS 1.1 must be
+			// refused. Dial directly (not via the HTTP client) to avoid reusing a
+			// pooled TLS 1.3 connection.
+			conn, err := tls.Dial("tcp", srv.Listener.Addr().String(), &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // G402: test-only handshake-version probe; we assert it is REFUSED.
+				MinVersion:         tls.VersionTLS10,
+				MaxVersion:         tls.VersionTLS11,
+			})
+			if err == nil {
+				_ = conn.Close()
+				t.Error("server accepted a TLS 1.1 handshake; MinVersion not enforced")
+			}
+		})
+	}
+}
+
+// --- shared cert helpers (used across the package's tests) ---
+
+// writeFixturePair generates a fresh self-signed pair and writes it to temp files,
+// returning their paths. Used as a stand-in for an operator's bring-your-own cert.
+func writeFixturePair(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	now := time.Now()
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	if err != nil {
+		t.Fatalf("generate fixture: %v", err)
+	}
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+// certFromPEM parses the first CERTIFICATE block from PEM.
+func certFromPEM(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func mustLeaf(t *testing.T, cert *tls.Certificate) *x509.Certificate {
+	t.Helper()
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return leaf
+}
+
+func serialOf(t *testing.T, cert *tls.Certificate) string {
+	t.Helper()
+	return mustLeaf(t, cert).SerialNumber.String()
+}
+
+func serialOfPEM(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	c, err := certFromPEM(certPEM)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return c.SerialNumber.String()
+}


### PR DESCRIPTION
## Summary

Implements **lane 5 (TLS)** of the authenticated-web-access design (`docs/design/2026-06-14-204-auth-web-tls.md`, Area 4 + Decomposition #5) - the final lane of the #241 web-auth umbrella (lanes 1-4 already shipped). Adds optional TLS to `mxlrcgo-svc serve`, **off by default** (no behavior change for existing deployments).

- **BYO certificate** (`[server.tls].cert_file` + `key_file`): the serve listener terminates TLS itself, MinVersion 1.2.
- **Self-signed bootstrap** (`self_signed = true`): generates an ECDSA P-256 cert on first run, persisted `0600` under `<dir(db_path)>/tls/`, real SANs (`mxlrcgo-svc`, `localhost`, `127.0.0.1`, `::1`), ~365-day validity, auto-regenerated when missing/expired, with a clear untrusted-cert warning.
- **Optional `redirect_http`** plain-HTTP listener that 301s to the HTTPS address.
- **`CertManager` interface seam** so the deferred ACME path (lane 6) drops in without a listener rewrite.
- `[server.tls]` config + `MXLRC_TLS_*` env overrides, fail-fast validation at startup (no silent plaintext downgrade), listener wiring in `runServe`. The session cookie's `Secure` flag flips on automatically under TLS (via lane 3's `r.TLS` check).

## Verification

| check | result |
|---|---|
| `make gate` | PASS (gofmt, build, race tests, golangci-lint 0 issues, actionlint, govulncheck) |
| patch coverage | 72.56% (above the 70% floor) |
| hostile security review (independent, opus) | **SHIP** - no blocker, no major |

The security review verified the high-risk areas: real SANs (not the CN-only Go-rejection bug), `0600`/`0700` perms with self-healing non-atomic writes, startup-only cert generation (no per-request race), MinVersion 1.2 on the actual listener config, fail-fast with **no silent plaintext downgrade**, an open-redirect/CRLF-safe redirect, and correct auto-`Secure` cookie wiring.

Fixed during review: an IPv6-literal redirect bug (now uses `net.JoinHostPort`/bracketing, with tests) and `slog.Default()` test-isolation in this lane's new tests.

## Deferred (tracked)

- **#275** - TLS lane-5 follow-ups: a config knob to add the operator's LAN address to the self-signed cert SANs, plus two redirect NITs (bind-failure handling, timeouts).
- **#274** - a pre-existing `go test -shuffle=on` flake (`TestApplyLogLevel` vs `TestRunServe_*` global-`slog` leak in `secrets_precedence_test.go`); not CI-gated. This PR does not extend it (its own new tests restore `slog.Default()`).

Closes #241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional TLS/HTTPS support for the serve listener with two configuration modes: bring-your-own certificates or automatic self-signed certificate generation.
  * Added HTTP to HTTPS redirect capability via the `redirect_http` configuration option.

* **Documentation**
  * Added comprehensive TLS configuration documentation in README and example configuration file covering certificate options, redirect settings, and behavioral details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->