### PR TITLE
ci(web): harden UI-Assets check with size-band + sentinel guard (#273)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,27 @@ ui-check: ui
 		echo "Generated web UI assets are stale or untracked. Run 'make ui' and commit the result."; \
 		exit 1; \
 	}
+	@# Guard the load-bearing shell-layout CSS rules (.mx-shell/.mx-sidebar/.mx-content,
+	@# authored directly in input.css as custom CSS) against an accidental committed
+	@# deletion. These classes are always emitted independent of @source globs; this
+	@# check is NOT an @source-glob coverage gate.
+	@for cls in mx-shell mx-sidebar mx-content; do \
+		if ! grep -q "\.$$cls{" web/static/css/output.css; then \
+			echo "ui-check: sentinel class .$$cls missing from output.css"; \
+			echo "  A @source glob may be missing from web/static/css/input.css for a new template location."; \
+			exit 1; \
+		fi; \
+	done
+	@# Size band: output.css should stay within 7000-15000 bytes.
+	@# Too small = a @source glob is too narrow (classes dropped silently).
+	@# Too large = Go vocabulary may be leaking back into output.css.
+	@# If an intentional change moves the size outside this band, update both bounds here.
+	@size=$$(wc -c < web/static/css/output.css | awk '{print $$1}'); \
+	if [ "$$size" -lt 7000 ] || [ "$$size" -gt 15000 ]; then \
+		echo "ui-check: output.css is $$size B, outside the expected 7000-15000 B band."; \
+		echo "  Update the band in the Makefile ui-check target if the change is intentional."; \
+		exit 1; \
+	fi
 
 ## clean: Remove build artifacts
 clean:

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -11,8 +11,11 @@
  * junk it never serves (issue #271). The explicit @source globs below are the
  * authoritative content list -- they must cover every web file that uses
  * Tailwind classes (the templ sources and the generated *_templ.go where the
- * class strings actually land). If you add a new web source with classes, add
- * its glob here or the classes will be missing from output.css.
+ * class strings actually land). If you add a new web source location with
+ * Tailwind classes, add a matching @source glob here or those classes will be
+ * silently absent from output.css -- this is a developer discipline requirement.
+ * The `make ui-check` size-band backstops gross scan drift (e.g. a too-broad
+ * glob re-leaking non-UI vocabulary) but does not verify per-view class coverage.
  */
 @import "tailwindcss" source(none);
 @import "./design-tokens.css";


### PR DESCRIPTION
## Summary

Hardens the `UI Assets` CI check (`make ui-check`, which the workflow runs) against silent web-asset regressions, following up on #272's Tailwind content-scoping fix. Touches the `Makefile` `ui-check` target and an `input.css` comment only - no Go, no workflow edit.

After `make ui` regenerates `output.css`, `ui-check` now also:

- **Size band (7000-15000 B):** the genuinely valuable guard - it catches a Go-vocabulary re-leak (`output.css` ballooning if an `@source` glob goes too broad, the actual #271 regression class) and gross under-generation.
- **Sentinel-class grep** (`.mx-shell` / `.mx-sidebar` / `.mx-content`): an honest regression guard against an accidental committed deletion of the load-bearing shell-layout CSS rules.

## Honest scope note

An adversarial review correctly flagged that these sentinel classes are **hand-written custom CSS in `input.css`**, so they are always emitted regardless of `@source` globs - the sentinel grep therefore cannot enforce `@source` coverage the way #273 originally implied (the repo's templates use only custom `.mx-*` classes, zero bare Tailwind utilities, so that failure mode is largely theoretical here). The comments were corrected to describe what each check actually does, rather than overclaiming `@source` enforcement. The size-band is the substantive protection; the sentinel grep is a bonus regression guard, now accurately documented.

## Verification

- `make ui-check` passes (exit 0), tree clean, no asset drift.

Closes #273
