### PR TITLE
test(commands): restore global slog default in TestRunServe_* to fix -shuffle order-dependence (#274)

### DIFF
--- a/internal/commands/secrets_precedence_test.go
+++ b/internal/commands/secrets_precedence_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -297,6 +298,8 @@ func TestResolveWebhookKeysWithStore_BlankDBValue(t *testing.T) {
 // nonexistent ffmpeg causes exit code 1 there. The key-file stat after the call
 // is the actual proof that the store initialized and created the file.
 func TestRunServe_DockerAutoKeyFile(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
 	t.Setenv("MXLRC_DOCKER", "true")
 	t.Setenv("MXLRC_MASTER_KEY", "")
 	// In Docker mode xdgDataPath returns /config/... which is not writable in tests.
@@ -339,6 +342,8 @@ func TestRunServe_DockerAutoKeyFile(t *testing.T) {
 // verifier construction (verification enabled with a nonexistent ffmpeg) so the
 // HTTP server never starts. Exit code 1.
 func TestRunServe_DBSecretsThenVerifierFailure(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
 	t.Setenv("MXLRC_DOCKER", "")
 	key, err := secrets.GenerateKey()
 	if err != nil {


### PR DESCRIPTION
Fixes the pre-existing `go test -race -shuffle=on` order-dependence flake in `internal/commands` (surfaced during the #276 lane-5 review/triage).

## Root cause

`TestRunServe_DockerAutoKeyFile` and `TestRunServe_DBSecretsThenVerifierFailure` (`internal/commands/secrets_precedence_test.go`) call `runServe` -> `initLogging` -> `slog.SetDefault(...)`, replacing the **process-global** default logger and never restoring it. When shuffled before `TestApplyLogLevel`, the global default stays a fixed-`LevelInfo` handler, so `slog.Default().Enabled(ctx, LevelDebug)` is false and `TestApplyLogLevel/debug`+`/warn` fail.

## Fix

Snapshot + restore the global default in both tests (test-only, +5 lines, no production change):

```go
prev := slog.Default()
t.Cleanup(func() { slog.SetDefault(prev) })
```

(#276 already applied the same pattern to its own new `serve_tls_test.go` tests; this completes the package.)

## Verification

- `make gate`: PASS.
- `go test -race -shuffle=on ./internal/commands/` x4: all ok.
- The deterministic repro seed `1781655304133329000`: now passes.

`-shuffle` is not a CI-gated check, so this is a test-quality fix, not a CI unblock.

Closes #274