### PR TITLE
feat(serve): configurable self-signed SANs + redirect bind-fail/timeouts (#275)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -851,11 +852,25 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// The self-signed bootstrap persists under <dir(db_path)>/tls/. Built before
 	// the run context so a bad cert/key or generation failure is a clean early
 	// return rather than a leaked listener.
-	certMgr, err := servetls.BuildCertManager(cfg.Server.TLS.CertFile, cfg.Server.TLS.KeyFile, cfg.Server.TLS.SelfSigned, filepath.Dir(cfg.DB.Path))
+	certMgr, err := servetls.BuildCertManager(cfg.Server.TLS.CertFile, cfg.Server.TLS.KeyFile, cfg.Server.TLS.SelfSigned, filepath.Dir(cfg.DB.Path), cfg.Server.TLS.SelfSignedHosts)
 	if err != nil {
 		_ = sqlDB.Close()
 		slog.Error("failed to initialize TLS", "error", err)
 		return 1
+	}
+
+	// Bind the redirect listener eagerly (before starting goroutines) so a bind
+	// failure is a clean startup error. An operator who explicitly configured
+	// redirect_http expects it to work; silently skipping it would be confusing.
+	var redirectLn net.Listener
+	if certMgr != nil && cfg.Server.TLS.RedirectHTTP != "" {
+		ln, listenErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.Server.TLS.RedirectHTTP)
+		if listenErr != nil {
+			_ = sqlDB.Close()
+			slog.Error("HTTP redirect listener failed to bind; aborting startup", "addr", cfg.Server.TLS.RedirectHTTP, "error", listenErr)
+			return 1
+		}
+		redirectLn = ln
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -929,16 +944,10 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		}
 	}()
 
-	// Optional plain-HTTP redirect listener (#204, lane 5): only when TLS is on
-	// and server.tls.redirect_http is set. Every request 301s to the HTTPS addr.
-	// Lifecycle mirrors the main server: graceful shutdown on context cancel.
-	var redirectSrv *http.Server
-	if certMgr != nil && cfg.Server.TLS.RedirectHTTP != "" {
-		redirectSrv = &http.Server{
-			Addr:              cfg.Server.TLS.RedirectHTTP,
-			Handler:           servetls.RedirectHandler(addr),
-			ReadHeaderTimeout: 5 * time.Second,
-		}
+	// Optional plain-HTTP redirect listener (#204, lane 5): listener already bound
+	// above (fail-fast on error); here we just start serving on it.
+	if redirectLn != nil {
+		redirectSrv := buildRedirectServer(cfg.Server.TLS.RedirectHTTP, addr)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -951,7 +960,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 				}
 			}()
 			slog.Info("starting HTTP->HTTPS redirect listener", "addr", redirectSrv.Addr, "target", addr)
-			if err := redirectSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if err := redirectSrv.Serve(redirectLn); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				slog.Error("HTTP redirect server failed", "error", err)
 			}
 		}()
@@ -978,6 +987,19 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		slog.Warn("failed to close database", "error", err)
 	}
 	return code
+}
+
+// buildRedirectServer constructs the HTTP->HTTPS redirect http.Server. Extracted so
+// the timeout values can be verified in tests without starting a live listener.
+func buildRedirectServer(redirectAddr, tlsAddr string) *http.Server {
+	return &http.Server{
+		Addr:              redirectAddr,
+		Handler:           servetls.RedirectHandler(tlsAddr),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
 }
 
 // buildWebAuth constructs the authenticated web UI subsystem for serve mode

--- a/internal/commands/serve_tls_test.go
+++ b/internal/commands/serve_tls_test.go
@@ -150,6 +150,78 @@ func TestRunServe_TLSSelfSignedServesHTTPS(t *testing.T) {
 	}
 }
 
+// TestBuildRedirectServer verifies that the redirect-only server struct carries all
+// four required timeout fields. A redirect server that can block indefinitely on
+// a slow client is a denial-of-service risk.
+func TestBuildRedirectServer(t *testing.T) {
+	srv := buildRedirectServer(":8080", ":8443")
+	if srv.ReadHeaderTimeout == 0 {
+		t.Error("ReadHeaderTimeout not set")
+	}
+	if srv.ReadTimeout == 0 {
+		t.Error("ReadTimeout not set")
+	}
+	if srv.WriteTimeout == 0 {
+		t.Error("WriteTimeout not set")
+	}
+	if srv.IdleTimeout == 0 {
+		t.Error("IdleTimeout not set")
+	}
+	if srv.Handler == nil {
+		t.Error("Handler not set")
+	}
+	if srv.Addr != ":8080" {
+		t.Errorf("Addr = %q; want :8080", srv.Addr)
+	}
+}
+
+// TestRunServe_TLSRedirectBindFails verifies that runServe exits with code 1 when the
+// redirect listener cannot bind. An explicitly-configured redirect that cannot start
+// is an operator error; startup must abort rather than silently skip the redirect.
+func TestRunServe_TLSRedirectBindFails(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	t.Setenv("MXLRC_DOCKER", "")
+	t.Setenv("MUSIXMATCH_TOKEN", "tok")
+	keyFile := filepath.Join(t.TempDir(), "test.key")
+	t.Setenv("MXLRC_SECRETS_KEY_FILE", keyFile)
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "serve.db")
+	httpsAddr := freePort(t)
+
+	// Hold the redirect port open so runServe cannot bind it.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("block listen: %v", err)
+	}
+	blockedAddr := blocker.Addr().String()
+	defer blocker.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	var b strings.Builder
+	b.WriteString("[db]\npath = " + tomlString(dbPath) + "\n\n")
+	b.WriteString("[providers]\nprimary = \"musixmatch\"\n\n")
+	b.WriteString("[server]\naddr = " + tomlString(httpsAddr) + "\n\n")
+	b.WriteString("[server.tls]\nself_signed = true\nredirect_http = " + tomlString(blockedAddr) + "\n")
+	if err := os.WriteFile(cfgPath, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runServe(
+		context.Background(),
+		&out,
+		ServeCmd{ConfigPath: cfgPath},
+		func(string) musixmatch.Fetcher { return fakeFetcher{} },
+		func(...string) lyrics.Writer { return fakeWriter{} },
+	)
+	if code != 1 {
+		t.Fatalf("redirect bind fail: exit code = %d, want 1", code)
+	}
+}
+
 // TestRunServe_TLSBadCertFailsFast: a cert_file/key_file pointing at unreadable
 // PEM makes runServe fail before serving (exit 1).
 func TestRunServe_TLSBadCertFailsFast(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -216,6 +217,15 @@ type TLSConfig struct {
 	// no redirect listener. Only honored when TLS is enabled. Override:
 	// MXLRC_TLS_REDIRECT_HTTP.
 	RedirectHTTP string `toml:"redirect_http"`
+	// SelfSignedHosts lists extra hostnames and IP literals to include as Subject
+	// Alternative Names in the generated self-signed certificate, in addition to the
+	// built-in SANs (localhost, mxlrcgo-svc, 127.0.0.1, ::1). Allows browsers on
+	// LAN hosts to reach https://<lan-ip-or-hostname> without a name-mismatch error
+	// when they trust the cert. Each entry must be a valid hostname or IP literal;
+	// invalid entries are a startup error. Duplicates and entries already covered by
+	// the built-ins are silently ignored. Only honored when self_signed is true.
+	// Override: MXLRC_TLS_SELF_SIGNED_HOSTS (comma-separated).
+	SelfSignedHosts []string `toml:"self_signed_hosts"`
 }
 
 // Enabled reports whether TLS termination is configured (bring-your-own cert or
@@ -580,7 +590,7 @@ func LoadWithSources(path string) (Config, map[string]bool, error) {
 // applyEnvOverrides overlays environment variables onto cfg.
 // Token precedence within env vars: MUSIXMATCH_TOKEN > MXLRC_API_TOKEN.
 // Cooldown precedence: MXLRC_API_COOLDOWN > MXLRC_COOLDOWN.
-// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SECRETS_KEY_FILE, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_TRUSTED_CIDRS, MXLRC_TRUSTED_PROXIES, MXLRC_TLS_CERT_FILE, MXLRC_TLS_KEY_FILE, MXLRC_TLS_SELF_SIGNED, MXLRC_TLS_REDIRECT_HTTP, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
+// Supported: MUSIXMATCH_TOKEN, MXLRC_API_TOKEN, MXLRC_API_COOLDOWN, MXLRC_COOLDOWN, MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_MISS_BACKOFF_BASE_HOURS, MXLRC_MISS_BACKOFF_CAP_HOURS, MXLRC_MAX_MISS_ATTEMPTS, MXLRC_OUTPUT_DIR, MXLRC_BILINGUAL_OUTPUT, MXLRC_DB_PATH, MXLRC_SECRETS_KEY_FILE, MXLRC_SERVER_ADDR, MXLRC_WEBHOOK_API_KEY, MXLRC_SCAN_INTERVAL, MXLRC_WORK_INTERVAL, MXLRC_TRUSTED_CIDRS, MXLRC_TRUSTED_PROXIES, MXLRC_TLS_CERT_FILE, MXLRC_TLS_KEY_FILE, MXLRC_TLS_SELF_SIGNED, MXLRC_TLS_REDIRECT_HTTP, MXLRC_TLS_SELF_SIGNED_HOSTS, MXLRC_PROVIDER_PRIMARY, MXLRC_PROVIDERS_DISABLED, MXLRC_PROVIDERS_MODE, MXLRC_PROVIDERS_RACE_WAIT_SECONDS, MXLRC_PROVIDERS_FALLBACK_ORDER, MXLRC_VERIFICATION_ENABLED, MXLRC_VERIFICATION_WHISPER_URL, MXLRC_WHISPER_URL, MXLRC_VERIFICATION_FFMPEG_PATH, MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS, MXLRC_VERIFICATION_SAMPLE_DURATION, MXLRC_VERIFICATION_MIN_CONFIDENCE, MXLRC_VERIFICATION_MIN_SIMILARITY, MXLRC_INSTRUMENTAL_DETECTOR_ENABLED, MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL, MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH, MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS, MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE, MXLRC_INSTRUMENTAL_DETECTOR_CLASSES, MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS, MXLRC_ENRICHMENT_ENABLED, MXLRC_GUARD_ACCEPTED_SCRIPTS, MXLRC_GUARD_THRESHOLD, MXLRC_QUEUE_RANDOMIZE, MXLRC_LOG_LEVEL, MXLRC_LOG_FORMAT, MXLRC_LOG_FILE, MXLRC_LOG_MAX_SIZE_MB, MXLRC_LOG_MAX_FILES, MXLRC_LOG_MAX_AGE_DAYS, MXLRC_LOG_COMPRESS
 //
 // applied (must be non-nil) records the dotted config field path for every
 // override that ACTUALLY took effect. Env values that are rejected (invalid
@@ -740,6 +750,10 @@ func applyEnvOverrides(cfg *Config, applied map[string]bool) {
 	if v := os.Getenv("MXLRC_TLS_REDIRECT_HTTP"); v != "" {
 		cfg.Server.TLS.RedirectHTTP = v
 		applied["server.tls.redirect_http"] = true
+	}
+	if v := os.Getenv("MXLRC_TLS_SELF_SIGNED_HOSTS"); v != "" {
+		cfg.Server.TLS.SelfSignedHosts = splitCSV(v)
+		applied["server.tls.self_signed_hosts"] = true
 	}
 	if v := os.Getenv("MXLRC_PROVIDER_PRIMARY"); v != "" {
 		cfg.Providers.Primary = v
@@ -1093,6 +1107,7 @@ func validateTrustedNetworks(cfg Config) error {
 // validateServerTLS fails fast on a contradictory [server.tls] configuration
 // (issue #204, Area 4): self_signed cannot be combined with an explicit
 // cert_file/key_file, and cert_file and key_file must be supplied together.
+// Each entry in self_signed_hosts must parse as a valid IP literal or hostname.
 // Validation happens at load so a misconfiguration is a clear startup error
 // rather than a confusing listener failure.
 func validateServerTLS(cfg Config) error {
@@ -1103,7 +1118,35 @@ func validateServerTLS(cfg Config) error {
 	if (t.CertFile == "") != (t.KeyFile == "") {
 		return fmt.Errorf("config: server.tls: cert_file and key_file must be set together")
 	}
+	for _, h := range t.SelfSignedHosts {
+		if net.ParseIP(h) == nil && !isValidHostname(h) {
+			return fmt.Errorf("config: server.tls: self_signed_hosts: %q is not a valid hostname or IP address", h)
+		}
+	}
 	return nil
+}
+
+// isValidHostname reports whether s is a valid RFC 1123 hostname. Each dot-separated
+// label must be 1-63 characters of [a-zA-Z0-9-] with no leading or trailing hyphen.
+func isValidHostname(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		n := len(label)
+		if n == 0 || n > 63 {
+			return false
+		}
+		if label[0] == '-' || label[n-1] == '-' {
+			return false
+		}
+		for _, ch := range label {
+			if (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9') && ch != '-' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func splitCSV(s string) []string {

--- a/internal/config/tls_test.go
+++ b/internal/config/tls_test.go
@@ -127,6 +127,72 @@ func TestLoad_TLSSelfSignedInvalidEnvIgnored(t *testing.T) {
 	}
 }
 
+func TestLoad_TLSSelfSignedHostsFromFile(t *testing.T) {
+	isolateEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := "[server.tls]\nself_signed = true\nself_signed_hosts = [\"nas.local\", \"192.168.1.10\"]\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(cfg.Server.TLS.SelfSignedHosts) != 2 {
+		t.Errorf("SelfSignedHosts = %v; want [nas.local 192.168.1.10]", cfg.Server.TLS.SelfSignedHosts)
+	}
+}
+
+func TestLoad_TLSSelfSignedHostsEnvOverride(t *testing.T) {
+	isolateEnv(t)
+	t.Setenv("MXLRC_TLS_SELF_SIGNED_HOSTS", "nas.local,192.168.1.10")
+	cfg, applied, err := LoadWithSources(filepath.Join(t.TempDir(), "nonexistent.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithSources returned error: %v", err)
+	}
+	if len(cfg.Server.TLS.SelfSignedHosts) != 2 {
+		t.Errorf("SelfSignedHosts = %v; want 2 entries", cfg.Server.TLS.SelfSignedHosts)
+	}
+	if !applied["server.tls.self_signed_hosts"] {
+		t.Error("expected server.tls.self_signed_hosts marked applied")
+	}
+}
+
+func TestLoad_TLSSelfSignedHostsValidationRejectsInvalid(t *testing.T) {
+	isolateEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := "[server.tls]\nself_signed = true\nself_signed_hosts = [\"not a valid host!\"]\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected validation error for invalid host entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "self_signed_hosts") {
+		t.Errorf("error = %q; want mention of self_signed_hosts", err.Error())
+	}
+}
+
+func TestLoad_TLSSelfSignedHostsValidationAcceptsValidEntries(t *testing.T) {
+	isolateEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := "[server.tls]\nself_signed = true\nself_signed_hosts = [\"nas.local\", \"myhost\", \"192.168.1.10\", \"2001:db8::1\"]\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(cfg.Server.TLS.SelfSignedHosts) != 4 {
+		t.Errorf("SelfSignedHosts = %v; want 4 entries", cfg.Server.TLS.SelfSignedHosts)
+	}
+}
+
 func TestLoad_TLSValidationFailsFast(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/servetls/selfsigned.go
+++ b/internal/servetls/selfsigned.go
@@ -35,13 +35,14 @@ const (
 // selfSignedCertManager serves a self-signed certificate persisted under dir. The
 // certificate is loaded (or generated and persisted) once at construction;
 // regeneration happens only at startup when the stored pair is missing, unreadable,
-// or expired.
+// expired, or when the persisted SANs do not cover the currently-configured extras.
 type selfSignedCertManager struct {
 	cert *tls.Certificate
 }
 
-func newSelfSignedCertManager(dir string) (*selfSignedCertManager, error) {
-	cert, err := ensureSelfSignedCert(dir)
+func newSelfSignedCertManager(dir string, extraHosts []string) (*selfSignedCertManager, error) {
+	extraDNS, extraIPs := parseSelfSignedHosts(extraHosts)
+	cert, err := ensureSelfSignedCert(dir, extraDNS, extraIPs)
 	if err != nil {
 		return nil, err
 	}
@@ -55,22 +56,26 @@ func (m *selfSignedCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certi
 }
 
 // ensureSelfSignedCert loads the persisted self-signed pair under dir, generating
-// and persisting a fresh one when the pair is missing, unreadable, or expired
-// (or expires within the renewal window). The private key is written 0600.
-func ensureSelfSignedCert(dir string) (*tls.Certificate, error) {
+// and persisting a fresh one when the pair is missing, unreadable, expired (or
+// expires within the renewal window), or when the persisted cert's SAN set does not
+// cover the desired extras (extraDNS, extraIPs). The private key is written 0600.
+func ensureSelfSignedCert(dir string, extraDNS []string, extraIPs []net.IP) (*tls.Certificate, error) {
 	certPath := filepath.Join(dir, selfSignedCertFile)
 	keyPath := filepath.Join(dir, selfSignedKeyFile)
 
 	if cert, ok := loadValidCert(certPath, keyPath); ok {
-		slog.Info("reusing persisted self-signed TLS certificate", "cert", certPath)
-		return cert, nil
+		if sansCovered(cert, extraDNS, extraIPs) {
+			slog.Info("reusing persisted self-signed TLS certificate", "cert", certPath)
+			return cert, nil
+		}
+		slog.Info("configured SANs not covered by persisted certificate; regenerating", "cert", certPath)
 	}
 
 	if err := os.MkdirAll(dir, dirMode); err != nil {
 		return nil, fmt.Errorf("create TLS dir %s: %w", dir, err)
 	}
 	now := time.Now()
-	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity), extraDNS, extraIPs)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +128,9 @@ func loadValidCert(certPath, keyPath string) (*tls.Certificate, bool) {
 // generateSelfSignedCert builds an ECDSA P-256 self-signed certificate valid over
 // [notBefore, notAfter], returning the cert and key as PEM. CN=mxlrcgo-svc, with
 // loopback SANs so same-host HTTPS verifies against localhost/127.0.0.1/::1.
-func generateSelfSignedCert(notBefore, notAfter time.Time) (certPEM, keyPEM []byte, err error) {
+// extraDNS and extraIPs are appended to the built-in SANs; they must be pre-deduped
+// against the built-ins (parseSelfSignedHosts guarantees this).
+func generateSelfSignedCert(notBefore, notAfter time.Time, extraDNS []string, extraIPs []net.IP) (certPEM, keyPEM []byte, err error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate ECDSA key: %w", err)
@@ -140,8 +147,8 @@ func generateSelfSignedCert(notBefore, notAfter time.Time) (certPEM, keyPEM []by
 		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		DNSNames:              []string{selfSignedCommonName, "localhost"},
-		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:              append([]string{selfSignedCommonName, "localhost"}, extraDNS...),
+		IPAddresses:           append([]net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, extraIPs...),
 	}
 	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
@@ -154,6 +161,86 @@ func generateSelfSignedCert(notBefore, notAfter time.Time) (certPEM, keyPEM []by
 	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 	return certPEM, keyPEM, nil
+}
+
+// parseSelfSignedHosts splits a list of raw host strings (from self_signed_hosts)
+// into DNS names and IP addresses, deduplicating against the built-in loopback/localhost
+// SANs that generateSelfSignedCert always includes. Invalid entries are silently
+// skipped; config validation in validateServerTLS already rejects them before this
+// is called.
+func parseSelfSignedHosts(hosts []string) (dnsNames []string, ips []net.IP) {
+	builtinDNS := map[string]bool{selfSignedCommonName: true, "localhost": true}
+	builtinIPs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+	seenDNS := map[string]bool{}
+	seenIP := map[string]bool{}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			isBuiltin := false
+			for _, b := range builtinIPs {
+				if b.Equal(ip) {
+					isBuiltin = true
+					break
+				}
+			}
+			if isBuiltin {
+				continue
+			}
+			key := ip.String()
+			if !seenIP[key] {
+				seenIP[key] = true
+				ips = append(ips, ip)
+			}
+		} else {
+			if builtinDNS[h] || seenDNS[h] {
+				continue
+			}
+			seenDNS[h] = true
+			dnsNames = append(dnsNames, h)
+		}
+	}
+	return dnsNames, ips
+}
+
+// sansCovered reports whether cert already carries all SANs in wantDNS and wantIPs.
+// A true result means the persisted cert covers the configured extras and can be
+// reused without regeneration. An empty want-set always returns true.
+func sansCovered(cert *tls.Certificate, wantDNS []string, wantIPs []net.IP) bool {
+	if len(wantDNS) == 0 && len(wantIPs) == 0 {
+		return true
+	}
+	leaf := cert.Leaf
+	if leaf == nil {
+		if len(cert.Certificate) == 0 {
+			return false
+		}
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return false
+		}
+		leaf = parsed
+	}
+	haveDNS := make(map[string]bool, len(leaf.DNSNames))
+	for _, d := range leaf.DNSNames {
+		haveDNS[d] = true
+	}
+	for _, want := range wantDNS {
+		if !haveDNS[want] {
+			return false
+		}
+	}
+	for _, wantIP := range wantIPs {
+		found := false
+		for _, haveIP := range leaf.IPAddresses {
+			if haveIP.Equal(wantIP) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // writeFileMode writes data to path with exactly the given mode, removing any

--- a/internal/servetls/selfsigned_test.go
+++ b/internal/servetls/selfsigned_test.go
@@ -2,6 +2,7 @@ package servetls
 
 import (
 	"crypto/x509"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,7 +12,7 @@ import (
 
 func TestGenerateSelfSignedCert(t *testing.T) {
 	now := time.Now()
-	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity), nil, nil)
 	if err != nil {
 		t.Fatalf("generateSelfSignedCert: %v", err)
 	}
@@ -33,7 +34,7 @@ func TestGenerateSelfSignedCert(t *testing.T) {
 
 func TestEnsureSelfSignedCertGeneratesAndPersists(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "tls")
-	cert, err := ensureSelfSignedCert(dir)
+	cert, err := ensureSelfSignedCert(dir, nil, nil)
 	if err != nil {
 		t.Fatalf("ensureSelfSignedCert: %v", err)
 	}
@@ -51,11 +52,11 @@ func TestEnsureSelfSignedCertGeneratesAndPersists(t *testing.T) {
 
 func TestEnsureSelfSignedCertReusesExisting(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "tls")
-	first, err := ensureSelfSignedCert(dir)
+	first, err := ensureSelfSignedCert(dir, nil, nil)
 	if err != nil {
 		t.Fatalf("first ensure: %v", err)
 	}
-	second, err := ensureSelfSignedCert(dir)
+	second, err := ensureSelfSignedCert(dir, nil, nil)
 	if err != nil {
 		t.Fatalf("second ensure: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestEnsureSelfSignedCertRegeneratesWhenExpired(t *testing.T) {
 	}
 	// Write an already-expired pair.
 	past := time.Now().Add(-2 * selfSignedValidity)
-	certPEM, keyPEM, err := generateSelfSignedCert(past, past.Add(selfSignedValidity))
+	certPEM, keyPEM, err := generateSelfSignedCert(past, past.Add(selfSignedValidity), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +87,7 @@ func TestEnsureSelfSignedCertRegeneratesWhenExpired(t *testing.T) {
 	}
 	expiredSerial := serialOfPEM(t, certPEM)
 
-	cert, err := ensureSelfSignedCert(dir)
+	cert, err := ensureSelfSignedCert(dir, nil, nil)
 	if err != nil {
 		t.Fatalf("ensureSelfSignedCert: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestLoadValidCertRejectsMissing(t *testing.T) {
 
 func TestNewSelfSignedCertManagerGetCertificate(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "tls")
-	m, err := newSelfSignedCertManager(dir)
+	m, err := newSelfSignedCertManager(dir, nil)
 	if err != nil {
 		t.Fatalf("newSelfSignedCertManager: %v", err)
 	}
@@ -120,6 +121,144 @@ func TestNewSelfSignedCertManagerGetCertificate(t *testing.T) {
 	}
 	if cert == nil || len(cert.Certificate) == 0 {
 		t.Fatal("nil/empty certificate from manager")
+	}
+}
+
+func TestGenerateSelfSignedCertWithExtraSANs(t *testing.T) {
+	now := time.Now()
+	extraDNS := []string{"nas.local"}
+	extraIPs := []net.IP{net.ParseIP("192.168.1.100")}
+	certPEM, _, err := generateSelfSignedCert(now, now.Add(selfSignedValidity), extraDNS, extraIPs)
+	if err != nil {
+		t.Fatalf("generateSelfSignedCert: %v", err)
+	}
+	cert := mustParseCert(t, certPEM)
+	if !blockHasDNS(cert, "nas.local") {
+		t.Errorf("extra DNS SAN missing: DNSNames=%v", cert.DNSNames)
+	}
+	if !blockHasDNS(cert, "localhost") {
+		t.Errorf("built-in SAN localhost missing: DNSNames=%v", cert.DNSNames)
+	}
+	found := false
+	for _, ip := range cert.IPAddresses {
+		if ip.Equal(net.ParseIP("192.168.1.100")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("extra IP SAN 192.168.1.100 missing: IPAddresses=%v", cert.IPAddresses)
+	}
+}
+
+func TestEnsureSelfSignedCertRegeneratesOnSANChange(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		t.Fatal(err)
+	}
+	// Persist a cert with no extra SANs.
+	now := time.Now()
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath := filepath.Join(dir, selfSignedCertFile)
+	keyPath := filepath.Join(dir, selfSignedKeyFile)
+	if err := os.WriteFile(certPath, certPEM, certFileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, keyFileMode); err != nil {
+		t.Fatal(err)
+	}
+	originalSerial := serialOfPEM(t, certPEM)
+
+	// Request a cert with an extra DNS SAN the persisted cert doesn't cover.
+	cert, err := ensureSelfSignedCert(dir, []string{"nas.local"}, nil)
+	if err != nil {
+		t.Fatalf("ensureSelfSignedCert: %v", err)
+	}
+	if serialOf(t, cert) == originalSerial {
+		t.Error("certificate was reused; expected regeneration due to SAN change")
+	}
+	leaf := mustLeaf(t, cert)
+	if !blockHasDNS(leaf, "nas.local") {
+		t.Errorf("regenerated cert missing extra SAN nas.local; DNSNames=%v", leaf.DNSNames)
+	}
+}
+
+func TestEnsureSelfSignedCertReusesWhenSANsCovered(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tls")
+	cert1, err := ensureSelfSignedCert(dir, []string{"nas.local"}, nil)
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	serial1 := serialOf(t, cert1)
+	// Same extras: should reuse without regenerating.
+	cert2, err := ensureSelfSignedCert(dir, []string{"nas.local"}, nil)
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if serialOf(t, cert2) != serial1 {
+		t.Error("certificate was regenerated; expected reuse when configured SANs are already covered")
+	}
+}
+
+func TestParseSelfSignedHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		hosts    []string
+		wantDNS  []string
+		wantIPsN int
+	}{
+		{name: "empty input"},
+		{
+			name:    "hostname added",
+			hosts:   []string{"nas.local"},
+			wantDNS: []string{"nas.local"},
+		},
+		{
+			name:    "builtin hostnames deduplicated",
+			hosts:   []string{"localhost", selfSignedCommonName, "extra.host"},
+			wantDNS: []string{"extra.host"},
+		},
+		{
+			name:     "ip literal parsed",
+			hosts:    []string{"192.168.1.1"},
+			wantIPsN: 1,
+		},
+		{
+			name:     "builtin ips deduplicated",
+			hosts:    []string{"127.0.0.1", "::1", "192.168.1.1"},
+			wantIPsN: 1,
+		},
+		{
+			name:     "mixed hostname and ip",
+			hosts:    []string{"nas.local", "192.168.1.100"},
+			wantDNS:  []string{"nas.local"},
+			wantIPsN: 1,
+		},
+		{
+			name:    "dedup within extras",
+			hosts:   []string{"nas.local", "nas.local"},
+			wantDNS: []string{"nas.local"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dns, ips := parseSelfSignedHosts(tc.hosts)
+			if len(dns) != len(tc.wantDNS) {
+				t.Errorf("dnsNames = %v; want %v", dns, tc.wantDNS)
+			} else {
+				for i, want := range tc.wantDNS {
+					if dns[i] != want {
+						t.Errorf("dnsNames[%d] = %q; want %q", i, dns[i], want)
+					}
+				}
+			}
+			if len(ips) != tc.wantIPsN {
+				t.Errorf("ips count = %d; want %d (ips=%v)", len(ips), tc.wantIPsN, ips)
+			}
+		})
 	}
 }
 

--- a/internal/servetls/servetls.go
+++ b/internal/servetls/servetls.go
@@ -29,16 +29,17 @@ type CertManager interface {
 // the config precedence: an explicit cert_file+key_file pair (bring-your-own)
 // wins, else self_signed bootstraps a persisted certificate under <dbDir>/tls/,
 // else TLS is disabled and (nil, nil) is returned so the caller serves plain
-// HTTP. The caller is responsible for having validated that cert_file/key_file
-// are set together and that self_signed is not combined with them (see
-// config.validateServerTLS); this function trusts that contract and only acts on
-// it.
-func BuildCertManager(certFile, keyFile string, selfSigned bool, dbDir string) (CertManager, error) {
+// HTTP. selfSignedHosts carries the self_signed_hosts config field and is only
+// used when selfSigned is true. The caller is responsible for having validated
+// that cert_file/key_file are set together and that self_signed is not combined
+// with them (see config.validateServerTLS); this function trusts that contract
+// and only acts on it.
+func BuildCertManager(certFile, keyFile string, selfSigned bool, dbDir string, selfSignedHosts []string) (CertManager, error) {
 	switch {
 	case certFile != "" && keyFile != "":
 		return newFileCertManager(certFile, keyFile)
 	case selfSigned:
-		return newSelfSignedCertManager(filepath.Join(dbDir, "tls"))
+		return newSelfSignedCertManager(filepath.Join(dbDir, "tls"), selfSignedHosts)
 	default:
 		return nil, nil
 	}

--- a/internal/servetls/servetls_test.go
+++ b/internal/servetls/servetls_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTLSConfigMinVersionAndCert(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "tls")
-	cm, err := newSelfSignedCertManager(dir)
+	cm, err := newSelfSignedCertManager(dir, nil)
 	if err != nil {
 		t.Fatalf("newSelfSignedCertManager: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestTLSConfigMinVersionAndCert(t *testing.T) {
 }
 
 func TestBuildCertManagerDisabled(t *testing.T) {
-	cm, err := BuildCertManager("", "", false, t.TempDir())
+	cm, err := BuildCertManager("", "", false, t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("BuildCertManager: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestBuildCertManagerDisabled(t *testing.T) {
 
 func TestBuildCertManagerSelfSigned(t *testing.T) {
 	dbDir := t.TempDir()
-	cm, err := BuildCertManager("", "", true, dbDir)
+	cm, err := BuildCertManager("", "", true, dbDir, nil)
 	if err != nil {
 		t.Fatalf("BuildCertManager: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestBuildCertManagerSelfSigned(t *testing.T) {
 
 func TestBuildCertManagerBYO(t *testing.T) {
 	certPath, keyPath := writeFixturePair(t)
-	cm, err := BuildCertManager(certPath, keyPath, false, t.TempDir())
+	cm, err := BuildCertManager(certPath, keyPath, false, t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("BuildCertManager: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestBuildCertManagerBYO(t *testing.T) {
 
 func TestBuildCertManagerBYOTakesPrecedenceOverSelfSigned(t *testing.T) {
 	certPath, keyPath := writeFixturePair(t)
-	cm, err := BuildCertManager(certPath, keyPath, true, t.TempDir())
+	cm, err := BuildCertManager(certPath, keyPath, true, t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("BuildCertManager: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestServeTLSEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newFileCertManager: %v", err)
 	}
-	selfsigned, err := newSelfSignedCertManager(filepath.Join(t.TempDir(), "tls"))
+	selfsigned, err := newSelfSignedCertManager(filepath.Join(t.TempDir(), "tls"), nil)
 	if err != nil {
 		t.Fatalf("newSelfSignedCertManager: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestServeTLSEndToEnd(t *testing.T) {
 func writeFixturePair(t *testing.T) (certPath, keyPath string) {
 	t.Helper()
 	now := time.Now()
-	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity))
+	certPEM, keyPEM, err := generateSelfSignedCert(now, now.Add(selfSignedValidity), nil, nil)
 	if err != nil {
 		t.Fatalf("generate fixture: %v", err)
 	}


### PR DESCRIPTION
Implements the TLS lane-5 follow-ups from the #276 adversarial review (issue #275).

## Changes

1. **Configurable self-signed cert SANs (the real gap).** New `[server.tls].self_signed_hosts` (+ `MXLRC_TLS_SELF_SIGNED_HOSTS` env, comma-separated) lets an operator add their LAN hostname/IP to the self-signed certificate, so `https://<lan-ip>` no longer gives a name-mismatch on top of the untrusted-CA prompt. Entries are validated at startup (RFC 1123 hostnames / `net.ParseIP` IPs; invalid → fail-fast), split into DNSNames/IPAddresses, and deduped against the built-in loopback SANs. The persisted cert is **regenerated when the configured SAN set is no longer covered** (`sansCovered`), alongside the existing missing/expired/near-expiry triggers.
2. **Redirect bind failure now fails startup.** The optional `redirect_http` listener is bound **eagerly** (before goroutines/the HTTPS server); a configured-but-unbindable redirect listener returns a clean startup error instead of silently leaving HTTPS up with no redirect (no goroutine leak).
3. **Redirect server timeouts.** Added `ReadTimeout`/`WriteTimeout`/`IdleTimeout` (5s/5s/30s) alongside the existing `ReadHeaderTimeout`.

## Verification

- `make gate` green (build, race tests, golangci 0, actionlint, govulncheck); patch coverage above floor.
- Independent hostile security review: **SHIP** (no blocker/major). Verified SAN validation has no bypass, `sansCovered` regen direction/IP-equality/case-handling are correct with no boot churn, and the eager-bind redirect is leak-free with clean shutdown.
- Tests cover SAN parse/validate/dedupe, regen-on-SAN-change vs reuse-when-covered, redirect bind-fail (exit 1), the 301, and the timeouts.

Three optional NITs from review noted (validate-only-when-self_signed; case-insensitive built-in dedupe; a stale comment) — non-blocking.

Closes #275