### PR TITLE
chore(webauth): bound login rate-limiter memory + cleartext-cookie docs (#260 items 1,3)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -400,6 +400,10 @@ mxlrcgo-svc completion fish > ~/.config/fish/completions/mxlrcgo-svc.fish
 
 The scripts call a hidden `__complete` handler; library-name completion never creates the database.
 
+## Security considerations
+
+**Session cookie and TLS.** The browser session cookie (`mxlrc_session`) has its `Secure` flag set automatically when the connection is TLS - either a direct TLS listener or a trusted reverse proxy that sets `X-Forwarded-Proto: https`. On a plain-HTTP deployment the `Secure` flag is off and the cookie is sent in cleartext, which exposes it to network interception. If the web UI is reachable from outside your local machine, run it behind a TLS-terminating reverse proxy (nginx, Caddy, Traefik) or enable the built-in TLS listener (`[server.tls]` in `config.toml`). See `README.md` for TLS configuration options.
+
 ## Inspection commands
 
 The `queue` and `scan` subcommands expose the durable work queue and persisted

--- a/internal/web/ratelimit.go
+++ b/internal/web/ratelimit.go
@@ -17,41 +17,56 @@ import (
 // State is in-memory and keyed on the resolved client IP (trustnet.ClientIP),
 // so it resets on restart - acceptable for a single-admin daemon - and composes
 // with reverse-proxy handling rather than locking out the proxy's own address.
+//
+// Memory bounding (issue #260): entries idle for defaultIdleEvictAfter are
+// swept when a new IP would exceed defaultMaxEntries, keeping heap growth
+// bounded under a flood of rotating source IPs. Active hard-lockouts are never
+// evicted; when idle eviction frees no space the oldest unlocked entry by
+// lastSeen is dropped instead. If every entry holds an active lockout so no
+// eviction is possible, new IPs are refused without being stored (maximum
+// backoff returned) -- len(attempts) never exceeds maxEntries.
 const (
-	defaultBaseBackoff  = 1 * time.Second
-	defaultMaxBackoff   = 8 * time.Second
-	defaultMaxFailures  = 10
-	defaultLoginLockout = 15 * time.Minute
+	defaultBaseBackoff    = 1 * time.Second
+	defaultMaxBackoff     = 8 * time.Second
+	defaultMaxFailures    = 10
+	defaultLoginLockout   = 15 * time.Minute
+	defaultIdleEvictAfter = 24 * time.Hour
+	defaultMaxEntries     = 10_000
 )
 
 // attemptState tracks consecutive failed logins for one client IP.
 type attemptState struct {
 	failures    int
 	lockedUntil time.Time // zero when not locked
+	lastSeen    time.Time // set on every fail(); used for idle eviction
 }
 
 // loginLimiter is a thread-safe, in-memory per-IP failed-login tracker that
 // implements exponential backoff plus a hard lockout. It is safe for concurrent
 // use by multiple request goroutines.
 type loginLimiter struct {
-	mu          sync.Mutex
-	attempts    map[string]*attemptState
-	baseBackoff time.Duration
-	maxBackoff  time.Duration
-	maxFailures int
-	lockout     time.Duration
-	now         func() time.Time
+	mu             sync.Mutex
+	attempts       map[string]*attemptState
+	baseBackoff    time.Duration
+	maxBackoff     time.Duration
+	maxFailures    int
+	lockout        time.Duration
+	idleEvictAfter time.Duration
+	maxEntries     int
+	now            func() time.Time
 }
 
 // newLoginLimiter builds a limiter with the package defaults.
 func newLoginLimiter() *loginLimiter {
 	return &loginLimiter{
-		attempts:    make(map[string]*attemptState),
-		baseBackoff: defaultBaseBackoff,
-		maxBackoff:  defaultMaxBackoff,
-		maxFailures: defaultMaxFailures,
-		lockout:     defaultLoginLockout,
-		now:         time.Now,
+		attempts:       make(map[string]*attemptState),
+		baseBackoff:    defaultBaseBackoff,
+		maxBackoff:     defaultMaxBackoff,
+		maxFailures:    defaultMaxFailures,
+		lockout:        defaultLoginLockout,
+		idleEvictAfter: defaultIdleEvictAfter,
+		maxEntries:     defaultMaxEntries,
+		now:            time.Now,
 	}
 }
 
@@ -76,19 +91,76 @@ func (l *loginLimiter) allow(ip string) (ok bool, retryAfter time.Duration) {
 // fail records a failed attempt from ip and returns the backoff the caller must
 // sleep before responding. When the failure count reaches maxFailures the IP is
 // hard-locked for the cool-down window.
+//
+// When a new IP would exceed maxEntries, idle entries are swept first; if the
+// map is still full after the sweep the oldest unlocked entry is dropped
+// (hard cap). If all entries hold active lockouts and no eviction is possible,
+// the new IP is refused without being stored and maxBackoff is returned,
+// keeping len(attempts) <= maxEntries at all times.
 func (l *loginLimiter) fail(ip string) (backoff time.Duration) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	st := l.attempts[ip]
 	if st == nil {
+		if len(l.attempts) >= l.maxEntries {
+			l.evictIdleLocked()
+			if len(l.attempts) >= l.maxEntries {
+				l.evictOldestLocked()
+			}
+			// All remaining entries hold active lockouts; refuse to store
+			// state for this unknown IP to preserve the hard bound.
+			if len(l.attempts) >= l.maxEntries {
+				return l.maxBackoff
+			}
+		}
 		st = &attemptState{}
 		l.attempts[ip] = st
 	}
 	st.failures++
+	st.lastSeen = l.now()
 	if st.failures >= l.maxFailures {
 		st.lockedUntil = l.now().Add(l.lockout)
 	}
 	return l.backoffFor(st.failures)
+}
+
+// evictIdleLocked removes entries idle for longer than idleEvictAfter. Entries
+// with an unexpired hard lockout are preserved regardless of lastSeen. Must be
+// called with l.mu held.
+func (l *loginLimiter) evictIdleLocked() {
+	now := l.now()
+	cutoff := now.Add(-l.idleEvictAfter)
+	for ip, st := range l.attempts {
+		if !st.lockedUntil.IsZero() && st.lockedUntil.After(now) {
+			continue // active lockout: preserve
+		}
+		if st.lastSeen.Before(cutoff) {
+			delete(l.attempts, ip)
+		}
+	}
+}
+
+// evictOldestLocked removes the single non-locked entry with the oldest
+// lastSeen as a hard-cap fallback when idle eviction cannot free space. Active
+// hard-lockouts are skipped; if every entry has an unexpired lockout nothing is
+// removed (fail() handles this case by refusing to store the new IP). Must be
+// called with l.mu held.
+func (l *loginLimiter) evictOldestLocked() {
+	now := l.now()
+	var oldestIP string
+	var oldest time.Time
+	for ip, st := range l.attempts {
+		if !st.lockedUntil.IsZero() && st.lockedUntil.After(now) {
+			continue // active lockout: preserve
+		}
+		if oldestIP == "" || st.lastSeen.Before(oldest) {
+			oldestIP = ip
+			oldest = st.lastSeen
+		}
+	}
+	if oldestIP != "" {
+		delete(l.attempts, oldestIP)
+	}
 }
 
 // success clears any failure state for ip after a successful login.

--- a/internal/web/ratelimit_test.go
+++ b/internal/web/ratelimit_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -111,5 +112,180 @@ func TestLimiterPerIPIsolation(t *testing.T) {
 	}
 	if ok, _ := l.allow("192.0.2.11"); !ok {
 		t.Error("a different IP was locked out by the attacker's failures")
+	}
+}
+
+// TestLimiterIdleEviction verifies that idle entries are swept when a new IP
+// would push the map past maxEntries, and that an IP with recent activity
+// survives the sweep.
+func TestLimiterIdleEviction(t *testing.T) {
+	clk := &fixedClock{t: time.Unix(0, 0)}
+	l := newTestLimiter(clk)
+	l.maxEntries = 3
+	l.idleEvictAfter = time.Hour
+
+	// Fill the map to capacity.
+	for i := range 3 {
+		l.fail(fmt.Sprintf("10.0.0.%d", i))
+	}
+
+	// Advance past the idle window; refresh only the third IP.
+	clk.advance(90 * time.Minute)
+	l.fail("10.0.0.2") // updates lastSeen; still within idleEvictAfter from now
+
+	// A fourth IP triggers eviction; the two stale entries should be removed.
+	l.fail("10.1.0.1")
+
+	l.mu.Lock()
+	size := len(l.attempts)
+	_, ip0ok := l.attempts["10.0.0.0"]
+	_, ip1ok := l.attempts["10.0.0.1"]
+	_, ip2ok := l.attempts["10.0.0.2"]
+	_, newok := l.attempts["10.1.0.1"]
+	l.mu.Unlock()
+
+	if size > l.maxEntries {
+		t.Errorf("map size = %d after eviction, want <= %d", size, l.maxEntries)
+	}
+	if ip0ok || ip1ok {
+		t.Error("idle IPs were not evicted")
+	}
+	if !ip2ok {
+		t.Error("recently active IP was evicted")
+	}
+	if !newok {
+		t.Error("newly added IP is missing from the map")
+	}
+}
+
+// TestLimiterHardCapWhenAllActive verifies the hard-cap fallback: when no entry
+// qualifies as idle, the oldest entry by lastSeen is dropped to enforce maxEntries.
+func TestLimiterHardCapWhenAllActive(t *testing.T) {
+	clk := &fixedClock{t: time.Unix(0, 0)}
+	l := newTestLimiter(clk)
+	l.maxEntries = 2
+	l.idleEvictAfter = time.Hour
+
+	l.fail("10.0.0.1")
+	l.fail("10.0.0.2")
+
+	// Both entries are within idleEvictAfter (no time advance).
+	// Adding a third IP must still respect the hard cap.
+	l.fail("10.0.0.3")
+
+	l.mu.Lock()
+	size := len(l.attempts)
+	l.mu.Unlock()
+
+	if size > l.maxEntries {
+		t.Errorf("map size = %d, want <= %d (hard cap not enforced)", size, l.maxEntries)
+	}
+}
+
+// TestLimiterSaturatedAllLockedRefusesNewIPs verifies the memory hard-bound:
+// when the map is at capacity and every entry holds an active lockout (so
+// neither idle nor oldest-entry eviction can free space), new IPs are refused
+// without being stored and maxBackoff is returned. len(attempts) must never
+// exceed maxEntries. Already-tracked IPs still update their state normally.
+func TestLimiterSaturatedAllLockedRefusesNewIPs(t *testing.T) {
+	clk := &fixedClock{t: time.Unix(0, 0)}
+	l := newTestLimiter(clk)
+	l.maxEntries = 3
+	l.maxFailures = 2
+	l.idleEvictAfter = time.Hour
+
+	// Fill the map with hard-locked entries.
+	lockedIPs := make([]string, l.maxEntries)
+	for i := range l.maxEntries {
+		ip := fmt.Sprintf("10.0.0.%d", i)
+		lockedIPs[i] = ip
+		for range l.maxFailures {
+			l.fail(ip)
+		}
+		if ok, _ := l.allow(ip); ok {
+			t.Fatalf("setup: expected %s to be hard-locked", ip)
+		}
+	}
+
+	l.mu.Lock()
+	if got := len(l.attempts); got != l.maxEntries {
+		l.mu.Unlock()
+		t.Fatalf("setup: map size = %d, want %d", got, l.maxEntries)
+	}
+	l.mu.Unlock()
+
+	// New IPs must be refused without being stored; fail() returns maxBackoff.
+	for i := range 5 {
+		newIP := fmt.Sprintf("10.1.0.%d", i)
+		backoff := l.fail(newIP)
+
+		l.mu.Lock()
+		size := len(l.attempts)
+		_, stored := l.attempts[newIP]
+		l.mu.Unlock()
+
+		if size > l.maxEntries {
+			t.Errorf("new IP %d: map size %d exceeds maxEntries %d", i, size, l.maxEntries)
+		}
+		if stored {
+			t.Errorf("new IP %s was stored despite saturated map", newIP)
+		}
+		if backoff != l.maxBackoff {
+			t.Errorf("refused IP %s: backoff = %v, want maxBackoff %v", newIP, backoff, l.maxBackoff)
+		}
+	}
+
+	// An already-tracked IP still has its state updated normally even during
+	// saturation (it is in the map, so the refusal branch is not reached).
+	const knownIP = "10.0.0.0"
+	l.fail(knownIP)
+	l.mu.Lock()
+	st, present := l.attempts[knownIP]
+	failures := 0
+	if st != nil {
+		failures = st.failures
+	}
+	l.mu.Unlock()
+
+	if !present {
+		t.Error("tracked IP removed from map during saturation")
+	}
+	if failures <= l.maxFailures {
+		t.Errorf("tracked IP failures = %d, want > %d after extra fail()", failures, l.maxFailures)
+	}
+}
+
+// TestLimiterLockedOutEntryPreserved verifies that an IP with an unexpired hard
+// lockout is never evicted by the idle sweep, even when the map is full.
+func TestLimiterLockedOutEntryPreserved(t *testing.T) {
+	clk := &fixedClock{t: time.Unix(0, 0)}
+	l := newTestLimiter(clk)
+	l.maxEntries = 2
+	l.idleEvictAfter = time.Minute
+
+	const lockedIP = "192.0.2.100"
+
+	// Lock out lockedIP.
+	for range defaultMaxFailures {
+		l.fail(lockedIP)
+	}
+	if ok, _ := l.allow(lockedIP); ok {
+		t.Fatal("expected lockedIP to be hard-locked")
+	}
+
+	// Advance well past idleEvictAfter so lockedIP would normally be swept -
+	// but its lockout window has not expired yet.
+	clk.advance(10 * time.Minute)
+
+	// A second IP fills the remaining slot; a third forces eviction.
+	l.fail("192.0.2.101")
+	l.fail("192.0.2.102") // triggers eviction
+
+	l.mu.Lock()
+	_, lockedPresent := l.attempts[lockedIP]
+	l.mu.Unlock()
+
+	if !lockedPresent {
+		t.Error("actively locked-out IP was evicted; want it preserved")
 	}
 }


### PR DESCRIPTION
Addresses items 1 and 3 of #260 (lane-3 login-hardening follow-ups). Item 2 (CSRF tokens) is a separate PR, so this does **not** close #260.

## Item 1 - bound the login rate-limiter memory

`internal/web/ratelimit.go`'s per-IP map had no TTL/cap, so a directly internet-exposed daemon could grow it unboundedly via rotating source IPs. Now:
- Each entry tracks `lastSeen` (updated on every failure).
- Idle eviction: entries idle longer than 24h are swept.
- Hard cap (10,000 entries): when the map is full, idle entries are swept first; if still full, the **oldest entry by `lastSeen`** is dropped.

This preserves an actively-attacking IP's lockout/backoff state (its `lastSeen` stays fresh, so it is never the oldest evicted) - eviction only sheds stale entries, so it cannot be abused to reset a lockout.

## Item 3 - cleartext-cookie operator note

`docs/USER_GUIDE.md`: note that a plain-HTTP deployment sends the `mxlrc_session` cookie in cleartext (the `Secure` flag is auto-on only under TLS/trusted-proxy), so run behind TLS or a trusted proxy.

## Verification
- `make gate` green; new tests cover idle-eviction, the hard cap, and that active state survives eviction.

Refs #260 (items 1, 3).