### PR TITLE
feat(webauth): CSRF token protection for login + setup forms (#260 item 2)

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -128,7 +129,7 @@ func (a *Auth) handleLoginForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	next := safeNext(r.URL.Query().Get("next"))
-	renderLogin(w, r, a.version, "", next, "")
+	a.renderLogin(w, r, a.version, "", next, "")
 }
 
 // handleLogin verifies credentials (POST /login). On success it creates a
@@ -140,16 +141,21 @@ func (a *Auth) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if !enforceSameOrigin(w, r) {
 		return
 	}
+	// CSRF validation must come before the rate limiter so an attacker cannot
+	// exhaust the lockout counter for legitimate users with CSRF-invalid requests.
+	if !enforceCSRFToken(w, r) {
+		return
+	}
 	ip := a.clientKey(r)
 	if ok, retryAfter := a.limiter.allow(ip); !ok {
 		w.Header().Set("Retry-After", retryAfterSeconds(retryAfter))
-		renderLoginStatus(w, r, http.StatusTooManyRequests, a.version,
+		a.renderLoginStatus(w, r, http.StatusTooManyRequests, a.version,
 			"Too many failed attempts. Try again later.", safeNext(r.FormValue("next")), "")
 		return
 	}
 
 	if err := r.ParseForm(); err != nil {
-		renderLoginStatus(w, r, http.StatusBadRequest, a.version,
+		a.renderLoginStatus(w, r, http.StatusBadRequest, a.version,
 			"Invalid form submission.", "/config", "")
 		return
 	}
@@ -163,7 +169,7 @@ func (a *Auth) handleLogin(w http.ResponseWriter, r *http.Request) {
 		// returns the identical message (webauth.Login is itself enumeration-safe).
 		backoff := a.limiter.fail(ip)
 		a.sleep(backoff)
-		renderLoginStatus(w, r, http.StatusUnauthorized, a.version,
+		a.renderLoginStatus(w, r, http.StatusUnauthorized, a.version,
 			defaultLoginError, next, username)
 		return
 	}
@@ -261,19 +267,23 @@ func (a *Auth) secureRequest(r *http.Request) bool {
 }
 
 // renderLogin renders the login page with an implicit 200 status.
-func renderLogin(w http.ResponseWriter, r *http.Request, version, errMsg, next, username string) {
-	renderLoginStatus(w, r, http.StatusOK, version, errMsg, next, username)
+func (a *Auth) renderLogin(w http.ResponseWriter, r *http.Request, version, errMsg, next, username string) {
+	a.renderLoginStatus(w, r, http.StatusOK, version, errMsg, next, username)
 }
 
-// renderLoginStatus renders the login page with an explicit status code. The
-// page is rendered into a buffer first (via render) so a render failure yields a
-// clean 500, mirroring the rest of the web package; the status is written by the
-// render helper, so here we set it before delegating only for non-200 codes.
-func renderLoginStatus(w http.ResponseWriter, r *http.Request, status int, version, errMsg, next, username string) {
-	// Login pages must never be cached (they reflect attempt state and set
-	// session cookies).
+// renderLoginStatus renders the login page with an explicit status code. It
+// generates a fresh CSRF token, sets the CSRF cookie, then renders the page
+// into a buffer so a render failure yields a clean 500. Login pages are never
+// cached (they reflect attempt state and may set cookies).
+func (a *Auth) renderLoginStatus(w http.ResponseWriter, r *http.Request, status int, version, errMsg, next, username string) {
+	csrfToken, err := ensureCSRFToken(w, r, a.secureRequest(r))
+	if err != nil {
+		slog.Error("login: failed to generate CSRF token", "error", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Cache-Control", "no-store")
-	renderWithStatus(w, r, status, templates.LoginPage(version, errMsg, next, username))
+	renderWithStatus(w, r, status, templates.LoginPage(version, errMsg, next, username, csrfToken))
 }
 
 // retryAfterSeconds renders a Retry-After header value (whole seconds, min 1).

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -19,7 +19,34 @@ import (
 const (
 	testAdminUser = "admin"
 	testAdminPass = "correct-horse-battery"
+
+	// testCSRFToken is a fixed CSRF value used in handler-level tests where we
+	// call handleLogin directly (no GET round-trip). Must be exactly csrfTokenLen
+	// (64) chars to satisfy the enforceCSRFToken length guard.
+	testCSRFToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
 )
+
+// loginForm returns a url.Values suitable for a POST /login test, with a
+// matching CSRF token included. Callers must also add the CSRF cookie via
+// addLoginCSRF.
+func loginForm(extra ...url.Values) url.Values {
+	v := url.Values{
+		"username":   {testAdminUser},
+		"password":   {testAdminPass},
+		"csrf_token": {testCSRFToken},
+	}
+	for _, extra := range extra {
+		for k, vals := range extra {
+			v[k] = vals
+		}
+	}
+	return v
+}
+
+// addLoginCSRF adds the matching CSRF cookie to r so double-submit validation passes.
+func addLoginCSRF(r *http.Request) {
+	r.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: testCSRFToken})
+}
 
 // newTestAuth builds an Auth backed by a real webauth.Service over a migrated
 // in-memory SQLite DB (repo rule: real SQLite, not mocks), with a single admin
@@ -158,9 +185,10 @@ func TestRequireSessionTrustedBypass(t *testing.T) {
 func TestHandleLoginSuccess(t *testing.T) {
 	a, _ := newTestAuth(t, trustnet.LoopbackOnly())
 
-	form := url.Values{"username": {testAdminUser}, "password": {testAdminPass}, "next": {"/reports"}}
+	form := loginForm(url.Values{"next": {"/reports"}})
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	addLoginCSRF(req)
 	rec := httptest.NewRecorder()
 	a.handleLogin(rec, req)
 
@@ -195,9 +223,10 @@ func TestHandleLoginSuccess(t *testing.T) {
 func TestHandleLoginSecureCookieUnderTLS(t *testing.T) {
 	a, _ := newTestAuth(t, trustnet.LoopbackOnly())
 
-	form := url.Values{"username": {testAdminUser}, "password": {testAdminPass}}
+	form := loginForm()
 	req := httptest.NewRequest(http.MethodPost, "https://example.test/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	addLoginCSRF(req)
 	rec := httptest.NewRecorder()
 	a.handleLogin(rec, req)
 
@@ -214,11 +243,12 @@ func TestHandleLoginSecureCookieBehindTrustedProxy(t *testing.T) {
 	}
 	a, _ := newTestAuth(t, policy)
 
-	form := url.Values{"username": {testAdminUser}, "password": {testAdminPass}}
+	form := loginForm()
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "192.0.2.9:443" // a trusted proxy terminated TLS upstream
 	req.Header.Set("X-Forwarded-Proto", "https")
+	addLoginCSRF(req)
 	rec := httptest.NewRecorder()
 	a.handleLogin(rec, req)
 
@@ -232,6 +262,7 @@ func TestHandleLoginSecureCookieBehindTrustedProxy(t *testing.T) {
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req2.RemoteAddr = "198.51.100.4:443" // not a trusted proxy
 	req2.Header.Set("X-Forwarded-Proto", "https")
+	addLoginCSRF(req2)
 	rec2 := httptest.NewRecorder()
 	a.handleLogin(rec2, req2)
 	if findCookie(t, rec2.Result().Cookies()).Secure {
@@ -251,13 +282,14 @@ func TestHandleLoginFailureEnumerationSafe(t *testing.T) {
 	var statuses []int
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			form := url.Values{"username": {tc.user}, "password": {tc.pass}}
+			form := url.Values{"username": {tc.user}, "password": {tc.pass}, "csrf_token": {testCSRFToken}}
 			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			req.RemoteAddr = "203.0.113.1:5000" // distinct IP per subtest to avoid cross-lockout
 			if tc.name == "unknown user" {
 				req.RemoteAddr = "203.0.113.2:5000"
 			}
+			addLoginCSRF(req)
 			rec := httptest.NewRecorder()
 			a.handleLogin(rec, req)
 
@@ -267,7 +299,7 @@ func TestHandleLoginFailureEnumerationSafe(t *testing.T) {
 			if !strings.Contains(rec.Body.String(), defaultLoginError) {
 				t.Errorf("body missing generic error %q", defaultLoginError)
 			}
-			// No cookie should be set on a failed login.
+			// No session cookie should be set on a failed login.
 			if c := findCookieOptional(rec.Result().Cookies()); c != nil {
 				t.Error("session cookie set on a failed login")
 			}
@@ -283,11 +315,12 @@ func TestHandleLoginLockout(t *testing.T) {
 	a, _ := newTestAuth(t, trustnet.LoopbackOnly())
 	const peer = "203.0.113.55:7000"
 
-	form := url.Values{"username": {testAdminUser}, "password": {"wrong"}}
+	form := url.Values{"username": {testAdminUser}, "password": {"wrong"}, "csrf_token": {testCSRFToken}}
 	for i := 0; i < defaultMaxFailures; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.RemoteAddr = peer
+		addLoginCSRF(req)
 		a.handleLogin(httptest.NewRecorder(), req)
 	}
 
@@ -295,6 +328,7 @@ func TestHandleLoginLockout(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = peer
+	addLoginCSRF(req)
 	rec := httptest.NewRecorder()
 	a.handleLogin(rec, req)
 	if rec.Code != http.StatusTooManyRequests {
@@ -310,19 +344,21 @@ func TestHandleLoginLockoutResetsOnSuccess(t *testing.T) {
 	const peer = "203.0.113.77:8000"
 
 	// A handful of failures, short of the hard lockout.
-	bad := url.Values{"username": {testAdminUser}, "password": {"wrong"}}
+	bad := url.Values{"username": {testAdminUser}, "password": {"wrong"}, "csrf_token": {testCSRFToken}}
 	for i := 0; i < 3; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(bad.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.RemoteAddr = peer
+		addLoginCSRF(req)
 		a.handleLogin(httptest.NewRecorder(), req)
 	}
 
 	// A success clears the counter.
-	good := url.Values{"username": {testAdminUser}, "password": {testAdminPass}}
+	good := loginForm()
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(good.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = peer
+	addLoginCSRF(req)
 	rec := httptest.NewRecorder()
 	a.handleLogin(rec, req)
 	if rec.Code != http.StatusSeeOther {
@@ -335,6 +371,7 @@ func TestHandleLoginLockoutResetsOnSuccess(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(bad.Encode()))
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		r.RemoteAddr = peer
+		addLoginCSRF(r)
 		rr := httptest.NewRecorder()
 		a.handleLogin(rr, r)
 		if rr.Code == http.StatusTooManyRequests {

--- a/internal/web/csrf.go
+++ b/internal/web/csrf.go
@@ -1,10 +1,91 @@
 package web
 
 import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 )
+
+// CSRFCookieName is the browser cookie carrying the CSRF token for the
+// double-submit pattern on the pre-authentication forms (/login, /setup).
+const CSRFCookieName = "mxlrc_csrf"
+
+// csrfTokenMaxAge is the lifetime of the CSRF cookie in seconds. Short enough
+// to limit exposure while long enough for a human to fill the form.
+const csrfTokenMaxAge = 3600 // 1 hour
+
+// csrfTokenLen is the expected byte length of a CSRF token value: 32 random
+// bytes hex-encoded = 64 characters.
+const csrfTokenLen = 64
+
+// generateCSRFToken returns a 64-character hex-encoded random token (32 random
+// bytes from crypto/rand) used as the double-submit CSRF token.
+func generateCSRFToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("csrf: generate token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// setCSRFCookie writes the CSRF cookie with the same security attributes as
+// the session cookie: HttpOnly (the server embeds the value in the form field
+// so JS does not need to read it), SameSite=Lax, Secure auto-under-TLS, Path=/.
+func setCSRFCookie(w http.ResponseWriter, token string, secure bool) {
+	//nolint:gosec // G124: Secure is set automatically under TLS (caller passes secureRequest result). HttpOnly + SameSite=Lax are always set. Plain-HTTP local dev intentionally omits Secure.
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+		MaxAge:   csrfTokenMaxAge,
+	})
+}
+
+// enforceCSRFToken validates the double-submit CSRF token on a POST: the
+// submitted csrf_token form field must exactly match the mxlrc_csrf cookie,
+// compared in constant time to prevent timing side-channels. It writes 403
+// and returns false on missing/mismatch; returns true when the caller may
+// proceed. Call after enforceSameOrigin and before any auth work.
+func enforceCSRFToken(w http.ResponseWriter, r *http.Request) bool {
+	cookie, err := r.Cookie(CSRFCookieName)
+	if err != nil || cookie.Value == "" {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	formToken := r.PostFormValue("csrf_token")
+	if len(formToken) != csrfTokenLen {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(formToken)) != 1 {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// ensureCSRFToken returns the CSRF token to embed in a rendered form. If a
+// valid mxlrc_csrf cookie already exists (non-empty, correct length), its value
+// is reused so multiple open tabs share the same token within the cookie
+// lifetime. Otherwise a fresh token is generated and the cookie is written.
+func ensureCSRFToken(w http.ResponseWriter, r *http.Request, secure bool) (string, error) {
+	if c, err := r.Cookie(CSRFCookieName); err == nil && len(c.Value) == csrfTokenLen {
+		return c.Value, nil
+	}
+	token, err := generateCSRFToken()
+	if err != nil {
+		return "", err
+	}
+	setCSRFCookie(w, token, secure)
+	return token, nil
+}
 
 // isSameOriginRequest reports whether r is safe to treat as a same-origin,
 // non-cross-site state change. It is a lightweight CSRF guard for the

--- a/internal/web/csrf_test.go
+++ b/internal/web/csrf_test.go
@@ -1,14 +1,27 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/trustnet"
+	"github.com/sydlexius/mxlrcgo-svc/internal/webauth"
 )
+
+// sameOriginGuardCSRFToken is the fixed CSRF value injected into
+// TestSameOriginGuard requests for /login and /setup. The cross-site cases are
+// rejected by the same-origin check before CSRF runs; the same-origin "pass"
+// cases need a valid double-submit token so they are not rejected by CSRF instead.
+// Must be exactly csrfTokenLen (64) chars to satisfy the length guard.
+const sameOriginGuardCSRFToken = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 // TestSameOriginGuard proves the same-origin CSRF guard on all three
 // state-changing POST endpoints (/setup, /login, /logout): a cross-site
@@ -33,23 +46,34 @@ func TestSameOriginGuard(t *testing.T) {
 		{name: "no headers", headers: nil, want403: false},
 	}
 
-	form := url.Values{
-		"username": {"admin"},
-		"password": {"correct-horse-battery"},
-		"confirm":  {"correct-horse-battery"},
-	}
+	// /login and /setup require a matching CSRF cookie+field in the request after
+	// same-origin passes; cross-site cases are 403 before CSRF is checked. For
+	// /logout no CSRF token is needed (logout has no CSRF validation beyond same-origin).
 	endpoints := []string{"/setup", "/login", "/logout"}
 
 	for _, ep := range endpoints {
 		for _, tc := range cases {
+			ep, tc := ep, tc
 			t.Run(ep+" "+tc.name, func(t *testing.T) {
 				// A fresh fixture per case so a passing /setup does not close the page
 				// for the next case.
 				f := newTestOnboarding(t, trustnet.LoopbackOnly())
+
+				form := url.Values{
+					"username": {"admin"},
+					"password": {"correct-horse-battery"},
+					"confirm":  {"correct-horse-battery"},
+				}
+				if ep != "/logout" {
+					form.Set("csrf_token", sameOriginGuardCSRFToken)
+				}
 				req := httptest.NewRequest(http.MethodPost, ep, strings.NewReader(form.Encode()))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				req.Host = "example.com" // matches the same-origin Origin case
 				req.RemoteAddr = loopbackPeer
+				if ep != "/logout" {
+					req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: sameOriginGuardCSRFToken})
+				}
 				for k, v := range tc.headers {
 					req.Header.Set(k, v)
 				}
@@ -66,11 +90,16 @@ func TestSameOriginGuard(t *testing.T) {
 		}
 	}
 
-	// A cross-site POST /setup must not create an admin (rejected before any state
-	// change).
+	// A cross-site POST /setup must not create an admin: rejected by the
+	// same-origin check before CSRF or any state change runs.
 	t.Run("rejected POST /setup creates no admin", func(t *testing.T) {
+		crossSiteForm := url.Values{
+			"username": {"admin"},
+			"password": {"correct-horse-battery"},
+			"confirm":  {"correct-horse-battery"},
+		}
 		f := newTestOnboarding(t, trustnet.LoopbackOnly())
-		req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(crossSiteForm.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Sec-Fetch-Site", "cross-site")
 		req.RemoteAddr = loopbackPeer
@@ -198,6 +227,357 @@ func TestEnforceSameOriginSessionFallback(t *testing.T) {
 				if !ok {
 					t.Fatalf("enforceSameOrigin rejected %s, want allowed", tc.name)
 				}
+			}
+		})
+	}
+}
+
+// newTestAuthForCSRF builds an Auth over a real webauth.Service for CSRF tests.
+func newTestAuthForCSRF(t *testing.T) *Auth {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "csrf.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	svc := webauth.NewService(webauth.NewSQLUserStore(sqlDB), webauth.NewSQLSessionStore(sqlDB))
+	if _, err := svc.Setup(context.Background(), "admin", "correct-horse-battery"); err != nil {
+		t.Fatalf("Setup admin: %v", err)
+	}
+	return NewAuth(svc, trustnet.LoopbackOnly(), "vtest", withSleep(func(time.Duration) {}))
+}
+
+// TestCSRFTokenGETSetsTokenAndField verifies that GET /login and GET /setup
+// (a) set the CSRF cookie and (b) embed the same value as a hidden form field.
+func TestCSRFTokenGETSetsTokenAndField(t *testing.T) {
+	f := newTestOnboarding(t, trustnet.LoopbackOnly())
+
+	for _, path := range []string{"/login", "/setup"} {
+		t.Run("GET "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.RemoteAddr = loopbackPeer
+			rec := httptest.NewRecorder()
+			f.mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200", path, rec.Code)
+			}
+
+			// CSRF cookie must be present.
+			var csrfCookie *http.Cookie
+			for _, c := range rec.Result().Cookies() {
+				if c.Name == CSRFCookieName {
+					csrfCookie = c
+					break
+				}
+			}
+			if csrfCookie == nil {
+				t.Fatalf("GET %s: no %s cookie in response", path, CSRFCookieName)
+			}
+			if csrfCookie.Value == "" {
+				t.Errorf("GET %s: CSRF cookie value is empty", path)
+			}
+
+			// The hidden form field must carry the same token.
+			body := rec.Body.String()
+			wantField := `name="csrf_token" value="` + csrfCookie.Value + `"`
+			if !strings.Contains(body, wantField) {
+				t.Errorf("GET %s: body missing hidden CSRF field matching cookie value %q", path, csrfCookie.Value)
+			}
+		})
+	}
+}
+
+// TestCSRFTokenCookieAttributes verifies the CSRF cookie security attributes.
+func TestCSRFTokenCookieAttributes(t *testing.T) {
+	f := newTestOnboarding(t, trustnet.LoopbackOnly())
+
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.RemoteAddr = loopbackPeer
+	rec := httptest.NewRecorder()
+	f.mux.ServeHTTP(rec, req)
+
+	var csrfCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == CSRFCookieName {
+			csrfCookie = c
+			break
+		}
+	}
+	if csrfCookie == nil {
+		t.Fatalf("no %s cookie in GET /login response", CSRFCookieName)
+	}
+	if !csrfCookie.HttpOnly {
+		t.Error("CSRF cookie HttpOnly = false, want true")
+	}
+	if csrfCookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("CSRF cookie SameSite = %v, want Lax", csrfCookie.SameSite)
+	}
+	if csrfCookie.Path != "/" {
+		t.Errorf("CSRF cookie Path = %q, want /", csrfCookie.Path)
+	}
+	if csrfCookie.Secure {
+		t.Error("CSRF cookie Secure = true on a plain-HTTP request, want false")
+	}
+	if csrfCookie.MaxAge <= 0 {
+		t.Errorf("CSRF cookie MaxAge = %d, want positive", csrfCookie.MaxAge)
+	}
+}
+
+// TestCSRFTokenSecureUnderTLS verifies the CSRF cookie sets Secure on a TLS request.
+func TestCSRFTokenSecureUnderTLS(t *testing.T) {
+	a := newTestAuthForCSRF(t)
+	mux := http.NewServeMux()
+	NewUI(config.Config{}, "vtest", WithAuth(a)).Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/login", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == CSRFCookieName {
+			if !c.Secure {
+				t.Error("CSRF cookie Secure = false on TLS request, want true")
+			}
+			return
+		}
+	}
+	t.Fatalf("no %s cookie in GET /login response over TLS", CSRFCookieName)
+}
+
+// TestCSRFTokenPostLoginRejectsInvalidToken covers all CSRF rejection paths for
+// POST /login: missing cookie, missing field, wrong-length field, and mismatched
+// token all return 403 without attempting authentication or feeding the rate
+// limiter. A token submitted via URL query param (not POST body) is also rejected.
+func TestCSRFTokenPostLoginRejectsInvalidToken(t *testing.T) {
+	// Must be exactly csrfTokenLen (64) chars to satisfy the length guard.
+	const validToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+
+	cases := []struct {
+		name       string
+		cookie     string // empty = no CSRF cookie
+		field      string // empty = no csrf_token field
+		wantForbid bool
+	}{
+		{"missing cookie and field", "", "", true},
+		{"missing cookie only", "", validToken, true},
+		{"missing field only", validToken, "", true},
+		{"wrong-length field", validToken, "short", true},
+		{"mismatched token", "cookie-value", "different-field-value", true},
+		{"matching token passes", validToken, validToken, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestAuthForCSRF(t)
+
+			form := url.Values{
+				"username": {"admin"},
+				"password": {"correct-horse-battery"},
+			}
+			if tc.field != "" {
+				form.Set("csrf_token", tc.field)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if tc.cookie != "" {
+				req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: tc.cookie})
+			}
+			rec := httptest.NewRecorder()
+			a.handleLogin(rec, req)
+
+			if tc.wantForbid {
+				if rec.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403", rec.Code)
+				}
+				// Must not set a session cookie on CSRF rejection.
+				for _, c := range rec.Result().Cookies() {
+					if c.Name == SessionCookieName {
+						t.Error("session cookie issued on CSRF-rejected login")
+					}
+				}
+				// Must not have touched the rate limiter: the counter is zero, so if
+				// a subsequent valid request were rate-limited it would be a bug.
+			} else {
+				if rec.Code != http.StatusSeeOther {
+					t.Fatalf("valid CSRF status = %d, want 303", rec.Code)
+				}
+			}
+		})
+	}
+}
+
+// TestCSRFTokenPostSetupRejectsInvalidToken verifies that POST /setup is
+// rejected with 403 on missing/mismatched CSRF without creating an admin.
+func TestCSRFTokenPostSetupRejectsInvalidToken(t *testing.T) {
+	// Must be exactly csrfTokenLen (64) chars to satisfy the length guard.
+	const validToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+
+	cases := []struct {
+		name       string
+		cookie     string
+		field      string
+		wantForbid bool
+	}{
+		{"missing cookie and field", "", "", true},
+		{"missing cookie only", "", validToken, true},
+		{"missing field only", validToken, "", true},
+		{"wrong-length field", validToken, "short", true},
+		{"mismatched token", "cookie-value", "other-field-value", true},
+		{"matching token passes", validToken, validToken, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newTestOnboarding(t, trustnet.LoopbackOnly())
+
+			form := url.Values{
+				"username": {"admin"},
+				"password": {"correct-horse-battery"},
+				"confirm":  {"correct-horse-battery"},
+			}
+			if tc.field != "" {
+				form.Set("csrf_token", tc.field)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.RemoteAddr = loopbackPeer
+			if tc.cookie != "" {
+				req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: tc.cookie})
+			}
+			rec := httptest.NewRecorder()
+			f.mux.ServeHTTP(rec, req)
+
+			if tc.wantForbid {
+				if rec.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403", rec.Code)
+				}
+				// Must not create an admin on CSRF rejection.
+				if has, _ := f.svc.HasUsers(req.Context()); has {
+					t.Error("admin created despite CSRF rejection")
+				}
+			} else {
+				// A valid CSRF + valid form should succeed and redirect to /config.
+				if rec.Code != http.StatusSeeOther {
+					t.Fatalf("valid CSRF status = %d, want 303", rec.Code)
+				}
+				if loc := rec.Header().Get("Location"); loc != "/config" {
+					t.Errorf("Location = %q, want /config", loc)
+				}
+			}
+		})
+	}
+}
+
+// TestCSRFTokenDoesNotFeedRateLimiter proves that CSRF-rejected login attempts
+// do not consume rate-limiter capacity (the check fires before the limiter).
+func TestCSRFTokenDoesNotFeedRateLimiter(t *testing.T) {
+	a := newTestAuthForCSRF(t)
+	const peer = "203.0.113.99:9000"
+
+	// Fire many CSRF-invalid requests (well above the lockout threshold).
+	badForm := url.Values{"username": {"admin"}, "password": {"wrong"}}
+	for i := 0; i < defaultMaxFailures+5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(badForm.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.RemoteAddr = peer
+		// No CSRF cookie -> 403 before the rate limiter.
+		a.handleLogin(httptest.NewRecorder(), req)
+	}
+
+	// A valid CSRF + valid credentials from the same IP must still succeed (not 429).
+	good := url.Values{
+		"username":   {"admin"},
+		"password":   {"correct-horse-battery"},
+		"csrf_token": {testCSRFToken},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(good.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = peer
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: testCSRFToken})
+	rec := httptest.NewRecorder()
+	a.handleLogin(rec, req)
+
+	if rec.Code == http.StatusTooManyRequests {
+		t.Error("CSRF-rejected attempts fed the rate limiter; valid login was locked out")
+	}
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("valid login after CSRF-only failures = %d, want 303", rec.Code)
+	}
+}
+
+// TestCSRFTokenQueryParamRejected proves that a CSRF token supplied only as a
+// URL query parameter (not in the POST body) is rejected. enforceCSRFToken uses
+// PostFormValue, which reads only the request body, not the URL query string.
+func TestCSRFTokenQueryParamRejected(t *testing.T) {
+	a := newTestAuthForCSRF(t)
+	// A real-length token so the length guard is not what fires; the rejection
+	// must come from PostFormValue returning "" (query param ignored in body read).
+	token := testCSRFToken
+
+	req := httptest.NewRequest(http.MethodPost, "/login?csrf_token="+token, nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: token})
+	// POST body is empty: no csrf_token in the body.
+	rec := httptest.NewRecorder()
+	a.handleLogin(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("CSRF token in URL query param = %d, want 403 (PostFormValue must not read query string)", rec.Code)
+	}
+}
+
+// TestCSRFTokenGETReusesExistingCookie proves the multi-tab fix: a GET /login
+// or GET /setup request that carries a valid mxlrc_csrf cookie must reuse the
+// existing token (return it in the hidden field, set no new cookie) so a second
+// tab opened while the first is still open does not invalidate the first tab's
+// token.
+func TestCSRFTokenGETReusesExistingCookie(t *testing.T) {
+	for _, path := range []string{"/login", "/setup"} {
+		t.Run("GET "+path, func(t *testing.T) {
+			f := newTestOnboarding(t, trustnet.LoopbackOnly())
+
+			// First GET: no cookie -> server mints a fresh token and sets the cookie.
+			req1 := httptest.NewRequest(http.MethodGet, path, nil)
+			req1.RemoteAddr = loopbackPeer
+			rec1 := httptest.NewRecorder()
+			f.mux.ServeHTTP(rec1, req1)
+			if rec1.Code != http.StatusOK {
+				t.Fatalf("first GET %s = %d, want 200", path, rec1.Code)
+			}
+			var originalToken string
+			for _, c := range rec1.Result().Cookies() {
+				if c.Name == CSRFCookieName {
+					originalToken = c.Value
+					break
+				}
+			}
+			if originalToken == "" {
+				t.Fatalf("first GET %s: no CSRF cookie set", path)
+			}
+
+			// Second GET: send the existing cookie. The server must NOT overwrite it.
+			req2 := httptest.NewRequest(http.MethodGet, path, nil)
+			req2.RemoteAddr = loopbackPeer
+			req2.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: originalToken})
+			rec2 := httptest.NewRecorder()
+			f.mux.ServeHTTP(rec2, req2)
+			if rec2.Code != http.StatusOK {
+				t.Fatalf("second GET %s = %d, want 200", path, rec2.Code)
+			}
+
+			// No new CSRF cookie must appear in the second response.
+			for _, c := range rec2.Result().Cookies() {
+				if c.Name == CSRFCookieName {
+					t.Errorf("second GET %s set a new CSRF cookie (%q), want reuse of existing (%q)",
+						path, c.Value, originalToken)
+				}
+			}
+
+			// The hidden form field must carry the original token.
+			wantField := `name="csrf_token" value="` + originalToken + `"`
+			if !strings.Contains(rec2.Body.String(), wantField) {
+				t.Errorf("second GET %s: hidden CSRF field does not match original token", path)
 			}
 		})
 	}

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -137,7 +137,7 @@ func (o *Onboarding) handleSetupForm(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/login", http.StatusSeeOther)
 		return
 	}
-	renderSetup(w, r, http.StatusOK, o.version, "", "")
+	o.renderSetup(w, r, http.StatusOK, o.version, "", "")
 }
 
 // handleSetup processes the onboarding submission (POST /setup). It re-applies
@@ -151,6 +151,11 @@ func (o *Onboarding) handleSetup(w http.ResponseWriter, r *http.Request) {
 	}
 	if !o.policy.Trusted(r) {
 		http.NotFound(w, r)
+		return
+	}
+	// CSRF validation after the trust gate: untrusted peers are already refused
+	// above; for trusted peers the double-submit token prevents login-CSRF.
+	if !enforceCSRFToken(w, r) {
 		return
 	}
 	has, err := o.hasAdmin(r.Context())
@@ -167,7 +172,7 @@ func (o *Onboarding) handleSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := r.ParseForm(); err != nil {
-		renderSetup(w, r, http.StatusBadRequest, o.version, "Invalid form submission.", "")
+		o.renderSetup(w, r, http.StatusBadRequest, o.version, "Invalid form submission.", "")
 		return
 	}
 	username := strings.TrimSpace(r.PostFormValue("username"))
@@ -175,15 +180,15 @@ func (o *Onboarding) handleSetup(w http.ResponseWriter, r *http.Request) {
 	confirm := r.PostFormValue("confirm")
 
 	if username == "" {
-		renderSetup(w, r, http.StatusBadRequest, o.version, "Username is required.", username)
+		o.renderSetup(w, r, http.StatusBadRequest, o.version, "Username is required.", username)
 		return
 	}
 	if len(password) < webauth.MinPasswordLength {
-		renderSetup(w, r, http.StatusBadRequest, o.version, passwordTooShortMsg, username)
+		o.renderSetup(w, r, http.StatusBadRequest, o.version, passwordTooShortMsg, username)
 		return
 	}
 	if password != confirm {
-		renderSetup(w, r, http.StatusBadRequest, o.version, "Passwords do not match.", username)
+		o.renderSetup(w, r, http.StatusBadRequest, o.version, "Passwords do not match.", username)
 		return
 	}
 
@@ -194,10 +199,10 @@ func (o *Onboarding) handleSetup(w http.ResponseWriter, r *http.Request) {
 			o.adminExists.Store(true)
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 		case errors.Is(err, webauth.ErrPasswordTooShort):
-			renderSetup(w, r, http.StatusBadRequest, o.version, passwordTooShortMsg, username)
+			o.renderSetup(w, r, http.StatusBadRequest, o.version, passwordTooShortMsg, username)
 		default:
 			slog.Error("onboarding: admin creation failed", "error", err)
-			renderSetup(w, r, http.StatusInternalServerError, o.version,
+			o.renderSetup(w, r, http.StatusInternalServerError, o.version,
 				"Could not create the admin account. Please try again.", username)
 		}
 		return
@@ -248,9 +253,16 @@ func (o *Onboarding) writeSecrets(ctx context.Context, mxToken, webhookKey strin
 	}
 }
 
-// renderSetup renders the setup page with the given status. Like the login page
-// it is never cached (it reflects setup state and the POST issues a cookie).
-func renderSetup(w http.ResponseWriter, r *http.Request, status int, version, errMsg, username string) {
+// renderSetup renders the setup page with the given status. It generates a
+// fresh CSRF token, sets the CSRF cookie, then renders the page. Like the login
+// page, the setup page is never cached (it reflects setup state and may set cookies).
+func (o *Onboarding) renderSetup(w http.ResponseWriter, r *http.Request, status int, version, errMsg, username string) {
+	csrfToken, err := ensureCSRFToken(w, r, o.auth.secureRequest(r))
+	if err != nil {
+		slog.Error("setup: failed to generate CSRF token", "error", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Cache-Control", "no-store")
-	renderWithStatus(w, r, status, templates.SetupPage(version, errMsg, username))
+	renderWithStatus(w, r, status, templates.SetupPage(version, errMsg, username, csrfToken))
 }

--- a/internal/web/setup_test.go
+++ b/internal/web/setup_test.go
@@ -50,13 +50,24 @@ func newTestOnboarding(t *testing.T, policy *trustnet.Policy) onboardingFixture 
 	return onboardingFixture{mux: mux, svc: svc, store: store}
 }
 
+// testCSRFSetupToken is the fixed CSRF value used by postSetup. Must be exactly
+// csrfTokenLen (64) chars to satisfy the enforceCSRFToken length guard.
+const testCSRFSetupToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+
 // postSetup submits the onboarding form from the given peer with the given form
-// values and returns the recorder.
+// values (plus a matching CSRF cookie+field) and returns the recorder.
 func postSetup(t *testing.T, mux *http.ServeMux, peer string, form url.Values) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(form.Encode()))
+	// Clone to avoid mutating the caller's values.
+	v := make(url.Values)
+	for k, vals := range form {
+		v[k] = vals
+	}
+	v.Set("csrf_token", testCSRFSetupToken)
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(v.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = peer
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: testCSRFSetupToken})
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	return rec
@@ -426,8 +437,12 @@ func TestSetupHasUsersErrorReturns500(t *testing.T) {
 	})
 
 	t.Run("POST", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/setup", nil)
+		const csrfToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
+		form := url.Values{"csrf_token": {csrfToken}}
+		req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.RemoteAddr = loopbackPeer
+		req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: csrfToken})
 		rec := httptest.NewRecorder()
 		onb.handleSetup(rec, req)
 		if rec.Code != http.StatusInternalServerError {
@@ -447,17 +462,21 @@ func TestSetupHasUsersErrorReturns500(t *testing.T) {
 	})
 }
 
-// postFakeSetup submits a valid form to a fake-backed onboarding handler.
+// postFakeSetup submits a valid form directly to a fake-backed onboarding
+// handler, including a matching CSRF cookie+field so the double-submit check passes.
 func postFakeSetup(onb *Onboarding) *httptest.ResponseRecorder {
+	const csrfToken = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
 	form := url.Values{
 		"username":         {"admin"},
 		"password":         {"correct-horse-battery"},
 		"confirm":          {"correct-horse-battery"},
 		"musixmatch_token": {"tok"},
+		"csrf_token":       {csrfToken},
 	}
 	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = loopbackPeer
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: csrfToken})
 	rec := httptest.NewRecorder()
 	onb.handleSetup(rec, req)
 	return rec

--- a/web/templates/login.templ
+++ b/web/templates/login.templ
@@ -10,7 +10,7 @@ package templates
 // server-validated local return path carried through the POST so a deep link
 // resumes after login. username is echoed back on a failed attempt as a
 // convenience (the password never is).
-templ LoginPage(version string, errMsg string, next string, username string) {
+templ LoginPage(version string, errMsg string, next string, username string, csrfToken string) {
 	<!DOCTYPE html>
 	<html lang="en">
 		<head>
@@ -30,6 +30,7 @@ templ LoginPage(version string, errMsg string, next string, username string) {
 				}
 				<form class="mx-auth-form" method="post" action="/login">
 					<input type="hidden" name="next" value={ next }/>
+					<input type="hidden" name="csrf_token" value={ csrfToken }/>
 					<div class="mx-auth-field">
 						<label class="mx-auth-label" for="username">Username</label>
 						<input

--- a/web/templates/login_templ.go
+++ b/web/templates/login_templ.go
@@ -18,7 +18,7 @@ import templruntime "github.com/a-h/templ/runtime"
 // server-validated local return path carried through the POST so a deep link
 // resumes after login. username is echoed back on a failed attempt as a
 // convenience (the password never is).
-func LoginPage(version string, errMsg string, next string, username string) templ.Component {
+func LoginPage(version string, errMsg string, next string, username string, csrfToken string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -75,33 +75,46 @@ func LoginPage(version string, errMsg string, next string, username string) temp
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"username\">Username</label> <input class=\"mx-auth-input\" id=\"username\" name=\"username\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"> <input type=\"hidden\" name=\"csrf_token\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(username)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(csrfToken)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 40, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 33, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" autocomplete=\"username\" autofocus required></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"password\">Password</label> <input class=\"mx-auth-input\" id=\"password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required></div><button class=\"mx-auth-button\" type=\"submit\">Sign in</button></form><p class=\"mx-auth-footer\">mxlrcgo-svc <span class=\"mx-auth-version\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"username\">Username</label> <input class=\"mx-auth-input\" id=\"username\" name=\"username\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(version)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(username)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 59, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 41, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span></p></main></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" autocomplete=\"username\" autofocus required></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"password\">Password</label> <input class=\"mx-auth-input\" id=\"password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required></div><button class=\"mx-auth-button\" type=\"submit\">Sign in</button></form><p class=\"mx-auth-footer\">mxlrcgo-svc <span class=\"mx-auth-version\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(version)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 60, Col: 81}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</span></p></main></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/templates/setup.templ
+++ b/web/templates/setup.templ
@@ -15,7 +15,7 @@ import (
 // match", "Password must be at least 8 characters"). username is echoed back on
 // a failed submission as a convenience; the password and the optional secret
 // fields are never echoed.
-templ SetupPage(version string, errMsg string, username string) {
+templ SetupPage(version string, errMsg string, username string, csrfToken string) {
 	<!DOCTYPE html>
 	<html lang="en">
 		<head>
@@ -38,6 +38,7 @@ templ SetupPage(version string, errMsg string, username string) {
 					<div class="mx-auth-error" role="alert">{ errMsg }</div>
 				}
 				<form class="mx-auth-form" method="post" action="/setup">
+					<input type="hidden" name="csrf_token" value={ csrfToken }/>
 					<div class="mx-auth-field">
 						<label class="mx-auth-label" for="username">Admin username</label>
 						<input

--- a/web/templates/setup_templ.go
+++ b/web/templates/setup_templ.go
@@ -23,7 +23,7 @@ import (
 // match", "Password must be at least 8 characters"). username is echoed back on
 // a failed submission as a convenience; the password and the optional secret
 // fields are never echoed.
-func SetupPage(version string, errMsg string, username string) templ.Component {
+func SetupPage(version string, errMsg string, username string, csrfToken string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -67,72 +67,85 @@ func SetupPage(version string, errMsg string, username string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form class=\"mx-auth-form\" method=\"post\" action=\"/setup\"><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"username\">Admin username</label> <input class=\"mx-auth-input\" id=\"username\" name=\"username\" type=\"text\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form class=\"mx-auth-form\" method=\"post\" action=\"/setup\"><input type=\"hidden\" name=\"csrf_token\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(username)
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(csrfToken)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 48, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 41, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" autocomplete=\"username\" autofocus required></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"password\">Password</label> <input class=\"mx-auth-input\" id=\"password\" name=\"password\" type=\"password\" autocomplete=\"new-password\" minlength=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"username\">Admin username</label> <input class=\"mx-auth-input\" id=\"username\" name=\"username\" type=\"text\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(webauth.MinPasswordLength))
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(username)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 62, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 49, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" required> <span class=\"mx-auth-hint\">At least ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" autocomplete=\"username\" autofocus required></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"password\">Password</label> <input class=\"mx-auth-input\" id=\"password\" name=\"password\" type=\"password\" autocomplete=\"new-password\" minlength=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(webauth.MinPasswordLength))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 65, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 63, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " characters.</span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"confirm\">Confirm password</label> <input class=\"mx-auth-input\" id=\"confirm\" name=\"confirm\" type=\"password\" autocomplete=\"new-password\" minlength=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" required> <span class=\"mx-auth-hint\">At least ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(webauth.MinPasswordLength))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 75, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 66, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" required></div><div class=\"mx-auth-section\"><span class=\"mx-auth-section-title\">Runtime secrets (optional)</span> <span class=\"mx-auth-hint\">Stored encrypted at rest. Leave a field blank to keep the value already set in config or the environment.</span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"musixmatch_token\">Musixmatch token</label> <input class=\"mx-auth-input\" id=\"musixmatch_token\" name=\"musixmatch_token\" type=\"password\" autocomplete=\"off\"> <span class=\"mx-auth-hint\"><a class=\"mx-auth-link\" href=\"https://sydlexius.github.io/mxlrcgo-svc/GETTING_STARTED/#get-a-musixmatch-token\" target=\"_blank\" rel=\"noopener noreferrer\">How do I get a token?</a></span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"webhook_api_key\">Webhook API key</label> <input class=\"mx-auth-input\" id=\"webhook_api_key\" name=\"webhook_api_key\" type=\"password\" autocomplete=\"off\"></div><button class=\"mx-auth-button\" type=\"submit\">Create account</button></form><p class=\"mx-auth-footer\">mxlrcgo-svc <span class=\"mx-auth-version\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " characters.</span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"confirm\">Confirm password</label> <input class=\"mx-auth-input\" id=\"confirm\" name=\"confirm\" type=\"password\" autocomplete=\"new-password\" minlength=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(version)
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(webauth.MinPasswordLength))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 111, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 76, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span></p></main></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" required></div><div class=\"mx-auth-section\"><span class=\"mx-auth-section-title\">Runtime secrets (optional)</span> <span class=\"mx-auth-hint\">Stored encrypted at rest. Leave a field blank to keep the value already set in config or the environment.</span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"musixmatch_token\">Musixmatch token</label> <input class=\"mx-auth-input\" id=\"musixmatch_token\" name=\"musixmatch_token\" type=\"password\" autocomplete=\"off\"> <span class=\"mx-auth-hint\"><a class=\"mx-auth-link\" href=\"https://sydlexius.github.io/mxlrcgo-svc/GETTING_STARTED/#get-a-musixmatch-token\" target=\"_blank\" rel=\"noopener noreferrer\">How do I get a token?</a></span></div><div class=\"mx-auth-field\"><label class=\"mx-auth-label\" for=\"webhook_api_key\">Webhook API key</label> <input class=\"mx-auth-input\" id=\"webhook_api_key\" name=\"webhook_api_key\" type=\"password\" autocomplete=\"off\"></div><button class=\"mx-auth-button\" type=\"submit\">Create account</button></form><p class=\"mx-auth-footer\">mxlrcgo-svc <span class=\"mx-auth-version\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(version)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/setup.templ`, Line: 112, Col: 81}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</span></p></main></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Implements item 2 of #260 (the maintainer chose "add CSRF tokens"). Adds double-submit CSRF protection to the pre-auth `/login` and `/setup` forms, closing the login-CSRF gap that `SameSite=Lax` alone does not cover.

> Companion: #280 carries #260 items 1 + 3 (rate-limiter memory bound + cleartext-cookie docs). This PR completes #260, so it carries `Closes #260` - both should merge.

## Mechanism (server-side double-submit)

- On GET `/login` and `/setup`: generate a 32-byte `crypto/rand` token (64 hex), set it in the `mxlrc_csrf` cookie **and** render it as a hidden `csrf_token` field. The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, `Secure` auto-under-TLS (via the existing proxy-aware `secureRequest`), MaxAge 1h.
- On POST: `enforceCSRFToken` requires a non-empty cookie (rejected **before** any compare, so the `ConstantTimeCompare("","")` bypass cannot fire) whose value matches the submitted field via `crypto/subtle.ConstantTimeCompare`. Failure → generic 403.
- Order: on `/login`, CSRF runs **before** the rate limiter, so CSRF-invalid floods cannot burn a victim's lockout counter; on `/setup`, after the trusted-network gate. The existing `enforceSameOrigin` is also applied (defense-in-depth).

## Verification

- `make gate` green; `make ui-check` clean (templ regenerated + committed).
- Independent hostile security review: **SHIP** - verified the empty/missing-token matrix all rejects (six paths), cookie attributes, constant-time compare, token strength, and that fresh tokens are issued on every render/error-render.
- Tests cover the happy path + every reject path (missing/empty cookie, missing/empty/mismatched field), cookie attributes, Secure-under-TLS, and that CSRF-invalid requests do not feed the rate limiter.

## Noted (optional follow-ups, non-blocking)

- POST `/logout` relies on `enforceSameOrigin` (no token) - logout-CSRF is a forced-sign-out nuisance, not a state/privilege compromise; same-origin already blocks the cross-site vector. Optional hardening later.
- An expired CSRF cookie yields a bare 403 rather than a friendly re-render (security-correct; minor UX).

Closes #260