### PR TITLE
feat(reports): read-only reports data layer (5 canned queries) (#211)

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -51,7 +51,7 @@ func (r *Repo) QueueSummary(ctx context.Context) (QueueSummary, error) {
 	if err != nil {
 		return QueueSummary{}, fmt.Errorf("reports: queue summary: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var status string
@@ -146,7 +146,7 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
 	if err != nil {
 		return nil, fmt.Errorf("reports: recent outcomes: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	defer func() { _ = rows.Close() }()
 
 	var out []RecentOutcome
 	for rows.Next() {
@@ -160,9 +160,9 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
 			return nil, fmt.Errorf("reports: scan recent outcome: %w", err)
 		}
 		if completedAt.Valid && completedAt.String != "" {
-			t, perr := time.Parse(timeFormat, completedAt.String)
-			if perr != nil {
-				return nil, fmt.Errorf("reports: parse completed_at %q: %w", completedAt.String, perr)
+			t, err := time.Parse(timeFormat, completedAt.String)
+			if err != nil {
+				return nil, fmt.Errorf("reports: parse completed_at %q: %w", completedAt.String, err)
 			}
 			o.CompletedAt = t
 		}
@@ -217,7 +217,7 @@ func (r *Repo) ProviderEffectiveness(ctx context.Context) ([]ProviderEffectivene
 	if err != nil {
 		return nil, fmt.Errorf("reports: provider effectiveness: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	defer func() { _ = rows.Close() }()
 
 	var out []ProviderEffectiveness
 	for rows.Next() {
@@ -275,7 +275,7 @@ func (r *Repo) InstrumentalInventory(ctx context.Context) ([]InstrumentalTrack, 
 	if err != nil {
 		return nil, fmt.Errorf("reports: instrumental inventory: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	defer func() { _ = rows.Close() }()
 
 	var out []InstrumentalTrack
 	for rows.Next() {
@@ -323,7 +323,7 @@ func (r *Repo) FailureAnalysis(ctx context.Context) ([]FailureGroup, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reports: failure analysis: %w", err)
 	}
-	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+	defer func() { _ = rows.Close() }()
 
 	var out []FailureGroup
 	for rows.Next() {

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -1,0 +1,340 @@
+// Package reports provides read-only, run-on-demand reports over the existing
+// SQLite data (work_queue, scan_results, provider_outcomes). Every method is
+// strictly read-only: there are no write paths and no schema migrations -- all
+// five reports are answerable over columns the DB already holds.
+//
+// The repository wraps *sql.DB and follows the same pattern as internal/cache.
+package reports
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// timeFormat matches the layout work_queue.completed_at is stored in
+// (see internal/queue: time.RFC3339).
+const timeFormat = time.RFC3339
+
+// Repo provides read-only report queries over the application database.
+type Repo struct {
+	db *sql.DB
+}
+
+// New returns a Repo backed by db.
+func New(db *sql.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// QueueSummary is a count of work_queue rows per status. Every status field is
+// populated (zero when no rows have that status) so callers can render a
+// complete table without special-casing absent statuses.
+type QueueSummary struct {
+	Pending    int64
+	Processing int64
+	Done       int64
+	Failed     int64
+	Deferred   int64
+	Total      int64
+}
+
+// QueueSummary returns the count of work_queue rows grouped by status.
+//
+// Source: work_queue.status (CHECK-constrained to pending/processing/done/
+// failed/deferred by migrations 001 + 012). Zero-count statuses are reported
+// as 0 rather than omitted.
+func (r *Repo) QueueSummary(ctx context.Context) (QueueSummary, error) {
+	var s QueueSummary
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT status, COUNT(*) FROM work_queue GROUP BY status`)
+	if err != nil {
+		return QueueSummary{}, fmt.Errorf("reports: queue summary: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+
+	for rows.Next() {
+		var status string
+		var count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			return QueueSummary{}, fmt.Errorf("reports: scan queue summary: %w", err)
+		}
+		switch status {
+		case "pending":
+			s.Pending = count
+		case "processing":
+			s.Processing = count
+		case "done":
+			s.Done = count
+		case "failed":
+			s.Failed = count
+		case "deferred":
+			s.Deferred = count
+		}
+		s.Total += count
+	}
+	if err := rows.Err(); err != nil {
+		return QueueSummary{}, fmt.Errorf("reports: queue summary rows: %w", err)
+	}
+	return s, nil
+}
+
+// ResultClass is the derived classification of a completed work_queue row.
+type ResultClass string
+
+const (
+	// ResultSynced means an .lrc (synced lyrics) file was written.
+	ResultSynced ResultClass = "synced"
+	// ResultUnsyncedOrInstrumental means a .txt file was written. This groups
+	// plain unsynced lyrics and instrumental markers together: both land in a
+	// .txt output and are not distinguishable from output_paths alone (per the
+	// issue's Design Choice 2). Use InstrumentalInventory to isolate
+	// audio-detected instrumentals.
+	ResultUnsyncedOrInstrumental ResultClass = "unsynced-or-instrumental"
+	// ResultMiss means the item exhausted its miss budget with no lyrics found
+	// (status='done', last_error='miss limit reached', no output written).
+	ResultMiss ResultClass = "miss"
+	// ResultUnknown means the row could not be classified (e.g. legacy row with
+	// no/empty output_paths and no miss marker).
+	ResultUnknown ResultClass = "unknown"
+)
+
+// RecentOutcome is one recently-completed track with its derived result class.
+type RecentOutcome struct {
+	Artist string
+	Title  string
+	Album  string
+	// CompletedAt is the completion timestamp; zero value when completed_at is
+	// NULL (such rows sort last).
+	CompletedAt time.Time
+	// ProviderLane is the winning provider lane recorded at completion; empty
+	// when NULL (not recorded, or a miss with no winning provider).
+	ProviderLane string
+	// Result is the classification derived from last_error / output_paths.
+	Result ResultClass
+}
+
+// RecentOutcomes returns the most recently completed (status='done') tracks,
+// newest first by completed_at (NULLs sorted last), capped at limit.
+//
+// Source: work_queue rows where status='done'. The result classification is
+// computed in SQL: last_error='miss limit reached' -> miss; otherwise the first
+// output filename (json_extract(output_paths, '$[0].filename')) ending in .lrc
+// -> synced, .txt -> unsynced-or-instrumental (grouped, see ResultClass),
+// anything else -> unknown. json_valid guards legacy rows whose output_paths is
+// empty/non-JSON so json_extract never errors.
+func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT artist, title, album, completed_at, provider_lane,
+            CASE
+                WHEN last_error = 'miss limit reached' THEN 'miss'
+                WHEN json_valid(output_paths)
+                    AND json_extract(output_paths, '$[0].filename') LIKE '%.lrc' THEN 'synced'
+                WHEN json_valid(output_paths)
+                    AND json_extract(output_paths, '$[0].filename') LIKE '%.txt' THEN 'unsynced-or-instrumental'
+                ELSE 'unknown'
+            END AS result
+         FROM work_queue
+         WHERE status = 'done'
+         ORDER BY completed_at IS NULL, completed_at DESC, id DESC
+         LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("reports: recent outcomes: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+
+	var out []RecentOutcome
+	for rows.Next() {
+		var (
+			o            RecentOutcome
+			completedAt  sql.NullString
+			providerLane sql.NullString
+			result       string
+		)
+		if err := rows.Scan(&o.Artist, &o.Title, &o.Album, &completedAt, &providerLane, &result); err != nil {
+			return nil, fmt.Errorf("reports: scan recent outcome: %w", err)
+		}
+		if completedAt.Valid && completedAt.String != "" {
+			t, perr := time.Parse(timeFormat, completedAt.String)
+			if perr != nil {
+				return nil, fmt.Errorf("reports: parse completed_at %q: %w", completedAt.String, perr)
+			}
+			o.CompletedAt = t
+		}
+		o.ProviderLane = providerLane.String
+		o.Result = ResultClass(result)
+		out = append(out, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reports: recent outcomes rows: %w", err)
+	}
+	return out, nil
+}
+
+// ProviderEffectiveness is the hit/miss tally and derived hit-rate for one
+// provider lane.
+type ProviderEffectiveness struct {
+	Lane   string
+	Hits   int64
+	Misses int64
+	// HitRate is Hits / (Hits + Misses), in [0,1]; 0 when the lane has no
+	// recorded outcomes. APPROXIMATE: the underlying counters are
+	// attempt-weighted, not clean per-track, so this can over-state lanes that
+	// were tried but lost to a later winning lane. A true per-track hit-rate is
+	// a deferred follow-up (see #282); the UI layer should surface this value
+	// with an "approximate" label.
+	HitRate float64
+}
+
+// ProviderEffectiveness returns per-lane hit/miss counts and hit-rate.
+//
+// Source-of-truth decision: the provider_outcomes table (migration 018), NOT
+// aggregation over work_queue.provider_lane. provider_outcomes is the
+// worker-maintained aggregate; work_queue.provider_lane only records the winning
+// lane of a completed row (per-track provenance) and has no miss signal, so a
+// hit-rate cannot be computed from it.
+//
+// HitRate caveat (attempt-weighted, APPROXIMATE): the counters are NOT a clean
+// per-track tally. internal/worker.recordHit records a hit only for the WINNING
+// lane (worker.go: w.recordHit(..., song.WinningLane)), and
+// internal/worker.recordMisses records a miss for every active lane only on the
+// all-lanes-benign-miss path (worker.go: w.recordMisses on musixmatch.
+// IsBenignMiss). So a lane that was tried but lost to a later winning lane
+// records neither a hit nor a miss, and HitRate over-states such tried-but-not-
+// winning lanes. A true per-track hit-rate is a deferred follow-up (issue #282);
+// this report intentionally surfaces the approximate aggregate unchanged and
+// labels it (see the HitRate field doc) rather than re-deriving it here. The
+// hit-rate is computed in Go to keep integer-vs-float division explicit and
+// avoid SQL NULL-on-zero-divisor edge cases.
+func (r *Repo) ProviderEffectiveness(ctx context.Context) ([]ProviderEffectiveness, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT lane, hits, misses FROM provider_outcomes ORDER BY lane`)
+	if err != nil {
+		return nil, fmt.Errorf("reports: provider effectiveness: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+
+	var out []ProviderEffectiveness
+	for rows.Next() {
+		var p ProviderEffectiveness
+		if err := rows.Scan(&p.Lane, &p.Hits, &p.Misses); err != nil {
+			return nil, fmt.Errorf("reports: scan provider effectiveness: %w", err)
+		}
+		if total := p.Hits + p.Misses; total > 0 {
+			p.HitRate = float64(p.Hits) / float64(total)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reports: provider effectiveness rows: %w", err)
+	}
+	return out, nil
+}
+
+// InstrumentalTrack is one audio-detected instrumental work_queue row, joined to
+// its source file(s).
+type InstrumentalTrack struct {
+	WorkQueueID int64
+	Artist      string
+	Title       string
+	// FilePath is the source audio path from scan_results; empty when the row
+	// has no linked scan_results (e.g. CLI-enqueued items). A work_queue row
+	// that collapsed multiple files yields one InstrumentalTrack per file.
+	FilePath string
+	// DetectRequested is the per-item detect_instrumental request flag stamped
+	// at enqueue (migration 016): NULL (not Valid) = no decision stamped, the
+	// worker used the global config default; 0 = detection off; 1 = detection
+	// on. This is the REQUEST source, distinct from the detection RESULT
+	// (instrumental_result), which equals 1 for every row returned here.
+	DetectRequested sql.NullInt64
+}
+
+// InstrumentalInventory returns work_queue rows the audio detector confirmed as
+// instrumental (instrumental_result = 1), joined to scan_results for file
+// identity, and surfaces the detect_instrumental request flag so callers can
+// distinguish detection-requested from detected-instrumental.
+//
+// Source: work_queue.instrumental_result (migration 018; NULL=not run, 0=ran
+// not instrumental, 1=detected instrumental) filtered to =1, left-joined via
+// work_queue_scan_results (migration 010) to scan_results for file_path, with
+// work_queue.detect_instrumental (migration 016) carried as the request flag.
+// The LEFT JOIN keeps CLI-enqueued rows that have no scan_results link.
+func (r *Repo) InstrumentalInventory(ctx context.Context) ([]InstrumentalTrack, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT wq.id, wq.artist, wq.title, wq.detect_instrumental, COALESCE(sr.file_path, '')
+         FROM work_queue wq
+         LEFT JOIN work_queue_scan_results wqsr ON wqsr.work_queue_id = wq.id
+         LEFT JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+         WHERE wq.instrumental_result = 1
+         ORDER BY wq.id, sr.id`)
+	if err != nil {
+		return nil, fmt.Errorf("reports: instrumental inventory: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+
+	var out []InstrumentalTrack
+	for rows.Next() {
+		var t InstrumentalTrack
+		if err := rows.Scan(&t.WorkQueueID, &t.Artist, &t.Title, &t.DetectRequested, &t.FilePath); err != nil {
+			return nil, fmt.Errorf("reports: scan instrumental track: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reports: instrumental inventory rows: %w", err)
+	}
+	return out, nil
+}
+
+// FailureGroup is a count of failed/deferred work_queue rows sharing one status
+// and reason.
+type FailureGroup struct {
+	// Status is 'failed' or 'deferred'. Grouping keeps the two distinct because
+	// they mean different things: 'deferred' rows are benign misses awaiting a
+	// later retry, while 'failed' rows hit a hard error.
+	Status string
+	// Reason is the normalized work_queue.last_error text ('unknown' when no
+	// error was recorded), matching the empty-string-to-unknown normalization
+	// used by internal/queue.CountFailuresByReason.
+	Reason string
+	Count  int64
+}
+
+// FailureAnalysis returns failed and deferred work_queue rows grouped by reason
+// (last_error), with a count per group, ordered most-frequent first.
+//
+// Source: work_queue rows where status IN ('failed','deferred'), grouped by
+// (status, normalized last_error). Status is included in the grouping so a
+// deferred miss and a hard failure carrying the same last_error text are
+// reported separately. An empty last_error normalizes to 'unknown' (via
+// COALESCE over NULLIF), matching internal/queue.CountFailuresByReason.
+func (r *Repo) FailureAnalysis(ctx context.Context) ([]FailureGroup, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT status, COALESCE(NULLIF(last_error, ''), 'unknown') AS reason, COUNT(*) AS n
+         FROM work_queue
+         WHERE status IN ('failed', 'deferred')
+         GROUP BY status, reason
+         ORDER BY n DESC, status, reason`)
+	if err != nil {
+		return nil, fmt.Errorf("reports: failure analysis: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is not actionable
+
+	var out []FailureGroup
+	for rows.Next() {
+		var g FailureGroup
+		if err := rows.Scan(&g.Status, &g.Reason, &g.Count); err != nil {
+			return nil, fmt.Errorf("reports: scan failure group: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reports: failure analysis rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -1,0 +1,473 @@
+package reports_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/reports"
+)
+
+// openTestDB opens a temp-file SQLite with all migrations applied, mirroring the
+// helper in internal/cache. Real SQLite, no mocks.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+// insertWorkItem inserts one work_queue row and returns its id. Only the columns
+// a test cares about are passed; everything else takes its schema default.
+type workItem struct {
+	artist             string
+	title              string
+	album              string
+	status             string
+	lastError          string
+	outputPaths        string
+	completedAt        any // string (RFC3339) or nil
+	providerLane       any // string or nil
+	instrumentalResult any // int or nil
+	detectInstrumental any // int or nil
+}
+
+func insertWorkItem(t *testing.T, sqlDB *sql.DB, w workItem) int64 {
+	t.Helper()
+	// artist_key/title_key carry a UNIQUE index; the app normally stamps them at
+	// enqueue. Tests use distinct titles, so derive the keys from artist+title to
+	// satisfy the constraint without a normalize dependency.
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue
+            (artist, title, artist_key, title_key, album, status, last_error, output_paths,
+             completed_at, provider_lane, instrumental_result, detect_instrumental)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		w.artist, w.title, w.artist, w.title, w.album, w.status, w.lastError, w.outputPaths,
+		w.completedAt, w.providerLane, w.instrumentalResult, w.detectInstrumental)
+	if err != nil {
+		t.Fatalf("insert work_queue: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+func insertLibrary(t *testing.T, sqlDB *sql.DB) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO libraries (path, name) VALUES (?, ?)`, "/music", "lib")
+	if err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+func insertScanResult(t *testing.T, sqlDB *sql.DB, libraryID int64, filePath string) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO scan_results (library_id, file_path) VALUES (?, ?)`, libraryID, filePath)
+	if err != nil {
+		t.Fatalf("insert scan_results: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+func linkScanResult(t *testing.T, sqlDB *sql.DB, workQueueID, scanResultID int64) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+		workQueueID, scanResultID); err != nil {
+		t.Fatalf("link scan_results: %v", err)
+	}
+}
+
+func insertProviderOutcome(t *testing.T, sqlDB *sql.DB, lane string, hits, misses int64) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO provider_outcomes (lane, hits, misses) VALUES (?, ?, ?)`,
+		lane, hits, misses); err != nil {
+		t.Fatalf("insert provider_outcomes: %v", err)
+	}
+}
+
+// pathsJSON builds an output_paths JSON array with one entry, matching the
+// shape internal/queue.marshalOutputPaths writes ([{outdir,filename}]).
+func pathsJSON(filename string) string { return `[{"outdir":"/out","filename":"` + filename + `"}]` }
+
+func TestQueueSummary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// 2 pending, 1 processing, 3 done, 1 failed, 2 deferred. No 'processing'
+	// extras so we confirm zero-count statuses still report.
+	for i := 0; i < 2; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "p" + string(rune('a'+i)), status: "pending"})
+	}
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "proc", status: "processing"})
+	for i := 0; i < 3; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "d" + string(rune('a'+i)), status: "done"})
+	}
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "f1", status: "failed"})
+	for i := 0; i < 2; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "def" + string(rune('a'+i)), status: "deferred"})
+	}
+
+	got, err := repo.QueueSummary(ctx)
+	if err != nil {
+		t.Fatalf("QueueSummary: %v", err)
+	}
+	want := reports.QueueSummary{Pending: 2, Processing: 1, Done: 3, Failed: 1, Deferred: 2, Total: 9}
+	if got != want {
+		t.Errorf("QueueSummary = %+v, want %+v", got, want)
+	}
+}
+
+func TestQueueSummaryEmpty(t *testing.T) {
+	got, err := reports.New(openTestDB(t)).QueueSummary(context.Background())
+	if err != nil {
+		t.Fatalf("QueueSummary: %v", err)
+	}
+	if (got != reports.QueueSummary{}) {
+		t.Errorf("QueueSummary on empty DB = %+v, want zero value", got)
+	}
+}
+
+func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// Insert in scrambled completion order to verify DESC sort; one NULL
+	// completed_at must sort last.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Synced", title: "S", album: "Al1", status: "done",
+		outputPaths: pathsJSON("song.lrc"), completedAt: "2026-06-10T10:00:00Z",
+		providerLane: "musixmatch",
+	})
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Unsynced", title: "U", status: "done",
+		outputPaths: pathsJSON("song.txt"), completedAt: "2026-06-12T10:00:00Z",
+	})
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Miss", title: "M", status: "done",
+		lastError: "miss limit reached", outputPaths: pathsJSON("ignored.lrc"),
+		completedAt: "2026-06-11T10:00:00Z",
+	})
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Legacy", title: "L", status: "done",
+		outputPaths: "", completedAt: nil, // NULL completed_at, empty output_paths
+	})
+	// A non-done row must be excluded.
+	insertWorkItem(t, sqlDB, workItem{artist: "Pending", title: "P", status: "pending"})
+
+	got, err := repo.RecentOutcomes(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentOutcomes: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d outcomes, want 4 (done only): %+v", len(got), got)
+	}
+
+	// Order: newest completed first, NULL completed_at last.
+	wantOrder := []struct {
+		artist string
+		result reports.ResultClass
+	}{
+		{"Unsynced", reports.ResultUnsyncedOrInstrumental},
+		{"Miss", reports.ResultMiss},
+		{"Synced", reports.ResultSynced},
+		{"Legacy", reports.ResultUnknown},
+	}
+	for i, w := range wantOrder {
+		if got[i].Artist != w.artist {
+			t.Errorf("outcome[%d].Artist = %q, want %q", i, got[i].Artist, w.artist)
+		}
+		if got[i].Result != w.result {
+			t.Errorf("outcome[%d].Result = %q, want %q", i, got[i].Result, w.result)
+		}
+	}
+
+	// Field carry-through on the synced row.
+	synced := got[2]
+	if synced.Album != "Al1" || synced.ProviderLane != "musixmatch" {
+		t.Errorf("synced row fields = album %q lane %q, want Al1/musixmatch", synced.Album, synced.ProviderLane)
+	}
+	if synced.CompletedAt != mustParse(t, "2026-06-10T10:00:00Z") {
+		t.Errorf("synced CompletedAt = %v, want 2026-06-10T10:00:00Z", synced.CompletedAt)
+	}
+	// NULL completed_at -> zero time.
+	if !got[3].CompletedAt.IsZero() {
+		t.Errorf("legacy CompletedAt = %v, want zero", got[3].CompletedAt)
+	}
+}
+
+func TestRecentOutcomesLimit(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+	for i := 0; i < 5; i++ {
+		insertWorkItem(t, sqlDB, workItem{
+			artist: "A", title: "t" + string(rune('a'+i)), status: "done",
+			outputPaths: pathsJSON("x.lrc"), completedAt: "2026-06-0" + string(rune('1'+i)) + "T10:00:00Z",
+		})
+	}
+	got, err := repo.RecentOutcomes(ctx, 2)
+	if err != nil {
+		t.Fatalf("RecentOutcomes: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit 2 returned %d rows", len(got))
+	}
+	// Zero/negative limit returns nothing without touching the DB.
+	if out, err := repo.RecentOutcomes(ctx, 0); err != nil || out != nil {
+		t.Errorf("RecentOutcomes(0) = %v, %v; want nil, nil", out, err)
+	}
+}
+
+func TestProviderEffectiveness(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	insertProviderOutcome(t, sqlDB, "musixmatch", 75, 25) // 0.75
+	insertProviderOutcome(t, sqlDB, "petitlyrics", 0, 0)  // no outcomes -> 0
+	insertProviderOutcome(t, sqlDB, "aaa", 1, 3)          // 0.25, sorts first
+
+	got, err := repo.ProviderEffectiveness(ctx)
+	if err != nil {
+		t.Fatalf("ProviderEffectiveness: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d lanes, want 3", len(got))
+	}
+	// ORDER BY lane: aaa, musixmatch, petitlyrics.
+	if got[0].Lane != "aaa" || got[0].HitRate != 0.25 {
+		t.Errorf("got[0] = %+v, want aaa/0.25", got[0])
+	}
+	if got[1].Lane != "musixmatch" || got[1].HitRate != 0.75 {
+		t.Errorf("got[1] = %+v, want musixmatch/0.75", got[1])
+	}
+	if got[2].Lane != "petitlyrics" || got[2].HitRate != 0 {
+		t.Errorf("got[2] = %+v, want petitlyrics/0 (no divide-by-zero)", got[2])
+	}
+}
+
+func TestInstrumentalInventory(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+	libID := insertLibrary(t, sqlDB)
+
+	// Detected instrumental, detection explicitly requested, with a file link.
+	one := insertWorkItem(t, sqlDB, workItem{
+		artist: "Mogwai", title: "Inst", status: "done",
+		instrumentalResult: 1, detectInstrumental: 1,
+	})
+	sr := insertScanResult(t, sqlDB, libID, "/music/mogwai.flac")
+	linkScanResult(t, sqlDB, one, sr)
+
+	// Detected instrumental, detection flag NULL (used global default), no link.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "CLI", title: "Track", status: "done",
+		instrumentalResult: 1, detectInstrumental: nil,
+	})
+
+	// Detection ran but NOT instrumental -> excluded.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Vocal", title: "Song", status: "done",
+		instrumentalResult: 0, detectInstrumental: 1,
+	})
+	// Detection not run -> excluded.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "NoDetect", title: "Song", status: "done",
+		instrumentalResult: nil, detectInstrumental: 0,
+	})
+
+	got, err := repo.InstrumentalInventory(ctx)
+	if err != nil {
+		t.Fatalf("InstrumentalInventory: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d instrumental tracks, want 2: %+v", len(got), got)
+	}
+
+	// First row (lower id): file-linked, detect requested.
+	if got[0].FilePath != "/music/mogwai.flac" {
+		t.Errorf("got[0].FilePath = %q, want /music/mogwai.flac", got[0].FilePath)
+	}
+	if !got[0].DetectRequested.Valid || got[0].DetectRequested.Int64 != 1 {
+		t.Errorf("got[0].DetectRequested = %+v, want Valid 1", got[0].DetectRequested)
+	}
+	// Second row: no link, NULL request flag.
+	if got[1].FilePath != "" {
+		t.Errorf("got[1].FilePath = %q, want empty (no scan link)", got[1].FilePath)
+	}
+	if got[1].DetectRequested.Valid {
+		t.Errorf("got[1].DetectRequested = %+v, want NULL (global default)", got[1].DetectRequested)
+	}
+}
+
+func TestFailureAnalysis(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// 3 failed with "timeout", 1 failed with "auth", 2 deferred with "miss".
+	for i := 0; i < 3; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "to" + string(rune('a'+i)), status: "failed", lastError: "timeout"})
+	}
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "auth", status: "failed", lastError: "auth error"})
+	for i := 0; i < 2; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "df" + string(rune('a'+i)), status: "deferred", lastError: "miss"})
+	}
+	// done/pending rows must be excluded.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "ok", status: "done"})
+
+	got, err := repo.FailureAnalysis(ctx)
+	if err != nil {
+		t.Fatalf("FailureAnalysis: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d groups, want 3: %+v", len(got), got)
+	}
+	// ORDER BY count DESC: timeout(3), miss(2), auth(1).
+	if got[0].Status != "failed" || got[0].Reason != "timeout" || got[0].Count != 3 {
+		t.Errorf("got[0] = %+v, want failed/timeout/3", got[0])
+	}
+	if got[1].Status != "deferred" || got[1].Reason != "miss" || got[1].Count != 2 {
+		t.Errorf("got[1] = %+v, want deferred/miss/2", got[1])
+	}
+	if got[2].Status != "failed" || got[2].Reason != "auth error" || got[2].Count != 1 {
+		t.Errorf("got[2] = %+v, want failed/auth error/1", got[2])
+	}
+}
+
+// TestRecentOutcomesMalformedJSON exercises the json_valid guard: a done row
+// whose output_paths is NON-EMPTY but invalid JSON must classify as "unknown"
+// (the else branch) without erroring, proving json_valid short-circuits before
+// json_extract is ever evaluated on the malformed value.
+func TestRecentOutcomesMalformedJSON(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Garbage", title: "G", status: "done",
+		outputPaths: "garbage", completedAt: "2026-06-12T10:00:00Z",
+	})
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Truncated", title: "T", status: "done",
+		outputPaths: "{", completedAt: "2026-06-11T10:00:00Z",
+	})
+
+	got, err := repo.RecentOutcomes(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentOutcomes with malformed output_paths: want no error, got %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d outcomes, want 2: %+v", len(got), got)
+	}
+	for _, o := range got {
+		if o.Result != reports.ResultUnknown {
+			t.Errorf("outcome %q Result = %q, want %q (json_valid else branch)", o.Artist, o.Result, reports.ResultUnknown)
+		}
+	}
+}
+
+// TestFailureAnalysisEmptyReasonNormalized verifies an empty last_error
+// normalizes to reason "unknown", matching internal/queue.CountFailuresByReason.
+func TestFailureAnalysisEmptyReasonNormalized(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// A failed and a deferred row, each with an empty last_error: both must land
+	// under reason 'unknown', kept distinct by status.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "ferr", status: "failed", lastError: ""})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "derr", status: "deferred", lastError: ""})
+
+	got, err := repo.FailureAnalysis(ctx)
+	if err != nil {
+		t.Fatalf("FailureAnalysis: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d groups, want 2: %+v", len(got), got)
+	}
+	for _, g := range got {
+		if g.Reason != "unknown" {
+			t.Errorf("group %+v Reason = %q, want unknown (empty last_error normalized)", g, g.Reason)
+		}
+		if g.Count != 1 {
+			t.Errorf("group %+v Count = %d, want 1", g, g.Count)
+		}
+	}
+}
+
+// TestRecentOutcomesMalformedTimestamp exercises the completed_at parse-error
+// path: a done row whose completed_at is not RFC3339 must surface an error
+// rather than silently zeroing the field.
+func TestRecentOutcomesMalformedTimestamp(t *testing.T) {
+	sqlDB := openTestDB(t)
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Bad", title: "T", status: "done",
+		outputPaths: pathsJSON("x.lrc"), completedAt: "not-a-timestamp",
+	})
+	if _, err := reports.New(sqlDB).RecentOutcomes(context.Background(), 5); err == nil {
+		t.Fatal("RecentOutcomes with malformed completed_at: want error, got nil")
+	}
+}
+
+// TestQueryErrorsSurface verifies every report returns an error (rather than
+// panicking or returning a bogus zero value) when the underlying query fails.
+// Closing the DB makes the next query fail deterministically and
+// env-independently.
+func TestQueryErrorsSurface(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	repo := reports.New(sqlDB)
+
+	if _, err := repo.QueueSummary(ctx); err == nil {
+		t.Error("QueueSummary on closed DB: want error")
+	}
+	if _, err := repo.RecentOutcomes(ctx, 5); err == nil {
+		t.Error("RecentOutcomes on closed DB: want error")
+	}
+	if _, err := repo.ProviderEffectiveness(ctx); err == nil {
+		t.Error("ProviderEffectiveness on closed DB: want error")
+	}
+	if _, err := repo.InstrumentalInventory(ctx); err == nil {
+		t.Error("InstrumentalInventory on closed DB: want error")
+	}
+	if _, err := repo.FailureAnalysis(ctx); err == nil {
+		t.Error("FailureAnalysis on closed DB: want error")
+	}
+}
+
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return parsed
+}


### PR DESCRIPTION
## Summary

PR-A of #211 (Reports workspace), split into two PRs: this is the **read-only data layer**; the two-pane web UI follows in PR-B. Adds a new `internal/reports/` package with five canned, read-only report queries over the **existing** schema. **No schema migrations.**

The CodeRabbit Coding Plan on #211 was stale (it predated migration 018 + the #210 UI foundation) and assumed reports 3 & 4 needed new columns or placeholders. They do not: migration 018 already added `provider_lane` and `instrumental_result`, and the `provider_outcomes` table exists. All five reports are implemented for real over existing data.

## The five reports

Repository pattern (`Repo` wrapping `*sql.DB`, `New(db)`), one read-only `context`-aware method each:

1. **QueueSummary** - counts by status (pending/processing/done/failed/deferred), zero-count statuses reported as 0.
2. **RecentOutcomes(limit)** - last N `done` tracks, newest first (NULLs-last), with a SQL-derived result class from `output_paths` (`.lrc` -> synced, `.txt` -> unsynced-or-instrumental, miss-limit -> miss), guarded by `json_valid` against legacy/empty values.
3. **ProviderEffectiveness** - per-lane hits/misses/hit-rate from the worker-maintained `provider_outcomes` aggregate. **The hit-rate is attempt-weighted and APPROXIMATE** (a lane tried-but-lost to a later winning lane records neither a hit nor a miss), so it is labeled honestly and the UI is told to surface an "approximate" label. A true per-track hit-rate is tracked as follow-up **#282**.
4. **InstrumentalInventory** - tracks detected instrumental (`instrumental_result = 1`), distinguishing the detection-request flag (`detect_instrumental`) from the detection outcome, joined to `scan_results` for the file path.
5. **FailureAnalysis** - failed/deferred tracks grouped by status + normalized reason (`COALESCE(NULLIF(last_error,''),'unknown')`, consistent with the existing `CountFailuresByReason`).

## Constraints honored

- **Strictly read-only** - every method is a bare `SELECT` via `QueryContext`; zero write paths.
- **No migrations** - all five reports run on existing schema.
- Repository pattern + **real-SQLite** in-package integration tests (no mocks), mirroring `internal/cache/`.
- Patch coverage **80.13%** (threshold 70%).

## Test plan

- `make gate` green (build, race tests, patch coverage, golangci-lint, actionlint, govulncheck).
- `go test -race ./internal/reports/...` passes; whole-module `go build ./... && go vet ./...` clean.
- Tests assert concrete values + edge cases: NULLs-last ordering, miss-classification precedence, malformed/empty `output_paths` -> unknown, hit-rate divide-by-zero, instrumental tri-state with/without scan link, failure grouping by status + normalized reason, and error paths (closed DB, malformed timestamp).

## Notes

- Part of #211 (does **not** close it; PR-B - the two-pane UI - completes the feature).
- Follow-up: #282 (true per-track provider hit-rate).
- An independent hostile review found 0 MAJOR and no correctness/injection/read-only/scope defects; the 2 MINOR + 1 NIT it surfaced are fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New reporting suite now available: monitor queue status summary by work category, review recently completed outcomes with track metadata, measure provider effectiveness metrics by lane with hit rates, track instrumental music detections in inventory, and analyze failure patterns with categorized error reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->