### PR TITLE
feat(media): auto-provision checksum-pinned ffmpeg (#293 Phase 1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="GPL-3.0"
 
-RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
+RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc"
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="GPL-3.0"
 
-RUN apk add --no-cache bash ca-certificates su-exec tzdata && \
+RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -175,7 +175,22 @@ min_confidence = 0.85
 min_similarity = 0.35
 ```
 
-Optional Whisper-based speech-to-text verification for low-confidence scanned audio. When enabled, `ffmpeg` must be installed or `ffmpeg_path` must point to an executable ffmpeg binary. The worker extracts a bounded mono 16 kHz WAV sample using `sample_duration_seconds`, then sends it to a Whisper-compatible `/v1/audio/transcriptions` sidecar for audio whose Musixmatch metadata confidence is below `min_confidence`. The transcript must overlap the candidate lyrics by at least `min_similarity`. Environment variables override the TOML keys (`MXLRC_VERIFICATION_*`); `MXLRC_WHISPER_URL` and `MXLRC_VERIFICATION_SAMPLE_DURATION` remain accepted as legacy aliases.
+Optional Whisper-based speech-to-text verification for low-confidence scanned audio. When enabled, the worker extracts a bounded mono 16 kHz WAV sample using `sample_duration_seconds`, then sends it to a Whisper-compatible `/v1/audio/transcriptions` sidecar for audio whose Musixmatch metadata confidence is below `min_confidence`. The transcript must overlap the candidate lyrics by at least `min_similarity`. Environment variables override the TOML keys (`MXLRC_VERIFICATION_*`); `MXLRC_WHISPER_URL` and `MXLRC_VERIFICATION_SAMPLE_DURATION` remain accepted as legacy aliases.
+
+ffmpeg (used to extract the audio sample) is resolved automatically: see [ffmpeg resolution](#ffmpeg-resolution) below. Set `ffmpeg_path` only to pin a specific binary.
+
+### ffmpeg resolution
+
+Both verification and the instrumental detector need `ffmpeg` to extract an audio sample. You do not have to install or locate it yourself: when verification is enabled or a classifier URL is configured, the service resolves ffmpeg in this order:
+
+1. an explicit configured path (`ffmpeg_path`), if set - a missing configured binary is a hard error, never a silent download (air-gapped installs get a clear failure);
+2. a previously auto-provisioned binary in the cache;
+3. an `ffmpeg` already on your `PATH`;
+4. otherwise, a checksum-pinned static `ffmpeg` build is downloaded over HTTPS, verified against a pinned SHA256, and cached.
+
+The auto-download is available for Linux (amd64/arm64) and Windows (amd64). On macOS there is no published static build, so install ffmpeg yourself (`brew install ffmpeg`) or set `ffmpeg_path`. The cached binary lives next to the database (the same data directory, or `/config` under Docker), under `ffmpeg-<version>/`.
+
+Licensing: we do not bundle ffmpeg. The auto-downloaded build is a GPL static build from [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds), fetched at runtime only when needed. The official Docker images already include Alpine's `ffmpeg` package, so containers resolve it on `PATH` (step 3) and never download.
 
 ### `[guard]`
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLy
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/db"
 	"github.com/sydlexius/mxlrcgo-svc/internal/detector"
+	"github.com/sydlexius/mxlrcgo-svc/internal/ffmpeg"
 	"github.com/sydlexius/mxlrcgo-svc/internal/langguard"
 	"github.com/sydlexius/mxlrcgo-svc/internal/library"
 	"github.com/sydlexius/mxlrcgo-svc/internal/logging"
@@ -767,7 +768,21 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		slog.Error("failed to configure lyrics provider", "error", err)
 		return 1
 	}
-	verifier, err := newVerifier(cfg)
+	// Resolve ffmpeg once for both the verifier and the instrumental detector.
+	// Resolution auto-provisions a checksum-pinned static build when ffmpeg is
+	// neither configured nor on PATH; it is skipped entirely unless verification
+	// is enabled or a classifier is configured (the nil-guards below also short-
+	// circuit, but resolving here avoids a redundant download per constructor).
+	var ffmpegPath string
+	if cfg.Verification.Enabled || strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) != "" {
+		ffmpegPath, err = resolveFFmpeg(ctx, cfg)
+		if err != nil {
+			_ = sqlDB.Close()
+			slog.Error("failed to resolve ffmpeg", "error", err)
+			return 1
+		}
+	}
+	verifier, err := newVerifier(cfg, ffmpegPath)
 	if err != nil {
 		_ = sqlDB.Close()
 		slog.Error("failed to configure verification", "error", err)
@@ -812,7 +827,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	w.SetMissBackoff(time.Duration(cfg.API.MissBackoffBaseHours)*time.Hour, time.Duration(cfg.API.MissBackoffCapHours)*time.Hour)
 	w.SetMaxMissAttempts(cfg.API.MaxMissAttempts)
 	configureWorkerVerification(w, cfg, verifier)
-	audioDetector, err := newAudioDetector(cfg)
+	audioDetector, err := newAudioDetector(cfg, ffmpegPath)
 	if err != nil {
 		slog.Error("failed to configure instrumental detector", "error", err)
 		return 1
@@ -1250,7 +1265,22 @@ func providerDisabledIn(name string, disabled []string) bool {
 	return false
 }
 
-func newVerifier(cfg config.Config) (verification.Verifier, error) {
+// resolveFFmpeg picks the ffmpeg override from the existing config keys
+// (verification's path takes precedence, then the detector's) and resolves it
+// to an absolute executable path, auto-provisioning a pinned static build when
+// neither a configured path nor a PATH ffmpeg is available. The provisioned
+// cache lives beside the database so it inherits the same data directory
+// (including the Docker /config short-circuit).
+func resolveFFmpeg(ctx context.Context, cfg config.Config) (string, error) {
+	override := strings.TrimSpace(cfg.Verification.FFmpegPath)
+	if override == "" {
+		override = strings.TrimSpace(cfg.InstrumentalDetector.FFmpegPath)
+	}
+	cacheDir := filepath.Join(filepath.Dir(cfg.DB.Path), "ffmpeg")
+	return ffmpeg.Resolve(ctx, override, ffmpeg.Options{CacheDir: cacheDir})
+}
+
+func newVerifier(cfg config.Config, ffmpegPath string) (verification.Verifier, error) {
 	if !cfg.Verification.Enabled {
 		return nil, nil
 	}
@@ -1258,7 +1288,7 @@ func newVerifier(cfg config.Config) (verification.Verifier, error) {
 		cfg.Verification.WhisperURL,
 		cfg.Verification.SampleDurationSeconds,
 		cfg.Verification.MinSimilarity,
-		cfg.Verification.FFmpegPath,
+		ffmpegPath,
 	)
 }
 
@@ -1275,7 +1305,7 @@ func configureWorkerVerification(w *worker.Worker, cfg config.Config, verifier v
 // global default and per-item decisions gate whether the worker actually calls it.
 // Returns (nil, nil) when no classifier URL is set; callers treat a nil return as
 // "no classifier configured".
-func newAudioDetector(cfg config.Config) (detector.Detector, error) {
+func newAudioDetector(cfg config.Config, ffmpegPath string) (detector.Detector, error) {
 	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
 		return nil, nil
 	}
@@ -1284,7 +1314,7 @@ func newAudioDetector(cfg config.Config) (detector.Detector, error) {
 		cfg.InstrumentalDetector.SampleDurationSeconds,
 		cfg.InstrumentalDetector.MinConfidence,
 		cfg.InstrumentalDetector.InstrumentalClasses,
-		cfg.InstrumentalDetector.FFmpegPath,
+		ffmpegPath,
 		cfg.InstrumentalDetector.CooldownSeconds,
 	)
 }

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -172,7 +172,7 @@ func TestConfigureWriterBilingual(t *testing.T) {
 func TestNewVerifierRequiresURLWhenEnabled(t *testing.T) {
 	_, err := newVerifier(config.Config{
 		Verification: config.VerificationConfig{Enabled: true},
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("newVerifier returned nil error; want missing URL error")
 	}
@@ -180,11 +180,8 @@ func TestNewVerifierRequiresURLWhenEnabled(t *testing.T) {
 
 func TestNewVerifierDisabledDoesNotRequireFFmpeg(t *testing.T) {
 	got, err := newVerifier(config.Config{
-		Verification: config.VerificationConfig{
-			Enabled:    false,
-			FFmpegPath: "/path/that/does/not/exist",
-		},
-	})
+		Verification: config.VerificationConfig{Enabled: false},
+	}, "/path/that/does/not/exist")
 	if err != nil {
 		t.Fatalf("newVerifier: %v", err)
 	}
@@ -246,10 +243,9 @@ func TestNewAudioDetectorDecoupledFromEnableFlag(t *testing.T) {
 	// Enabled=false but no classifier URL -> nil (no classifier configured).
 	got, err := newAudioDetector(config.Config{
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
-			Enabled:    false,
-			FFmpegPath: "/path/that/does/not/exist",
+			Enabled: false,
 		},
-	})
+	}, "/path/that/does/not/exist")
 	if err != nil {
 		t.Fatalf("newAudioDetector (no URL): %v", err)
 	}
@@ -268,12 +264,11 @@ func TestNewAudioDetectorDecoupledFromEnableFlag(t *testing.T) {
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
 			Enabled:               false,
 			ClassifierURL:         "http://yamnet:8080",
-			FFmpegPath:            stubFFmpeg,
 			SampleDurationSeconds: 30,
 			MinConfidence:         0.90,
 			InstrumentalClasses:   []string{"Music"},
 		},
-	})
+	}, stubFFmpeg)
 	if err != nil {
 		t.Fatalf("newAudioDetector (URL set, Enabled=false): %v", err)
 	}
@@ -289,13 +284,12 @@ func TestNewAudioDetectorEnabledWithoutFFmpegErrors(t *testing.T) {
 		InstrumentalDetector: config.InstrumentalDetectorConfig{
 			Enabled:               true,
 			ClassifierURL:         "http://yamnet:8080",
-			FFmpegPath:            filepath.Join(t.TempDir(), "nonexistent-ffmpeg"),
 			SampleDurationSeconds: 30,
 			MinConfidence:         0.90,
 			InstrumentalClasses:   []string{"Music"},
 			CooldownSeconds:       5,
 		},
-	})
+	}, filepath.Join(t.TempDir(), "nonexistent-ffmpeg"))
 	if err == nil {
 		t.Fatal("newAudioDetector with missing ffmpeg returned nil error; want error")
 	}
@@ -315,7 +309,7 @@ func TestNewAudioDetectorBlankClassifierURLReturnsNil(t *testing.T) {
 			MinConfidence:         0.90,
 			InstrumentalClasses:   []string{"Music"},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("newAudioDetector with blank ClassifierURL returned error %v; want nil", err)
 	}

--- a/internal/commands/secrets_precedence_test.go
+++ b/internal/commands/secrets_precedence_test.go
@@ -372,8 +372,8 @@ func TestRunServe_DBSecretsThenVerifierFailure(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.toml")
-	// Verification enabled with a nonexistent ffmpeg -> newVerifier fails after
-	// the banner and provider selection, before the server starts.
+	// Verification enabled with a nonexistent ffmpeg -> ffmpeg resolution fails
+	// (an explicit override that is missing is a hard error), before the server starts.
 	writeServeConfig(t, cfgPath, dbPath, true, filepath.Join(dir, "no-such-ffmpeg"))
 
 	var out bytes.Buffer

--- a/internal/ffmpeg/builds.go
+++ b/internal/ffmpeg/builds.go
@@ -1,0 +1,74 @@
+package ffmpeg
+
+import "fmt"
+
+// version names the pinned FFmpeg build. It is the cache subdirectory name
+// (<cacheDir>/ffmpeg-<version>/ffmpeg), so bumping it provisions into a fresh
+// directory instead of reusing a stale binary.
+const version = "n8.1.2"
+
+// releaseTag is the immutable BtbN FFmpeg-Builds snapshot the pinned artifacts
+// come from. BtbN's "latest" tag is rolling (its asset hashes drift on every
+// rebuild), so we pin a dated autobuild snapshot whose assets never change.
+const releaseTag = "autobuild-2026-06-17-14-17"
+
+const btbnBase = "https://github.com/BtbN/FFmpeg-Builds/releases/download/" + releaseTag + "/"
+
+// archiveKind selects the decompressor used during provisioning.
+type archiveKind int
+
+const (
+	archiveTarXz archiveKind = iota
+	archiveZip
+)
+
+// platformKey identifies a build by runtime.GOOS / runtime.GOARCH.
+type platformKey struct {
+	os   string
+	arch string
+}
+
+// artifact is a single pinned, checksum-verified FFmpeg build.
+type artifact struct {
+	URL              string
+	SHA256           string
+	BinPathInArchive string // path of the ffmpeg binary inside the archive
+	kind             archiveKind
+}
+
+// builds maps a platform to its pinned BtbN GPL static build. These are the
+// release-published per-asset SHA256s for releaseTag (GPL static, n8.1.2).
+// darwin is intentionally absent: see artifactFor.
+var builds = map[platformKey]artifact{
+	{os: "linux", arch: "amd64"}: {
+		URL:              btbnBase + "ffmpeg-n8.1.2-linux64-gpl-8.1.tar.xz",
+		SHA256:           "224df3946118c44b4be06d34282609ef180f62d076bd716ab176dbca6615fd25",
+		BinPathInArchive: "ffmpeg-n8.1.2-linux64-gpl-8.1/bin/ffmpeg",
+		kind:             archiveTarXz,
+	},
+	{os: "linux", arch: "arm64"}: {
+		URL:              btbnBase + "ffmpeg-n8.1.2-linuxarm64-gpl-8.1.tar.xz",
+		SHA256:           "8ab8ceaa9d0b53ddd8fbfd52a7dc4038f0e95934547a3bb77b60902d5372afca",
+		BinPathInArchive: "ffmpeg-n8.1.2-linuxarm64-gpl-8.1/bin/ffmpeg",
+		kind:             archiveTarXz,
+	},
+	{os: "windows", arch: "amd64"}: {
+		URL:              btbnBase + "ffmpeg-n8.1.2-win64-gpl-8.1.zip",
+		SHA256:           "496128d1b102c1919e0e30dc2dc14f582f3f1bd64d5acdb1bad6beda55e055c1",
+		BinPathInArchive: "ffmpeg-n8.1.2-win64-gpl-8.1/bin/ffmpeg.exe",
+		kind:             archiveZip,
+	},
+}
+
+// artifactFor returns the pinned build for goos/goarch, or a clear actionable
+// error when none exists. macOS gets a tailored message because BtbN publishes
+// no macOS builds.
+func artifactFor(goos, goarch string) (artifact, error) {
+	if a, ok := builds[platformKey{os: goos, arch: goarch}]; ok {
+		return a, nil
+	}
+	if goos == "darwin" {
+		return artifact{}, fmt.Errorf("ffmpeg: auto-download is unavailable on macOS; set media.ffmpeg_path or install ffmpeg (e.g. `brew install ffmpeg`)")
+	}
+	return artifact{}, fmt.Errorf("ffmpeg: no pinned build for %s/%s; set media.ffmpeg_path or install ffmpeg manually", goos, goarch)
+}

--- a/internal/ffmpeg/provision.go
+++ b/internal/ffmpeg/provision.go
@@ -1,0 +1,265 @@
+package ffmpeg
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/ulikunitz/xz"
+)
+
+// maxArtifactBytes bounds how much we will read from an archive entry or the
+// download stream, guarding against a decompression bomb. BtbN ffmpeg builds
+// are ~80MB; 512MB is a generous ceiling.
+const maxArtifactBytes = 512 << 20
+
+// resolveArtifact selects the pinned build for the running platform. It is a
+// package var so tests can substitute a fixture artifact without touching the
+// real pinned builds map.
+var resolveArtifact = artifactFor
+
+// provision downloads the pinned build for the current platform, verifies its
+// SHA256, extracts the ffmpeg binary into CacheDir, and returns its path. The
+// archive is never executed; only the checksum-verified binary is extracted.
+func provision(ctx context.Context, opts Options) (string, error) {
+	art, err := resolveArtifact(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", err
+	}
+	if opts.CacheDir == "" {
+		return "", fmt.Errorf("ffmpeg: cannot auto-provision without a cache directory; set media.ffmpeg_path or install ffmpeg")
+	}
+
+	dl := opts.Downloader
+	if dl == nil {
+		dl = &httpDownloader{client: opts.HTTPClient}
+	}
+
+	versionDir := filepath.Join(opts.CacheDir, "ffmpeg-"+version)
+	if err := os.MkdirAll(versionDir, 0o750); err != nil {
+		return "", fmt.Errorf("ffmpeg: create cache dir: %w", err)
+	}
+
+	// Stream the download into a temp file in the cache dir (same filesystem as
+	// the final binary, so the later rename is atomic) while hashing it.
+	archivePath, err := downloadVerified(ctx, dl, art, versionDir)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.Remove(archivePath) }()
+
+	finalPath := cachedPath(opts.CacheDir)
+	if err := extractBinary(art, archivePath, finalPath); err != nil {
+		return "", err
+	}
+	return finalPath, nil
+}
+
+// downloadVerified streams the artifact to a temp file in dir, computes its
+// SHA256, and rejects a mismatch. It returns the temp archive path on success.
+func downloadVerified(ctx context.Context, dl Downloader, art artifact, dir string) (string, error) {
+	body, err := dl.Download(ctx, art.URL)
+	if err != nil {
+		return "", fmt.Errorf("ffmpeg: download %s: %w", art.URL, err)
+	}
+	defer func() { _ = body.Close() }()
+
+	tmp, err := os.CreateTemp(dir, "download-*.archive")
+	if err != nil {
+		return "", fmt.Errorf("ffmpeg: create temp archive: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	hasher := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(tmp, hasher), io.LimitReader(body, maxArtifactBytes))
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("ffmpeg: download body: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("ffmpeg: write temp archive: %w", closeErr)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if !strings.EqualFold(got, art.SHA256) {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("ffmpeg: checksum mismatch for %s: got %s, want %s", art.URL, got, art.SHA256)
+	}
+	return tmpPath, nil
+}
+
+// extractBinary pulls the ffmpeg binary out of the verified archive, writes it
+// to a temp file, chmods it executable, and atomically renames it to dest.
+func extractBinary(art artifact, archivePath, dest string) error {
+	tmpBin, err := os.CreateTemp(filepath.Dir(dest), "ffmpeg-*.tmp")
+	if err != nil {
+		return fmt.Errorf("ffmpeg: create temp binary: %w", err)
+	}
+	tmpBinPath := tmpBin.Name()
+	cleanup := func() {
+		_ = tmpBin.Close()
+		_ = os.Remove(tmpBinPath)
+	}
+
+	var extractErr error
+	switch art.kind {
+	case archiveTarXz:
+		extractErr = extractTarXz(archivePath, art.BinPathInArchive, tmpBin)
+	case archiveZip:
+		extractErr = extractZip(archivePath, art.BinPathInArchive, tmpBin)
+	default:
+		extractErr = fmt.Errorf("ffmpeg: unknown archive kind %d", art.kind)
+	}
+	if extractErr != nil {
+		cleanup()
+		return extractErr
+	}
+	if err := tmpBin.Chmod(0o755); err != nil {
+		cleanup()
+		return fmt.Errorf("ffmpeg: chmod binary: %w", err)
+	}
+	if err := tmpBin.Close(); err != nil {
+		_ = os.Remove(tmpBinPath)
+		return fmt.Errorf("ffmpeg: close binary: %w", err)
+	}
+	if err := os.Rename(tmpBinPath, dest); err != nil {
+		_ = os.Remove(tmpBinPath)
+		return fmt.Errorf("ffmpeg: install binary: %w", err)
+	}
+	return nil
+}
+
+// extractTarXz finds wantPath inside a .tar.xz archive and copies it to w.
+func extractTarXz(archivePath, wantPath string, w io.Writer) error {
+	f, err := os.Open(archivePath) //nolint:gosec // reason: archivePath is our own sha256-verified temp file created under the cache dir, not user input
+	if err != nil {
+		return fmt.Errorf("ffmpeg: open archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	xzr, err := xz.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("ffmpeg: open xz stream: %w", err)
+	}
+	tr := tar.NewReader(xzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ffmpeg: read tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || !matchesBinary(hdr.Name, wantPath) {
+			continue
+		}
+		if _, err := io.Copy(w, io.LimitReader(tr, maxArtifactBytes)); err != nil {
+			return fmt.Errorf("ffmpeg: extract binary: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("ffmpeg: ffmpeg binary %q not found in archive", wantPath)
+}
+
+// extractZip finds wantPath inside a .zip archive and copies it to w.
+func extractZip(archivePath, wantPath string, w io.Writer) error {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("ffmpeg: open zip: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	for _, zf := range zr.File {
+		if zf.FileInfo().IsDir() || !matchesBinary(zf.Name, wantPath) {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			return fmt.Errorf("ffmpeg: open zip entry: %w", err)
+		}
+		_, copyErr := io.Copy(w, io.LimitReader(rc, maxArtifactBytes))
+		_ = rc.Close()
+		if copyErr != nil {
+			return fmt.Errorf("ffmpeg: extract binary: %w", copyErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("ffmpeg: ffmpeg binary %q not found in archive", wantPath)
+}
+
+// matchesBinary reports whether an archive entry is the ffmpeg binary we want.
+// It accepts the exact pinned path or, defensively, any entry ending in the
+// canonical bin/ffmpeg[.exe] suffix (tolerant of a top-level directory rename
+// in a future pinned build).
+func matchesBinary(entry, wantPath string) bool {
+	entry = path.Clean(strings.TrimPrefix(entry, "./"))
+	if entry == path.Clean(wantPath) {
+		return true
+	}
+	return strings.HasSuffix(entry, "/bin/"+binaryName())
+}
+
+// httpsOnlyRedirect rejects any redirect hop that is not https, preventing a
+// silent downgrade to cleartext mid-download.
+func httpsOnlyRedirect(req *http.Request, _ []*http.Request) error {
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing non-https redirect to %s", req.URL.Redacted())
+	}
+	return nil
+}
+
+// httpDownloader is the default HTTPS downloader.
+type httpDownloader struct {
+	client *http.Client
+}
+
+func (d *httpDownloader) Download(ctx context.Context, rawURL string) (io.ReadCloser, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("refusing non-https download: %s", rawURL)
+	}
+	client := d.client
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Minute}
+	}
+	// The scheme guard above only covers the initial URL. Go's http.Client
+	// silently follows redirects, so without a CheckRedirect hook an https->http
+	// redirect would downgrade the (~80MB) fetch to cleartext. The checksum still
+	// gates use, but reject the downgrade as defense in depth and to honor the
+	// "over HTTPS" contract. Shallow-copy so we never mutate a caller's client.
+	if client.CheckRedirect == nil {
+		c := *client
+		c.CheckRedirect = httpsOnlyRedirect
+		client = &c
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status %s", resp.Status)
+	}
+	return resp.Body, nil
+}

--- a/internal/ffmpeg/provision.go
+++ b/internal/ffmpeg/provision.go
@@ -137,6 +137,14 @@ func extractBinary(art artifact, archivePath, dest string) error {
 		return fmt.Errorf("ffmpeg: close binary: %w", err)
 	}
 	if err := os.Rename(tmpBinPath, dest); err != nil {
+		// A concurrent provision installed the binary first (on Windows os.Rename
+		// errors if dest already exists; there is no atomic replace). If dest is
+		// now a live non-empty file, the race was benign: drop our temp and
+		// treat the install as successful.
+		if info, statErr := os.Stat(dest); statErr == nil && info.Size() > 0 {
+			_ = os.Remove(tmpBinPath)
+			return nil
+		}
 		_ = os.Remove(tmpBinPath)
 		return fmt.Errorf("ffmpeg: install binary: %w", err)
 	}

--- a/internal/ffmpeg/provision_extra_test.go
+++ b/internal/ffmpeg/provision_extra_test.go
@@ -1,0 +1,224 @@
+package ffmpeg
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ulikunitz/xz"
+)
+
+// errDownloader always fails, exercising provision's download-error path.
+type errDownloader struct{}
+
+func (errDownloader) Download(context.Context, string) (io.ReadCloser, error) {
+	return nil, errors.New("boom")
+}
+
+func serveBytes(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestProvision_DownloadError(t *testing.T) {
+	useFixtureArtifact(t, builds[platformKey{os: "linux", arch: "amd64"}])
+	_, err := Resolve(context.Background(), "", Options{CacheDir: t.TempDir(), Downloader: errDownloader{}})
+	if err == nil || !strings.Contains(err.Error(), "download") {
+		t.Fatalf("error = %v, want download error", err)
+	}
+}
+
+func TestProvision_BinaryNotInArchive(t *testing.T) {
+	// A tar.xz containing only a README; the wanted binary path is absent and the
+	// suffix fallback cannot match either.
+	var buf bytes.Buffer
+	xw, _ := xz.NewWriter(&buf)
+	tw := tar.NewWriter(xw)
+	writeTar(t, tw, "pkg/README.txt", []byte("docs"))
+	_ = tw.Close()
+	_ = xw.Close()
+	payload := buf.Bytes()
+
+	srv := serveBytes(t, payload)
+	useFixtureArtifact(t, artifact{
+		URL:              srv.URL,
+		SHA256:           sha256Hex(payload),
+		BinPathInArchive: "pkg/does-not-exist",
+		kind:             archiveTarXz,
+	})
+	_, err := Resolve(context.Background(), "", Options{CacheDir: t.TempDir(), Downloader: &plainDownloader{}})
+	if err == nil || !strings.Contains(err.Error(), "not found in archive") {
+		t.Fatalf("error = %v, want not-found-in-archive", err)
+	}
+}
+
+func TestProvision_CorruptArchives(t *testing.T) {
+	for _, kind := range []archiveKind{archiveTarXz, archiveZip} {
+		payload := []byte("this is not a valid archive")
+		srv := serveBytes(t, payload)
+		useFixtureArtifact(t, artifact{
+			URL:              srv.URL,
+			SHA256:           sha256Hex(payload),
+			BinPathInArchive: archiveBinPath(),
+			kind:             kind,
+		})
+		_, err := Resolve(context.Background(), "", Options{CacheDir: t.TempDir(), Downloader: &plainDownloader{}})
+		if err == nil {
+			t.Fatalf("kind %d: expected extraction error, got nil", kind)
+		}
+	}
+}
+
+func TestProvision_UnknownArchiveKind(t *testing.T) {
+	payload := buildTarXz(t)
+	srv := serveBytes(t, payload)
+	useFixtureArtifact(t, artifact{
+		URL:              srv.URL,
+		SHA256:           sha256Hex(payload),
+		BinPathInArchive: archiveBinPath(),
+		kind:             archiveKind(99),
+	})
+	_, err := Resolve(context.Background(), "", Options{CacheDir: t.TempDir(), Downloader: &plainDownloader{}})
+	if err == nil || !strings.Contains(err.Error(), "unknown archive kind") {
+		t.Fatalf("error = %v, want unknown-archive-kind", err)
+	}
+}
+
+func TestHTTPDownloader(t *testing.T) {
+	ctx := context.Background()
+	d := &httpDownloader{}
+
+	if _, err := d.Download(ctx, "http://example.com/x"); err == nil || !strings.Contains(err.Error(), "non-https") {
+		t.Fatalf("http url: err = %v, want non-https refusal", err)
+	}
+	if _, err := d.Download(ctx, "https://exa mple.com/x"); err == nil {
+		t.Fatal("invalid url: expected error, got nil")
+	}
+
+	// Success over TLS, using the test server's client (trusts its cert).
+	tls := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer tls.Close()
+	ok := &httpDownloader{client: tls.Client()}
+	rc, err := ok.Download(ctx, tls.URL)
+	if err != nil {
+		t.Fatalf("tls download: %v", err)
+	}
+	body, _ := io.ReadAll(rc)
+	_ = rc.Close()
+	if string(body) != "payload" {
+		t.Fatalf("body = %q, want payload", body)
+	}
+
+	// Non-200 status is an error.
+	bad := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer bad.Close()
+	d404 := &httpDownloader{client: bad.Client()}
+	if _, err := d404.Download(ctx, bad.URL); err == nil || !strings.Contains(err.Error(), "status") {
+		t.Fatalf("404: err = %v, want status error", err)
+	}
+}
+
+func TestHTTPDownloader_RejectsHTTPSDowngradeRedirect(t *testing.T) {
+	ctx := context.Background()
+	// The cleartext target the redirect would downgrade to.
+	httpTarget := serveBytes(t, []byte("downgraded"))
+
+	// An https server that 302-redirects to the http target.
+	tls := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, httpTarget.URL, http.StatusFound)
+	}))
+	defer tls.Close()
+
+	// Use the TLS server's client (trusts its cert) but with no CheckRedirect, so
+	// our https-only policy is the thing under test.
+	d := &httpDownloader{client: tls.Client()}
+	if _, err := d.Download(ctx, tls.URL); err == nil || !strings.Contains(err.Error(), "non-https redirect") {
+		t.Fatalf("err = %v, want non-https redirect refusal", err)
+	}
+}
+
+// TestProvision_IgnoresTraversalEntries locks the invariant that the extracted
+// destination is fixed (cachedPath), never derived from the archive entry name,
+// so a path-traversal or absolute entry cannot write outside the cache.
+func TestProvision_IgnoresTraversalEntries(t *testing.T) {
+	var buf bytes.Buffer
+	xw, _ := xz.NewWriter(&buf)
+	tw := tar.NewWriter(xw)
+	writeTar(t, tw, "../../../evil", []byte("pwned"))
+	writeTar(t, tw, "/abs/evil", []byte("pwned"))
+	writeTar(t, tw, archiveBinPath(), fixtureBinary)
+	_ = tw.Close()
+	_ = xw.Close()
+	payload := buf.Bytes()
+
+	srv := serveBytes(t, payload)
+	cacheDir := t.TempDir()
+	useFixtureArtifact(t, artifact{
+		URL:              srv.URL,
+		SHA256:           sha256Hex(payload),
+		BinPathInArchive: archiveBinPath(),
+		kind:             archiveTarXz,
+	})
+
+	got, err := Resolve(context.Background(), "", Options{CacheDir: cacheDir, Downloader: &plainDownloader{}})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != cachedPath(cacheDir) {
+		t.Fatalf("path = %q, want %q", got, cachedPath(cacheDir))
+	}
+	content, _ := os.ReadFile(got)
+	if !bytes.Equal(content, fixtureBinary) {
+		t.Fatalf("extracted content = %q, want fixture binary", content)
+	}
+
+	// Only the binary may exist under the cache dir; no traversal entry escaped.
+	var files []string
+	if err := filepath.WalkDir(cacheDir, func(p string, de os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !de.IsDir() {
+			files = append(files, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(files) != 1 || files[0] != got {
+		t.Fatalf("cache dir files = %v, want only %q", files, got)
+	}
+	// And nothing named "evil" leaked to the cache dir's parent.
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(cacheDir), "evil")); !os.IsNotExist(statErr) {
+		t.Fatalf("traversal entry escaped: stat err = %v", statErr)
+	}
+}
+
+func TestProvision_CacheDirCreateFails(t *testing.T) {
+	// Point CacheDir at a path whose parent is a file, so MkdirAll fails.
+	notADir := t.TempDir() + "/file"
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	useFixtureArtifact(t, builds[platformKey{os: "linux", arch: "amd64"}])
+	_, err := Resolve(context.Background(), "", Options{CacheDir: notADir, Downloader: &plainDownloader{}})
+	if err == nil || !strings.Contains(err.Error(), "cache dir") {
+		t.Fatalf("error = %v, want cache dir create error", err)
+	}
+}

--- a/internal/ffmpeg/provision_test.go
+++ b/internal/ffmpeg/provision_test.go
@@ -1,0 +1,240 @@
+package ffmpeg
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ulikunitz/xz"
+)
+
+// fixtureBinary is the dummy content placed where ffmpeg lives in the archive.
+var fixtureBinary = []byte("#!/bin/sh\necho ffmpeg-fixture\n")
+
+// archiveBinPath is the in-archive path of the fixture binary, platform-correct
+// (ffmpeg.exe on Windows) so exact-match extraction works everywhere.
+func archiveBinPath() string { return "ffmpeg-pkg/bin/" + binaryName() }
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func buildTarXz(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	xw, err := xz.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("xz writer: %v", err)
+	}
+	tw := tar.NewWriter(xw)
+	// A directory entry and a decoy file, to prove extraction picks the binary.
+	writeTar(t, tw, "ffmpeg-pkg/README.txt", []byte("docs"))
+	writeTar(t, tw, archiveBinPath(), fixtureBinary)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := xw.Close(); err != nil {
+		t.Fatalf("xz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeTar(t *testing.T, tw *tar.Writer, name string, data []byte) {
+	t.Helper()
+	hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(data)), Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+}
+
+func buildZip(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, data := range map[string][]byte{
+		"ffmpeg-pkg/README.txt": []byte("docs"),
+		archiveBinPath():        fixtureBinary,
+	} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create: %v", err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("zip write: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// plainDownloader fetches over plain HTTP for the httptest server (the default
+// downloader refuses non-https). It records how many fetches happened.
+type plainDownloader struct{ hits int32 }
+
+func (d *plainDownloader) Download(ctx context.Context, rawURL string) (io.ReadCloser, error) {
+	atomic.AddInt32(&d.hits, 1)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+// useFixtureArtifact swaps resolveArtifact for one returning art (restored on
+// cleanup) and hides ffmpeg from PATH so resolution must reach the download step.
+func useFixtureArtifact(t *testing.T, art artifact) {
+	t.Helper()
+	prev := resolveArtifact
+	resolveArtifact = func(_, _ string) (artifact, error) { return art, nil }
+	t.Cleanup(func() { resolveArtifact = prev })
+	t.Setenv("PATH", t.TempDir()) // empty dir: no ffmpeg on PATH
+}
+
+func TestProvision_SuccessExtractsCachesAndReuses(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		kind    archiveKind
+		payload []byte
+	}{
+		{"tar.xz", archiveTarXz, buildTarXz(t)},
+		{"zip", archiveZip, buildZip(t)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(tc.payload)
+			}))
+			defer srv.Close()
+
+			useFixtureArtifact(t, artifact{
+				URL:              srv.URL + "/ffmpeg.archive",
+				SHA256:           sha256Hex(tc.payload),
+				BinPathInArchive: archiveBinPath(),
+				kind:             tc.kind,
+			})
+			dl := &plainDownloader{}
+			cacheDir := t.TempDir()
+			opts := Options{CacheDir: cacheDir, Downloader: dl}
+
+			got, err := Resolve(context.Background(), "", opts)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got != cachedPath(cacheDir) {
+				t.Fatalf("path = %q, want %q", got, cachedPath(cacheDir))
+			}
+			content, err := os.ReadFile(got)
+			if err != nil {
+				t.Fatalf("read extracted binary: %v", err)
+			}
+			if !bytes.Equal(content, fixtureBinary) {
+				t.Fatalf("extracted content = %q, want fixture", content)
+			}
+			if hits := atomic.LoadInt32(&dl.hits); hits != 1 {
+				t.Fatalf("download hits = %d, want 1", hits)
+			}
+
+			// Second resolve must hit the cache, not re-download.
+			got2, err := Resolve(context.Background(), "", opts)
+			if err != nil {
+				t.Fatalf("second Resolve: %v", err)
+			}
+			if got2 != got {
+				t.Fatalf("second path = %q, want %q", got2, got)
+			}
+			if hits := atomic.LoadInt32(&dl.hits); hits != 1 {
+				t.Fatalf("after cache hit, download hits = %d, want 1 (no re-fetch)", hits)
+			}
+		})
+	}
+}
+
+func TestProvision_ChecksumMismatchRejected(t *testing.T) {
+	payload := buildTarXz(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	useFixtureArtifact(t, artifact{
+		URL:              srv.URL + "/ffmpeg.archive",
+		SHA256:           strings.Repeat("0", 64), // deliberately wrong
+		BinPathInArchive: archiveBinPath(),
+		kind:             archiveTarXz,
+	})
+	cacheDir := t.TempDir()
+	opts := Options{CacheDir: cacheDir, Downloader: &plainDownloader{}}
+
+	_, err := Resolve(context.Background(), "", opts)
+	if err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want checksum mismatch", err)
+	}
+	if _, statErr := os.Stat(cachedPath(cacheDir)); !os.IsNotExist(statErr) {
+		t.Fatalf("binary must not be cached on mismatch; stat err = %v", statErr)
+	}
+}
+
+func TestProvision_NoCacheDir(t *testing.T) {
+	useFixtureArtifact(t, builds[platformKey{os: "linux", arch: "amd64"}])
+	_, err := Resolve(context.Background(), "", Options{})
+	if err == nil || !strings.Contains(err.Error(), "cache directory") {
+		t.Fatalf("error = %v, want cache directory error", err)
+	}
+}
+
+func TestArtifactFor(t *testing.T) {
+	if _, err := artifactFor("linux", "amd64"); err != nil {
+		t.Fatalf("linux/amd64: unexpected error %v", err)
+	}
+	dErr := mustErr(t, "darwin", "arm64")
+	if !strings.Contains(dErr.Error(), "macOS") {
+		t.Fatalf("darwin error = %v, want macOS guidance", dErr)
+	}
+	uErr := mustErr(t, "plan9", "mips")
+	if !strings.Contains(uErr.Error(), "no pinned build") {
+		t.Fatalf("unknown error = %v, want no-pinned-build", uErr)
+	}
+}
+
+func mustErr(t *testing.T, goos, goarch string) error {
+	t.Helper()
+	_, err := artifactFor(goos, goarch)
+	if err == nil {
+		t.Fatalf("%s/%s: expected error", goos, goarch)
+	}
+	return err
+}
+
+func TestMatchesBinary(t *testing.T) {
+	want := "ffmpeg-pkg/bin/" + binaryName()
+	for _, entry := range []string{want, "./" + want, "other-pkg/bin/" + binaryName()} {
+		if !matchesBinary(entry, want) {
+			t.Errorf("matchesBinary(%q) = false, want true", entry)
+		}
+	}
+	if matchesBinary("ffmpeg-pkg/README.txt", want) {
+		t.Error("matchesBinary(README) = true, want false")
+	}
+}

--- a/internal/ffmpeg/provision_test.go
+++ b/internal/ffmpeg/provision_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -165,6 +166,76 @@ func TestProvision_SuccessExtractsCachesAndReuses(t *testing.T) {
 				t.Fatalf("after cache hit, download hits = %d, want 1 (no re-fetch)", hits)
 			}
 		})
+	}
+}
+
+// barrierDownloader serves the fixture archive but blocks each Download until
+// `parties` concurrent callers have arrived, then releases them together. This
+// forces every racer past Resolve's cache-miss check before any one finishes
+// provisioning, so they extract and os.Rename into the same dest concurrently -
+// exercising the benign concurrent-install race the J1 fix handles.
+type barrierDownloader struct {
+	payload []byte
+	hits    int32
+	arrived *sync.WaitGroup
+	release <-chan struct{}
+}
+
+func (d *barrierDownloader) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	atomic.AddInt32(&d.hits, 1)
+	d.arrived.Done() // signal arrival, then wait for the whole cohort
+	<-d.release
+	return io.NopCloser(bytes.NewReader(d.payload)), nil
+}
+
+func TestProvision_ConcurrentResolveRace(t *testing.T) {
+	const parties = 4
+	payload := buildTarXz(t)
+	useFixtureArtifact(t, artifact{
+		URL:              "https://example.invalid/ffmpeg.archive",
+		SHA256:           sha256Hex(payload),
+		BinPathInArchive: archiveBinPath(),
+		kind:             archiveTarXz,
+	})
+
+	var arrived sync.WaitGroup
+	arrived.Add(parties)
+	release := make(chan struct{})
+	go func() { arrived.Wait(); close(release) }() // release all once the cohort assembles
+
+	dl := &barrierDownloader{payload: payload, arrived: &arrived, release: release}
+	cacheDir := t.TempDir()
+	opts := Options{CacheDir: cacheDir, Downloader: dl}
+
+	var wg sync.WaitGroup
+	paths := make([]string, parties)
+	errs := make([]error, parties)
+	for i := 0; i < parties; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			paths[i], errs[i] = Resolve(context.Background(), "", opts)
+		}(i)
+	}
+	wg.Wait()
+
+	want := cachedPath(cacheDir)
+	for i := 0; i < parties; i++ {
+		if errs[i] != nil {
+			t.Fatalf("racer %d: Resolve error: %v", i, errs[i])
+		}
+		if paths[i] != want {
+			t.Fatalf("racer %d: path = %q, want %q", i, paths[i], want)
+		}
+	}
+
+	// Every racer must agree on a single valid cached binary holding the fixture.
+	content, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read cached binary: %v", err)
+	}
+	if !bytes.Equal(content, fixtureBinary) {
+		t.Fatalf("cached content = %q, want fixture", content)
 	}
 }
 

--- a/internal/ffmpeg/resolve.go
+++ b/internal/ffmpeg/resolve.go
@@ -1,0 +1,107 @@
+// Package ffmpeg resolves an ffmpeg executable for the verification and
+// instrumental-detection sidecars, auto-provisioning a checksum-pinned static
+// build when ffmpeg is neither configured nor on PATH. The download is verified
+// against a pinned SHA256 before the extracted binary is ever used; the archive
+// itself is never executed.
+package ffmpeg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Downloader fetches a remote artifact. It is injected so tests never touch the
+// network; the default implementation streams over HTTPS.
+type Downloader interface {
+	Download(ctx context.Context, rawURL string) (io.ReadCloser, error)
+}
+
+// Options configures Resolve.
+type Options struct {
+	// CacheDir holds auto-provisioned builds. Required for the cache and
+	// auto-download resolution steps; when empty those steps are skipped.
+	CacheDir string
+	// HTTPClient backs the default downloader. Ignored when Downloader is set.
+	HTTPClient *http.Client
+	// Downloader is an injectable fetcher (tests). nil selects the default
+	// HTTPS downloader.
+	Downloader Downloader
+}
+
+// Resolve returns an absolute path to an ffmpeg executable, in priority order:
+//
+//  1. explicit override (a configured path) - resolved via PATH lookup, with a
+//     hard error if missing; air-gapped users expect a failure here, not a
+//     silent download.
+//  2. a previously auto-provisioned binary cached under CacheDir.
+//  3. an `ffmpeg` already on PATH.
+//  4. an auto-downloaded, checksum-verified pinned build (requires CacheDir).
+func Resolve(ctx context.Context, override string, opts Options) (string, error) {
+	// (1) explicit override: hard error if missing.
+	if o := strings.TrimSpace(override); o != "" {
+		resolved, err := exec.LookPath(o)
+		if err != nil {
+			return "", fmt.Errorf("ffmpeg: configured ffmpeg path %q not found: %w", o, err)
+		}
+		return resolved, nil
+	}
+
+	// (2) cached auto-provisioned binary.
+	if opts.CacheDir != "" {
+		if cached := cachedBinary(opts.CacheDir); cached != "" {
+			return cached, nil
+		}
+	}
+
+	// (3) ffmpeg on PATH.
+	if resolved, err := exec.LookPath("ffmpeg"); err == nil {
+		return resolved, nil
+	}
+
+	// (4) auto-download.
+	return provision(ctx, opts)
+}
+
+// binaryName is the ffmpeg executable filename for the current platform.
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "ffmpeg.exe"
+	}
+	return "ffmpeg"
+}
+
+// cachedPath is the absolute path the auto-provisioned binary lives at under
+// cacheDir for the pinned version.
+func cachedPath(cacheDir string) string {
+	return filepath.Join(cacheDir, "ffmpeg-"+version, binaryName())
+}
+
+// cachedBinary returns the cached binary path if it exists and passes a cheap
+// liveness check (a non-empty regular file, executable on POSIX). It returns ""
+// when no usable cached binary is present.
+//
+// A cache hit is trusted by presence and permissions; it is NOT re-hashed
+// against the pinned SHA256. This is a deliberate trade-off: re-reading the
+// ~80MB binary on every serve boot is wasteful, and re-hashing buys nothing
+// against the only attacker who can corrupt it - one with write access to the
+// cache directory could equally swap the binary AND any stored hash. The
+// checksum gate that matters runs once, at download time, before the binary is
+// ever written to the cache.
+func cachedBinary(cacheDir string) string {
+	path := cachedPath(cacheDir)
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+		return ""
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return ""
+	}
+	return path
+}

--- a/internal/ffmpeg/resolve_test.go
+++ b/internal/ffmpeg/resolve_test.go
@@ -1,0 +1,141 @@
+package ffmpeg
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// failDownloader fails if Download is ever called: precedence tests use it to
+// prove an earlier resolution step short-circuited before the download step.
+type failDownloader struct{ t *testing.T }
+
+func (d failDownloader) Download(context.Context, string) (io.ReadCloser, error) {
+	d.t.Fatalf("downloader called, but an earlier step should have resolved")
+	return nil, errors.New("unreachable")
+}
+
+// makeExecStub writes an executable stub named name into dir and returns its
+// path. It skips on Windows, where a bare-name shell script is not executable
+// via exec.LookPath.
+func makeExecStub(t *testing.T, dir, name string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("exec stub not supported on windows")
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return p
+}
+
+func TestResolve_OverrideWins(t *testing.T) {
+	dir := t.TempDir()
+	stub := makeExecStub(t, dir, "my-ffmpeg")
+	// A different ffmpeg on PATH must be ignored in favor of the override.
+	pathDir := t.TempDir()
+	makeExecStub(t, pathDir, "ffmpeg")
+	t.Setenv("PATH", pathDir)
+
+	got, err := Resolve(context.Background(), stub, Options{
+		CacheDir:   t.TempDir(),
+		Downloader: failDownloader{t},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != stub {
+		t.Fatalf("path = %q, want override %q", got, stub)
+	}
+}
+
+func TestResolve_OverrideMissingErrors(t *testing.T) {
+	_, err := Resolve(context.Background(), "/nonexistent/ffmpeg-xyz", Options{
+		Downloader: failDownloader{t},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing override, got nil")
+	}
+}
+
+func TestResolve_CacheWinsOverPathAndDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH stub not supported on windows")
+	}
+	cacheDir := t.TempDir()
+	// Pre-populate the cache with a live binary.
+	versionDir := filepath.Join(cacheDir, "ffmpeg-"+version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(cachedPath(cacheDir), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write cached: %v", err)
+	}
+	// Also place an ffmpeg on PATH; cache must win.
+	pathDir := t.TempDir()
+	makeExecStub(t, pathDir, "ffmpeg")
+	t.Setenv("PATH", pathDir)
+
+	got, err := Resolve(context.Background(), "", Options{
+		CacheDir:   cacheDir,
+		Downloader: failDownloader{t},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != cachedPath(cacheDir) {
+		t.Fatalf("path = %q, want cached %q", got, cachedPath(cacheDir))
+	}
+}
+
+func TestResolve_PathWinsOverDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH stub not supported on windows")
+	}
+	pathDir := t.TempDir()
+	stub := makeExecStub(t, pathDir, "ffmpeg")
+	t.Setenv("PATH", pathDir)
+
+	// Empty cache dir: no cached binary, so PATH is the resolver - download
+	// must not be reached.
+	got, err := Resolve(context.Background(), "", Options{
+		CacheDir:   t.TempDir(),
+		Downloader: failDownloader{t},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != stub {
+		t.Fatalf("path = %q, want PATH stub %q", got, stub)
+	}
+}
+
+func TestCachedBinary_RejectsNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits differ on windows")
+	}
+	cacheDir := t.TempDir()
+	versionDir := filepath.Join(cacheDir, "ffmpeg-"+version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Non-executable file must not count as a live cached binary.
+	if err := os.WriteFile(cachedPath(cacheDir), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := cachedBinary(cacheDir); got != "" {
+		t.Fatalf("cachedBinary = %q, want empty for non-executable file", got)
+	}
+	// Empty file must also be rejected.
+	if err := os.WriteFile(cachedPath(cacheDir), nil, 0o755); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	if got := cachedBinary(cacheDir); got != "" {
+		t.Fatalf("cachedBinary = %q, want empty for zero-byte file", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of #293. When a feature that needs ffmpeg is enabled (verification or instrumental detection), the server resolves the binary in order: explicit override → cached auto-provisioned copy → `ffmpeg` on `PATH` → else auto-download a **checksum-pinned** static build (verified before use, cached under the data dir). Removes the "install ffmpeg yourself" burden for typical users. Container images ship ffmpeg via apk, so they never download at runtime.

## What's included

- New `internal/ffmpeg` package:
  - `Resolve(ctx, override, opts)` — override → cache → PATH → download, with an injectable downloader for tests.
  - `provision` — HTTPS stream → SHA256 verify (the hashed bytes are the extracted bytes) → reject-on-mismatch → extract `.tar.xz`/`.zip` → `chmod 0755` → atomic rename. The archive is never executed; only the verified binary.
  - `builds` — pinned BtbN static-build matrix (linux amd64/arm64, windows amd64; macOS → clear PATH/override message, no published build).
- Wiring: `runServe` resolves ffmpeg **once** and threads the absolute path into the verification + instrumental-detector constructors; resolves only when a feature actually needs it (no download for users who run neither).
- Dockerfiles: `ffmpeg` added to the apk install in both `Dockerfile` and `build/docker/Dockerfile.goreleaser` — containers resolve on PATH, no runtime download.
- Docs: an ffmpeg-resolution section in `docs/CONFIGURATION.md` (resolver order, platform support, cache location, GPL download-not-bundle licensing note).
- New dependency: `github.com/ulikunitz/xz` (pure-Go `.xz` decoder — no cgo, keeps cross-compilation intact).

## Security

Reviewed as a download-and-execute path:
- Checksum verified **before** the binary is ever used; mismatch deletes the temp file and hard-errors with no fallback.
- Archive extraction writes to a **fixed destination**, never an entry-derived path — zip-slip / path-traversal is structurally impossible (regression test included).
- Decompression bounded (512 MB limit on stream and entries).
- Non-https refused, including across redirects (a `CheckRedirect` hook rejects an https→http downgrade).
- Download URLs are compiled-in constants — no user-influenced URL, no SSRF.
- A missing explicit override hard-errors (air-gapped expectation), never silently downloads.
- Tests stub the downloader (no real network, no host ffmpeg) and cover checksum-mismatch rejection, redirect-downgrade refusal, path-traversal archive entries, cache reuse, and the full resolver order.

## Scope / follow-up

**Phase 1 only** — this does **not** close #293. Phase 3 (collapsing `verification.ffmpeg_path` + `instrumental_detector.ffmpeg_path` into one optional `media.ffmpeg_path` with deprecated aliases) is deferred until #288 merges, since it touches the config surface #288 owns.

## Test plan

`make gate` green (build/vet, race tests, golangci-lint 0 issues, govulncheck clean, actionlint, codecov dry-run validated). Patch coverage 74.37%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
