### PR TITLE
feat(reports): true per-track provider hit-rate for Report 3 (Closes #282)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -465,3 +465,78 @@ func TestMigration017SecretsUpDown(t *testing.T) {
 		t.Fatalf("secrets table still present after down-migration")
 	}
 }
+
+func TestMigration022LaneAttemptsUpDown(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig022.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	sqlDB.SetMaxOpenConns(1)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+
+	countMaster := func(typ, name string) int {
+		t.Helper()
+		var n int
+		if err := sqlDB.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM sqlite_master WHERE type=? AND name=?`, typ, name).Scan(&n); err != nil {
+			t.Fatalf("query sqlite_master %s %s: %v", typ, name, err)
+		}
+		return n
+	}
+
+	// At v21 the lane_attempts table does not exist yet.
+	if _, err := provider.UpTo(ctx, 21); err != nil {
+		t.Fatalf("UpTo(21): %v", err)
+	}
+	if countMaster("table", "lane_attempts") != 0 {
+		t.Fatal("lane_attempts table present before migration 022")
+	}
+
+	// Apply 022 and exercise the table + UNIQUE upsert + index.
+	if _, err := provider.UpTo(ctx, 22); err != nil {
+		t.Fatalf("UpTo(22): %v", err)
+	}
+	if countMaster("table", "lane_attempts") != 1 {
+		t.Fatal("lane_attempts table missing after migration 022")
+	}
+	if countMaster("index", "idx_lane_attempts_lane") != 1 {
+		t.Fatal("idx_lane_attempts_lane missing after migration 022")
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (?, ?, ?, ?)
+             ON CONFLICT(queue_id, lane) DO UPDATE SET hit = excluded.hit, attempted_at = excluded.attempted_at`,
+			int64(1), "musixmatch", int64(i), "2026-06-18T00:00:00Z"); err != nil {
+			t.Fatalf("upsert lane_attempts[%d]: %v", i, err)
+		}
+	}
+	var rows, hit int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*), MAX(hit) FROM lane_attempts`).Scan(&rows, &hit); err != nil {
+		t.Fatalf("query lane_attempts: %v", err)
+	}
+	if rows != 1 || hit != 1 {
+		t.Fatalf("after upsert: rows=%d hit=%d; want 1/1 (UNIQUE upsert refreshed in place)", rows, hit)
+	}
+
+	// Down-migrate 022 and confirm the index and table are dropped.
+	if _, err := provider.Down(ctx); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+	if countMaster("table", "lane_attempts") != 0 {
+		t.Fatal("lane_attempts table still present after down-migration")
+	}
+	if countMaster("index", "idx_lane_attempts_lane") != 0 {
+		t.Fatal("idx_lane_attempts_lane still present after down-migration")
+	}
+}

--- a/internal/db/migrations/022_lane_attempts.sql
+++ b/internal/db/migrations/022_lane_attempts.sql
@@ -18,7 +18,7 @@
 CREATE TABLE lane_attempts (
     queue_id     INTEGER NOT NULL,
     lane         TEXT    NOT NULL,
-    hit          INTEGER NOT NULL,
+    hit          INTEGER NOT NULL CHECK (hit IN (0, 1)),
     attempted_at TEXT    NOT NULL,
     UNIQUE(queue_id, lane)
 );

--- a/internal/db/migrations/022_lane_attempts.sql
+++ b/internal/db/migrations/022_lane_attempts.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-track, per-lane provider attempt outcomes for a TRUE per-track hit-rate
+-- (issue #282). Unlike the attempt-weighted aggregate in provider_outcomes
+-- (migration 018), this table records one row per (track, lane) pair for every
+-- lane that was ATTEMPTED on a track: hit=1 for the lane that served the track,
+-- hit=0 for every other attempted lane that lost (including lanes that lost to a
+-- LATER winning lane, the exact over-count provider_outcomes cannot express).
+--
+-- queue_id is the work_queue row id at the time of the attempt. There is
+-- deliberately NO foreign key to work_queue: these are durable historical facts
+-- that must survive queue-row cleanup (ClearDone) so the cumulative per-track
+-- hit-rate is not erased when completed rows are pruned. UNIQUE(queue_id, lane)
+-- makes re-fetches idempotent (an --upgrade re-run upserts rather than
+-- duplicating). The table starts empty and self-populates on new traffic; pre-022
+-- rows have no per-lane history, so Report 3 relies on its empty-state branch
+-- until new attempts accrue (NO backfill is possible -- the history did not exist).
+CREATE TABLE lane_attempts (
+    queue_id     INTEGER NOT NULL,
+    lane         TEXT    NOT NULL,
+    hit          INTEGER NOT NULL,
+    attempted_at TEXT    NOT NULL,
+    UNIQUE(queue_id, lane)
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+-- Index the lane column so the per-lane aggregate in Report 3
+-- (reports.ProviderEffectiveness) can group by lane without a full table scan.
+CREATE INDEX idx_lane_attempts_lane ON lane_attempts(lane);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_lane_attempts_lane;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS lane_attempts;
+-- +goose StatementEnd

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -63,11 +63,27 @@ type Song struct {
 	// Empty on cache hits and zero-value songs. Used by the worker write-path to
 	// record per-lane hit counters without changing the Fetcher interface.
 	WinningLane string `json:"-"`
+	// LaneAttempts carries the per-lane hit/miss attribution for THIS track out of
+	// the orchestrator so the worker can persist a true per-track hit-rate (issue
+	// #282). One entry per ATTEMPTED lane: Hit is true for the winning lane and
+	// false for every other attempted lane (including lanes that lost to a later
+	// winner). Empty on cache hits and zero-value songs. Transient: not persisted
+	// as part of the song and never serialized.
+	LaneAttempts []LaneAttempt `json:"-"`
 	// FetchedAt is the time the song was fetched from the provider. Set by the
 	// worker immediately after a successful fetch and before any write path so
 	// all output formats share one consistent timestamp. Zero on cache hits
 	// (timestamp not available without a live fetch). Transient: not persisted.
 	FetchedAt time.Time `json:"-"`
+}
+
+// LaneAttempt is one provider lane's outcome for a single track: the lane name
+// and whether it served the track (Hit) or was attempted and lost (miss). The
+// orchestrator emits one per attempted lane on Song.LaneAttempts; the worker
+// persists them to lane_attempts (migration 022) for a true per-track hit-rate.
+type LaneAttempt struct {
+	Lane string
+	Hit  bool
 }
 
 // Inputs represents a single work item in the processing queue.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -116,6 +116,12 @@ func (o *Orchestrator) FindLyrics(ctx context.Context, track models.Track) (mode
 //   - If every available lane's breaker was open, return ErrLaneUnavailable.
 func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (models.Song, error) {
 	var r dispatchResult
+	// attempted accumulates the names of lanes actually CONSULTED (the provider was
+	// called), in order, so per-track hit/miss attribution counts only lanes that
+	// were tried. Ordered mode stops at the first suitable result, so lanes after
+	// the winner are never consulted and never appear here. Skipped (breaker-open)
+	// lanes are excluded too: the provider was not called, so it was not attempted.
+	var attempted []string
 	for _, lane := range o.lanes {
 		if err := ctx.Err(); err != nil {
 			return models.Song{}, err
@@ -131,10 +137,12 @@ func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (mod
 			continue
 		}
 		r.consulted++
+		attempted = append(attempted, lane.Name())
 
 		if err == nil {
 			if IsSuitable(song, o.guard) {
 				song.WinningLane = lane.Name()
+				song.LaneAttempts = laneAttemptsFor(attempted, lane.Name())
 				return song, nil
 			}
 			r.retain(song, lane.Name())
@@ -144,7 +152,28 @@ func (o *Orchestrator) findOrdered(ctx context.Context, track models.Track) (mod
 		r.rankErr(err, class)
 	}
 
-	return o.resolve(ctx, &r)
+	song, err := o.resolve(ctx, &r)
+	// Attach per-track attribution to whatever resolve returns: a best-available
+	// fallback names its serving lane as the hit; an error (benign miss / transport)
+	// returns no winner, so every attempted lane is recorded as a miss. The worker
+	// persists these only on the success and benign-miss paths (not on hard
+	// failures), so carrying them on the error song here is harmless.
+	song.LaneAttempts = laneAttemptsFor(attempted, song.WinningLane)
+	return song, err
+}
+
+// laneAttemptsFor builds the per-track attribution for the given attempted lane
+// names: Hit is true for the lane equal to winner (the empty string means no
+// winner -> all misses) and false for every other attempted lane.
+func laneAttemptsFor(attempted []string, winner string) []models.LaneAttempt {
+	if len(attempted) == 0 {
+		return nil
+	}
+	out := make([]models.LaneAttempt, len(attempted))
+	for i, name := range attempted {
+		out[i] = models.LaneAttempt{Lane: name, Hit: name == winner}
+	}
+	return out
 }
 
 // dispatchResult accumulates the cross-lane outcome state shared by both dispatch

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -234,6 +234,129 @@ func TestWinningLaneSetOnBestAvailable(t *testing.T) {
 	}
 }
 
+// attemptHit looks up the recorded outcome for lane in a LaneAttempts slice.
+// found is false when the lane has no attempt entry.
+func attemptHit(attempts []models.LaneAttempt, lane string) (hit, found bool) {
+	for _, a := range attempts {
+		if a.Lane == lane {
+			return a.Hit, true
+		}
+	}
+	return false, false
+}
+
+// TestLaneAttemptsOrderedLoserRecordsMiss is the exact over-count fix (#282):
+// in ordered mode a lane that was tried but lost to a LATER winning lane must be
+// recorded as a miss, not silently dropped.
+func TestLaneAttemptsOrderedLoserRecordsMiss(t *testing.T) {
+	miss := &stubProvider{name: "aaa", err: musixmatch.ErrNoLyrics} // tried first, no lyrics
+	synced := &stubProvider{name: "musixmatch", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "lyric"}}}}}
+	o, _ := New("ordered", laneFor(miss), laneFor(synced))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.WinningLane != "musixmatch" {
+		t.Fatalf("WinningLane = %q; want musixmatch", song.WinningLane)
+	}
+	if hit, found := attemptHit(song.LaneAttempts, "musixmatch"); !found || !hit {
+		t.Errorf("musixmatch attempt = (hit=%v, found=%v); want hit", hit, found)
+	}
+	if hit, found := attemptHit(song.LaneAttempts, "aaa"); !found || hit {
+		t.Errorf("aaa (lost to later winner) attempt = (hit=%v, found=%v); want recorded miss", hit, found)
+	}
+}
+
+// TestLaneAttemptsOrderedLaterLaneNotConsulted verifies a lane after the winner,
+// never consulted in ordered mode, has no attempt entry (it was not tried).
+func TestLaneAttemptsOrderedLaterLaneNotConsulted(t *testing.T) {
+	synced := &stubProvider{name: "aaa", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "lyric"}}}}}
+	never := &stubProvider{name: "zzz", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "unused"}}}}}
+	o, _ := New("ordered", laneFor(synced), laneFor(never))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if _, found := attemptHit(song.LaneAttempts, "zzz"); found {
+		t.Errorf("zzz was never consulted; want no attempt entry, got one")
+	}
+}
+
+// TestLaneAttemptsParallelAllMiss verifies parallel mode attributes every
+// CONSULTED lane on the all-miss path (both lanes report, no early return): each
+// is recorded as a miss. Deterministic because resolve runs only after pending
+// reaches 0, so both lanes are always in the consulted set.
+func TestLaneAttemptsParallelAllMiss(t *testing.T) {
+	m1 := &stubProvider{name: "aaa", err: musixmatch.ErrNoLyrics}
+	m2 := &stubProvider{name: "bbb", err: musixmatch.ErrNoLyrics}
+	o, _ := New("parallel", laneFor(m1), laneFor(m2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if !musixmatch.IsBenignMiss(err) {
+		t.Fatalf("err = %v; want benign miss", err)
+	}
+	for _, lane := range []string{"aaa", "bbb"} {
+		if hit, found := attemptHit(song.LaneAttempts, lane); !found || hit {
+			t.Errorf("%s attempt = (hit=%v, found=%v); want recorded miss", lane, hit, found)
+		}
+	}
+}
+
+// TestLaneAttemptsParallelExcludesUnavailable is the parallel-mode over-count
+// guard (F1): a breaker-open lane never calls the provider, so it must get NO
+// lane_attempts row -- it was not consulted. Deterministic regardless of result
+// ordering: the unavailable lane is skipped on every path, and the synced lane
+// wins (immediately or after the miss reports), so the breaker-open lane is never
+// added to the consulted set.
+func TestLaneAttemptsParallelExcludesUnavailable(t *testing.T) {
+	down := &stubProvider{name: "down", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "unused"}}}}}
+	synced := &stubProvider{name: "musixmatch", song: models.Song{Subtitles: models.Synced{Lines: []models.Lines{{Text: "lyric"}}}}}
+	downLane := laneFor(down)
+	downLane.Breaker().Trip() // open the breaker: provider not called -> OutcomeUnavailable
+	o, _ := New("parallel", downLane, laneFor(synced))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if song.WinningLane != "musixmatch" {
+		t.Fatalf("WinningLane = %q; want musixmatch", song.WinningLane)
+	}
+	if hit, found := attemptHit(song.LaneAttempts, "musixmatch"); !found || !hit {
+		t.Errorf("musixmatch attempt = (hit=%v, found=%v); want hit", hit, found)
+	}
+	if _, found := attemptHit(song.LaneAttempts, "down"); found {
+		t.Errorf("breaker-open lane 'down' was never consulted; want NO attempt row, got one")
+	}
+	if down.calls != 0 {
+		t.Errorf("breaker-open provider calls = %d; want 0", down.calls)
+	}
+}
+
+// TestLaneAttemptsAllMissRecorded verifies that when every lane misses (the
+// orchestrator returns a benign-miss error and an empty song), the attempts are
+// still carried so the worker can record an all-miss per-track row.
+func TestLaneAttemptsAllMissRecorded(t *testing.T) {
+	m1 := &stubProvider{name: "aaa", err: musixmatch.ErrNoLyrics}
+	m2 := &stubProvider{name: "bbb", err: musixmatch.ErrNoLyrics}
+	o, _ := New("ordered", laneFor(m1), laneFor(m2))
+
+	song, err := o.FindLyrics(context.Background(), models.Track{})
+	if !musixmatch.IsBenignMiss(err) {
+		t.Fatalf("err = %v; want benign miss", err)
+	}
+	if song.WinningLane != "" {
+		t.Errorf("WinningLane = %q; want empty on all-miss", song.WinningLane)
+	}
+	for _, lane := range []string{"aaa", "bbb"} {
+		if hit, found := attemptHit(song.LaneAttempts, lane); !found || hit {
+			t.Errorf("%s attempt = (hit=%v, found=%v); want recorded miss", lane, hit, found)
+		}
+	}
+}
+
 func TestWinningLaneEmptyOnBenignMiss(t *testing.T) {
 	p1 := &stubProvider{name: "musixmatch", err: musixmatch.ErrNoLyrics}
 	o, _ := New("ordered", laneFor(p1))

--- a/internal/orchestrator/parallel.go
+++ b/internal/orchestrator/parallel.go
@@ -54,6 +54,15 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 		haveHeld bool // a suitable unsynced result is held, pending a synced upgrade
 		upgrade  <-chan time.Time
 		pending  = len(o.lanes)
+		// consulted accumulates the names of lanes that ACTUALLY ran the provider
+		// (everything that increments r.consulted), so per-track attribution counts
+		// only attempted lanes -- mirroring ordered mode. A breaker-open lane
+		// (OutcomeUnavailable, provider not called) and a canceled loser are
+		// excluded, so neither is recorded as a spurious miss. On an early synced
+		// win, lanes still in flight have not reported and so get no row: we do not
+		// know their outcome, and recording them as misses would be the very
+		// over-count this table exists to avoid.
+		consulted []string
 	)
 
 	for {
@@ -73,10 +82,18 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 				// Breaker open, provider not called: skip (matters only if ALL unavailable).
 			default:
 				r.consulted++
+				consulted = append(consulted, res.name)
 				switch {
 				case res.err == nil && IsSuitable(res.song, o.guard):
 					if QualityOf(res.song) >= QualitySynced {
 						res.song.WinningLane = res.name
+						// Attribute over the lanes consulted SO FAR (the winner plus any
+						// lane that already reported a non-unavailable result): the winner
+						// is the hit, every consulted loser a miss. This is the over-count
+						// fix -- a lane that reported a miss before this synced winner is
+						// recorded as a miss -- without inventing misses for breaker-open
+						// or still-in-flight lanes that were never consulted.
+						res.song.LaneAttempts = laneAttemptsFor(consulted, res.name)
 						return res.song, nil // synced: commit now; defer cancels the losers.
 					}
 					// Suitable but unsynced: hold the first such result. Arm the upgrade
@@ -100,9 +117,18 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 				}
 				if haveHeld {
 					heldSong.WinningLane = heldLane
+					heldSong.LaneAttempts = laneAttemptsFor(consulted, heldLane)
 					return heldSong, nil
 				}
-				return o.resolve(ctx, &r)
+				song, err := o.resolve(ctx, &r)
+				// Every lane has now reported, so consulted holds exactly the attempted
+				// lanes (unavailable / canceled lanes excluded). A best-available
+				// fallback names its serving lane as the hit; an error returns no
+				// winner, so every consulted lane is a miss. The worker persists only on
+				// the success and benign-miss paths, so attaching on the error song is
+				// harmless.
+				song.LaneAttempts = laneAttemptsFor(consulted, song.WinningLane)
+				return song, err
 			}
 		case <-upgrade:
 			// The window elapsed with no synced upgrade: commit the held unsynced,
@@ -111,6 +137,7 @@ func (o *Orchestrator) findParallel(ctx context.Context, track models.Track) (mo
 				return models.Song{}, err
 			}
 			heldSong.WinningLane = heldLane
+			heldSong.LaneAttempts = laneAttemptsFor(consulted, heldLane)
 			return heldSong, nil
 		}
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1039,6 +1039,47 @@ func (q *DBQueue) RecordProviderMiss(ctx context.Context, lane string) error {
 	return nil
 }
 
+// RecordLaneAttempts persists the per-track, per-lane attempt outcomes for one
+// work_queue row into lane_attempts (migration 022) for a true per-track
+// hit-rate (issue #282). attempts holds one entry per ATTEMPTED lane: Hit true
+// for the lane that served the track, false for every other attempted lane
+// (including a lane that lost to a later winner). An empty attempts slice is a
+// no-op. The whole batch is written in one transaction so a row's attempts are
+// all-or-nothing. UNIQUE(queue_id, lane) makes re-fetches idempotent: an
+// --upgrade re-run upserts the latest outcome (and refreshes attempted_at)
+// rather than violating the constraint.
+func (q *DBQueue) RecordLaneAttempts(ctx context.Context, queueID int64, attempts []models.LaneAttempt) error {
+	if len(attempts) == 0 {
+		return nil
+	}
+	at := formatTime(q.now())
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("queue: record lane attempts begin for id %d: %w", queueID, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, a := range attempts {
+		if a.Lane == "" {
+			continue
+		}
+		hit := 0
+		if a.Hit {
+			hit = 1
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO lane_attempts(queue_id, lane, hit, attempted_at) VALUES(?, ?, ?, ?)
+             ON CONFLICT(queue_id, lane) DO UPDATE SET hit = excluded.hit, attempted_at = excluded.attempted_at`,
+			queueID, a.Lane, hit, at,
+		); err != nil {
+			return fmt.Errorf("queue: record lane attempt for id %d lane %q: %w", queueID, a.Lane, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("queue: record lane attempts commit for id %d: %w", queueID, err)
+	}
+	return nil
+}
+
 // SetProviderLane stamps the winning provider lane name onto a work_queue row.
 // Call at completion time (before Complete) so the row permanently records which
 // provider served it. A NULL provider_lane means not-yet-completed, retired

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -2964,6 +2964,70 @@ func TestDBQueue_ProviderOutcomes(t *testing.T) {
 	}
 }
 
+// TestDBQueue_RecordLaneAttempts verifies the per-track, per-lane attempt rows
+// round-trip, that an empty slice is a no-op, that an empty lane name within a
+// batch is skipped, and that a re-fetch of the same (queue_id, lane) upserts
+// (idempotent under the UNIQUE constraint) rather than erroring.
+func TestDBQueue_RecordLaneAttempts(t *testing.T) {
+	ctx := context.Background()
+	db := openQueueTestDB(t)
+	q := NewDBQueue(db)
+
+	countRows := func() int {
+		t.Helper()
+		var n int
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM lane_attempts`).Scan(&n); err != nil {
+			t.Fatalf("count lane_attempts: %v", err)
+		}
+		return n
+	}
+
+	// Empty slice: no-op.
+	if err := q.RecordLaneAttempts(ctx, 1, nil); err != nil {
+		t.Fatalf("RecordLaneAttempts empty: %v", err)
+	}
+	if got := countRows(); got != 0 {
+		t.Fatalf("after empty batch: %d rows, want 0", got)
+	}
+
+	// One track, two lanes: winner hit, loser miss. An empty lane is skipped.
+	attempts := []models.LaneAttempt{
+		{Lane: "musixmatch", Hit: true},
+		{Lane: "petitlyrics", Hit: false},
+		{Lane: "", Hit: false},
+	}
+	if err := q.RecordLaneAttempts(ctx, 42, attempts); err != nil {
+		t.Fatalf("RecordLaneAttempts: %v", err)
+	}
+	if got := countRows(); got != 2 {
+		t.Fatalf("after batch: %d rows, want 2 (empty lane skipped)", got)
+	}
+
+	var hit int
+	if err := db.QueryRowContext(ctx,
+		`SELECT hit FROM lane_attempts WHERE queue_id = 42 AND lane = 'musixmatch'`).Scan(&hit); err != nil {
+		t.Fatalf("select winner: %v", err)
+	}
+	if hit != 1 {
+		t.Errorf("musixmatch hit = %d; want 1", hit)
+	}
+
+	// Re-fetch the same row with a flipped outcome: upsert, not a UNIQUE violation.
+	if err := q.RecordLaneAttempts(ctx, 42, []models.LaneAttempt{{Lane: "musixmatch", Hit: false}}); err != nil {
+		t.Fatalf("RecordLaneAttempts upsert: %v", err)
+	}
+	if got := countRows(); got != 2 {
+		t.Fatalf("after upsert: %d rows, want 2 (no duplicate)", got)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT hit FROM lane_attempts WHERE queue_id = 42 AND lane = 'musixmatch'`).Scan(&hit); err != nil {
+		t.Fatalf("select winner after upsert: %v", err)
+	}
+	if hit != 0 {
+		t.Errorf("musixmatch hit after upsert = %d; want 0 (refreshed)", hit)
+	}
+}
+
 // TestDBQueue_RecordProviderHitEmptyLane verifies that an empty lane name is a
 // no-op (no row inserted, no error).
 func TestDBQueue_RecordProviderHitEmptyLane(t *testing.T) {
@@ -3117,6 +3181,9 @@ func TestDBQueue_ProviderMethodsClosedDB(t *testing.T) {
 	}
 	if err := q.RecordProviderMiss(ctx, "musixmatch"); err == nil {
 		t.Fatal("RecordProviderMiss on closed db: want error, got nil")
+	}
+	if err := q.RecordLaneAttempts(ctx, 1, []models.LaneAttempt{{Lane: "musixmatch", Hit: true}}); err == nil {
+		t.Fatal("RecordLaneAttempts on closed db: want error, got nil")
 	}
 	if err := q.SetProviderLane(ctx, 1, "musixmatch"); err == nil {
 		t.Fatal("SetProviderLane on closed db: want error, got nil")

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -183,37 +183,38 @@ type ProviderEffectiveness struct {
 	Hits   int64
 	Misses int64
 	// HitRate is Hits / (Hits + Misses), in [0,1]; 0 when the lane has no
-	// recorded outcomes. APPROXIMATE: the underlying counters are
-	// attempt-weighted, not clean per-track, so this can over-state lanes that
-	// were tried but lost to a later winning lane. A true per-track hit-rate is
-	// a deferred follow-up (see #282); the UI layer should surface this value
-	// with an "approximate" label.
+	// recorded attempts. This is a TRUE per-track hit-rate (issue #282): Hits and
+	// Misses are per-track attempt outcomes from lane_attempts, so a lane that was
+	// tried but lost to a later winning lane is correctly counted as a miss.
 	HitRate float64
 }
 
-// ProviderEffectiveness returns per-lane hit/miss counts and hit-rate.
+// ProviderEffectiveness returns per-lane hit/miss counts and a TRUE per-track
+// hit-rate (issue #282).
 //
-// Source-of-truth decision: the provider_outcomes table (migration 018), NOT
-// aggregation over work_queue.provider_lane. provider_outcomes is the
-// worker-maintained aggregate; work_queue.provider_lane only records the winning
-// lane of a completed row (per-track provenance) and has no miss signal, so a
-// hit-rate cannot be computed from it.
+// Source-of-truth decision: the lane_attempts table (migration 022), NOT the
+// attempt-weighted provider_outcomes aggregate (migration 018). lane_attempts
+// records one row per (track, lane) for every ATTEMPTED lane: hit=1 for the lane
+// that served the track and hit=0 for every other attempted lane, INCLUDING a
+// lane that lost to a later winning lane. That is the exact case provider_outcomes
+// cannot express (it records a miss only on the all-lanes-benign-miss path), so a
+// hit-rate derived from it over-states tried-but-not-winning lanes. provider_outcomes
+// is intentionally kept in parallel (still maintained by the worker and read by
+// /metrics); this report no longer reads it.
 //
-// HitRate caveat (attempt-weighted, APPROXIMATE): the counters are NOT a clean
-// per-track tally. internal/worker.recordHit records a hit only for the WINNING
-// lane (worker.go: w.recordHit(..., song.WinningLane)), and
-// internal/worker.recordMisses records a miss for every active lane only on the
-// all-lanes-benign-miss path (worker.go: w.recordMisses on musixmatch.
-// IsBenignMiss). So a lane that was tried but lost to a later winning lane
-// records neither a hit nor a miss, and HitRate over-states such tried-but-not-
-// winning lanes. A true per-track hit-rate is a deferred follow-up (issue #282);
-// this report intentionally surfaces the approximate aggregate unchanged and
-// labels it (see the HitRate field doc) rather than re-deriving it here. The
-// hit-rate is computed in Go to keep integer-vs-float division explicit and
-// avoid SQL NULL-on-zero-divisor edge cases.
+// NO BACKFILL: lane_attempts is empty for all traffic that predates migration 022
+// (the per-lane history did not exist before, so it cannot be reconstructed). Until
+// new attempts accrue, this query returns no rows and Report 3 shows its empty
+// state. The hit-rate is computed in Go to keep integer-vs-float division explicit
+// and avoid SQL NULL-on-zero-divisor edge cases.
 func (r *Repo) ProviderEffectiveness(ctx context.Context) ([]ProviderEffectiveness, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT lane, hits, misses FROM provider_outcomes ORDER BY lane`)
+		`SELECT lane,
+		        SUM(CASE WHEN hit = 1 THEN 1 ELSE 0 END) AS hits,
+		        SUM(CASE WHEN hit = 0 THEN 1 ELSE 0 END) AS misses
+		   FROM lane_attempts
+		  GROUP BY lane
+		  ORDER BY lane`)
 	if err != nil {
 		return nil, fmt.Errorf("reports: provider effectiveness: %w", err)
 	}

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -97,12 +97,27 @@ func linkScanResult(t *testing.T, sqlDB *sql.DB, workQueueID, scanResultID int64
 	}
 }
 
-func insertProviderOutcome(t *testing.T, sqlDB *sql.DB, lane string, hits, misses int64) {
+// insertLaneAttempts seeds lane_attempts with `hits` hit rows and `misses` miss
+// rows for the named lane, one per-track row each. queue_id is unique within the
+// lane (the UNIQUE constraint is (queue_id, lane), so different lanes may reuse
+// the same ids). This is the true per-track source for Report 3 (issue #282).
+func insertLaneAttempts(t *testing.T, sqlDB *sql.DB, lane string, hits, misses int64) {
 	t.Helper()
-	if _, err := sqlDB.ExecContext(context.Background(),
-		`INSERT INTO provider_outcomes (lane, hits, misses) VALUES (?, ?, ?)`,
-		lane, hits, misses); err != nil {
-		t.Fatalf("insert provider_outcomes: %v", err)
+	insert := func(qid, hit int64) {
+		if _, err := sqlDB.ExecContext(context.Background(),
+			`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (?, ?, ?, ?)`,
+			qid, lane, hit, "2026-06-18T00:00:00Z"); err != nil {
+			t.Fatalf("insert lane_attempts: %v", err)
+		}
+	}
+	var qid int64
+	for range hits {
+		qid++
+		insert(qid, 1)
+	}
+	for range misses {
+		qid++
+		insert(qid, 0)
 	}
 }
 
@@ -246,26 +261,25 @@ func TestProviderEffectiveness(t *testing.T) {
 	sqlDB := openTestDB(t)
 	repo := reports.New(sqlDB)
 
-	insertProviderOutcome(t, sqlDB, "musixmatch", 75, 25) // 0.75
-	insertProviderOutcome(t, sqlDB, "petitlyrics", 0, 0)  // no outcomes -> 0
-	insertProviderOutcome(t, sqlDB, "aaa", 1, 3)          // 0.25, sorts first
+	// Per-track attempt rows in lane_attempts (the true source, issue #282).
+	insertLaneAttempts(t, sqlDB, "musixmatch", 75, 25) // 0.75
+	insertLaneAttempts(t, sqlDB, "aaa", 1, 3)          // 0.25, sorts first
 
 	got, err := repo.ProviderEffectiveness(ctx)
 	if err != nil {
 		t.Fatalf("ProviderEffectiveness: %v", err)
 	}
-	if len(got) != 3 {
-		t.Fatalf("got %d lanes, want 3", len(got))
+	// petitlyrics has no attempts, so it does not appear (GROUP BY lane over
+	// lane_attempts only yields lanes with at least one recorded attempt).
+	if len(got) != 2 {
+		t.Fatalf("got %d lanes, want 2", len(got))
 	}
-	// ORDER BY lane: aaa, musixmatch, petitlyrics.
-	if got[0].Lane != "aaa" || got[0].HitRate != 0.25 {
-		t.Errorf("got[0] = %+v, want aaa/0.25", got[0])
+	// ORDER BY lane: aaa, musixmatch.
+	if got[0].Lane != "aaa" || got[0].Hits != 1 || got[0].Misses != 3 || got[0].HitRate != 0.25 {
+		t.Errorf("got[0] = %+v, want aaa hits=1 misses=3 rate=0.25", got[0])
 	}
-	if got[1].Lane != "musixmatch" || got[1].HitRate != 0.75 {
-		t.Errorf("got[1] = %+v, want musixmatch/0.75", got[1])
-	}
-	if got[2].Lane != "petitlyrics" || got[2].HitRate != 0 {
-		t.Errorf("got[2] = %+v, want petitlyrics/0 (no divide-by-zero)", got[2])
+	if got[1].Lane != "musixmatch" || got[1].Hits != 75 || got[1].Misses != 25 || got[1].HitRate != 0.75 {
+		t.Errorf("got[1] = %+v, want musixmatch hits=75 misses=25 rate=0.75", got[1])
 	}
 }
 

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -111,11 +111,11 @@ func insertLaneAttempts(t *testing.T, sqlDB *sql.DB, lane string, hits, misses i
 		}
 	}
 	var qid int64
-	for range hits {
+	for i := int64(0); i < hits; i++ {
 		qid++
 		insert(qid, 1)
 	}
-	for range misses {
+	for i := int64(0); i < misses; i++ {
 		qid++
 		insert(qid, 0)
 	}

--- a/internal/web/reports_ui_test.go
+++ b/internal/web/reports_ui_test.go
@@ -123,19 +123,24 @@ func TestReportFragmentRecentOutcomes(t *testing.T) {
 	}
 }
 
-// TestProviderEffectivenessApproxLabel asserts the hit-rate is rendered with the
-// required "approximate" caveat (the underlying counter is attempt-weighted).
-func TestProviderEffectivenessApproxLabel(t *testing.T) {
+// TestProviderEffectivenessTrueRate asserts the hit-rate renders from the true
+// per-track lane_attempts source (issue #282) and no longer carries the old
+// "approximate" caveat.
+func TestProviderEffectivenessTrueRate(t *testing.T) {
 	sqlDB := openReportsTestDB(t)
-	if _, err := sqlDB.ExecContext(context.Background(),
-		`INSERT INTO provider_outcomes (lane, hits, misses) VALUES ('musixmatch', 3, 1)`); err != nil {
-		t.Fatalf("insert provider_outcomes: %v", err)
+	// 3 hits + 1 miss for musixmatch -> 75.0%, as distinct per-track rows.
+	for i, hit := range []int64{1, 1, 1, 0} {
+		if _, err := sqlDB.ExecContext(context.Background(),
+			`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (?, 'musixmatch', ?, '2026-06-18T00:00:00Z')`,
+			int64(i+1), hit); err != nil {
+			t.Fatalf("insert lane_attempts: %v", err)
+		}
 	}
 	mux := newReportsUIServer(t, sqlDB)
 
 	body := getFragment(t, mux, "provider-effectiveness").Body.String()
-	if !strings.Contains(strings.ToLower(body), "approximate") {
-		t.Error("provider-effectiveness must label the hit-rate approximate")
+	if strings.Contains(strings.ToLower(body), "approximate") {
+		t.Error("provider-effectiveness must no longer label the hit-rate approximate")
 	}
 	if !strings.Contains(body, "75.0%") {
 		t.Errorf("expected hit-rate 75.0%% for 3 hits / 1 miss; body:\n%s", body)

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -38,7 +38,7 @@ type reportDef struct {
 var reportDefs = []reportDef{
 	{"queue-summary", "Queue summary", "Work-queue rows grouped by status."},
 	{"recent-outcomes", "Recent outcomes", "The most recently completed tracks and their derived result."},
-	{"provider-effectiveness", "Provider effectiveness", "Per-lane hits, misses, and approximate hit-rate."},
+	{"provider-effectiveness", "Provider effectiveness", "Per-lane hits, misses, and true per-track hit-rate."},
 	{"instrumental-inventory", "Instrumental inventory", "Tracks the audio detector confirmed instrumental."},
 	{"failure-analysis", "Failure analysis", "Failed and deferred tracks grouped by reason."},
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -52,6 +52,11 @@ type Queue interface {
 type ProviderRecorder interface {
 	RecordProviderHit(ctx context.Context, lane string) error
 	RecordProviderMiss(ctx context.Context, lane string) error
+	// RecordLaneAttempts persists the per-track, per-lane hit/miss attribution for
+	// one work_queue row so a TRUE per-track hit-rate can be derived (issue #282),
+	// distinct from the attempt-weighted RecordProviderHit/Miss aggregate. An empty
+	// slice is a no-op.
+	RecordLaneAttempts(ctx context.Context, queueID int64, attempts []models.LaneAttempt) error
 }
 
 // ScriptGuard rejects lyric results whose body is dominated by scripts outside
@@ -484,6 +489,20 @@ func (w *Worker) recordMisses(ctx context.Context) {
 	}
 }
 
+// recordLaneAttempts persists the per-track, per-lane hit/miss attribution carried
+// out of the orchestrator on song.LaneAttempts, for a true per-track hit-rate
+// (issue #282), alongside the attempt-weighted provider_outcomes counters. An
+// empty attempts slice (cache hit, or no lane consulted) is a no-op. Errors are
+// logged at Warn and do not affect the processing outcome.
+func (w *Worker) recordLaneAttempts(ctx context.Context, id int64, attempts []models.LaneAttempt) {
+	if w.providerRecorder == nil || len(attempts) == 0 {
+		return
+	}
+	if err := w.providerRecorder.RecordLaneAttempts(ctx, id, attempts); err != nil {
+		slog.Warn("worker: record lane attempts failed", "id", id, "error", err)
+	}
+}
+
 // guardReject reports whether the script guard rejects this song. It returns
 // (false, "") when no guard is configured or the guard is disabled, so the
 // caller can treat a nil/disabled guard as a no-op.
@@ -627,6 +646,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// each. Errors are non-fatal; recording happens before the Defer/Complete
 			// so the queue state is clean regardless of the recording outcome.
 			w.recordMisses(context.WithoutCancel(ctx))
+			// Also persist the per-track attribution (all attempted lanes missed this
+			// track) for the true per-track hit-rate (#282). The orchestrator carries
+			// the attempts on the returned song even on the benign-miss error path.
+			w.recordLaneAttempts(context.WithoutCancel(ctx), item.ID, song.LaneAttempts)
 			// Optional audio-based instrumental detection. Only runs on provider
 			// misses (no lyrics and not already flagged instrumental). Errors are
 			// non-fatal: starvation of the detector sidecar is acceptable; the miss
@@ -719,6 +742,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// per-track provenance are always written when the provider round-trip
 		// succeeds, even if verify/guard/store fails later.
 		w.recordHit(context.WithoutCancel(ctx), item.ID, song.WinningLane)
+		// Persist the per-track attribution (winning lane hit, every other attempted
+		// lane a miss) for the true per-track hit-rate (#282), alongside the
+		// attempt-weighted provider_outcomes counter recorded above.
+		w.recordLaneAttempts(context.WithoutCancel(ctx), item.ID, song.LaneAttempts)
 		// The lane already recorded the circuit success and recovered its breaker
 		// inside FindLyrics, so a later bare 401 is correctly read as throttling
 		// rather than a dead token.
@@ -845,7 +872,12 @@ func (w *Worker) song(ctx context.Context, track models.Track, bypassCache bool)
 	// fallback exactly as before.
 	song, err := w.orch.FindLyrics(ctx, track)
 	if err != nil {
-		return models.Song{}, false, err
+		// Propagate the orchestrator's song even on error: on the benign-miss path
+		// it carries song.LaneAttempts (every attempted lane missed this track),
+		// which the worker persists for the true per-track hit-rate (#282). The
+		// caller only reads LaneAttempts on the benign-miss branch; other error
+		// branches ignore the song, so carrying it here is harmless.
+		return song, false, err
 	}
 	return song, false, nil
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -235,10 +235,12 @@ func (f *fakeFetcher) FindLyrics(context.Context, models.Track) (models.Song, er
 }
 
 type fakeProviderRecorder struct {
-	hits    []string
-	misses  []string
-	hitErr  error
-	missErr error
+	hits        []string
+	misses      []string
+	attempts    map[int64][]models.LaneAttempt
+	hitErr      error
+	missErr     error
+	attemptsErr error
 }
 
 func (r *fakeProviderRecorder) RecordProviderHit(_ context.Context, lane string) error {
@@ -249,6 +251,14 @@ func (r *fakeProviderRecorder) RecordProviderHit(_ context.Context, lane string)
 func (r *fakeProviderRecorder) RecordProviderMiss(_ context.Context, lane string) error {
 	r.misses = append(r.misses, lane)
 	return r.missErr
+}
+
+func (r *fakeProviderRecorder) RecordLaneAttempts(_ context.Context, queueID int64, attempts []models.LaneAttempt) error {
+	if r.attempts == nil {
+		r.attempts = make(map[int64][]models.LaneAttempt)
+	}
+	r.attempts[queueID] = append(r.attempts[queueID], attempts...)
+	return r.attemptsErr
 }
 
 type fakeWriter struct {
@@ -2117,6 +2127,50 @@ func TestRunOnceRecordsProviderMissOnBenignMiss(t *testing.T) {
 	}
 	if len(q.deferred) != 1 {
 		t.Errorf("deferred = %v; want [302]", q.deferred)
+	}
+}
+
+// TestRunOnceRecordsLaneAttemptsOnSuccess verifies the worker persists the
+// per-track attribution carried out of the orchestrator on a successful fetch:
+// the winning lane recorded as a hit for this queue row (#282).
+func TestRunOnceRecordsLaneAttemptsOnSuccess(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 301, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  models.Track{ArtistName: "A", TrackName: "T"},
+		Lyrics: models.Lyrics{LyricsBody: "lyrics"},
+	}}
+	rec := &fakeProviderRecorder{}
+
+	w := New(q, c, fetcher, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	got := rec.attempts[301]
+	if len(got) != 1 || got[0].Lane != "musixmatch" || !got[0].Hit {
+		t.Errorf("lane attempts for 301 = %+v; want [{musixmatch hit=true}]", got)
+	}
+}
+
+// TestRunOnceRecordsLaneAttemptsOnBenignMiss verifies the worker persists an
+// all-miss per-track attribution when every lane misses (#282).
+func TestRunOnceRecordsLaneAttemptsOnBenignMiss(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 302, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	rec := &fakeProviderRecorder{}
+
+	w := New(q, c, fetcher, &fakeWriter{})
+	w.SetProviderRecorder(rec)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	got := rec.attempts[302]
+	if len(got) != 1 || got[0].Lane != "musixmatch" || got[0].Hit {
+		t.Errorf("lane attempts for 302 = %+v; want [{musixmatch hit=false}]", got)
 	}
 }
 

--- a/web/templates/reports.templ
+++ b/web/templates/reports.templ
@@ -173,7 +173,7 @@ templ tableProviders(rows []ProviderRow) {
 						<th scope="col">Lane</th>
 						<th scope="col">Hits</th>
 						<th scope="col">Misses</th>
-						<th scope="col">Hit-rate (approx.)</th>
+						<th scope="col">Hit-rate</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/web/templates/reports.templ
+++ b/web/templates/reports.templ
@@ -163,9 +163,8 @@ templ tableRecentOutcomes(rows []RecentOutcomeRow) {
 }
 
 templ tableProviders(rows []ProviderRow) {
-	<p class="mx-approx">Hit-rate is approximate (attempt-weighted, not a clean per-track tally). A true per-track rate is a deferred follow-up (#282).</p>
 	if len(rows) == 0 {
-		@reportEmpty("No provider outcomes recorded yet.")
+		@reportEmpty("No provider attempts recorded yet. This populates as tracks are processed.")
 	} else {
 		<div class="mx-table-wrap">
 			<table class="mx-table">

--- a/web/templates/reports_templ.go
+++ b/web/templates/reports_templ.go
@@ -592,31 +592,40 @@ func tableProviders(rows []ProviderRow) templ.Component {
 			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<p class=\"mx-approx\">Hit-rate is approximate (attempt-weighted, not a clean per-track tally). A true per-track rate is a deferred follow-up (#282).</p>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
 		if len(rows) == 0 {
-			templ_7745c5c3_Err = reportEmpty("No provider outcomes recorded yet.").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = reportEmpty("No provider attempts recorded yet. This populates as tracks are processed.").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Lane</th><th scope=\"col\">Hits</th><th scope=\"col\">Misses</th><th scope=\"col\">Hit-rate (approx.)</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Lane</th><th scope=\"col\">Hits</th><th scope=\"col\">Misses</th><th scope=\"col\">Hit-rate (approx.)</th></tr></thead> <tbody>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range rows {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<tr><td>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<tr><td>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(r.Lane)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 183, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 182, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</td><td class=\"mx-cell-mono\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var26 string
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(r.Hits)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 183, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -624,12 +633,12 @@ func tableProviders(rows []ProviderRow) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var26 string
-				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(r.Hits)
+				var templ_7745c5c3_Var27 string
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(r.Misses)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 184, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 184, Col: 42}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -637,34 +646,21 @@ func tableProviders(rows []ProviderRow) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var27 string
-				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(r.Misses)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 185, Col: 42}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</td><td class=\"mx-cell-mono\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 				var templ_7745c5c3_Var28 string
 				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(r.HitRate)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 186, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 185, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</tbody></table></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</tbody></table></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -700,21 +696,34 @@ func tableInstrumentals(rows []InstrumentalRow) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">ID</th><th scope=\"col\">Artist</th><th scope=\"col\">Title</th><th scope=\"col\">File</th><th scope=\"col\">Detect requested</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">ID</th><th scope=\"col\">Artist</th><th scope=\"col\">Title</th><th scope=\"col\">File</th><th scope=\"col\">Detect requested</th></tr></thead> <tbody>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range rows {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<tr><td class=\"mx-cell-mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<tr><td class=\"mx-cell-mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var30 string
 				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(r.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 213, Col: 38}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 212, Col: 38}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</td><td>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var31 string
+				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(r.Artist)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 213, Col: 21}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -722,25 +731,25 @@ func tableInstrumentals(rows []InstrumentalRow) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var31 string
-				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(r.Artist)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 214, Col: 21}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</td><td>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 215, Col: 20}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 214, Col: 20}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</td><td class=\"mx-cell-mono\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var33 string
+				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(r.File)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 215, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -748,34 +757,21 @@ func tableInstrumentals(rows []InstrumentalRow) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var33 string
-				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(r.File)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 216, Col: 40}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</td><td class=\"mx-cell-mono\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 				var templ_7745c5c3_Var34 string
 				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(r.DetectRequested)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 217, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 216, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</tbody></table></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</tbody></table></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -811,56 +807,56 @@ func tableFailures(rows []FailureRow) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Status</th><th scope=\"col\">Reason</th><th scope=\"col\">Count</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Status</th><th scope=\"col\">Reason</th><th scope=\"col\">Count</th></tr></thead> <tbody>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range rows {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<tr><td class=\"mx-cell-mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<tr><td class=\"mx-cell-mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var36 string
 				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(r.Status)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 242, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 241, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</td><td>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</td><td>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var37 string
 				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(r.Reason)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 243, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 242, Col: 21}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</td><td class=\"mx-cell-mono\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</td><td class=\"mx-cell-mono\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var38 string
 				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(r.Count)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 244, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reports.templ`, Line: 243, Col: 41}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</tbody></table></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</tbody></table></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/templates/reports_templ.go
+++ b/web/templates/reports_templ.go
@@ -598,7 +598,7 @@ func tableProviders(rows []ProviderRow) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Lane</th><th scope=\"col\">Hits</th><th scope=\"col\">Misses</th><th scope=\"col\">Hit-rate (approx.)</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"mx-table-wrap\"><table class=\"mx-table\"><thead><tr><th scope=\"col\">Lane</th><th scope=\"col\">Hits</th><th scope=\"col\">Misses</th><th scope=\"col\">Hit-rate</th></tr></thead> <tbody>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/templates/reports_view.go
+++ b/web/templates/reports_view.go
@@ -50,7 +50,7 @@ type RecentOutcomeRow struct {
 	CompletedAt string
 }
 
-// ProviderRow is one provider lane's hit/miss tally and approximate hit-rate.
+// ProviderRow is one provider lane's hit/miss tally and true per-track hit-rate.
 type ProviderRow struct {
 	Lane    string
 	Hits    string


### PR DESCRIPTION
## Summary

Closes #282. Report 3 (Provider effectiveness) derived its per-lane hit-rate from the **attempt-weighted** `provider_outcomes` counters, which over-state — a lane that was tried but lost to a *later* winner never recorded a miss. This replaces that with a **true per-track** hit/miss attribution.

## What changed

- **Migration 022 `lane_attempts`** — one row per track per *consulted* lane (hit/miss). `UNIQUE(queue_id, lane)`, no FK (history survives `ClearDone`), indexed for the report aggregate.
- **Orchestrator attribution** (ordered + parallel) — records only **actually-consulted** lanes: winner = hit, every consulted loser = miss (including a lane that lost to a *later* winner — the exact over-count this fixes). A breaker-open / never-consulted lane gets **no** row.
- **Idempotent upsert** — `ON CONFLICT(queue_id, lane)` so an `--upgrade` re-fetch overwrites in place.
- **Report 3** computes the true rate from `lane_attempts`; `provider_outcomes` kept in parallel for `/metrics`. The "approximate" caveat label is dropped.
- **No backfill** — pre-022 rows have no per-lane history; the report's empty-state covers it until new traffic accrues.

## Review

An independent hostile review caught one real major — parallel mode initially recorded a spurious miss for a breaker-open (never-consulted) lane — now fixed (attribute consulted-only), with a regression test plus a 022 up/down migration test.

## Test plan

`make gate` green (build/vet, race tests, golangci-lint 0, govulncheck, actionlint, codecov dry-run). Patch coverage 91.67%. Real-SQLite integration tests for the new table, the attribution paths (ordered loser-miss, later-lane-not-consulted, parallel all-lanes, breaker-open-excluded), the idempotent upsert, and the migration up/down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lane-level outcome tracking system now captures per-track hit/miss attribution for each provider to enable accurate effectiveness analytics.

* **Bug Fixes**
  * Provider effectiveness reports now compute true per-track hit rates from actual attempt records instead of approximate aggregates.

* **Documentation**
  * Updated provider effectiveness report labels to indicate true per-track hit rate calculations instead of approximate values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->