### PR TITLE
harden(serve): URL-encode report rail key path segment in sidebar links (#286)

### DIFF
--- a/internal/web/reports_ui_test.go
+++ b/internal/web/reports_ui_test.go
@@ -340,6 +340,41 @@ func TestReportSelectionHighlightMovesAcrossReports(t *testing.T) {
 	}
 }
 
+// TestBuildRailEncodesKeyPath verifies the rail link target is the report key
+// encoded as a single path segment (#286). For the canned kebab-case keys the
+// encoding is a no-op, so the rendered href stays byte-identical to the
+// pre-encoding "/reports/<key>" form; a key with reserved characters is escaped
+// so it cannot break the URL.
+func TestBuildRailEncodesKeyPath(t *testing.T) {
+	ui := NewUI(config.Config{}, "v-test")
+	rail := ui.buildRail("queue-summary")
+
+	wantKeys := []string{
+		"queue-summary",
+		"recent-outcomes",
+		"provider-effectiveness",
+		"instrumental-inventory",
+		"failure-analysis",
+	}
+	if len(rail) != len(wantKeys) {
+		t.Fatalf("buildRail returned %d items, want %d", len(rail), len(wantKeys))
+	}
+	for i, want := range wantKeys {
+		if rail[i].Key != want {
+			t.Errorf("rail[%d].Key = %q, want %q", i, rail[i].Key, want)
+		}
+		// Encoding is a no-op for kebab-case keys: the path is unchanged.
+		if got, exp := rail[i].Path, "/reports/"+want; got != exp {
+			t.Errorf("rail[%d].Path = %q, want %q (encoding must be a no-op here)", i, got, exp)
+		}
+	}
+
+	// A key with reserved characters is escaped per url.PathEscape semantics.
+	if got, want := reportPath("a b/c%d"), "/reports/a%20b%2Fc%25d"; got != want {
+		t.Errorf("reportPath(%q) = %q, want %q", "a b/c%d", got, want)
+	}
+}
+
 // TestBuildReportViewUnimplementedKey exercises the defensive default case: a
 // reportDef whose key has no switch arm must fail fast with an error rather than
 // returning an empty (misleading) view. Unreachable via the HTTP path (keys are

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -204,12 +205,24 @@ func (u *UI) handleReportFragment(w http.ResponseWriter, r *http.Request) {
 	render(w, r, templates.ReportsPage(u.version, rail, &view))
 }
 
+// reportPath builds the sidebar link target for a report key, encoding the key
+// as a single path segment so a key containing reserved characters cannot break
+// the URL. It is a no-op for the kebab-case canned-report keys.
+func reportPath(key string) string {
+	return "/reports/" + url.PathEscape(key)
+}
+
 // buildRail builds the sidebar report-nav view models in design-doc order,
 // marking activeKey selected.
 func (u *UI) buildRail(activeKey string) []templates.RailItem {
 	rail := make([]templates.RailItem, 0, len(reportDefs))
 	for _, d := range reportDefs {
-		rail = append(rail, templates.RailItem{Key: d.key, Title: d.title, Active: d.key == activeKey})
+		rail = append(rail, templates.RailItem{
+			Key:    d.key,
+			Path:   reportPath(d.key),
+			Title:  d.title,
+			Active: d.key == activeKey,
+		})
 	}
 	return rail
 }

--- a/web/templates/reports_view.go
+++ b/web/templates/reports_view.go
@@ -7,8 +7,13 @@ package templates
 
 // RailItem is one report row in the sidebar's REPORTS group.
 type RailItem struct {
-	// Key is the report's stable URL slug (e.g. "queue-summary").
+	// Key is the report's stable URL slug (e.g. "queue-summary"). Kept raw for
+	// the active-state comparison; Path is the encoded value used for links.
 	Key string
+	// Path is the pre-computed, path-segment-encoded link target
+	// (e.g. "/reports/queue-summary"). The handler builds it with
+	// url.PathEscape so a key with reserved characters cannot break the URL.
+	Path string
 	// Title is the human label shown in the sidebar row.
 	Title string
 	// Active marks the currently-selected report (drives the accent highlight).

--- a/web/templates/sidebar.templ
+++ b/web/templates/sidebar.templ
@@ -70,8 +70,8 @@ templ reportNav(reports []RailItem, oob bool) {
 			<li>
 				<a
 					class="mx-nav-link mx-report-nav-link"
-					href={ templ.SafeURL("/reports/" + it.Key) }
-					hx-get={ "/reports/" + it.Key }
+					href={ templ.SafeURL(it.Path) }
+					hx-get={ it.Path }
 					hx-target="#mx-main"
 					hx-swap="innerHTML"
 					hx-push-url="true"

--- a/web/templates/sidebar_templ.go
+++ b/web/templates/sidebar_templ.go
@@ -155,9 +155,9 @@ func reportNav(reports []RailItem, oob bool) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var5 templ.SafeURL
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/reports/" + it.Key))
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(it.Path))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/sidebar.templ`, Line: 73, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/sidebar.templ`, Line: 73, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -168,9 +168,9 @@ func reportNav(reports []RailItem, oob bool) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs("/reports/" + it.Key)
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(it.Path)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/sidebar.templ`, Line: 74, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/sidebar.templ`, Line: 74, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
Closes #286.

## What
The report rail (sidebar) built its `/reports/<key>` link by raw string concatenation marked `templ.SafeURL`, bypassing path-segment encoding. If a report key ever contained a reserved character it could malform the `href`/`hx-get`. This encodes the key path segment once and reuses it.

## Changes
- `web/templates/reports_view.go`: add a `Path` field to the existing `RailItem` (no new struct).
- `internal/web/ui.go`: new `reportPath(key)` helper = `"/reports/" + url.PathEscape(key)`; `buildRail` sets `Path` on each item. Edits localized to the import block + rail region.
- `web/templates/sidebar.templ`: use `templ.SafeURL(it.Path)` for `href` and `it.Path` for `hx-get` (raw `it.Key` kept for active-state); regenerated templ.
- `internal/web/reports_ui_test.go`: asserts the five canned kebab keys produce byte-identical `/reports/<key>` (encoding is a no-op) and that a reserved-char key round-trips correctly.

## Notes
- **No behavior change** for the existing five report keys (developer-controlled, kebab-case) — rendered output is byte-identical; this is defense-in-depth for the day keys stop being a closed constant set.
- Deferred hardening from #284 (Codoki). The CR Coding Plan on the issue was steered (it had proposed a dead duplicate struct + a stale #211 deferral); this wires the encoding into the live render path instead.
- `make gate` green (build/vet, gofmt, templ-up-to-date, race tests, golangci-lint 0, actionlint, govulncheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)