### PR TITLE
chore(ci): suppress unreachable rav1e/rand advisory in grype scan (#297)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.goreleaser.yml'
               - '.golangci.yml'
+              - '.grype.yaml'
               - 'Dockerfile'
               - 'build/docker/**'
               - 'web/**'
@@ -202,6 +203,88 @@ jobs:
             ($rules | map(select(.id == $result.ruleId)) | first) as $rule |
             "CVE: \($result.ruleId)  severity: \(if $rule then ($rule.properties["security-severity"] // $rule.defaultConfiguration.level // "unknown") else "unknown" end)  package: \($result.message.text // "unknown")"
           ' "$SARIF_FILE" || { echo "(jq failed to parse SARIF)"; cat "$SARIF_FILE"; }
+
+  grype-ignore-expiry:
+    name: Grype Ignore Expiry Check
+    runs-on: ubuntu-latest
+    # Runs unconditionally (not gated on `changes`): a .grype.yaml ignore entry
+    # expires by date, independent of whether code changed, so this policy check
+    # must fire on every push/PR rather than only when the scan job runs.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Check for expired ignore entries
+        run: |
+          if [ ! -f .grype.yaml ]; then
+            echo "No .grype.yaml found, nothing to check."
+            exit 0
+          fi
+          today=$(date -u +%Y-%m-%d)
+          errors=0
+          vuln=""
+          review_by=""
+          reason=""
+          while IFS= read -r line; do
+            # Strip leading whitespace, then skip comments and blank lines
+            trimmed=${line#"${line%%[![:space:]]*}"}
+            case "$trimmed" in ''|'#'*) continue ;; esac
+            case "$trimmed" in
+              *"vulnerability:"*)
+                # Check previous entry had valid review-by and reason
+                if [ -n "$vuln" ]; then
+                  if [ -z "$review_by" ]; then
+                    echo "::error::Grype ignore missing review-by: $vuln"
+                    errors=$((errors + 1))
+                  fi
+                  if [ -z "$reason" ]; then
+                    echo "::error::Grype ignore missing reason: $vuln"
+                    errors=$((errors + 1))
+                  fi
+                fi
+                vuln=$(echo "$trimmed" | sed 's/.*vulnerability:[[:space:]]*//; s/"//g')
+                review_by=""
+                reason=""
+                ;;
+              *"review-by:"*)
+                review_by=$(echo "$trimmed" | sed 's/.*review-by:[[:space:]]*//; s/"//g')
+                if ! echo "$review_by" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+                  echo "::error::Invalid review-by format for $vuln: $review_by (expected YYYY-MM-DD)"
+                  errors=$((errors + 1))
+                elif ! date -ud "$review_by" +%s >/dev/null 2>&1; then
+                  echo "::error::Invalid review-by date for $vuln: $review_by"
+                  errors=$((errors + 1))
+                # review-by is the last valid day; entry expires the day after
+                elif [ "$today" '>' "$review_by" ]; then
+                  echo "::error::Grype ignore expired: $vuln (review-by: $review_by)"
+                  errors=$((errors + 1))
+                else
+                  days_left=$(( ( $(date -ud "$review_by" +%s) - $(date -ud "$today" +%s) ) / 86400 ))
+                  echo "OK: $vuln (review-by: $review_by, ${days_left} days remaining)"
+                fi
+                ;;
+              *"reason:"*)
+                reason=$(echo "$trimmed" | sed 's/.*reason:[[:space:]]*//; s/"//g')
+                ;;
+            esac
+          done < .grype.yaml
+          # Check the last entry in the file
+          if [ -n "$vuln" ]; then
+            if [ -z "$review_by" ]; then
+              echo "::error::Grype ignore missing review-by: $vuln"
+              errors=$((errors + 1))
+            fi
+            if [ -z "$reason" ]; then
+              echo "::error::Grype ignore missing reason: $vuln"
+              errors=$((errors + 1))
+            fi
+          fi
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::${errors} Grype ignore policy error(s). Review and fix the entries listed above."
+            exit 1
+          fi
+          echo "All Grype ignore entries are within their review-by window."
 
   # Per-package coverage-floor CI enforcement is deferred: Codecov handles patch
   # coverage for PR gates, and scripts/coverage-floor.sh remains available for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,10 @@ jobs:
             echo "No .grype.yaml found, nothing to check."
             exit 0
           fi
+          # escape_gha: escape %, CR, LF before echoing into GHA workflow
+          # commands so untrusted .grype.yaml values cannot forge annotations.
+          # Order matters: % must be escaped first (to %25) before CR/LF.
+          escape_gha() { printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g'; }
           today=$(date -u +%Y-%m-%d)
           errors=0
           vuln=""
@@ -235,11 +239,11 @@ jobs:
                 # Check previous entry had valid review-by and reason
                 if [ -n "$vuln" ]; then
                   if [ -z "$review_by" ]; then
-                    echo "::error::Grype ignore missing review-by: $vuln"
+                    echo "::error::Grype ignore missing review-by: $(escape_gha "$vuln")"
                     errors=$((errors + 1))
                   fi
                   if [ -z "$reason" ]; then
-                    echo "::error::Grype ignore missing reason: $vuln"
+                    echo "::error::Grype ignore missing reason: $(escape_gha "$vuln")"
                     errors=$((errors + 1))
                   fi
                 fi
@@ -250,14 +254,14 @@ jobs:
               *"review-by:"*)
                 review_by=$(echo "$trimmed" | sed 's/.*review-by:[[:space:]]*//; s/"//g')
                 if ! echo "$review_by" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
-                  echo "::error::Invalid review-by format for $vuln: $review_by (expected YYYY-MM-DD)"
+                  echo "::error::Invalid review-by format for $(escape_gha "$vuln"): $(escape_gha "$review_by") (expected YYYY-MM-DD)"
                   errors=$((errors + 1))
                 elif ! date -ud "$review_by" +%s >/dev/null 2>&1; then
-                  echo "::error::Invalid review-by date for $vuln: $review_by"
+                  echo "::error::Invalid review-by date for $(escape_gha "$vuln"): $(escape_gha "$review_by")"
                   errors=$((errors + 1))
                 # review-by is the last valid day; entry expires the day after
                 elif [ "$today" '>' "$review_by" ]; then
-                  echo "::error::Grype ignore expired: $vuln (review-by: $review_by)"
+                  echo "::error::Grype ignore expired: $(escape_gha "$vuln") (review-by: $(escape_gha "$review_by"))"
                   errors=$((errors + 1))
                 else
                   days_left=$(( ( $(date -ud "$review_by" +%s) - $(date -ud "$today" +%s) ) / 86400 ))
@@ -272,11 +276,11 @@ jobs:
           # Check the last entry in the file
           if [ -n "$vuln" ]; then
             if [ -z "$review_by" ]; then
-              echo "::error::Grype ignore missing review-by: $vuln"
+              echo "::error::Grype ignore missing review-by: $(escape_gha "$vuln")"
               errors=$((errors + 1))
             fi
             if [ -z "$reason" ]; then
-              echo "::error::Grype ignore missing reason: $vuln"
+              echo "::error::Grype ignore missing reason: $(escape_gha "$vuln")"
               errors=$((errors + 1))
             fi
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,13 @@ dist/
 
 # Local token config
 .env
+profile.env
 
 # Superpowers plans (local-only)
 docs/superpowers/
+
+# Design docs (local working notes; already-tracked docs stay tracked)
+docs/design/
 
 # Serena MCP
 .serena/

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,21 @@
+# Grype vulnerability scanner configuration
+#
+# Ignored CVEs must include a justification and review-by date.
+# Remove entries once the upstream fix lands in Alpine stable.
+# The grype-ignore-expiry job in ci.yml fails when entries expire.
+
+ignore:
+  # rand 0.9.1 inside librav1e.so (the rav1e AV1 *encoder*), pulled transitively
+  # by the apk ffmpeg in the runtime image. Unreachable: mxlrcgo-svc only DECODES
+  # audio via ffmpeg and never AV1-encodes, so the rav1e code path -- and the rand
+  # 0.9.1 it embeds -- is never invoked. LOW severity; surfaces only as a code
+  # scanning alert (below the build's HIGH fail-on cutoff). Re-evaluate on any
+  # ffmpeg/base-image bump (fix is rand 0.9.3); a slimmed ffmpeg without librav1e
+  # would remove it outright (tracked in #297 as a future option).
+  # Upstream: https://github.com/advisories/GHSA-cq8v-f236-94qc
+  - vulnerability: GHSA-cq8v-f236-94qc
+    package:
+      name: rand
+      type: rust-crate
+    review-by: "2026-09-18"
+    reason: "Unreachable: librav1e is the AV1 encoder; mxlrcgo only decodes audio, never AV1-encodes. LOW severity. Fix is rand 0.9.3."


### PR DESCRIPTION
Closes #297.

## What
The Image Scan job's grype SARIF upload was raising a code-scanning alert for `GHSA-cq8v-f236-94qc` (Rust crate `rand` 0.9.1) inside `/usr/lib/librav1e.so.0.8.1` — rav1e, the AV1 **encoder**, pulled transitively by the apk ffmpeg in the runtime image. mxlrcgo-svc only **decodes** audio via ffmpeg and never AV1-encodes, so the code path (and the `rand` it embeds) is unreachable; LOW severity.

- **`.grype.yaml`** (new): ignores `GHSA-cq8v-f236-94qc` with a justification + `review-by: 2026-09-18`, matching the grype-ignore discipline. grype auto-discovers a root `.grype.yaml` from the checkout, and anchore/scan-action runs grype from the repo root — no config/working-dir wiring needed (verified empirically: baseline SARIF = 1 result → 0 with the ignore).
- **`.github/workflows/ci.yml`**: see the decision below.

## Note: it clears a code-scanning alert, not a red check
The scan is `severity-cutoff: high` + `fail-build: true`; this is LOW, so it never failed the build. It surfaces only because the SARIF upload sends **all** findings to the Security tab. So this PR clears a Security-tab alert.

## Decision flagged (easy to revert)
The repo had the scan job but **never** ported the **grype-ignore-expiry enforcement** job — so a `review-by` date would be decorative and rot silently (the whole point of the discipline is to prevent that). I **ported the expiry job** (verbatim from sydlexius/stillwater, POSIX sh) so the entry is re-checked at its date. It runs on push/PR to main (not a weekly cron — adding a cron to `ci.yml` would re-run all CI jobs weekly; `nightly.yml` is the place for a scheduled hook later). If you'd rather keep this PR to just `.grype.yaml`, say so and I'll drop the job.

NOT done (your earlier call): the slim-ffmpeg-without-librav1e alternative (the deeper fix that removes the CVE at source) — left as a future option noted in `.grype.yaml`.

## Test
`make gate` green (race tests, golangci-lint 0, actionlint on ci.yml, govulncheck; no Go changes). Expiry-check parse simulated locally: 1 entry, 92 days remaining, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration workflow enhanced to validate vulnerability ignore entries for policy compliance and expiration dates
  * Added automated checks to enforce required metadata and date formats in ignore configurations
  * Updated local development ignore patterns to include configuration and documentation working directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->