### PR TITLE
fix(config): purge config .bak after atomic write + tolerate absent config on save (#290, #296)

### DIFF
--- a/internal/config/foundation_cover_test.go
+++ b/internal/config/foundation_cover_test.go
@@ -205,8 +205,14 @@ func TestSetValue_TypeErrors(t *testing.T) {
 }
 
 func TestLoadDocument_MissingFile(t *testing.T) {
-	if _, err := LoadDocument(filepath.Join(t.TempDir(), "nope.toml")); err == nil {
-		t.Error("expected error loading a missing file")
+	// A missing config file is treated as an empty document (create-on-save),
+	// not an error, so settings can be saved before any config.toml exists (#296).
+	doc, err := LoadDocument(filepath.Join(t.TempDir(), "nope.toml"))
+	if err != nil {
+		t.Errorf("missing file should load as an empty document, got error: %v", err)
+	}
+	if doc == nil {
+		t.Error("expected a non-nil empty document for a missing file")
 	}
 }
 
@@ -241,9 +247,14 @@ func TestApplyChanges_EmptyMapNoOp(t *testing.T) {
 }
 
 func TestApplyChanges_LoadErrorPropagates(t *testing.T) {
-	// Valid change, but the config file does not exist -> load error surfaces.
-	missing := filepath.Join(t.TempDir(), "absent.toml")
-	if err := ApplyChanges(missing, map[string]string{"logging.level": "info"}); err == nil {
-		t.Error("expected a load error for a missing config file")
+	// Valid change, but the config file is present and malformed -> the parse
+	// error surfaces. (A MISSING file is not an error: it is create-on-save, see
+	// TestApplyChanges_CreatesConfigWhenAbsent.)
+	path := filepath.Join(t.TempDir(), "malformed.toml")
+	if err := os.WriteFile(path, []byte("this is = not [valid toml"), 0o600); err != nil {
+		t.Fatalf("write malformed fixture: %v", err)
+	}
+	if err := ApplyChanges(path, map[string]string{"logging.level": "info"}); err == nil {
+		t.Error("expected a parse error for a malformed config file")
 	}
 }

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -21,6 +21,13 @@ import (
 func LoadDocument(path string) (*tomledit.Document, error) {
 	f, err := os.Open(path) //nolint:gosec // G304: path is the operator's own config file, resolved by the app, not attacker-controlled
 	if err != nil {
+		// A missing config file is not an error on the write path: operators may
+		// save settings before any config.toml exists. Treat it as an empty
+		// document (create-on-save), mirroring SetValue's create-on-absent-section
+		// behavior and WriteAtomic's ErrNotExist tolerance for the .bak step.
+		if errors.Is(err, os.ErrNotExist) {
+			return &tomledit.Document{}, nil
+		}
 		return nil, fmt.Errorf("config: open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
@@ -154,7 +161,12 @@ func WriteAtomic(path string, doc *tomledit.Document) error {
 
 	// Mirror the original file's mode and keep a single .bak of the prior
 	// content. Reading the original up front means a failure here aborts before
-	// the rename, leaving the live file untouched.
+	// the rename, leaving the live file untouched. The .bak is a transient
+	// crash-safety copy for the write window only: it is purged once the new
+	// config is durably in place (see below), so no lingering plaintext copy of
+	// a file-resident secret (server.webhook_api_keys) survives the write (#290).
+	bakPath := path + ".bak"
+	wroteBak := false
 	mode := os.FileMode(0o600)
 	orig, err := os.ReadFile(path) //nolint:gosec // G304: operator's own config file
 	switch {
@@ -162,9 +174,10 @@ func WriteAtomic(path string, doc *tomledit.Document) error {
 		if fi, statErr := os.Stat(path); statErr == nil {
 			mode = fi.Mode()
 		}
-		if err := os.WriteFile(path+".bak", orig, mode); err != nil { //nolint:gosec // G304: .bak sits beside the operator's own config file; path is app-resolved, not attacker-controlled
+		if err := os.WriteFile(bakPath, orig, mode); err != nil { //nolint:gosec // G304: .bak sits beside the operator's own config file; path is app-resolved, not attacker-controlled
 			return fmt.Errorf("config: write backup: %w", err)
 		}
+		wroteBak = true
 	case errors.Is(err, os.ErrNotExist):
 		// First write: there is nothing to back up.
 	default:
@@ -185,6 +198,13 @@ func WriteAtomic(path string, doc *tomledit.Document) error {
 	if d, err := os.Open(dir); err == nil { //nolint:gosec // G304: dir is filepath.Dir of the operator's own config path
 		_ = d.Sync()
 		_ = d.Close()
+	}
+	// The new config is durably in place; the .bak has served its crash-safety
+	// purpose for this write window. Purge it so no lingering plaintext copy of
+	// a file-resident secret remains on disk. Best-effort: a removal failure does
+	// not corrupt the (already-renamed) config, so it must not fail the write.
+	if wroteBak {
+		_ = os.Remove(bakPath)
 	}
 	return nil
 }

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -120,9 +120,12 @@ func TestWriterRoundTrip_AllTypes(t *testing.T) {
 	}
 }
 
-// TestWriteAtomic_KeepsBackupAndIsAtomic verifies a .bak of the prior file is
-// kept and the write replaces the original.
-func TestWriteAtomic_KeepsBackup(t *testing.T) {
+// TestWriteAtomic_PurgesBackupAfterSuccess verifies that a successful write
+// replaces the original and leaves NO lingering .bak on disk. The .bak is a
+// transient crash-safety copy for the write window only; keeping it would
+// leak a plaintext copy of a file-resident secret (server.webhook_api_keys)
+// after the write completes (#290).
+func TestWriteAtomic_PurgesBackupAfterSuccess(t *testing.T) {
 	path := writeTempConfig(t)
 	doc, err := LoadDocument(path)
 	if err != nil {
@@ -134,11 +137,85 @@ func TestWriteAtomic_KeepsBackup(t *testing.T) {
 	if err := WriteAtomic(path, doc); err != nil {
 		t.Fatalf("WriteAtomic: %v", err)
 	}
-	bak, err := os.ReadFile(path + ".bak")
+	// The new content is in place...
+	got, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read .bak: %v", err)
+		t.Fatalf("re-read config: %v", err)
 	}
-	if string(bak) != roundtripFixture {
-		t.Errorf(".bak is not the prior file content")
+	if !strings.Contains(string(got), `level = "warn"`) {
+		t.Errorf("write did not replace the original; got:\n%s", got)
+	}
+	// ...and the .bak is gone.
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("expected .bak to be purged after a successful write, stat err = %v", err)
+	}
+}
+
+// TestWriteAtomic_FailedWriteLeavesOriginalIntact verifies the crash-safety
+// guarantee: when the write fails (here, the containing directory is not
+// writable so the temp file cannot be created), the original config is left
+// byte-identical and no stray .bak is created. The purge step (#290) never
+// runs on a failed write, so it cannot destroy a recovery copy.
+func TestWriteAtomic_FailedWriteLeavesOriginalIntact(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root bypasses directory write permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(roundtripFixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	doc, err := LoadDocument(path)
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	if err := SetValue(doc, "logging.level", TypeString, "warn"); err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	// Make the directory unwritable so os.CreateTemp (the first mutation) fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) // let t.TempDir clean up
+	if err := WriteAtomic(path, doc); err == nil {
+		t.Fatal("expected WriteAtomic to fail on an unwritable directory")
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore dir perms: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read config: %v", err)
+	}
+	if string(got) != roundtripFixture {
+		t.Errorf("original config was modified by a failed write:\n%s", got)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("a failed write must not leave a .bak, stat err = %v", err)
+	}
+}
+
+// TestApplyChanges_CreatesConfigWhenAbsent verifies the create-on-save path:
+// saving a setting when config.toml does not yet exist creates the file with
+// the change, rather than returning an error (#296). This mirrors the
+// absent-[section] create behavior added in #288.
+func TestApplyChanges_CreatesConfigWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("precondition: config should be absent, stat err = %v", err)
+	}
+	if err := ApplyChanges(path, map[string]string{"logging.level": "debug"}); err != nil {
+		t.Fatalf("ApplyChanges on an absent config: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config was not created: %v", err)
+	}
+	if !strings.Contains(string(got), `level = "debug"`) {
+		t.Errorf("created config missing the saved change:\n%s", got)
+	}
+	// First write: nothing to back up, so no .bak should exist either.
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("expected no .bak after a create-on-save write, stat err = %v", err)
 	}
 }


### PR DESCRIPTION
## What

Two bundled `internal/config/writer.go` hardenings surfaced during the #288 settings-write work:

- **#290 — purge the `.bak` after a successful atomic write.** `WriteAtomic` keeps a `path + ".bak"` recovery copy for crash safety. When a file-resident secret is present (`server.webhook_api_keys`; `api.token` lives in the encrypted store, not TOML), that `.bak` lingered as plaintext on disk after the write completed. Now the `.bak` is removed once the new config is durably in place (temp fsync'd, atomic rename, dir fsync), so no lingering plaintext-secret copy survives. The `.bak` still exists as a transient 0600 same-dir recovery copy **during** the write window; removal is best-effort and only runs on the success path (a failed write never reaches the purge, so it can never destroy a recovery copy).
- **#296 — tolerate an absent `config.toml` on save.** `LoadDocument` now treats `os.ErrNotExist` as an empty document (create-on-save) instead of returning a 500, consistent with the absent-`[section]` create behavior from #288 and `WriteAtomic`'s existing ENOENT tolerance. Other `os.Open` errors still propagate.

Out of scope (tracked elsewhere): routing secrets to the encrypted store (#300); a single-writer lock around concurrent `ApplyChanges` (belongs in the #288 handler layer).

## Test plan

- New + updated tests (env-independent, temp dirs only): `.bak` is gone after a successful write; a failed write leaves the original byte-identical with no stray `.bak`; `ApplyChanges` creates the file when absent; `LoadDocument` returns an empty doc for a missing file; non-ErrNotExist load errors still propagate.
- `make gate` green (build, race tests, golangci-lint 0 issues, actionlint, govulncheck, codecov dry-run). Measured patch coverage `internal/config/writer.go` **92.9%** (threshold 70).
- Independent hostile review hand-traced every crash sequence (power-loss before/between rename, fsync, purge): no crash-safety regression, no secret survives the purge, no error-masking, new-file perms 0600.

Two LOW test-completeness gaps were noted and intentionally deferred (trivially-correct, hard-to-reach error branches whose only deterministic trigger would require adding fault-injection seams to this security-critical file): a mid-write-failure-after-`.bak`-written variant, and the `.bak`-write error line.

Closes #290
Closes #296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config file handling to automatically create configuration files when they don't exist (create-on-save behavior).
  * Cleaned up temporary backup files after successful configuration writes for a tidier file system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->