### PR TITLE
feat(musixmatch): self-tuning adaptive request cooldown (#326)

### DIFF
--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -20,6 +20,17 @@ import (
 
 const apiURL = "https://apic-desktop.musixmatch.com/ws/1.1/macro.subtitles.get"
 
+const (
+	// adaptiveMaxLevel caps the adaptive ratcheting level. The effective request
+	// interval is minInterval << adaptiveLevel, so a max level of 3 yields a
+	// maximum multiplier of 1 << 3 = 8x the configured cooldown floor.
+	adaptiveMaxLevel = 3
+	// adaptiveSuccessThreshold is the number of consecutive successful fetches
+	// required before the adaptive level steps down by one. Requiring a sustained
+	// clean streak prevents premature recovery that would restart the sawtooth.
+	adaptiveSuccessThreshold = 5
+)
+
 // Sentinel errors returned by the Musixmatch client. Callers should use
 // errors.Is to test for these classes rather than string-matching the message.
 var (
@@ -97,6 +108,14 @@ type Client struct {
 	lastRequest time.Time
 	now         func() time.Time
 	sleep       func(ctx context.Context, d time.Duration) bool
+
+	// Adaptive pacing state, guarded by mu. adaptiveLevel ratchets the effective
+	// request interval: effectiveMultiplier = 1 << adaptiveLevel (so level 0 ==
+	// 1x, the configured floor). It rises on throttle notifications and only
+	// falls after a sustained success streak, so it persists across circuit
+	// recovery cycles (the breaker's trip count is deliberately NOT used).
+	adaptiveLevel        int
+	consecutiveSuccesses int
 }
 
 // NewClient creates a new Musixmatch API client.
@@ -158,7 +177,14 @@ func (c *Client) pace(ctx context.Context) error {
 	for {
 		c.mu.Lock()
 		now := c.now()
-		wait := c.minInterval - now.Sub(c.lastRequest)
+		// Adaptive interval: minInterval scaled by the current ratcheting level.
+		// minInterval is the floor (level 0 == 1x), keeping api.cooldown as the
+		// explicit override the operator configured.
+		adaptiveLevel := c.adaptiveLevel
+		effectiveMultiplier := 1 << adaptiveLevel
+		baseInterval := c.minInterval
+		effectiveInterval := baseInterval * time.Duration(effectiveMultiplier)
+		wait := effectiveInterval - now.Sub(c.lastRequest)
 		if wait <= 0 {
 			c.lastRequest = now
 			c.mu.Unlock()
@@ -166,10 +192,48 @@ func (c *Client) pace(ctx context.Context) error {
 		}
 		c.mu.Unlock()
 
+		if adaptiveLevel > 0 {
+			slog.Debug("musixmatch pacer: adaptive interval in effect",
+				"level", adaptiveLevel, "multiplier", effectiveMultiplier,
+				"effective_interval", effectiveInterval, "base_interval", baseInterval)
+		}
+
 		slog.Debug("musixmatch pacer: waiting before next request", "wait", wait)
 		if !c.sleep(ctx, wait) {
 			return fmt.Errorf("musixmatch: pace: %w", ctx.Err())
 		}
+	}
+}
+
+// OnThrottle implements the providers.AdaptivePacer interface. It raises the
+// adaptive ratcheting level by one (capped at adaptiveMaxLevel), increasing the
+// effective request interval, and resets the consecutive-success counter. It
+// takes no parameter: the level is maintained independently of the circuit
+// breaker's trip count so it persists across circuit recovery cycles (using the
+// breaker's trips would snap the multiplier back to 1x on every recovery, the
+// exact sawtooth this fixes).
+func (c *Client) OnThrottle() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.adaptiveLevel < adaptiveMaxLevel {
+		c.adaptiveLevel++
+	}
+	c.consecutiveSuccesses = 0
+}
+
+// OnSuccess implements the providers.AdaptivePacer interface. It records a
+// successful fetch; once consecutiveSuccesses reaches adaptiveSuccessThreshold
+// it steps the adaptive level down by one (floored at 0) and resets the
+// counter, gradually easing the effective interval back toward the floor.
+func (c *Client) OnSuccess() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consecutiveSuccesses++
+	if c.consecutiveSuccesses >= adaptiveSuccessThreshold {
+		if c.adaptiveLevel > 0 {
+			c.adaptiveLevel--
+		}
+		c.consecutiveSuccesses = 0
 	}
 }
 

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -268,3 +268,203 @@ func TestCtxSleepReturnsFalseOnCancel(t *testing.T) {
 		t.Fatal("ctxSleep returned true on already-canceled ctx; want false")
 	}
 }
+
+// readAdaptiveLevel returns the client's adaptive level under the mutex.
+func readAdaptiveLevel(c *Client) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.adaptiveLevel
+}
+
+// readConsecutiveSuccesses returns the success counter under the mutex.
+func readConsecutiveSuccesses(c *Client) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.consecutiveSuccesses
+}
+
+func TestOnThrottleRatchetsToCap(t *testing.T) {
+	c := NewClient("token")
+	if got := readAdaptiveLevel(c); got != 0 {
+		t.Fatalf("initial level = %d; want 0", got)
+	}
+	want := []int{1, 2, 3, 3, 3} // 0->1->2->3, then stays capped at adaptiveMaxLevel
+	for i, w := range want {
+		c.OnThrottle()
+		if got := readAdaptiveLevel(c); got != w {
+			t.Fatalf("after OnThrottle call %d: level = %d; want %d", i+1, got, w)
+		}
+	}
+	if adaptiveMaxLevel != 3 {
+		t.Fatalf("adaptiveMaxLevel = %d; test assumes 3", adaptiveMaxLevel)
+	}
+}
+
+func TestOnThrottleIndependentOfTripCount(t *testing.T) {
+	// The pacer takes no trip-count parameter: each OnThrottle increments by
+	// exactly one regardless of any external counter. Verify monotonic +1 steps.
+	c := NewClient("token")
+	c.OnThrottle()
+	c.OnThrottle()
+	if got := readAdaptiveLevel(c); got != 2 {
+		t.Fatalf("level after two throttles = %d; want 2 (one step each)", got)
+	}
+}
+
+func TestOnSuccessStepsDownAfterThreshold(t *testing.T) {
+	c := NewClient("token")
+	// Ratchet up to level 2.
+	c.OnThrottle()
+	c.OnThrottle()
+	if got := readAdaptiveLevel(c); got != 2 {
+		t.Fatalf("level = %d; want 2", got)
+	}
+	// Below threshold: no step-down yet.
+	for i := 0; i < adaptiveSuccessThreshold-1; i++ {
+		c.OnSuccess()
+		if got := readAdaptiveLevel(c); got != 2 {
+			t.Fatalf("after %d successes: level = %d; want 2 (below threshold)", i+1, got)
+		}
+	}
+	// The threshold-th success steps the level down by one and resets the counter.
+	c.OnSuccess()
+	if got := readAdaptiveLevel(c); got != 1 {
+		t.Fatalf("after threshold successes: level = %d; want 1", got)
+	}
+	if got := readConsecutiveSuccesses(c); got != 0 {
+		t.Fatalf("success counter = %d after step-down; want 0", got)
+	}
+}
+
+func TestOnSuccessFlooredAtZero(t *testing.T) {
+	c := NewClient("token")
+	// No throttles: level is 0. A full streak must not drive it negative.
+	for i := 0; i < adaptiveSuccessThreshold; i++ {
+		c.OnSuccess()
+	}
+	if got := readAdaptiveLevel(c); got != 0 {
+		t.Fatalf("level = %d after streak at floor; want 0", got)
+	}
+}
+
+func TestOnThrottleResetsSuccessCounter(t *testing.T) {
+	c := NewClient("token")
+	c.OnThrottle() // level 1
+	// Accumulate a partial streak below the threshold.
+	c.OnSuccess()
+	c.OnSuccess()
+	if got := readConsecutiveSuccesses(c); got != 2 {
+		t.Fatalf("success counter = %d; want 2", got)
+	}
+	// A throttle mid-streak resets the success counter.
+	c.OnThrottle()
+	if got := readConsecutiveSuccesses(c); got != 0 {
+		t.Fatalf("success counter = %d after throttle; want 0", got)
+	}
+	if got := readAdaptiveLevel(c); got != 2 {
+		t.Fatalf("level = %d after second throttle; want 2", got)
+	}
+}
+
+func TestPaceUsesAdaptiveInterval(t *testing.T) {
+	minInterval := 10 * time.Second
+	base := time.Unix(1000, 0)
+	var mu sync.Mutex
+	fakeNow := base
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	var gotSleep time.Duration
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		gotSleep = d
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+	ctx := context.Background()
+
+	// Ratchet to level 2 => effective interval = minInterval * (1 << 2) = 40s.
+	c.OnThrottle()
+	c.OnThrottle()
+
+	// First call sets lastRequest (huge elapsed, no sleep).
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if gotSleep != 0 {
+		t.Fatalf("first call slept %v; want 0", gotSleep)
+	}
+	// Second call at the same simulated instant must wait the derived interval.
+	if _, err := c.FindLyrics(ctx, track); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	wantWait := minInterval * time.Duration(1<<2)
+	if gotSleep != wantWait {
+		t.Fatalf("adaptive sleep = %v; want %v (minInterval * 1<<level)", gotSleep, wantWait)
+	}
+}
+
+func TestAdaptiveLevelPersistsAcrossRecovery(t *testing.T) {
+	// Simulate a circuit recovery cycle: throttle, then some (sub-threshold)
+	// successes as the breaker recovers, then another throttle. The level must
+	// NOT have reset to base on recovery -- it persists and ratchets further.
+	c := NewClient("token")
+	c.OnThrottle() // level 1
+	c.OnThrottle() // level 2
+	// Breaker recovers; a few successes arrive but not enough to step down.
+	for i := 0; i < adaptiveSuccessThreshold-1; i++ {
+		c.OnSuccess()
+	}
+	if got := readAdaptiveLevel(c); got != 2 {
+		t.Fatalf("level dropped during recovery = %d; want 2 (must persist)", got)
+	}
+	// IP throttles again: level keeps ratcheting from where it was, not from 0.
+	c.OnThrottle()
+	if got := readAdaptiveLevel(c); got != 3 {
+		t.Fatalf("level after re-throttle = %d; want 3 (ratchets from persisted 2)", got)
+	}
+}
+
+func TestAdaptiveStateConcurrencySafe(t *testing.T) {
+	// Hammer OnThrottle/OnSuccess/pace concurrently; the mutex must serialize all
+	// adaptive-state access. Run under -race to catch data races.
+	base := time.Unix(3000, 0)
+	var mu sync.Mutex
+	fakeNow := base
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+	c := newPacerTestClient(time.Nanosecond, nowFn, sleepFn)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				c.OnThrottle()
+				c.OnSuccess()
+				_ = c.pace(context.Background())
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := readAdaptiveLevel(c); got < 0 || got > adaptiveMaxLevel {
+		t.Fatalf("level = %d out of bounds [0,%d]", got, adaptiveMaxLevel)
+	}
+}

--- a/internal/orchestrator/lane.go
+++ b/internal/orchestrator/lane.go
@@ -76,7 +76,27 @@ func (l *Lane) FindLyrics(ctx context.Context, track models.Track) (models.Song,
 	if l.breaker.RecordSuccess() {
 		slog.Info("lane circuit closed; provider recovered", "provider", l.Name())
 	}
+	// Notify the adaptive pacer of a genuine lyric retrieval only. Benign misses
+	// are handled in classify and intentionally do not stabilize the pacer: they
+	// are successful HTTP round-trips but not catalog hits.
+	l.notifySuccess()
 	return song, nil
+}
+
+// notifyThrottle forwards a throttle notification to the provider when it
+// implements providers.AdaptivePacer; it is a no-op otherwise.
+func (l *Lane) notifyThrottle() {
+	if ap, ok := l.provider.(providers.AdaptivePacer); ok {
+		ap.OnThrottle()
+	}
+}
+
+// notifySuccess forwards a success notification to the provider when it
+// implements providers.AdaptivePacer; it is a no-op otherwise.
+func (l *Lane) notifySuccess() {
+	if ap, ok := l.provider.(providers.AdaptivePacer); ok {
+		ap.OnSuccess()
+	}
 }
 
 // classify drives the breaker for an error outcome and returns the error
@@ -111,6 +131,14 @@ func (l *Lane) classify(err error) error {
 		default:
 			slog.Warn("lane circuit opened: no successful fetch yet this session; verify your token",
 				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		}
+		// Ratchet the adaptive pacer only on throttle-attributable trips. A
+		// truncated response is always a throttle signal; a 401 AFTER the token has
+		// succeeded this session (EverSucceeded) is an egress-IP throttle. The
+		// remaining case -- no successful fetch yet this session -- is a bad/expired
+		// token, not a throttle, so it must not advance the pacer.
+		if errors.Is(err, musixmatch.ErrTruncatedResponse) || l.breaker.EverSucceeded() {
+			l.notifyThrottle()
 		}
 		return err
 	}

--- a/internal/orchestrator/lane.go
+++ b/internal/orchestrator/lane.go
@@ -132,12 +132,13 @@ func (l *Lane) classify(err error) error {
 			slog.Warn("lane circuit opened: no successful fetch yet this session; verify your token",
 				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
 		}
-		// Ratchet the adaptive pacer only on throttle-attributable trips. A
-		// truncated response is always a throttle signal; a 401 AFTER the token has
-		// succeeded this session (EverSucceeded) is an egress-IP throttle. The
-		// remaining case -- no successful fetch yet this session -- is a bad/expired
-		// token, not a throttle, so it must not advance the pacer.
-		if errors.Is(err, musixmatch.ErrTruncatedResponse) || l.breaker.EverSucceeded() {
+		// Ratchet the adaptive pacer only on genuine throttle signals: a rate-limit
+		// or truncated response is ALWAYS throttling; a 401 is throttling only AFTER
+		// the token has succeeded this session (before that it's a bad token, not a
+		// throttle). Never ratchet on a never-succeeded 401.
+		if errors.Is(err, musixmatch.ErrRateLimited) ||
+			errors.Is(err, musixmatch.ErrTruncatedResponse) ||
+			(errors.Is(err, musixmatch.ErrUnauthorized) && l.breaker.EverSucceeded()) {
 			l.notifyThrottle()
 		}
 		return err

--- a/internal/orchestrator/lane_test.go
+++ b/internal/orchestrator/lane_test.go
@@ -215,3 +215,179 @@ func TestLaneRecoveryLogsOnHalfOpenSuccess(t *testing.T) {
 		t.Fatalf("breaker state after recovery = %v; want closed", cb.Allow())
 	}
 }
+
+// adaptiveStubProvider implements both providers.LyricsProvider and
+// providers.AdaptivePacer, recording the adaptive notifications it receives so
+// tests can assert the Lane wiring drives it correctly.
+type adaptiveStubProvider struct {
+	name       string
+	song       models.Song
+	err        error
+	throttles  int
+	successes  int
+	pacerLevel int // mock ratchet: +1 per throttle (capped at 3), tracks independence
+}
+
+func (p *adaptiveStubProvider) Name() string { return p.name }
+func (p *adaptiveStubProvider) FindLyrics(context.Context, models.Track) (models.Song, error) {
+	if p.err != nil {
+		return models.Song{}, p.err
+	}
+	return p.song, nil
+}
+func (p *adaptiveStubProvider) OnThrottle() {
+	p.throttles++
+	if p.pacerLevel < 3 {
+		p.pacerLevel++
+	}
+}
+func (p *adaptiveStubProvider) OnSuccess() { p.successes++ }
+
+func TestLaneCallsOnThrottleOnTripAfterSuccess(t *testing.T) {
+	// A 401 AFTER the token has succeeded this session is an egress-IP throttle:
+	// the pacer must ratchet.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	cb.RecordSuccess()
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized", err)
+	}
+	if p.throttles != 1 {
+		t.Fatalf("OnThrottle calls = %d; want 1 (throttle after a prior success)", p.throttles)
+	}
+	if p.successes != 0 {
+		t.Fatalf("OnSuccess calls = %d; want 0 on a throttle trip", p.successes)
+	}
+}
+
+func TestLaneCallsOnThrottleOnTruncated(t *testing.T) {
+	// A truncated response is always a throttle signal, even with no prior
+	// success this session: the pacer must ratchet.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrTruncatedResponse) {
+		t.Fatalf("err = %v; want ErrTruncatedResponse", err)
+	}
+	if p.throttles != 1 {
+		t.Fatalf("OnThrottle calls = %d; want 1 (truncated response is always a throttle)", p.throttles)
+	}
+}
+
+func TestLaneNoOnThrottleOnBadTokenNeverSucceeded(t *testing.T) {
+	// A bare 401 with NO successful fetch yet this session is a bad/expired token,
+	// not a throttle: the pacer must NOT ratchet. Slowing requests cannot fix a
+	// bad token.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized", err)
+	}
+	if cb.EverSucceeded() {
+		t.Fatal("precondition: breaker must report !EverSucceeded for this case")
+	}
+	if p.throttles != 0 {
+		t.Fatalf("OnThrottle calls = %d; want 0 (bad token, never succeeded, is not a throttle)", p.throttles)
+	}
+}
+
+func TestLaneNoOnThrottleOnRenewal(t *testing.T) {
+	// A token-renewal trip is not an IP throttle: slowing requests cannot fix an
+	// expired token, so the pacer must NOT ratchet -- even after a prior success.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	cb.RecordSuccess()
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrTokenRenewalRequired) {
+		t.Fatalf("err = %v; want ErrTokenRenewalRequired", err)
+	}
+	if p.throttles != 0 {
+		t.Fatalf("OnThrottle calls = %d; want 0 (token renewal is not a throttle)", p.throttles)
+	}
+}
+
+func TestLaneCallsOnSuccessOnFetch(t *testing.T) {
+	p := &adaptiveStubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "ok"}}}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+
+	if _, err := l.FindLyrics(context.Background(), models.Track{}); err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if p.successes != 1 {
+		t.Fatalf("OnSuccess calls = %d; want 1 on a successful fetch", p.successes)
+	}
+	if p.throttles != 0 {
+		t.Fatalf("OnThrottle calls = %d; want 0 on success", p.throttles)
+	}
+}
+
+func TestLaneNoOnSuccessOnBenignMiss(t *testing.T) {
+	// A benign miss is a successful round-trip but not a catalog hit; the pacer
+	// must not be stabilized by it.
+	p := &adaptiveStubProvider{name: "musixmatch", err: musixmatch.ErrNotFound}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound", err)
+	}
+	if p.successes != 0 {
+		t.Fatalf("OnSuccess calls = %d; want 0 on a benign miss", p.successes)
+	}
+	if p.throttles != 0 {
+		t.Fatalf("OnThrottle calls = %d; want 0 on a benign miss", p.throttles)
+	}
+}
+
+func TestLaneBackwardCompatNonAdaptiveProvider(t *testing.T) {
+	// A provider that implements only LyricsProvider must drive the Lane fine; no
+	// adaptive notifications are attempted (the type assertion simply fails).
+	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+	if _, err := l.FindLyrics(context.Background(), models.Track{}); !errors.Is(err, musixmatch.ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized", err)
+	}
+	// Also exercise the success path on a non-adaptive provider.
+	ok := &stubProvider{name: "musixmatch", song: models.Song{Lyrics: models.Lyrics{LyricsBody: "ok"}}}
+	l2 := NewLane(ok, circuit.New(60*time.Second, 30*time.Minute))
+	if _, err := l2.FindLyrics(context.Background(), models.Track{}); err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+}
+
+func TestLaneMultipleThrottlesRatchetMock(t *testing.T) {
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrUnauthorized)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	cb.RecordSuccess() // a 401 after a prior success this session is an egress-IP throttle
+	l := NewLane(p, cb)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+
+	// Drive several throttle trips; the mock's level ratchets +1 each, capped at 3,
+	// independent of the breaker's own trip count.
+	for i := 0; i < 5; i++ {
+		// Advance past the window each round so the breaker re-trips rather than
+		// short-circuiting on an open gate.
+		cb.SetClock(func() time.Time { return fixed.Add(time.Duration(i) * time.Hour) })
+		_, _ = l.FindLyrics(context.Background(), models.Track{})
+	}
+	if p.throttles != 5 {
+		t.Fatalf("OnThrottle calls = %d; want 5", p.throttles)
+	}
+	if p.pacerLevel != 3 {
+		t.Fatalf("mock pacer level = %d; want 3 (ratchets capped, independent of trip count)", p.pacerLevel)
+	}
+}

--- a/internal/orchestrator/lane_test.go
+++ b/internal/orchestrator/lane_test.go
@@ -263,6 +263,42 @@ func TestLaneCallsOnThrottleOnTripAfterSuccess(t *testing.T) {
 	}
 }
 
+func TestLaneCallsOnThrottleOnRateLimitNoPriorSuccess(t *testing.T) {
+	// A rate-limit is ALWAYS a throttle signal: the pacer must ratchet even with
+	// no successful fetch yet this session.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrRateLimited)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited", err)
+	}
+	if cb.EverSucceeded() {
+		t.Fatal("precondition: breaker must report !EverSucceeded for this case")
+	}
+	if p.throttles != 1 {
+		t.Fatalf("OnThrottle calls = %d; want 1 (rate-limit is always a throttle, even with no prior success)", p.throttles)
+	}
+}
+
+func TestLaneCallsOnThrottleOnRateLimitAfterSuccess(t *testing.T) {
+	// A rate-limit AFTER a prior success is likewise a throttle: the pacer must
+	// ratchet.
+	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrRateLimited)}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	cb.RecordSuccess()
+	l := NewLane(p, cb)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited", err)
+	}
+	if p.throttles != 1 {
+		t.Fatalf("OnThrottle calls = %d; want 1 (rate-limit after a prior success is a throttle)", p.throttles)
+	}
+}
+
 func TestLaneCallsOnThrottleOnTruncated(t *testing.T) {
 	// A truncated response is always a throttle signal, even with no prior
 	// success this session: the pacer must ratchet.

--- a/internal/providers/adaptive.go
+++ b/internal/providers/adaptive.go
@@ -1,0 +1,27 @@
+package providers
+
+// AdaptivePacer is an optional interface a provider (or its underlying fetcher)
+// may implement to receive throttle and success notifications from the
+// orchestration layer. It lets the provider self-tune its effective request
+// interval to whatever the egress IP's throttle threshold turns out to be,
+// instead of relying on a hand-tuned static cooldown.
+//
+// The interface is optional: callers must use a type assertion to check for
+// support before invoking these methods. A provider that does not implement
+// AdaptivePacer simply receives no notifications.
+type AdaptivePacer interface {
+	// OnThrottle notifies the pacer that a throttle-attributable failure
+	// occurred (e.g. a circuit trip on a 401 egress-IP throttle). It takes no
+	// parameter on purpose: the pacer maintains its OWN ratcheting level that is
+	// independent of the circuit breaker's trip count. Passing the breaker's
+	// trip count instead would snap the multiplier back to 1x on every circuit
+	// recovery (trips reset when the breaker closes), which is the exact
+	// sawtooth bug this adaptive pacing fixes. The pacer's level only steps down
+	// after a sustained clean streak (see OnSuccess).
+	OnThrottle()
+
+	// OnSuccess notifies the pacer that a genuine lyric fetch succeeded. After a
+	// sustained streak of successes the pacer eases its effective interval back
+	// down by one step.
+	OnSuccess()
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -46,6 +46,23 @@ func (p namedProvider) FindLyrics(ctx context.Context, track models.Track) (mode
 	return p.fetcher.FindLyrics(ctx, track)
 }
 
+// OnThrottle forwards a throttle notification to the underlying fetcher when it
+// implements AdaptivePacer. It is a no-op for fetchers that do not, so the
+// wrapper itself always satisfies AdaptivePacer regardless of the inner type.
+func (p namedProvider) OnThrottle() {
+	if ap, ok := p.fetcher.(AdaptivePacer); ok {
+		ap.OnThrottle()
+	}
+}
+
+// OnSuccess forwards a success notification to the underlying fetcher when it
+// implements AdaptivePacer; it is a no-op otherwise.
+func (p namedProvider) OnSuccess() {
+	if ap, ok := p.fetcher.(AdaptivePacer); ok {
+		ap.OnSuccess()
+	}
+}
+
 // Select chooses the configured provider from the available candidates.
 func Select(primary string, disabled []string, candidates ...LyricsProvider) (LyricsProvider, error) {
 	primary = NormalizeName(primary)

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -63,3 +63,47 @@ func TestIsKnown(t *testing.T) {
 		}
 	}
 }
+
+// adaptiveFetcher implements both Fetcher and AdaptivePacer to verify the
+// namedProvider wrapper forwards adaptive notifications to the inner fetcher.
+type adaptiveFetcher struct {
+	throttles int
+	successes int
+}
+
+func (a *adaptiveFetcher) FindLyrics(context.Context, models.Track) (models.Song, error) {
+	return models.Song{}, nil
+}
+func (a *adaptiveFetcher) OnThrottle() { a.throttles++ }
+func (a *adaptiveFetcher) OnSuccess()  { a.successes++ }
+
+func TestNamedProviderForwardsAdaptivePacer(t *testing.T) {
+	af := &adaptiveFetcher{}
+	p := New(Musixmatch, af)
+
+	ap, ok := p.(AdaptivePacer)
+	if !ok {
+		t.Fatal("namedProvider does not satisfy AdaptivePacer")
+	}
+	ap.OnThrottle()
+	ap.OnThrottle()
+	ap.OnSuccess()
+	if af.throttles != 2 {
+		t.Fatalf("forwarded throttles = %d; want 2", af.throttles)
+	}
+	if af.successes != 1 {
+		t.Fatalf("forwarded successes = %d; want 1", af.successes)
+	}
+}
+
+func TestNamedProviderAdaptiveNoopForPlainFetcher(t *testing.T) {
+	// A fetcher without AdaptivePacer: the wrapper's methods must be safe no-ops.
+	p := New(Musixmatch, fakeFetcher{})
+	ap, ok := p.(AdaptivePacer)
+	if !ok {
+		t.Fatal("namedProvider should always satisfy AdaptivePacer")
+	}
+	// Must not panic even though the inner fetcher does not implement the iface.
+	ap.OnThrottle()
+	ap.OnSuccess()
+}


### PR DESCRIPTION
## What

Closes #326. Self-tuning adaptive request cooldown for the Musixmatch provider.

Musixmatch throttles by **egress IP**. A fixed `api.cooldown` set too low for a given IP runs a relentless sawtooth: fetch → `401` "IP throttled" → circuit opens (1m→2m→4m) → recovers → **resumes at the same cooldown** → trips again (~25-30% duty cycle observed on prod at 15s/30s). The operator otherwise has to *know* the magic value by hand.

## How

- New optional `providers.AdaptivePacer` interface (`OnThrottle()` / `OnSuccess()`), forwarded through the `namedProvider` wrapper via type assertion (a no-op for providers that don't implement it).
- `musixmatch.Client` keeps an independent `adaptiveLevel` (0..3) under its existing mutex; the effective request interval is `minInterval * (1 << adaptiveLevel)` — up to **8×**. `api.cooldown` stays the floor.
- **The level is decoupled from the circuit breaker's `trips`** so it persists across circuit recovery. (Deriving it from `trips` — which resets on recovery — would snap the interval back to 1× every cycle and restart the sawtooth. That was the original plan's flaw, caught in plan review.)
- The Lane ratchets **only on throttle-attributable trips**: a truncated response, or a `401`/rate-limit *after* the token has succeeded this session (`EverSucceeded()`). It does **not** ratchet on token-renewal or never-succeeded bad-token trips — slowing requests can't fix a bad/expired token, and that's not the IP throttle this targets.
- The level steps down one notch after **5 consecutive successful** fetches (sustained clean streak), so it eases back as the IP recovers.

Cap (8×) and success threshold (5) are hardcoded constants for now; can be made configurable in a follow-up if operators need tuning.

## Testing

- `make gate` green; **patch coverage 100%** (49/49 executable lines: client 27, lane, providers). golangci-lint 0 issues, govulncheck clean.
- Tests cover: ratchet bounds (0→3 cap, floor at 0), step-down after 5 successes, throttle-counter reset on throttle, **persistence across simulated circuit recovery**, throttle-attribution (truncated + post-success 401 ratchet; renewal + never-succeeded-token do NOT), and **concurrency safety under `-race`**.

## Review notes

- Plan was vetted + steered before implementation (the `trips`-derived-multiplier flaw was corrected in the issue's CR plan).
- Adversarial review found no blockers; its one real finding (ratcheting on bad-token trips) is fixed here (the throttle-attribution gating above).

Prod context: at 60s cooldown the egress IP still throttles persistently, so the 8× headroom (→ 480s) is the range this needs to reach and hold.
