### PR TITLE
harden(serve): add nosniff + baseline CSP security headers (#331)

### DIFF
--- a/internal/server/headers_test.go
+++ b/internal/server/headers_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+)
+
+// TestSecurityHeadersOnEveryResponse confirms the baseline security headers are
+// applied to every serve-mode response, across a JSON API route (/healthz), a
+// UI page route (/login), and a static asset (/static/...). The assertions go
+// through a real Handler.ServeHTTP round-trip rather than calling
+// setSecurityHeaders in isolation, so the load-bearing ordering (headers set
+// before dispatch) is exercised end to end.
+func TestSecurityHeadersOnEveryResponse(t *testing.T) {
+	const wantCSP = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'"
+
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics", WithWebUI(config.Config{}, "vtest"))
+
+	routes := []struct {
+		name string
+		path string
+	}{
+		{"api route", "/healthz"},
+		{"ui route", "/login"},
+		{"static asset", "/static/css/output.css"},
+	}
+
+	for _, tc := range routes {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+			}
+			if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+				t.Errorf("X-Frame-Options = %q, want %q", got, "DENY")
+			}
+			if got := rec.Header().Get("Content-Security-Policy"); got != wantCSP {
+				t.Errorf("Content-Security-Policy = %q, want %q", got, wantCSP)
+			}
+		})
+	}
+}

--- a/internal/server/headers_test.go
+++ b/internal/server/headers_test.go
@@ -15,7 +15,8 @@ import (
 // setSecurityHeaders in isolation, so the load-bearing ordering (headers set
 // before dispatch) is exercised end to end.
 func TestSecurityHeadersOnEveryResponse(t *testing.T) {
-	const wantCSP = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'"
+	// Reference the single authoritative policy, not a duplicated literal.
+	const wantCSP = contentSecurityPolicy
 
 	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics", WithWebUI(config.Config{}, "vtest"))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -327,8 +327,30 @@ func (h *Handler) handleStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// setSecurityHeaders applies a conservative baseline of security headers to
+// every serve-mode response (static assets and pages alike). It must be called
+// before any handler writes a status line or body, otherwise the headers are
+// dropped.
+func setSecurityHeaders(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("X-Frame-Options", "DENY")
+	// 'unsafe-inline' in script-src is required by the dashboard's inline
+	// timezone-rewrite <script> IIFE (web/templates/dashboard.templ), which
+	// runs before paint to localize timestamps. A stricter script-src would
+	// break that page. Future hardening: replace 'unsafe-inline' with a
+	// per-request nonce or a precomputed hash for that one inline block.
+	// There are no inline styles, so style-src stays at 'self'.
+	h.Set("Content-Security-Policy", "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'")
+}
+
 // ServeHTTP logs requests and dispatches them to API routes.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set security headers before dispatch so they are present on every
+	// response, including ones whose handlers write status/body immediately.
+	// statusRecorder embeds w and does not override Header(), so setting on w
+	// is equivalent to setting on rec.
+	setSecurityHeaders(w)
 	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 	h.mux.ServeHTTP(rec, r)
 	slog.Debug("http request", "method", r.Method, "uri", redactURI(r.URL), "status", rec.status) //nolint:gosec // G706: request URI is logged as a structured slog field after apikey redaction; slog escapes values

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -327,6 +327,15 @@ func (h *Handler) handleStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// contentSecurityPolicy is the single authoritative CSP applied to every
+// serve-mode response. 'unsafe-inline' in script-src is required by the
+// dashboard's inline timezone-rewrite <script> IIFE (web/templates/dashboard.templ),
+// which runs before paint to localize timestamps; a stricter script-src would
+// break that page. Future hardening: replace 'unsafe-inline' with a per-request
+// nonce or a precomputed hash for that one inline block. There are no inline
+// styles, so style-src stays at 'self'.
+const contentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'"
+
 // setSecurityHeaders applies a conservative baseline of security headers to
 // every serve-mode response (static assets and pages alike). It must be called
 // before any handler writes a status line or body, otherwise the headers are
@@ -335,13 +344,7 @@ func setSecurityHeaders(w http.ResponseWriter) {
 	h := w.Header()
 	h.Set("X-Content-Type-Options", "nosniff")
 	h.Set("X-Frame-Options", "DENY")
-	// 'unsafe-inline' in script-src is required by the dashboard's inline
-	// timezone-rewrite <script> IIFE (web/templates/dashboard.templ), which
-	// runs before paint to localize timestamps. A stricter script-src would
-	// break that page. Future hardening: replace 'unsafe-inline' with a
-	// per-request nonce or a precomputed hash for that one inline block.
-	// There are no inline styles, so style-src stays at 'self'.
-	h.Set("Content-Security-Policy", "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'")
+	h.Set("Content-Security-Policy", contentSecurityPolicy)
 }
 
 // ServeHTTP logs requests and dispatches them to API routes.


### PR DESCRIPTION
## What

Adds baseline security response headers to every serve-mode response (static assets + pages): `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a fail-closed `Content-Security-Policy`.

## Why

The server set no security headers. nosniff prevents MIME-sniffing of static assets; a `default-src 'none'` CSP with explicit self-scoped allowances limits the blast radius of any injected content.

## How

- New package-level `setSecurityHeaders(w)` in `internal/server/server.go`.
- Called in `Handler.ServeHTTP` **before** `h.mux.ServeHTTP(rec, r)` — ordering is load-bearing (headers must be set before any handler writes status/body). All routes flow through this single chokepoint.
- CSP: `default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'`
- `script-src` keeps `'unsafe-inline'` (with a comment) because the dashboard's inline TZ-rewrite `<script>` IIFE requires it; a stricter policy would break the dashboard. Future-hardening note (nonce/hash) left in the comment. No inline styles exist, so `style-src 'self'` is safe.

## Test plan

- `internal/server/headers_test.go` round-trips a real GET through `Handler.ServeHTTP` for an API route (`/healthz`), a UI route (`/login`), and a static asset (`/static/css/output.css`), asserting all three headers on each.
- `make gate` green (race tests, golangci 0, ui-check, govulncheck).

Closes #331
