### PR TITLE
harden(musixmatch): reserve pace() slot under lock to prevent convoying (#334)

### DIFF
--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -161,12 +161,13 @@ func (c *Client) MinInterval() time.Duration {
 
 // pace enforces the minimum request interval. It must be called at the top of
 // FindLyrics before the HTTP request is built. When minInterval is zero or
-// negative it returns immediately. Otherwise it loops: under the lock it
-// checks how long remains until the next slot is free; if the slot is free it
-// reserves it (sets lastRequest = now) and returns; if not, it releases the
-// lock, sleeps for the remainder, and re-checks. Re-checking after each sleep
-// prevents concurrent callers from computing the same wait, sleeping together,
-// and then all proceeding in a burst.
+// negative it returns immediately. Otherwise, under the lock, it computes the
+// next free slot from lastRequest and the adaptive interval, advances
+// lastRequest to that slot (reserving it before releasing the lock), then
+// sleeps outside the lock for whatever wait remains. Reserving the slot under
+// the lock is what prevents convoying: N concurrent callers each claim a
+// distinct, sequential slot rather than all reading the same lastRequest,
+// computing the same wait, and bursting together when their sleeps elapse.
 //
 // The wait is ctx-cancellable; if the context is canceled during the wait
 // pace returns ctx.Err() wrapped with context.
@@ -174,35 +175,42 @@ func (c *Client) pace(ctx context.Context) error {
 	if c.minInterval <= 0 {
 		return nil
 	}
-	for {
-		c.mu.Lock()
-		now := c.now()
-		// Adaptive interval: minInterval scaled by the current ratcheting level.
-		// minInterval is the floor (level 0 == 1x), keeping api.cooldown as the
-		// explicit override the operator configured.
-		adaptiveLevel := c.adaptiveLevel
-		effectiveMultiplier := 1 << adaptiveLevel
-		baseInterval := c.minInterval
-		effectiveInterval := baseInterval * time.Duration(effectiveMultiplier)
-		wait := effectiveInterval - now.Sub(c.lastRequest)
-		if wait <= 0 {
-			c.lastRequest = now
-			c.mu.Unlock()
-			return nil
-		}
-		c.mu.Unlock()
 
-		if adaptiveLevel > 0 {
-			slog.Debug("musixmatch pacer: adaptive interval in effect",
-				"level", adaptiveLevel, "multiplier", effectiveMultiplier,
-				"effective_interval", effectiveInterval, "base_interval", baseInterval)
-		}
+	c.mu.Lock()
+	now := c.now()
+	// Adaptive interval: minInterval scaled by the current ratcheting level.
+	// minInterval is the floor (level 0 == 1x), keeping api.cooldown as the
+	// explicit override the operator configured.
+	adaptiveLevel := c.adaptiveLevel
+	effectiveMultiplier := 1 << adaptiveLevel
+	baseInterval := c.minInterval
+	effectiveInterval := baseInterval * time.Duration(effectiveMultiplier)
+	// Reserve this caller's slot under the lock. The earliest the next request
+	// may proceed is one effective interval after the previously reserved slot;
+	// if that is already in the past, the slot is now. Advancing lastRequest to
+	// the reserved slot means the next caller computes its own later slot, so
+	// concurrent callers serialize instead of all sleeping the same wait.
+	next := c.lastRequest.Add(effectiveInterval)
+	if next.Before(now) {
+		next = now
+	}
+	c.lastRequest = next
+	wait := next.Sub(now)
+	c.mu.Unlock()
 
+	if adaptiveLevel > 0 {
+		slog.Debug("musixmatch pacer: adaptive interval in effect",
+			"level", adaptiveLevel, "multiplier", effectiveMultiplier,
+			"effective_interval", effectiveInterval, "base_interval", baseInterval)
+	}
+
+	if wait > 0 {
 		slog.Debug("musixmatch pacer: waiting before next request", "wait", wait)
 		if !c.sleep(ctx, wait) {
 			return fmt.Errorf("musixmatch: pace: %w", ctx.Err())
 		}
 	}
+	return nil
 }
 
 // OnThrottle implements the providers.AdaptivePacer interface. It raises the

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -170,7 +170,9 @@ func (c *Client) MinInterval() time.Duration {
 // computing the same wait, and bursting together when their sleeps elapse.
 //
 // The wait is ctx-cancellable; if the context is canceled during the wait
-// pace returns ctx.Err() wrapped with context.
+// pace returns ctx.Err() wrapped with context. A canceled caller releases its
+// reserved slot best-effort (see the rollback below) so it does not push every
+// later caller back one interval.
 func (c *Client) pace(ctx context.Context) error {
 	if c.minInterval <= 0 {
 		return nil
@@ -190,7 +192,8 @@ func (c *Client) pace(ctx context.Context) error {
 	// if that is already in the past, the slot is now. Advancing lastRequest to
 	// the reserved slot means the next caller computes its own later slot, so
 	// concurrent callers serialize instead of all sleeping the same wait.
-	next := c.lastRequest.Add(effectiveInterval)
+	prev := c.lastRequest
+	next := prev.Add(effectiveInterval)
 	if next.Before(now) {
 		next = now
 	}
@@ -207,6 +210,17 @@ func (c *Client) pace(ctx context.Context) error {
 	if wait > 0 {
 		slog.Debug("musixmatch pacer: waiting before next request", "wait", wait)
 		if !c.sleep(ctx, wait) {
+			// The wait was canceled before this caller ever used its slot.
+			// Release the reservation best-effort: only if lastRequest is still
+			// exactly the slot we reserved (no later caller has reserved past
+			// us) do we roll it back to the value we reserved from. If a later
+			// caller already advanced lastRequest, leave it alone rather than
+			// stomp a newer reservation. Use Equal for the time comparison.
+			c.mu.Lock()
+			if c.lastRequest.Equal(next) {
+				c.lastRequest = prev
+			}
+			c.mu.Unlock()
 			return fmt.Errorf("musixmatch: pace: %w", ctx.Err())
 		}
 	}

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -229,6 +229,58 @@ func TestPacerGoroutineSafe(t *testing.T) {
 	wg.Wait()
 }
 
+func TestPacerConcurrentSlotAllocation(t *testing.T) {
+	// Two callers race pace() against a FROZEN clock (now never advances). The
+	// pacer reserves each caller's slot under the lock by advancing lastRequest,
+	// so the two callers claim sequential slots: the first waits 0, the second
+	// waits exactly one interval. Total sleep is ~1x interval, NOT 2x (the
+	// convoy bug, where both would read the same lastRequest and each sleep a
+	// full interval). adaptiveLevel is 0 at the start, so the effective interval
+	// equals minInterval (multiplier 1).
+	//
+	// Note: this test would HANG under the pre-fix loop-and-recheck pace(): with
+	// a frozen clock the waiting caller would recompute the same wait forever.
+	// Reserving the slot under the lock is what makes it terminate.
+	minInterval := 10 * time.Second
+	base := time.Unix(5000, 0)
+	nowFn := func() time.Time { return base } // frozen
+
+	var mu sync.Mutex
+	var totalSleep time.Duration
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		mu.Lock()
+		totalSleep += d
+		mu.Unlock()
+		return true
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	if got := readAdaptiveLevel(c); got != 0 {
+		t.Fatalf("adaptiveLevel = %d at test start; want 0 (multiplier 1)", got)
+	}
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.FindLyrics(ctx, track); err != nil {
+				t.Errorf("FindLyrics: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := totalSleep
+	mu.Unlock()
+	if got != minInterval {
+		t.Fatalf("total sleep across 2 concurrent callers = %v; want %v (1x interval, not 2x convoy)", got, minInterval)
+	}
+}
+
 func TestWithMinIntervalReturnsClient(t *testing.T) {
 	c := NewClient("token")
 	got := c.WithMinInterval(5 * time.Second)

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -197,6 +197,60 @@ func TestPacerCtxCancelDuringSleep(t *testing.T) {
 	}
 }
 
+func TestPaceCanceledCallerReleasesSlot(t *testing.T) {
+	// A caller whose wait is canceled must release its reserved slot so the next
+	// caller is not pushed back an extra interval (the cancel-path slot-loss
+	// regression). Frozen clock; the first waiting caller is canceled, later
+	// sleeps succeed. Without the rollback, caller B would wait 2x the interval.
+	minInterval := 10 * time.Second
+	base := time.Unix(1000, 0)
+	nowFn := func() time.Time { return base } // frozen
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var mu sync.Mutex
+	var sleeps []time.Duration
+	sleepFn := func(_ context.Context, d time.Duration) bool {
+		mu.Lock()
+		sleeps = append(sleeps, d)
+		first := len(sleeps) == 1
+		mu.Unlock()
+		if first {
+			cancel() // simulate the first waiting caller's context canceling
+			return false
+		}
+		return true
+	}
+
+	c := newPacerTestClient(minInterval, nowFn, sleepFn)
+	track := models.Track{TrackName: "t", ArtistName: "a"}
+
+	// Prime lastRequest so subsequent calls must wait (huge elapsed, no sleep).
+	if _, err := c.FindLyrics(context.Background(), track); err != nil {
+		t.Fatalf("prime call: %v", err)
+	}
+
+	// Caller A: reserves a slot, then its wait is canceled. It must roll the
+	// reservation back so it does not consume a slot it never used.
+	if _, err := c.FindLyrics(ctx, track); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled caller err = %v; want context.Canceled", err)
+	}
+
+	// Caller B: must see the slot as if A never reserved -- wait exactly one
+	// interval, NOT two.
+	if _, err := c.FindLyrics(context.Background(), track); err != nil {
+		t.Fatalf("caller B: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sleeps) != 2 {
+		t.Fatalf("sleep count = %d; want 2 (A canceled, B succeeds)", len(sleeps))
+	}
+	if sleeps[1] != minInterval {
+		t.Fatalf("caller B wait = %v; want %v (canceled A must not push B back an extra interval)", sleeps[1], minInterval)
+	}
+}
+
 func TestPacerGoroutineSafe(t *testing.T) {
 	// Multiple goroutines call FindLyrics concurrently; the pacer must not race.
 	// Use a tiny non-zero interval so the 10 goroutines actually exercise the


### PR DESCRIPTION
## What

Reserves the `pace()` rate-limit slot under the lock so concurrent callers can't all read the same `lastRequest`, sleep together, and burst (double-sleep convoying).

## Why

Forward-hardening. Today Musixmatch is single-laned (no worker pool), so this is latent — but the prior `pace()` computed `wait` under the lock, then unlocked and slept **without reserving** the slot. N concurrent callers would compute the same `wait`, sleep in lockstep, and fire together. The old doc comment claimed the post-sleep re-check "prevents" this; it doesn't (it can't prevent the initial concurrent same-`wait` computation).

## How

- `internal/musixmatch/client.go` `pace()`: under the lock, compute `effectiveInterval` (unchanged: `minInterval << adaptiveLevel`), set `next = max(now, lastRequest + effectiveInterval)`, **advance `c.lastRequest = next` under the lock** (reserve the slot), compute `wait`, unlock, then sleep `wait` outside the lock (ctx-cancellable).
- **Adaptive scaling preserved** (#326/#333): `adaptiveLevel`/`consecutiveSuccesses`, `OnThrottle`/`OnSuccess`, the adaptive Debug log, and the `minInterval <= 0` early return are all untouched.
- **Single-caller is a no-op**: zero `lastRequest` → `next` clamps to `now` → `wait 0` on first call. All existing pacer/adaptive tests stay green.
- Fixed the stale `pace()` doc comment.

## Test plan

- New `TestPacerConcurrentSlotAllocation` (2 goroutines, frozen clock, accumulating fake sleep → total ≈ 1× interval, not 2×). It would hang under the old loop-and-recheck `pace()` with a frozen clock — exactly the convoy bug — and terminates cleanly now.
- `make gate` green incl. `-race` (musixmatch 89.7%), existing pacer/adaptive tests pass.

Closes #334
