### PR TITLE
docs: Docker/Unraid web UI enablement walkthrough (#328)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acae
 # The two differ only in how the binary arrives (built here vs copied by goreleaser).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
-      org.opencontainers.image.licenses="GPL-3.0"
+      org.opencontainers.image.licenses="GPL-3.0" \
+      net.unraid.docker.webui="http://[IP]:[PORT:50705]/"
 
 RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
     apk upgrade --no-cache && \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -5,7 +5,8 @@ FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acae
 # The two differ only in how the binary arrives (copied here vs built in the root Dockerfile).
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
-      org.opencontainers.image.licenses="GPL-3.0"
+      org.opencontainers.image.licenses="GPL-3.0" \
+      net.unraid.docker.webui="http://[IP]:[PORT:50705]/"
 
 RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
     apk upgrade --no-cache && \

--- a/config.example.toml
+++ b/config.example.toml
@@ -87,6 +87,12 @@ dir = "lyrics"
 # HTTP listen address for --serve mode.
 addr = "127.0.0.1:3876"
 
+# Enable the browser UI on the serve listener. Off by default; the web routes
+# (including /login and /setup) only mount when this is true. The
+# MXLRC_WEB_UI_ENABLED env var overrides this value. See docs/USER_GUIDE.md
+# "Web UI enablement" for headless admin bootstrap.
+# web_ui_enabled = false
+
 # API keys accepted by webhook endpoints. Generate/store these outside the file
 # when possible; MXLRC_WEBHOOK_API_KEY can also provide one or more comma-separated keys.
 # webhook_api_keys = ["mxlrc_your-webhook-key"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -14,7 +14,8 @@ services:
       # loopback/trusted-CIDR only). Both vars are required; the password must be
       # at least 8 characters. The bootstrap is idempotent (skipped once an admin
       # exists). Rotate the password in the UI and remove these vars after first
-      # login. See docs/USER_GUIDE.md "Web UI enablement".
+      # login. See docs/USER_GUIDE.md "Web UI enablement" for secret-hygiene guidance.
+      # Supply MXLRC_WEBAUTH_ADMIN_PASSWORD from an uncommitted .env file -- never hardcode it here.
       # MXLRC_WEBAUTH_ADMIN_USER: "admin"
       # MXLRC_WEBAUTH_ADMIN_PASSWORD: "${MXLRC_WEBAUTH_ADMIN_PASSWORD}"
       MXLRC_OUTPUT_DIR: "/data/media/music"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,6 +10,13 @@ services:
       MXLRC_SERVER_ADDR: "0.0.0.0:50705"
       # Enable the browser UI (overrides web_ui_enabled in config.toml).
       MXLRC_WEB_UI_ENABLED: "true"
+      # Bootstrap the first web-UI admin on a headless host (the /setup page is
+      # loopback/trusted-CIDR only). Both vars are required; the password must be
+      # at least 8 characters. The bootstrap is idempotent (skipped once an admin
+      # exists). Rotate the password in the UI and remove these vars after first
+      # login. See docs/USER_GUIDE.md "Web UI enablement".
+      # MXLRC_WEBAUTH_ADMIN_USER: "admin"
+      # MXLRC_WEBAUTH_ADMIN_PASSWORD: "${MXLRC_WEBAUTH_ADMIN_PASSWORD}"
       MXLRC_OUTPUT_DIR: "/data/media/music"
       PUID: "99"
       PGID: "100"

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -196,6 +196,8 @@ The browser UI is **off by default**. The serve listener only mounts the web rou
 -e MXLRC_WEBAUTH_ADMIN_PASSWORD=your-strong-password
 ```
 
+**Secret hygiene.** Never hardcode the bootstrap password in a compose file or source control. Supply it from an uncommitted `.env` file or a secret manager using `${MXLRC_WEBAUTH_ADMIN_PASSWORD}` interpolation, as shown in `docker-compose.example.yml`. The binary reads `MXLRC_WEBAUTH_ADMIN_PASSWORD` from the environment variable only - it does not read Docker or Swarm secret files (`/run/secrets/...`) directly. If you store the password as a Docker Secret, export it into the variable in your container entrypoint before the service starts: `export MXLRC_WEBAUTH_ADMIN_PASSWORD="$(cat /run/secrets/webauth_admin_password)"`.
+
 Bootstrap behavior:
 
 - **Both vars required.** Setting only one logs a warning and skips the bootstrap.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -183,6 +183,29 @@ docker exec mxlrcgo-svc mxlrcgo-svc scan
 
 If your music instead lives in several separate top-level shares, map their common parent once, or add one **Path** mapping per share beneath `/data/media` (for example `/mnt/user/<share>` to `/data/media/<share>`) and register each with `library add`. Lyrics are written next to each audio file, so libraries do not need a shared output root; set `MXLRC_OUTPUT_DIR` only for the webhook metadata-fallback case (step 3 under [Path resolution](#path-resolution-dockerunraid)).
 
+### Web UI enablement
+
+The browser UI is **off by default**. The serve listener only mounts the web routes when the UI is explicitly enabled, so a fresh Docker or Unraid deployment serves the webhook API alone until you turn it on.
+
+**Enable it (headless).** Set `MXLRC_WEB_UI_ENABLED=true` in the container environment (the Unraid template ships this variable, and `docker-compose.example.yml` sets it). The equivalent config-file setting is `web_ui_enabled = true` under `[server]` in `config.toml`; the env var overrides the file when both are present. With the UI off, neither the pages nor the `/login` or `/setup` routes exist.
+
+**Bootstrap the first admin (headless).** The setup page (`/setup`) is reachable **only from loopback or a configured trusted CIDR**, so a remote Unraid box cannot complete first-run setup through the browser. For headless deployments, create the first admin from the environment instead:
+
+```sh
+-e MXLRC_WEBAUTH_ADMIN_USER=admin
+-e MXLRC_WEBAUTH_ADMIN_PASSWORD=your-strong-password
+```
+
+Bootstrap behavior:
+
+- **Both vars required.** Setting only one logs a warning and skips the bootstrap.
+- **Password floor.** The password must be at least 8 characters. A shorter one is a **fatal startup error** (the container will not start), not a silent skip.
+- **Idempotent.** The bootstrap runs only when no admin exists yet. Once any admin account is present it is skipped (never an overwrite), so leaving the vars set across restarts is harmless. The password is never logged.
+
+**First login and cleanup.** After the container is up, browse to `http://[host]:[port]/login` and sign in with the bootstrapped credentials. Then **rotate the password from inside the UI and remove the `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` env vars** (and restart). Because the bootstrap is idempotent, the stale vars do nothing on the next start, but removing them keeps the plaintext password out of the container environment.
+
+If the UI is reachable beyond your local machine, also read [Security considerations](#security-considerations) below: put it behind TLS so the session cookie is not sent in cleartext.
+
 ## Windows
 
 Download the signed `.zip` archive for `windows/amd64` from the [GitHub releases page](https://github.com/sydlexius/mxlrcgo-svc/releases). Extract `mxlrcgo-svc.exe` to one of:
@@ -401,6 +424,8 @@ mxlrcgo-svc completion fish > ~/.config/fish/completions/mxlrcgo-svc.fish
 The scripts call a hidden `__complete` handler; library-name completion never creates the database.
 
 ## Security considerations
+
+**Web UI and admin bootstrap.** The browser UI is off by default; enabling it and bootstrapping the first admin on a headless Docker/Unraid host is covered in [Web UI enablement](#web-ui-enablement) under the Unraid section. The short version: enable with `MXLRC_WEB_UI_ENABLED=true`, bootstrap with `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` (8-char minimum, idempotent), then rotate the password and remove those env vars after first login. The interactive `/setup` page is restricted to loopback or a trusted CIDR, so env-bootstrap is the headless path.
 
 **Session cookie and TLS.** The browser session cookie (`mxlrc_session`) has its `Secure` flag set automatically when the connection is TLS - either a direct TLS listener or a trusted reverse proxy that sets `X-Forwarded-Proto: https`. On a plain-HTTP deployment the `Secure` flag is off and the cookie is sent in cleartext, which exposes it to network interception. If the web UI is reachable from outside your local machine, run it behind a TLS-terminating reverse proxy (nginx, Caddy, Traefik) or enable the built-in TLS listener (`[server.tls]` in `config.toml`). See `README.md` for TLS configuration options.
 

--- a/unraid/mxlrcgo-svc.xml
+++ b/unraid/mxlrcgo-svc.xml
@@ -16,7 +16,7 @@
   <Overview>Fetch synced lyrics from Musixmatch and save them as .lrc files for music libraries.</Overview>
   <Description>mxlrcgo-svc fetches synced lyrics from the Musixmatch API, writes .lrc files, and can run as a small HTTP service for Lidarr webhook-driven lyric fetching.</Description>
   <Category>MediaApp:Music</Category>
-  <WebUI/>
+  <WebUI>http://[IP]:[PORT:50705]/</WebUI>
   <Icon>https://raw.githubusercontent.com/sydlexius/unraid-templates/main/icon.svg</Icon>
   <ExtraParams/>
   <PostArgs/>


### PR DESCRIPTION
## What

Documents how to enable the web UI on Docker/Unraid, including admin bootstrap and the Unraid WebUI link.

## How

- `docs/USER_GUIDE.md`: new `### Web UI enablement` under `## Unraid` — enable via `MXLRC_WEB_UI_ENABLED=true` (the primary headless path, added in #327) or `web_ui_enabled` in config.toml; admin bootstrap via `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` (both required, 8-char min = fatal startup error, idempotent — skipped if an admin already exists); first login at `/login`; rotate + remove the bootstrap env vars after first login; `/setup` is loopback/trusted-CIDR only, so env-bootstrap is the headless path. Cross-referenced from Security considerations.
- `config.example.toml`: `# web_ui_enabled = false` under `[server]`.
- `unraid/mxlrcgo-svc.xml`: populated the empty `<WebUI>` element.
- `Dockerfile` + `build/docker/Dockerfile.goreleaser`: added the `net.unraid.docker.webui` label (both, to keep the released image — the one users pull — in sync).
- `docker-compose.example.yml`: commented `MXLRC_WEBAUTH_ADMIN_USER/PASSWORD` lines pointing to the walkthrough.

Verified against live code: `MinPasswordLength=8` (webauth/service.go), idempotent/fatal bootstrap (commands.go), `/setup` trust gate (web/setup.go).

## Test plan

- `make gate` green. (Dockerfile edits trip the `code` paths-filter, so full CI runs.)

Closes #328
