### PR TITLE
chore(ci): reduce cache thrash and LRU eviction pressure (#304)

### DIFF
--- a/.github/workflows/cache-usage-guardrail.yml
+++ b/.github/workflows/cache-usage-guardrail.yml
@@ -28,8 +28,15 @@ jobs:
           THRESHOLD_BYTES: '8589934592'
         run: |
           set -euo pipefail
+          # The API call can fail or the field can be empty/null; never let a
+          # missing value emit a false warning. Default to empty on call failure,
+          # then require a non-empty, purely-numeric value before comparing.
           bytes=$(gh api "repos/$GH_REPO/actions/cache/usage" \
-            --jq '.active_caches_size_in_bytes')
+            --jq '.active_caches_size_in_bytes // empty' 2>/dev/null || true)
+          if [ -z "${bytes:-}" ] || ! printf '%s' "$bytes" | grep -Eq '^[0-9]+$'; then
+            echo "::notice::Could not read a numeric cache usage value (got '${bytes:-}'); skipping guardrail check."
+            exit 0
+          fi
           gib=$(awk -v b="$bytes" 'BEGIN { printf "%.2f", b / (1024*1024*1024) }')
           echo "Active Actions cache usage: ${gib} GiB (${bytes} bytes)"
           if [ "$bytes" -gt "$THRESHOLD_BYTES" ]; then

--- a/.github/workflows/cache-usage-guardrail.yml
+++ b/.github/workflows/cache-usage-guardrail.yml
@@ -1,0 +1,39 @@
+name: Cache Usage Guardrail
+
+# Weekly heads-up on Actions cache pressure. Reads the repo's active cache usage
+# and emits a ::warning:: annotation once it crosses 8 GB (80% of the 10 GB/repo
+# cap), so growth is caught before the global LRU starts evicting live caches.
+# Read-only: it observes, it never deletes.
+
+on:
+  schedule:
+    # Mondays 08:00 UTC.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check-usage:
+    name: Check cache usage
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Warn if active cache usage exceeds 8 GB
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # 8 GB in bytes (8 * 1024^3).
+          THRESHOLD_BYTES: '8589934592'
+        run: |
+          set -euo pipefail
+          bytes=$(gh api "repos/$GH_REPO/actions/cache/usage" \
+            --jq '.active_caches_size_in_bytes')
+          gib=$(awk -v b="$bytes" 'BEGIN { printf "%.2f", b / (1024*1024*1024) }')
+          echo "Active Actions cache usage: ${gib} GiB (${bytes} bytes)"
+          if [ "$bytes" -gt "$THRESHOLD_BYTES" ]; then
+            echo "::warning::Actions cache usage is ${gib} GiB, above the 8 GiB guardrail (10 GiB/repo cap). Investigate cache growth or prune stale entries."
+          else
+            echo "Within guardrail (<= 8 GiB)."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,9 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.12.2
-          cache-invalidation-interval: 1
+          # Weekly (not daily) lint-cache key rotation: a daily interval cold-
+          # rebuilds the cache every calendar day and accretes ~7 entries/week.
+          cache-invalidation-interval: 7
 
   test:
     name: Test
@@ -156,8 +158,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
       - name: Build image
-        run: docker build -t mxlrcgo-svc:scan -f Dockerfile .
+        # buildx + GHA layer cache reuses the nightly's exported BuildKit layers
+        # instead of cold-building. load:true keeps mxlrcgo-svc:scan in the local
+        # daemon so the grype scan step below can still find it.
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: mxlrcgo-svc:scan
+          cache-from: type=gha
 
       - name: Scan image for HIGH+ CVEs
         id: scan

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,4 +59,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # mode=min exports only the final-image layers (not every intermediate
+          # build stage), cutting exported BuildKit blob count ~70-80%.
+          cache-to: type=gha,mode=min

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,50 @@
+name: PR Cache Cleanup
+
+# Deletes a PR's Actions caches when it closes. GitHub never evicts
+# refs/pull/N/merge caches on its own, so without this they accumulate against
+# the 10 GB/repo cap until the global LRU starts evicting live branch caches.
+# Scope is strictly this PR's own merge ref -- refs/heads/* (main and release
+# branches) are never touched.
+
+on:
+  pull_request:
+    types: [closed]
+
+# Least privilege: the workflow grants nothing by default; only the cleanup job
+# elevates to actions:write to delete caches.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete PR caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches for this PR's merge ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Hardcoded to the PR's own merge ref; never refs/heads/*.
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          echo "Listing caches for ref: $PR_REF"
+          # Defensive: the API is already scoped by ?ref=, but re-assert the ref
+          # client-side so a misfiled cache can never be deleted by this job.
+          ids=$(gh api --paginate \
+            "repos/$GH_REPO/actions/caches?ref=$PR_REF" \
+            --jq '.actions_caches[] | select(.ref == env.PR_REF) | .id')
+          if [ -z "$ids" ]; then
+            echo "No caches found for $PR_REF; nothing to delete."
+            exit 0
+          fi
+          for id in $ids; do
+            echo "Deleting cache id=$id"
+            gh api -X DELETE "repos/$GH_REPO/actions/caches/$id"
+          done
+          echo "Cache cleanup complete for $PR_REF."

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -29,16 +29,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          # Hardcoded to the PR's own merge ref; never refs/heads/*.
-          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Numeric PR number; the merge ref is assembled in the step from this.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          # Validate the PR number is a non-empty, purely-numeric value before we
+          # build a ref from it; fail safe (clean exit, no deletion) otherwise so
+          # a malformed value can never widen the deletion scope.
+          if [ -z "${PR_NUMBER:-}" ] || ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+            echo "PR number is empty or non-numeric ('${PR_NUMBER:-}'); nothing to delete."
+            exit 0
+          fi
+          PR_REF="refs/pull/${PR_NUMBER}/merge"
           echo "Listing caches for ref: $PR_REF"
           # Defensive: the API is already scoped by ?ref=, but re-assert the ref
-          # client-side so a misfiled cache can never be deleted by this job.
+          # client-side (via --arg, never string-interpolated into the filter) so
+          # a misfiled cache can never be deleted by this job.
+          # $ref below is a jq variable (set via --arg), not a shell expansion, so it must stay single-quoted.
+          # shellcheck disable=SC2016
           ids=$(gh api --paginate \
             "repos/$GH_REPO/actions/caches?ref=$PR_REF" \
-            --jq '.actions_caches[] | select(.ref == env.PR_REF) | .id')
+            --jq '.actions_caches[] | select(.ref == $ref) | .id' \
+            --arg ref "$PR_REF")
           if [ -z "$ids" ]; then
             echo "No caches found for $PR_REF; nothing to delete."
             exit 0


### PR DESCRIPTION
## What

Reduces CI cache thrash and 10GB LRU eviction pressure (P1-P5 from the issue).

## How

- **P1** `ci.yml`: golangci-lint `cache-invalidation-interval` 1 → 7 (fewer full-cache rebuilds).
- **P2** new `pr-cache-cleanup.yml` (`pull_request: [closed]`): deletes ONLY that PR's `refs/pull/N/merge` caches (hardcoded PR ref + defensive client-side filter; `refs/heads/*` never touched). Workflow-level `permissions: {}`, job-level `actions: write`, no checkout.
- **P3** `ci.yml` scan job: raw `docker build` → `docker/setup-buildx-action` + `docker/build-push-action` with `cache-from: type=gha`. Keeps `load: true` + `tags: mxlrcgo-svc:scan` so the image stays in the local daemon and the grype/anchore scan step still finds it — the required **Image Scan** check is intact.
- **P4** `nightly.yml`: `cache-to` `mode=max` → `mode=min`.
- **P5** new `cache-usage-guardrail.yml` (weekly cron + dispatch): warns when cache usage exceeds 8 GiB. Job-level `actions: read`.

All actions SHA-pinned with `# vX` (buildx/build-push pins reused from `nightly.yml`), `persist-credentials: false` on every checkout, least-privilege job-level `permissions` throughout.

## Test plan

- `make gate` + `actionlint` on all four workflows green. Scan-job image confirmed load-able for the scan step.

Closes #304
