### PR TITLE
fix(ci): use env.PR_REF in pr-cache-cleanup gh --jq (drop unsupported --arg) (#347)

### DIFF
--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -41,16 +41,15 @@ jobs:
             exit 0
           fi
           PR_REF="refs/pull/${PR_NUMBER}/merge"
+          export PR_REF
           echo "Listing caches for ref: $PR_REF"
           # Defensive: the API is already scoped by ?ref=, but re-assert the ref
-          # client-side (via --arg, never string-interpolated into the filter) so
-          # a misfiled cache can never be deleted by this job.
-          # $ref below is a jq variable (set via --arg), not a shell expansion, so it must stay single-quoted.
-          # shellcheck disable=SC2016
+          # client-side (via env.PR_REF in the jq filter) so a misfiled cache
+          # can never be deleted by this job. PR_REF is exported so the jq env
+          # builtin can read it; gh api does not support --arg.
           ids=$(gh api --paginate \
             "repos/$GH_REPO/actions/caches?ref=$PR_REF" \
-            --jq '.actions_caches[] | select(.ref == $ref) | .id' \
-            --arg ref "$PR_REF")
+            --jq '.actions_caches[] | select(.ref == env.PR_REF) | .id')
           if [ -z "$ids" ]; then
             echo "No caches found for $PR_REF; nothing to delete."
             exit 0

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -45,8 +45,13 @@ jobs:
           echo "Listing caches for ref: $PR_REF"
           # Defensive: the API is already scoped by ?ref=, but re-assert the ref
           # client-side (via env.PR_REF in the jq filter) so a misfiled cache
-          # can never be deleted by this job. PR_REF is exported so the jq env
-          # builtin can read it; gh api does not support --arg.
+          # can never be deleted by this job. export (not a command-prefix
+          # assignment) is required because PR_REF is reused in the URL and
+          # echo lines below: a command-prefix assignment (PR_REF=x gh api
+          # "...$PR_REF...") is applied to the child's environment only after
+          # the current shell expands all words, so $PR_REF in the URL would
+          # expand to the old (empty) value. gh api also does not support jq's
+          # --arg flag, so env.PR_REF is the only safe injection point.
           ids=$(gh api --paginate \
             "repos/$GH_REPO/actions/caches?ref=$PR_REF" \
             --jq '.actions_caches[] | select(.ref == env.PR_REF) | .id')


### PR DESCRIPTION
## What

Fixes `pr-cache-cleanup.yml` (added in #304), which **failed on every PR-close run** ([example](https://github.com/sydlexius/mxlrcgo-svc/actions/runs/27927824664)).

## Root cause

The cache-list call used `gh api --jq '... select(.ref == $ref) ...' --arg ref "$PR_REF"`. **`gh api` does not support `--arg`** (that's standalone `jq`'s flag), so `gh api` printed its usage and exited 1. (Regression from #304's hardening fix-round — a Codoki suggestion that applies to `jq`, not `gh api --jq`.)

## Fix

`gh api --jq` exposes process env via the jq `env` builtin: `export PR_REF` and use `select(.ref == env.PR_REF)`; drop `--arg`. The server-side `?ref=$PR_REF` query already scopes results; the client-side select is belt-and-suspenders. Kept the PR-number numeric validation guard. Comments updated.

## Test plan

- `make gate` + `actionlint` green. (Functional verification is the next PR-close run going green.)

Closes #347
