### PR TITLE
feat(web): add ARIA tab semantics to settings tabs (#305)

### DIFF
--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -154,12 +154,80 @@
     }
   }
 
+  // --- ARIA tab semantics -------------------------------------------------
+  // Maps each radio id to the corresponding tabctl label id.
+  var TAB_RADIOS = ["mx-tab-common", "mx-tab-advanced", "mx-tab-raw"];
+  var TAB_CTLS   = ["mx-tabctl-common", "mx-tabctl-advanced", "mx-tabctl-raw"];
+
+  // Sync aria-selected + tabindex on the three tab labels to match which radio
+  // is :checked. Called on init (via syncAll) and after any radio state change.
+  function syncTabs() {
+    for (var i = 0; i < TAB_RADIOS.length; i++) {
+      var radio = document.getElementById(TAB_RADIOS[i]);
+      var ctl   = document.getElementById(TAB_CTLS[i]);
+      if (!radio || !ctl) {
+        console.error("settings.js syncTabs: missing element", TAB_RADIOS[i], TAB_CTLS[i]);
+        continue;
+      }
+      var active = radio.checked;
+      ctl.setAttribute("aria-selected", active ? "true" : "false");
+      ctl.setAttribute("tabindex", active ? "0" : "-1");
+    }
+  }
+
+  // Keyboard navigation for the tablist: Left/Right cycle through tabs,
+  // Home/End jump to the first/last tab. Checks the radio and focuses the label.
+  function initTabKeyboard() {
+    var tablist = document.querySelector(".mx-tablist");
+    if (!tablist) {
+      console.error("settings.js initTabKeyboard: .mx-tablist not found");
+      return;
+    }
+    tablist.addEventListener("keydown", function (event) {
+      var key = event.key;
+      if (key !== "ArrowLeft" && key !== "ArrowRight" && key !== "Home" && key !== "End") {
+        return;
+      }
+      event.preventDefault();
+      var currentIndex = -1;
+      for (var i = 0; i < TAB_RADIOS.length; i++) {
+        var radio = document.getElementById(TAB_RADIOS[i]);
+        if (radio && radio.checked) {
+          currentIndex = i;
+          break;
+        }
+      }
+      if (currentIndex === -1) {
+        return;
+      }
+      var nextIndex;
+      if (key === "ArrowLeft") {
+        nextIndex = (currentIndex - 1 + TAB_RADIOS.length) % TAB_RADIOS.length;
+      } else if (key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % TAB_RADIOS.length;
+      } else if (key === "Home") {
+        nextIndex = 0;
+      } else {
+        nextIndex = TAB_RADIOS.length - 1;
+      }
+      var nextRadio = document.getElementById(TAB_RADIOS[nextIndex]);
+      var nextCtl   = document.getElementById(TAB_CTLS[nextIndex]);
+      if (nextRadio && nextCtl) {
+        nextRadio.checked = true;
+        syncTabs();
+        nextCtl.focus();
+      }
+    });
+  }
+  // -------------------------------------------------------------------------
+
   function handleJump(link) {
     var tabId = link.getAttribute("data-jump-tab");
     var targetId = link.getAttribute("data-jump-target");
     var tab = tabId ? document.getElementById(tabId) : null;
     if (tab) {
       tab.checked = true; // switch the CSS-only tab to reveal the target panel
+      syncTabs();
     } else {
       console.error("settings.js: jump tab not found:", tabId);
     }
@@ -466,6 +534,7 @@
     syncGating();
     syncProviders();
     syncTLS();
+    syncTabs();
   }
   document.addEventListener("change", function (event) {
     syncAll();
@@ -475,8 +544,12 @@
     }
   });
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", syncAll);
+    document.addEventListener("DOMContentLoaded", function () {
+      syncAll();
+      initTabKeyboard();
+    });
   } else {
     syncAll();
+    initTabKeyboard();
   }
 })();

--- a/web/templates/settings.templ
+++ b/web/templates/settings.templ
@@ -32,23 +32,23 @@ templ SettingsPage(version string, view SettingsView, reports []RailItem) {
 			<input type="radio" name="mx-settings-tab" id="mx-tab-advanced" class="mx-tab-radio"/>
 			<input type="radio" name="mx-settings-tab" id="mx-tab-raw" class="mx-tab-radio"/>
 			<div class="mx-tablist" role="tablist" aria-label="Settings sections">
-				<label class="mx-tab" for="mx-tab-common">Common</label>
-				<label class="mx-tab" for="mx-tab-advanced">Advanced</label>
-				<label class="mx-tab" for="mx-tab-raw">Raw config</label>
+				<label class="mx-tab" id="mx-tabctl-common" for="mx-tab-common" role="tab" aria-controls="mx-panel-common" aria-selected="false" tabindex="0">Common</label>
+				<label class="mx-tab" id="mx-tabctl-advanced" for="mx-tab-advanced" role="tab" aria-controls="mx-panel-advanced" aria-selected="false" tabindex="-1">Advanced</label>
+				<label class="mx-tab" id="mx-tabctl-raw" for="mx-tab-raw" role="tab" aria-controls="mx-panel-raw" aria-selected="false" tabindex="-1">Raw config</label>
 			</div>
-			<div class="mx-tabpanel" id="mx-panel-common">
+			<div class="mx-tabpanel" id="mx-panel-common" role="tabpanel" aria-labelledby="mx-tabctl-common">
 				<section class="mx-settings-section">
 					for _, field := range view.Common {
 						@settingsField(field)
 					}
 				</section>
 			</div>
-			<div class="mx-tabpanel" id="mx-panel-advanced">
+			<div class="mx-tabpanel" id="mx-panel-advanced" role="tabpanel" aria-labelledby="mx-tabctl-advanced">
 				for _, section := range view.Sections {
 					@settingsSection(section)
 				}
 			</div>
-			<div class="mx-tabpanel" id="mx-panel-raw">
+			<div class="mx-tabpanel" id="mx-panel-raw" role="tabpanel" aria-labelledby="mx-tabctl-raw">
 				<p class="mx-settings-field-desc">The current effective configuration, with secrets redacted. Read-only.</p>
 				<pre class="mx-code-block" aria-label="Effective configuration">{ view.RawTOML }</pre>
 			</div>

--- a/web/templates/settings_templ.go
+++ b/web/templates/settings_templ.go
@@ -73,7 +73,7 @@ func SettingsPage(version string, view SettingsView, reports []RailItem) templ.C
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " <div class=\"mx-tabs\"><input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-common\" class=\"mx-tab-radio\" checked> <input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-advanced\" class=\"mx-tab-radio\"> <input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-raw\" class=\"mx-tab-radio\"><div class=\"mx-tablist\" role=\"tablist\" aria-label=\"Settings sections\"><label class=\"mx-tab\" for=\"mx-tab-common\">Common</label> <label class=\"mx-tab\" for=\"mx-tab-advanced\">Advanced</label> <label class=\"mx-tab\" for=\"mx-tab-raw\">Raw config</label></div><div class=\"mx-tabpanel\" id=\"mx-panel-common\"><section class=\"mx-settings-section\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " <div class=\"mx-tabs\"><input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-common\" class=\"mx-tab-radio\" checked> <input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-advanced\" class=\"mx-tab-radio\"> <input type=\"radio\" name=\"mx-settings-tab\" id=\"mx-tab-raw\" class=\"mx-tab-radio\"><div class=\"mx-tablist\" role=\"tablist\" aria-label=\"Settings sections\"><label class=\"mx-tab\" id=\"mx-tabctl-common\" for=\"mx-tab-common\" role=\"tab\" aria-controls=\"mx-panel-common\" aria-selected=\"false\" tabindex=\"0\">Common</label> <label class=\"mx-tab\" id=\"mx-tabctl-advanced\" for=\"mx-tab-advanced\" role=\"tab\" aria-controls=\"mx-panel-advanced\" aria-selected=\"false\" tabindex=\"-1\">Advanced</label> <label class=\"mx-tab\" id=\"mx-tabctl-raw\" for=\"mx-tab-raw\" role=\"tab\" aria-controls=\"mx-panel-raw\" aria-selected=\"false\" tabindex=\"-1\">Raw config</label></div><div class=\"mx-tabpanel\" id=\"mx-panel-common\" role=\"tabpanel\" aria-labelledby=\"mx-tabctl-common\"><section class=\"mx-settings-section\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -83,7 +83,7 @@ func SettingsPage(version string, view SettingsView, reports []RailItem) templ.C
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</section></div><div class=\"mx-tabpanel\" id=\"mx-panel-advanced\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</section></div><div class=\"mx-tabpanel\" id=\"mx-panel-advanced\" role=\"tabpanel\" aria-labelledby=\"mx-tabctl-advanced\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -93,7 +93,7 @@ func SettingsPage(version string, view SettingsView, reports []RailItem) templ.C
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div class=\"mx-tabpanel\" id=\"mx-panel-raw\"><p class=\"mx-settings-field-desc\">The current effective configuration, with secrets redacted. Read-only.</p><pre class=\"mx-code-block\" aria-label=\"Effective configuration\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div class=\"mx-tabpanel\" id=\"mx-panel-raw\" role=\"tabpanel\" aria-labelledby=\"mx-tabctl-raw\"><p class=\"mx-settings-field-desc\">The current effective configuration, with secrets redacted. Read-only.</p><pre class=\"mx-code-block\" aria-label=\"Effective configuration\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
## What

Adds ARIA tab semantics to the settings page tabs (keyboard + screen-reader accessible).

## How

- `web/templates/settings.templ`: each `<label class="mx-tab">` gets `role="tab"`, a distinct id (`mx-tabctl-common/advanced/raw`), `aria-controls` → the existing panel ids, `aria-selected`, and roving `tabindex` (0 on the active, -1 on the rest). Each `<div class="mx-tabpanel">` gets `role="tabpanel"` + `aria-labelledby`. The existing `role="tablist"` and panel ids are reused (not duplicated).
- `web/static/js/settings.js` (existing file, no new tabs.js): `syncTabs()` keeps `aria-selected`/`tabindex` in sync with the checked radio (called from `syncAll()` + the change listener + `handleJump`); `initTabKeyboard()` adds Left/Right/Home/End arrow navigation on the tablist.
- `settings_templ.go` regenerated. No `layout.templ` change, no new Tailwind.

## Test plan

- `make gate` green.
- **Rendered ARIA evidence** (attached at UAT): on `/settings`, the three tabs report `role=tab` with exactly one `aria-selected=true` matching the visible panel; `aria-controls`/`aria-labelledby` resolve correctly; arrow keys move selection + focus; axe-core 0 tab violations.

Closes #305
