### PR TITLE
docs: config reference gaps + metrics/settings/reports User Guide sections (#312, #313, #314, #315)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -236,6 +236,44 @@ sample_duration_seconds = 30
 min_confidence = 0.85
 min_similarity = 0.35
 
+[instrumental_detector]
+# Optional audio-based instrumental detection sidecar. When enabled and a
+# classifier_url is configured, the detector samples each track's audio with
+# ffmpeg and asks an external AudioSet classifier whether it is instrumental,
+# writing an instrumental marker on a provider miss. It runs ONLY on provider
+# misses and never overrides provider-supplied data. Disabled by default.
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_ENABLED.
+# enabled = false
+
+# Base URL of the AudioSet classifier sidecar (e.g. "http://yamnet:8080").
+# Required when enabled is true. Env: MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL.
+# classifier_url = ""
+
+# Path to the ffmpeg binary used for audio sampling. Default "ffmpeg" (resolved
+# via PATH or auto-downloaded; see docs/CONFIGURATION.md "ffmpeg resolution").
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH.
+# ffmpeg_path = "ffmpeg"
+
+# Length of the audio sample in seconds, clamped to [30, 60]. Default 30.
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS.
+# sample_duration_seconds = 30
+
+# Minimum summed AudioSet class probability to mark a track instrumental.
+# Values outside (0, 1] reset to 0.90 (the default). Intentionally conservative:
+# false-instrumental errors are worse than false-misses.
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE.
+# min_confidence = 0.90
+
+# AudioSet class names whose probabilities are summed and compared against
+# min_confidence. Default ["Music", "Musical instrument"].
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_CLASSES (comma-separated).
+# instrumental_classes = ["Music", "Musical instrument"]
+
+# Minimum gap in seconds between consecutive classifier inference calls.
+# Default 5. Set to 0 to disable the cooldown.
+# Env: MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS.
+# cooldown_seconds = 5
+
 [enrichment]
 # Recording enrichment reads the ISRC, MusicBrainz recording ID, and duration
 # from each file's audio tags and feeds them to the matcher to disambiguate

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,7 +56,11 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_WEBHOOK_API_KEY` | (none) | Comma-separated webhook API key(s) accepted by the server. Generate with `mxlrcgo-svc keys create --scope webhook`. |
 | `MXLRC_SERVER_ADDR` | `127.0.0.1:3876` | HTTP listen address for `serve`. Docker images default this to `0.0.0.0:50705`. |
 | `MXLRC_WEB_UI_ENABLED` | `false` | Enable the browser UI on the serve listener. Env override of `web_ui_enabled` (precedence: env > file). Restart to apply. |
+| `MXLRC_TRUSTED_CIDRS` | (none) | Comma-separated CIDRs of trusted client networks (serve mode). Loopback is always trusted. Requests from listed CIDRs may scrape `GET /metrics` and bypass the web UI session requirement. |
+| `MXLRC_TRUSTED_PROXIES` | (none) | Comma-separated CIDRs of reverse proxies whose `X-Forwarded-For` is trusted to carry the real client IP (serve mode). Must not overlap `MXLRC_TRUSTED_CIDRS`. |
 | `MXLRC_OUTPUT_DIR` | XDG / `/music` | Output directory for `fetch` mode. **Ignored in `serve` mode** (lyrics are written next to the audio file; the metadata-only webhook fallback uses the internal default). |
+| `MXLRC_EMBEDDED_LYRICS` | `off` | Embedded unsynced lyrics handling. `off` - ignore (default); `respect` - skip fetching when embedded lyrics exist; `extract` - write embedded lyrics to a `.txt` sidecar, then skip fetching. |
+| `MXLRC_BILINGUAL_OUTPUT` | `false` | When `true` and a provider returns a translation track, interleave original and translated lines under shared timestamps in a single `.lrc`. |
 | `MXLRC_DB_PATH` | XDG / `/config/mxlrcgo.db` | SQLite database path. |
 | `MXLRC_DOCKER` | `false` | When `true`, storage defaults resolve under `/config`. Set automatically in the images. |
 | `MXLRC_MASTER_KEY` | (none) | Optional. Base64 of 32 random bytes; overrides the auto-generated key file as the master key for encrypted-at-rest secrets. When set, no key file is read or written. Use for key/data separation (recommended Docker hardening when the threat model includes whole-volume theft). Generate with `openssl rand -base64 32`. See the [Encrypted secrets](USER_GUIDE.md#encrypted-secrets) guide. |
@@ -66,6 +70,9 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_API_COOLDOWN` | `15` | Seconds between Musixmatch requests. `MXLRC_COOLDOWN` is a lower-precedence alias. |
 | `MXLRC_API_CIRCUIT_OPEN_DURATION` | `1800` | Cap (seconds) for the worker circuit-breaker window; the window ramps geometrically up to this ceiling, and a token-renewal signal opens for the full cap (floor 300). |
 | `MXLRC_API_CIRCUIT_BACKOFF_BASE` | `60` | Trip-1 circuit-breaker window (seconds); doubles each consecutive throttle up to `MXLRC_API_CIRCUIT_OPEN_DURATION`, resets on a successful fetch or clean miss (floor 15, capped at the open-duration). |
+| `MXLRC_MISS_BACKOFF_BASE_HOURS` | `168` | Initial re-check delay in hours for a benign miss (7 days). Doubles on each successive miss up to `MXLRC_MISS_BACKOFF_CAP_HOURS`. Minimum 1. |
+| `MXLRC_MISS_BACKOFF_CAP_HOURS` | `672` | Maximum re-check delay in hours for a benign miss (28 days). Clamped to at least `MXLRC_MISS_BACKOFF_BASE_HOURS`. |
+| `MXLRC_MAX_MISS_ATTEMPTS` | `15` | Maximum number of miss re-fetches before retiring the queue row. `0` means no cap. |
 | `MXLRC_SCAN_INTERVAL` | `900` | `serve` library-scan interval in seconds. `0` scans once without repeating. |
 | `MXLRC_WORK_INTERVAL` | `0` | Worker poll interval in seconds. `0` falls back to `api.cooldown` (15s floor). |
 | `MXLRC_PROVIDER_PRIMARY` | `musixmatch` | Primary lyrics provider. |
@@ -89,6 +96,14 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_VERIFICATION_SAMPLE_DURATION_SECONDS` | `30` | Audio sample length sent to Whisper. `MXLRC_VERIFICATION_SAMPLE_DURATION` is an alias. |
 | `MXLRC_VERIFICATION_MIN_CONFIDENCE` | `0.85` | Below this Musixmatch confidence, verify against Whisper (0-1). |
 | `MXLRC_VERIFICATION_MIN_SIMILARITY` | `0.35` | Minimum transcript/lyric overlap to accept (0-1). |
+| `MXLRC_INSTRUMENTAL_DETECTOR_ENABLED` | `false` | Enable the audio-based instrumental detection sidecar. Requires `MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL`. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL` | (none) | Base URL of the AudioSet classifier sidecar, e.g. `http://yamnet:8080`. Required when the detector is enabled. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH` | `ffmpeg` | Path to the `ffmpeg` binary used for audio sampling by the instrumental detector. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS` | `30` | Length of the audio sample sent to the classifier, clamped to [30, 60]. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE` | `0.90` | Minimum summed AudioSet class probability to mark a track instrumental. Values outside (0, 1] reset to `0.90`. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_CLASSES` | `Music,Musical instrument` | Comma-separated AudioSet class names whose probabilities are summed and compared against the confidence threshold. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS` | `5` | Minimum gap in seconds between consecutive classifier inference calls. `0` disables the cooldown. |
+| `MXLRC_ENRICHMENT_ENABLED` | `true` | Global default for recording enrichment (reading ISRC, MusicBrainz ID, and duration from audio tags). Per-library and per-run flags override this. |
 | `PUID` / `PGID` | `99` / `100` | Container-only: user/group the process drops to for file ownership. |
 
 ## TOML config keys
@@ -101,19 +116,30 @@ The TOML config file mirrors the environment variables in named sections. The ke
 [api]
 cooldown = 15
 circuit_open_duration = 1800
-# circuit_backoff_base = 60
+# circuit_backoff_base_seconds = 60
+# miss_backoff_base_hours = 168   # initial re-check delay (hours; 7 days); minimum 1
+# miss_backoff_cap_hours = 672    # maximum re-check delay (hours; 28 days)
+# max_miss_attempts = 15          # 0 = no cap
 ```
 
-Request cooldown and the worker circuit-breaker window (env: `MXLRC_API_COOLDOWN`, `MXLRC_API_CIRCUIT_OPEN_DURATION`, `MXLRC_API_CIRCUIT_BACKOFF_BASE`).
+Request cooldown, the worker circuit-breaker window, and miss re-check backoff (env: `MXLRC_API_COOLDOWN`, `MXLRC_API_CIRCUIT_OPEN_DURATION`, `MXLRC_API_CIRCUIT_BACKOFF_BASE`, `MXLRC_MISS_BACKOFF_BASE_HOURS`, `MXLRC_MISS_BACKOFF_CAP_HOURS`, `MXLRC_MAX_MISS_ATTEMPTS`).
+
+`miss_backoff_base_hours` (default 168, i.e. 7 days) and `miss_backoff_cap_hours` (default 672, i.e. 28 days) govern the escalating re-check cadence for benign misses: the delay doubles each miss (base, 2 x base, 4 x base, ...) up to the cap. `max_miss_attempts` retires the queue row after N miss fetches; `0` means no cap.
 
 ### `[output]`
 
 ```toml
 [output]
 dir = "lyrics"
+# embedded_lyrics = "off"
+# bilingual_output = false
 ```
 
-Fallback output directory for webhook jobs that resolve via metadata (env: `MXLRC_OUTPUT_DIR`).
+Fallback output directory and per-file output controls (env: `MXLRC_OUTPUT_DIR`, `MXLRC_EMBEDDED_LYRICS`, `MXLRC_BILINGUAL_OUTPUT`; CLI: `--embedded-lyrics`).
+
+`embedded_lyrics` controls how unsynced lyrics already embedded in the audio file's tags are handled. `off` (default) ignores them and always fetches from providers. `respect` skips fetching for files that already carry embedded lyrics. `extract` writes the embedded lyrics to a `.txt` sidecar (never overwriting an existing one) and then skips fetching. Synced (SYLT) tags are intentionally not handled.
+
+`bilingual_output` (default `false`): when `true` and a provider returns a non-empty translation track, the original and translation lines are interleaved under shared timestamps in a single `.lrc`. See `docs/multilingual-output-policy.md`.
 
 ### `[db]`
 
@@ -138,6 +164,22 @@ addr = "127.0.0.1:3876"
 HTTP listen address, webhook keys, and the scheduler scan/worker poll intervals (env: `MXLRC_SERVER_ADDR`, `MXLRC_WEBHOOK_API_KEY`, `MXLRC_SCAN_INTERVAL`, `MXLRC_WORK_INTERVAL`; CLI: `--listen`, `--scan-interval`, `--work-interval`).
 
 `web_ui_enabled` (default `false`, env: `MXLRC_WEB_UI_ENABLED`, precedence env > file) gates the browser UI on the serve listener. When enabled, the UI pages require a session login (a single admin account, separate from the webhook API key), or a request from a trusted network (the `[server.trusted_networks]` CIDR allowlist). Secret values (API token, webhook keys) are always redacted in the Config view. See [Web UI access](#web-ui-access) for the first-run onboarding flow.
+
+### `[server.trusted_networks]`
+
+```toml
+[server.trusted_networks]
+# cidrs = ["192.168.1.0/24", "10.0.0.0/8"]
+# trusted_proxies = ["172.16.0.0/12"]
+```
+
+Trusted-network allowlist for serve mode (env: `MXLRC_TRUSTED_CIDRS`, `MXLRC_TRUSTED_PROXIES`). Controls two things: access to `GET /metrics` (see the [User Guide](USER_GUIDE.md#metrics-endpoint)) and the web UI session bypass (requests from a trusted network skip the login prompt).
+
+`cidrs` - CIDRs of trusted client networks. Loopback (`127.x.x.x`, `::1`) is always trusted and does not need to be listed. An empty list (the default) means only loopback is trusted.
+
+`trusted_proxies` - CIDRs of reverse proxies allowed to set `X-Forwarded-For`. Only when a request's immediate peer is within one of these networks is the XFF header consulted (walked right-to-left, skipping proxies) to find the real client IP. Default empty: XFF is never trusted, so a spoofed header cannot forge a trusted source. Entries must not overlap `cidrs`.
+
+An invalid CIDR in either list is a fatal startup error.
 
 #### Web UI access
 
@@ -179,6 +221,38 @@ min_similarity = 0.35
 Optional Whisper-based speech-to-text verification for low-confidence scanned audio. When enabled, the worker extracts a bounded mono 16 kHz WAV sample using `sample_duration_seconds`, then sends it to a Whisper-compatible `/v1/audio/transcriptions` sidecar for audio whose Musixmatch metadata confidence is below `min_confidence`. The transcript must overlap the candidate lyrics by at least `min_similarity`. Environment variables override the TOML keys (`MXLRC_VERIFICATION_*`); `MXLRC_WHISPER_URL` and `MXLRC_VERIFICATION_SAMPLE_DURATION` remain accepted as legacy aliases.
 
 ffmpeg (used to extract the audio sample) is resolved automatically: see [ffmpeg resolution](#ffmpeg-resolution) below. Set `ffmpeg_path` only to pin a specific binary.
+
+### `[instrumental_detector]`
+
+```toml
+[instrumental_detector]
+# enabled = false
+# classifier_url = "http://yamnet:8080"
+# ffmpeg_path = "ffmpeg"
+# sample_duration_seconds = 30
+# min_confidence = 0.90
+# instrumental_classes = ["Music", "Musical instrument"]
+# cooldown_seconds = 5
+```
+
+Optional audio-based instrumental detection sidecar (env: `MXLRC_INSTRUMENTAL_DETECTOR_ENABLED`, `MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL`, `MXLRC_INSTRUMENTAL_DETECTOR_FFMPEG_PATH`, `MXLRC_INSTRUMENTAL_DETECTOR_SAMPLE_DURATION_SECONDS`, `MXLRC_INSTRUMENTAL_DETECTOR_MIN_CONFIDENCE`, `MXLRC_INSTRUMENTAL_DETECTOR_CLASSES`, `MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS`).
+
+When enabled and a `classifier_url` is set, the detector samples each track's audio with ffmpeg and sends the sample to an external AudioSet classifier (e.g. a YAMNet sidecar). It runs only on provider misses and never overrides provider-supplied data. The summed probability of the `instrumental_classes` must meet `min_confidence` to mark a track instrumental.
+
+`sample_duration_seconds` is clamped to [30, 60]. `min_confidence` values outside (0, 1] reset to `0.90`. `cooldown_seconds` is the minimum gap between consecutive inference calls; `0` disables the cooldown. See the [Instrumental detection](USER_GUIDE.md#instrumental-detection) guide for the per-library and per-run override controls.
+
+ffmpeg resolution is shared with `[verification]`; see [ffmpeg resolution](#ffmpeg-resolution) below. Set `ffmpeg_path` here only to pin a binary separately from the verification path.
+
+### `[enrichment]`
+
+```toml
+[enrichment]
+enabled = true
+```
+
+Global default for recording enrichment (env: `MXLRC_ENRICHMENT_ENABLED`). When enabled, the scanner reads the ISRC, MusicBrainz recording ID, and audio duration from each file's tags and passes them to the matcher to disambiguate results.
+
+Default `true`, preserving the always-on behavior from before per-library control existed. Per-library and per-run flags override this; see [Recording enrichment](USER_GUIDE.md#recording-enrichment) for the full precedence chain.
 
 ### ffmpeg resolution
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,6 +40,40 @@ The scheduler scan interval and worker poll interval are configurable for Docker
 
 Example Docker healthcheck: `curl -fsS http://127.0.0.1:3876/readyz`.
 
+### Metrics endpoint
+
+`GET /metrics` returns a Prometheus text-exposition (version 0.0.4) response suitable for scraping by Prometheus, Grafana Agent, or any compatible collector. Metrics are computed from read-only database queries at scrape time; there is no in-process registry or caching.
+
+**Exposed metric families:**
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `mxlrcgo_queue_items{status="..."}` | gauge | Work queue item count per status (`pending`, `processing`, `done`, `failed`, `deferred`). |
+| `mxlrcgo_queue_failures{reason="..."}` | gauge | Failed queue items grouped by error reason. |
+| `mxlrcgo_provider_hits_total{lane="..."}` | counter | Successful lyrics fetches per provider lane. |
+| `mxlrcgo_provider_misses_total{lane="..."}` | counter | Benign no-result misses per provider lane. |
+| `mxlrcgo_instrumental_tracks` | gauge | Queue items confirmed instrumental by audio detection. |
+
+**Access control.** The endpoint is gated by the trusted-network allowlist, not an API key or session cookie. Loopback (`127.x.x.x`, `::1`) is always trusted. A remote scraper (Prometheus server, Grafana Agent, etc.) must have its host CIDR listed in `[server.trusted_networks].cidrs`. A spoofed `X-Forwarded-For` header cannot forge a trusted source.
+
+To enable a remote scraper, add its CIDR to `config.toml`:
+
+```toml
+[server.trusted_networks]
+cidrs = ["192.168.1.0/24"]   # replace with your Prometheus host's CIDR
+```
+
+Or override with the environment variable: `MXLRC_TRUSTED_CIDRS=192.168.1.0/24`.
+
+Example Prometheus `scrape_configs` entry:
+
+```yaml
+scrape_configs:
+  - job_name: mxlrcgo-svc
+    static_configs:
+      - targets: ["mxlrcgo-svc-host:3876"]
+```
+
 ## Docker
 
 The container runs the webhook service on port `50705` and stores its config and SQLite database under `/config`. Mount your media following the [TRaSH Guides](https://trash-guides.info/File-and-Folder-Structure/How-to-set-up/Unraid/) single-mount convention: map your data parent to `/data` and point the app at `/data/media/music`. (The image's built-in default is `/music`, which still works for the simplest single-folder case; just keep `MXLRC_OUTPUT_DIR` at its `/music` default and mount there instead.)
@@ -207,6 +241,45 @@ Bootstrap behavior:
 **First login and cleanup.** After the container is up, browse to `http://[host]:[port]/login` and sign in with the bootstrapped credentials. Then **rotate the password from inside the UI and remove the `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` env vars** (and restart). Because the bootstrap is idempotent, the stale vars do nothing on the next start, but removing them keeps the plaintext password out of the container environment.
 
 If the UI is reachable beyond your local machine, also read [Security considerations](#security-considerations) below: put it behind TLS so the session cookie is not sent in cleartext.
+
+## Web UI: Settings page
+
+The Settings page (`/settings`) is the single destination for editing the daemon configuration from the browser. It is available whenever `web_ui_enabled = true` and the operator is signed in as admin (or is accessing from a trusted network).
+
+**Prerequisite.** The page is only reachable when the web UI is enabled (`web_ui_enabled = true` under `[server]` or `MXLRC_WEB_UI_ENABLED=true`). See [Web UI enablement](#web-ui-enablement) for the bootstrap steps.
+
+### Tab layout
+
+The page has three CSS-only tabs (no JavaScript round-trip to switch):
+
+- **Common** - everyday fields: API token, webhook key, listen address, web UI toggle, and similar high-touch settings. This is the default tab.
+- **Advanced** - every other field, organized by config section (API, output, providers, verification, instrumental detector, enrichment, guard, queue, logging, and so on).
+- **Raw config** - a read-only view of the effective configuration as TOML, with secrets redacted. Use this to verify exactly what the daemon is running before a restart.
+
+### Risk-tiered saves
+
+Fields are classified into three risk tiers that control how a save is triggered:
+
+- **safe** - auto-saves on change; no button click required.
+- **caution** - requires an explicit Save button click.
+- **critical** - requires Save plus a browser confirmation dialog before the value is written.
+
+Changes are written to the config file and take effect on the next restart, not live. A status line below each field reports the result of the save POST.
+
+### Locked fields
+
+A field whose value is set by an environment variable or a command-line flag shows a "Locked" pill and cannot be edited in the UI. The override source is described below the field. To regain control from the UI, clear the environment variable (or remove the flag) and restart the daemon.
+
+### CSRF
+
+Write operations use a double-submit cookie token (`mx-csrf-token`). This is transparent during normal browser use but means direct `curl` POSTs without the matching cookie are rejected. The page must be loaded from the same origin before any write can succeed.
+
+### Recommended workflow
+
+1. Open the **Common** tab for routine changes (rotating the API token, updating the webhook key, changing the listen address).
+2. Use the **Advanced** tab for tuning (backoff windows, provider mode, verification thresholds, etc.).
+3. After saving, open the **Raw config** tab to verify the effective state before restarting the daemon.
+4. Restart the daemon to apply changes.
 
 ## Windows
 
@@ -468,3 +541,40 @@ mxlrcgo-svc scan results --library 1 --limit 200
 mxlrcgo-svc scan clear --library Music
 mxlrcgo-svc scan clear --library Music --yes
 ```
+
+## Reports workspace
+
+The web UI exposes five read-only report views under the Reports section. Every report runs a live database query at request time; there is no pre-aggregation or caching. The reports require the web UI to be enabled (`web_ui_enabled = true`).
+
+### Queue summary
+
+Shows the count of work queue items grouped by status: pending, processing, done, failed, deferred, and total. Use this as a quick health check - a rising `failed` count warrants a look at the Failure analysis report; a large `deferred` count is normal (those are benign misses awaiting their next retry).
+
+### Recent outcomes
+
+Lists the most recently completed tracks, newest first, with:
+- Artist, title, and album.
+- Completion timestamp.
+- Provider lane that served the result.
+- Result class: `synced` (an `.lrc` was written), `unsynced-or-instrumental` (a `.txt` was written - covers both plain unsynced lyrics and instrumental markers), or `miss` (the track exhausted its miss budget with no lyrics found).
+
+Note: `.txt` results group plain unsynced lyrics and audio-detected instrumentals together. Use the Instrumental inventory report to isolate audio-detected instrumentals.
+
+### Provider effectiveness
+
+Shows per-lane hit/miss counts and a true per-track hit-rate for each provider lane. The hit-rate is computed as `hits / (hits + misses)` where a "hit" means the lane served the winning result and a "miss" means the lane was tried but did not win (including being outcompeted by a later lane in ordered mode).
+
+**No-backfill caveat.** This report reads the `lane_attempts` table, which was added in a later migration. Traffic that predates the migration has no lane-level records, so the report shows an empty state until new attempts accrue after the migration. This is expected; no historical backfill is possible.
+
+### Instrumental inventory
+
+Lists every work queue item the audio detector confirmed as instrumental, joined to the source file path from scan results. Each item shows:
+- Artist and title.
+- Source file path (empty for items enqueued via CLI without a library scan link).
+- Whether per-item detection was requested explicitly, inherited from a library setting, or fell back to the global default.
+
+Use this to audit which tracks the detector marked instrumental and whether they match expectation.
+
+### Failure analysis
+
+Lists failed and deferred work queue items grouped by status and error reason, with a count per group, ordered most-frequent first. "Failed" rows hit a hard error; "deferred" rows are benign misses waiting for a retry. Grouping keeps the two separate because they require different responses - deferred rows self-resolve on their retry schedule, while failed rows may need manual intervention (`mxlrcgo-svc queue retry <id>`).


### PR DESCRIPTION
## Documentation: config reference + User Guide sections

Closes #312, #313, #314, #315.

- **#312** — `docs/CONFIGURATION.md`: filled missing TOML sections (`[server.trusted_networks]`, `[enrichment]`, `[instrumental_detector]`), `[api]` miss-backoff keys, `[output]` `embedded_lyrics`/`bilingual_output`, and the 15 missing env vars. Added the `[instrumental_detector]` section to `config.example.toml`.
- **#313** — `docs/USER_GUIDE.md`: documented `GET /metrics` (metric families, trusted-network access control, Prometheus scrape config).
- **#314** — `docs/USER_GUIDE.md`: documented the web UI `/settings` page (tabs, risk-tiered saves, locked fields, CSRF, restart-to-apply).
- **#315** — `docs/USER_GUIDE.md`: documented the Reports workspace (all five reports + the provider-effectiveness no-backfill caveat).

All entries verified against current source (config structs, `/metrics` handler, settings handler, reports pkg). Docs-only — no code changes.

Note: a stale `MXLRC_EMBEDDED_LYRICS` comment in `config.go` (works at runtime; the line-638 comment omits it) is tracked separately — out of scope here (config package is frozen by in-flight PRs).
