### PR TITLE
ci: require auto-approve bot identity for Dependabot merge gate (#364)

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -77,7 +77,7 @@ jobs:
           # That workflow already skips semver-major bumps, so requiring its
           # identity here means majors stay manual even if another reviewer
           # (e.g. CodeRabbit) auto-approves the PR.
-          APPROVER: github-actions[bot]
+          APPROVER: "github-actions[bot]"
         run: |
           # Check for an APPROVED review directly via the reviews API.
           # This works regardless of whether branch protection requires
@@ -90,7 +90,7 @@ jobs:
             APPROVED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
               | jq -s --arg approver "$APPROVER" '
                 add
-                | map(select(.user.login == $approver))
+                | map(select(.user.login == $approver and .user.type == "Bot"))
                 | sort_by(.submitted_at)
                 | group_by(.user.login)
                 | map(last)

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -71,17 +71,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
+          # Only the auto-approve workflow's approval satisfies the merge gate.
+          # dependabot-auto-approve.yml runs `gh pr review --approve` with
+          # secrets.GITHUB_TOKEN, so its review author is github-actions[bot].
+          # That workflow already skips semver-major bumps, so requiring its
+          # identity here means majors stay manual even if another reviewer
+          # (e.g. CodeRabbit) auto-approves the PR.
+          APPROVER: github-actions[bot]
         run: |
           # Check for an APPROVED review directly via the reviews API.
           # This works regardless of whether branch protection requires
           # pull request reviews (which controls the reviewDecision field).
           for i in $(seq 1 10); do
-            # Slurp all pages into one array, sort, group by user, and take
-            # only the latest review per user to avoid stale approvals.
+            # Slurp all pages into one array, keep only reviews from the
+            # auto-approve bot, then take that bot's latest review to avoid a
+            # stale approval (e.g. a later dismissal). A non-bot approval
+            # (CodeRabbit, a human) never counts.
             APPROVED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-              | jq -s '
+              | jq -s --arg approver "$APPROVER" '
                 add
-                | sort_by(.user.login, .submitted_at)
+                | map(select(.user.login == $approver))
+                | sort_by(.submitted_at)
                 | group_by(.user.login)
                 | map(last)
                 | map(select(.state == "APPROVED"))

--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -32,7 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     # Strictly Dependabot-only. Human PRs are untouched, so the `UI Assets` gate
     # still fails when a human forgets to run `make ui`.
-    if: github.actor == 'dependabot[bot]'
+    #
+    # Combined condition (do NOT reduce to author-only):
+    #   - github.event.pull_request.user.login == 'dependabot[bot]' keeps this
+    #     Dependabot-only and, unlike keying on github.actor, still runs when a
+    #     maintainer manually re-runs the job (actor becomes the maintainer).
+    #   - github.actor != 'github-actions[bot]' is the no-loop guard: this job
+    #     commits regenerated assets then close+reopens the PR to re-trigger
+    #     checks. That `reopened` event has the SAME PR author (dependabot[bot]),
+    #     so an author-only gate would re-run regen -> infinite loop. The reopen's
+    #     actor is github-actions[bot] (the token), so excluding it breaks the
+    #     self-trigger loop while still letting Dependabot and maintainer re-runs
+    #     through.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     permissions:
       contents: write # push the regenerated assets back to the PR branch
       pull-requests: write # close+reopen to re-trigger checks on the new HEAD

--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -1,0 +1,88 @@
+# Regenerate committed code-gen output on Dependabot PRs.
+#
+# Why this exists: the `UI Assets` CI gate runs `make ui-check`, which regenerates
+# web/templates/*_templ.go from the .templ sources using the templ tool pinned in
+# go.mod's `tool` directive, then fails if the committed output differs. When
+# Dependabot bumps github.com/a-h/templ it updates go.mod but never regenerates
+# the committed *_templ.go, so the newer generator's output differs from what is
+# committed and `UI Assets` fails -- the bump can never pass or auto-merge.
+#
+# This workflow, scoped strictly to Dependabot-authored PRs, regenerates the templ
+# output with the bumped tool, commits it back to the PR branch, and re-triggers
+# the check suite. It does NOT weaken the `UI Assets` gate for human PRs: that gate
+# still fails when a human forgets `make ui`.
+#
+# Re-trigger without a stored secret: a commit pushed with the default GITHUB_TOKEN
+# does NOT re-trigger required checks (GitHub's recursion guard), so dependabot-merge
+# would wait forever on a HEAD that has no checks. We close-then-reopen the PR with
+# the same GITHUB_TOKEN (pull-requests: write) to force a fresh check suite on the
+# regenerated HEAD -- no new PAT/App secret needed.
+
+name: Regenerate Dependabot codegen
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  regen:
+    name: Regenerate codegen assets
+    runs-on: ubuntu-latest
+    # Strictly Dependabot-only. Human PRs are untouched, so the `UI Assets` gate
+    # still fails when a human forgets to run `make ui`.
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write # push the regenerated assets back to the PR branch
+      pull-requests: write # close+reopen to re-trigger checks on the new HEAD
+    concurrency:
+      group: dependabot-regen-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Check out the PR head branch (not the read-only merge ref) so HEAD is
+          # the branch tip we will commit onto and push back.
+          ref: ${{ github.head_ref }}
+          # persist-credentials:false (org rule); we push via an explicit token URL
+          # below so no credentials are written to .git/config.
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Regenerate templ output
+        # Only templ is Dependabot-managed. Tailwind is a hardcoded, pinned curl
+        # install (not in go.mod/actions), so a Dependabot bump never changes
+        # output.css -- regenerating templ alone is sufficient and avoids the
+        # Tailwind download.
+        run: make templ
+
+      - name: Commit and re-trigger if assets changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          git add -A web/
+          if git diff --cached --quiet; then
+            echo "Generated codegen assets already current; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "ci: regenerate codegen assets for dependabot bump"
+          # GITHUB_TOKEN in the push URL is auto-masked in logs and is not
+          # persisted to .git/config (inline URL only).
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+          # A GITHUB_TOKEN push does not re-trigger required checks, so close+reopen
+          # the PR to force a fresh check suite on the regenerated HEAD.
+          gh pr close "$PR_NUMBER" --repo "$REPO"
+          sleep 5
+          gh pr reopen "$PR_NUMBER" --repo "$REPO"
+          echo "Regenerated assets committed; PR closed+reopened to re-run checks."


### PR DESCRIPTION
## What

Harden Dependabot automation end-to-end. Closes #364.

## Gap 2 — merge gate requires the auto-approve bot's approval

`dependabot-auto-approve.yml` correctly skips `semver-major` bumps, but `dependabot-merge.yml` counted an APPROVED review from **any** user — so CodeRabbit's auto-approval of the `actions/checkout` **v7 major** (#359) auto-merged it against policy.

Fix (`.github/workflows/dependabot-merge.yml`): the approval check now filters to `github-actions[bot]` (the identity `dependabot-auto-approve.yml` reviews as) **before** the latest-per-user dedup, and asserts `.user.type == "Bot"`; `APPROVER` is quoted. A CodeRabbit-only (or human) approval no longer satisfies the gate. Verified by replaying both filters against the actual #359 incident: old filter → `1` (would auto-merge the major), new filter → `0` (blocked).

## Gap 1 — auto-regenerate codegen on Dependabot bumps (root cause of #355)

The `UI Assets` gate runs `make ui-check`, which regenerates `*_templ.go` and fails on drift. Dependabot bumps the templ tool in `go.mod` but never regenerates the committed output, so every templ bump fails the gate (PR #355 is the live instance).

Fix (new `.github/workflows/dependabot-regen.yml`): on a Dependabot PR it runs `make templ`, commits the regenerated assets back, and re-triggers the check suite via a `GITHUB_TOKEN` close/reopen (**no stored secret**). Gated on `github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]'` — the author clause keeps it Dependabot-only and handles a maintainer re-run; the actor clause skips the workflow's own reopen so it can't self-loop (belt-and-suspenders with the `git diff --cached --quiet` idempotency exit). SHA-pinned actions, least-priv job-level permissions, `persist-credentials: false`, inline masked push URL. Human PRs are untouched (the `UI Assets` gate still fails when a human forgets `make ui`).

## Residual risk to validate (not statically provable)

**R1:** Dependabot `pull_request` runs may receive a **read-only `GITHUB_TOKEN`** regardless of the declared `permissions:`. The sibling `dependabot-auto-approve.yml` proves `pull-requests: write` works in this context here, but `contents: write` (the regen push) is the unproven part. If it's capped, the regen's push + close/reopen 403 and the job silently no-ops (the PR stays stuck — no worse than today, but the fix wouldn't fire). **Must be confirmed on the first real templ bump after merge.** If it fails, the escapes (workflow_run / pull_request_target / a Dependabot PAT) are larger changes — validate before adopting.

## Follow-up
Once merged, PR #355 just needs a `@dependabot rebase` — the new regen workflow makes it pass.
