### PR TITLE
chore(rebrand): rename binary/CLI/docs to Canticle (Option A, partial) (#330)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,7 @@ coverage.html
 dist
 lyrics
 mxlrc-go
-mxlrcgo-svc
+canticle
 *_failed.txt
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.so
 *.dylib
 mxlrc-go
-/mxlrcgo-svc
+/canticle
 
 # Test binary, built with `go test -c`
 *.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,7 @@ homebrew_casks:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
-    homepage: https://sydlexius.github.io/mxlrcgo-svc/
+    homepage: https://sydlexius.github.io/canticle/
     description: Fetch synced lyrics from Musixmatch and save them as .lrc files
     caveats: |
       Set your Musixmatch token via MUSIXMATCH_TOKEN or in the config file:
@@ -74,7 +74,7 @@ nfpms:
     ids:
       - mxlrcgo-svc
     vendor: sydlexius
-    homepage: https://sydlexius.github.io/mxlrcgo-svc/
+    homepage: https://sydlexius.github.io/canticle/
     maintainer: sydlexius <maintainer@placeholder.example>
     description: Fetch synced lyrics from Musixmatch and save them as .lrc files
     license: GPL-3.0
@@ -200,7 +200,7 @@ changelog:
 release:
   github:
     owner: sydlexius
-    name: mxlrcgo-svc
+    name: canticle
   prerelease: auto
   make_latest: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
   header: |
@@ -211,7 +211,7 @@ release:
     **Docker:** `docker pull ghcr.io/sydlexius/canticle:{{ .Version }}`
 
     {{- if .PreviousTag }}
-    **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/sydlexius/mxlrcgo-svc/compare/{{ .PreviousTag }}...{{ .Tag }})
+    **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/sydlexius/canticle/compare/{{ .PreviousTag }}...{{ .Tag }})
     {{- else }}
-    **Full Changelog:** [{{ .Tag }}](https://github.com/sydlexius/mxlrcgo-svc/releases/tag/{{ .Tag }})
+    **Full Changelog:** [{{ .Tag }}](https://github.com/sydlexius/canticle/releases/tag/{{ .Tag }})
     {{- end }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
 version: 2
 
+project_name: canticle
+
 builds:
   - id: mxlrcgo-svc
     main: ./cmd/mxlrcgo-svc
-    binary: mxlrcgo-svc
+    binary: canticle
     env:
       - CGO_ENABLED=0
     # -trimpath: reproducible builds; strips local source paths from the binary.
@@ -47,7 +49,7 @@ homebrew_casks:
     # ffmpeg is only needed for the optional audio verification/instrumental
     # sidecar; it is NOT a required runtime dependency and is not listed here.
     binaries:
-      - mxlrcgo-svc
+      - canticle
     repository:
       owner: sydlexius
       name: homebrew-tap
@@ -121,7 +123,7 @@ nfpms:
 dockers_v2:
   - id: mxlrcgo-svc
     images:
-      - "ghcr.io/sydlexius/mxlrcgo-svc"
+      - "ghcr.io/sydlexius/canticle"
     # dockers_v2 ignores empty tag templates, so prerelease gating is encoded
     # by emitting "" for the disallowed branch:
     #   :VERSION       always
@@ -202,11 +204,11 @@ release:
   prerelease: auto
   make_latest: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
   header: |
-    ## mxlrcgo-svc {{ .Tag }}
+    ## Canticle {{ .Tag }}
 
     {{ if .Prerelease }}> This is a pre-release version. Use the `beta` Docker tag to try it out.{{ end }}
   footer: |
-    **Docker:** `docker pull ghcr.io/sydlexius/mxlrcgo-svc:{{ .Version }}`
+    **Docker:** `docker pull ghcr.io/sydlexius/canticle:{{ .Version }}`
 
     {{- if .PreviousTag }}
     **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/sydlexius/mxlrcgo-svc/compare/{{ .PreviousTag }}...{{ .Tag }})

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 # Runtime stage. KEEP IN SYNC with build/docker/Dockerfile.goreleaser (the goreleaser
 # release image): identical base digest, apk packages, user, ENV, EXPOSE, VOLUME, entrypoint.
 # The two differ only in how the binary arrives (built here vs copied by goreleaser).
-LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
+LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="GPL-3.0" \
       net.unraid.docker.webui="http://[IP]:[PORT:50705]/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/mxlrcgo-svc ./cmd/mxlrcgo-svc
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/canticle ./cmd/mxlrcgo-svc
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
@@ -27,7 +27,7 @@ RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
     mkdir -p /config /music && \
     chown mxlrcgo:mxlrcgo /config /music
 
-COPY --from=build /out/mxlrcgo-svc /usr/local/bin/mxlrcgo-svc
+COPY --from=build /out/canticle /usr/local/bin/canticle
 COPY build/docker/entrypoint.sh /entrypoint.sh
 # Make the entrypoint executable and pre-ship bash completion: generate the
 # static wrapper and source it from the system bashrc so interactive
@@ -36,8 +36,8 @@ COPY build/docker/entrypoint.sh /entrypoint.sh
 # one an interactive non-login shell reads here). We also write the conventional
 # /etc/bash.bashrc for robustness if the base image ever changes; both are guarded.
 RUN chmod +x /entrypoint.sh && \
-    mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
-    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' \
+    canticle completion bash > /etc/bash/canticle.bash && \
+    printf '\n[ -f /etc/bash/canticle.bash ] && . /etc/bash/canticle.bash\n' \
       | tee -a /etc/bash/bashrc /etc/bash.bashrc > /dev/null
 
 ENV MXLRC_DOCKER=true \
@@ -50,4 +50,4 @@ VOLUME ["/config", "/music"]
 # USER is intentionally omitted so entrypoint.sh can perform PUID/PGID
 # remapping and volume ownership fixes as root before dropping to mxlrcgo.
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["mxlrcgo-svc", "serve"]
+CMD ["canticle", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
         docs docs-serve docs-deps templ tailwind ui ui-check
 
 # Binary name
-BINARY=mxlrcgo-svc
+BINARY=canticle
 
 # Tailwind standalone CLI (v4). Override with `make ui TAILWIND=/path/to/tailwindcss`.
 # Install the single, node-free binary from

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# mxlrcgo-svc
+# Canticle
 
-[![CI](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml/badge.svg)](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/ci.yml)
-[![Release](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/release.yml/badge.svg)](https://github.com/sydlexius/mxlrcgo-svc/actions/workflows/release.yml)
-[![codecov](https://codecov.io/gh/sydlexius/mxlrcgo-svc/branch/main/graph/badge.svg)](https://codecov.io/gh/sydlexius/mxlrcgo-svc)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sydlexius/mxlrcgo-svc/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sydlexius/mxlrcgo-svc)
+[![CI](https://github.com/sydlexius/canticle/actions/workflows/ci.yml/badge.svg)](https://github.com/sydlexius/canticle/actions/workflows/ci.yml)
+[![Release](https://github.com/sydlexius/canticle/actions/workflows/release.yml/badge.svg)](https://github.com/sydlexius/canticle/actions/workflows/release.yml)
+[![codecov](https://codecov.io/gh/sydlexius/canticle/branch/main/graph/badge.svg)](https://codecov.io/gh/sydlexius/canticle)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sydlexius/canticle/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sydlexius/canticle)
 
 Command line tool and webhook service to fetch synced lyrics from [Musixmatch](https://www.musixmatch.com/) and save them as `.lrc` files.
 
 ## Documentation
 
-Full documentation is published at **<https://sydlexius.github.io/mxlrcgo-svc/>**:
+Full documentation is published at **<https://sydlexius.github.io/canticle/>**:
 
-- [Getting Started](https://sydlexius.github.io/mxlrcgo-svc/GETTING_STARTED/) - onboarding guide: pick a path (one-shot, directory, or daemon) and get to working lyrics.
-- [User Guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/) - webhook server, Docker/Unraid, the filesystem watcher, inspection commands.
-- [CLI Reference](https://sydlexius.github.io/mxlrcgo-svc/CLI_REFERENCE/) - every subcommand and flag.
-- [Configuration](https://sydlexius.github.io/mxlrcgo-svc/CONFIGURATION/) - env vars, TOML keys, token precedence, XDG paths.
-- [Developer Guide](https://sydlexius.github.io/mxlrcgo-svc/DEVELOPER/) - build, test, the quality gate, design decisions.
+- [Getting Started](https://sydlexius.github.io/canticle/GETTING_STARTED/) - onboarding guide: pick a path (one-shot, directory, or daemon) and get to working lyrics.
+- [User Guide](https://sydlexius.github.io/canticle/USER_GUIDE/) - webhook server, Docker/Unraid, the filesystem watcher, inspection commands.
+- [CLI Reference](https://sydlexius.github.io/canticle/CLI_REFERENCE/) - every subcommand and flag.
+- [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) - env vars, TOML keys, token precedence, XDG paths.
+- [Developer Guide](https://sydlexius.github.io/canticle/DEVELOPER/) - build, test, the quality gate, design decisions.
 
 ## Install
 
@@ -26,7 +26,7 @@ brew install sydlexius/tap/mxlrcgo-svc
 ```
 
 **Linux (.deb / .rpm / .apk):** Download the appropriate package for your distro
-from the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)
+from the [GitHub Releases](https://github.com/sydlexius/canticle/releases)
 page and install it with your package manager:
 
 ```sh
@@ -40,7 +40,7 @@ sudo rpm -i mxlrcgo-svc_*.rpm
 sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
 ```
 
-The package installs the binary to `/usr/local/bin/mxlrcgo-svc`, a systemd unit
+The package installs the binary to `/usr/local/bin/canticle`, a systemd unit
 (or OpenRC script on Alpine), and an example config at
 `/etc/mxlrcgo-svc/config.example.toml`. It also creates a `mxlrcgo-svc`
 system user and a state directory at `/var/lib/mxlrcgo-svc` (mode `0750`) that
@@ -58,47 +58,47 @@ sudo systemctl enable --now mxlrcgo-svc   # systemd
 
 The state directory and system user are preserved on package removal so the
 database survives upgrades and reinstalls. See the
-[User Guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/#native-packages)
+[User Guide](https://sydlexius.github.io/canticle/USER_GUIDE/#native-packages)
 for service commands, log access, and data paths.
 
 **Tarballs / macOS / Windows:** Versioned archives for all platforms are also
-available on the [GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases)
+available on the [GitHub Releases](https://github.com/sydlexius/canticle/releases)
 page.
 
 **Build from source** (requires Go 1.26.4+):
 
 ```sh
-go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest
+go install github.com/sydlexius/canticle/cmd/mxlrcgo-svc@latest
 ```
 
-> This fork starts its release line at `v1.0.0`. The upstream `fashni/mxlrc-go` repository does not publish semver release tags, so `v1.0.0` is reserved as the first `mxlrcgo-svc` version.
+> This fork starts its release line at `v1.0.0`. The upstream `fashni/mxlrc-go` repository does not publish semver release tags, so `v1.0.0` is reserved as the first `canticle` version.
 
 ## Quickstart
 
 ```sh
 # One song
-mxlrcgo-svc adele,hello
+canticle adele,hello
 
 # Multiple songs into a custom output directory
-mxlrcgo-svc adele,hello "the killers,mr. brightside" -o some_directory
+canticle adele,hello "the killers,mr. brightside" -o some_directory
 
 # Directory mode (recursive): writes each lyric file next to its audio file
-mxlrcgo-svc "Dream Theater"
+canticle "Dream Theater"
 
 # Lidarr webhook server
 MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key \
-  mxlrcgo-svc serve --listen 127.0.0.1:3876
+  canticle serve --listen 127.0.0.1:3876
 ```
 
-Directory mode overrides `-o/--outdir`; the output extension is `.lrc` for synced lyrics and `.txt` for unsynced lyrics or an instrumental marker. See the [CLI Reference](https://sydlexius.github.io/mxlrcgo-svc/CLI_REFERENCE/) for every flag and the [User Guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/) for Docker, Unraid, and webhook deployment.
+Directory mode overrides `-o/--outdir`; the output extension is `.lrc` for synced lyrics and `.txt` for unsynced lyrics or an instrumental marker. See the [CLI Reference](https://sydlexius.github.io/canticle/CLI_REFERENCE/) for every flag and the [User Guide](https://sydlexius.github.io/canticle/USER_GUIDE/) for Docker, Unraid, and webhook deployment.
 
 ## Token
 
-A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). To get a token, follow steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/mxlrcgo-svc/CONFIGURATION/) for the full env-var and TOML surface.
+A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). To get a token, follow steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
 
 ## Encrypted secrets
 
-The Musixmatch token and the webhook API key can be stored encrypted at rest in the SQLite database (AES-256-GCM) instead of as plaintext in config and environment variables. It is opt-in and backward compatible: the encrypted store is the lowest-precedence source, so existing env/TOML setups are unchanged. Import the current plaintext with `mxlrcgo-svc secrets import`, set one by name from stdin with `mxlrcgo-svc secrets set <name>`, and list stored names (never values) with `mxlrcgo-svc secrets list`. The 32-byte master key is auto-generated as a `0600` key file on first use (the universal zero-setup default on all platforms including Docker). Set `MXLRC_MASTER_KEY` to an optional base64-encoded override for key/data separation (recommended when the threat model includes whole-volume theft). Losing the key makes the encrypted secrets unrecoverable by design; the remedy is to re-import or re-set them with the original plaintext. See the [Encrypted secrets guide](https://sydlexius.github.io/mxlrcgo-svc/USER_GUIDE/#encrypted-secrets).
+The Musixmatch token and the webhook API key can be stored encrypted at rest in the SQLite database (AES-256-GCM) instead of as plaintext in config and environment variables. It is opt-in and backward compatible: the encrypted store is the lowest-precedence source, so existing env/TOML setups are unchanged. Import the current plaintext with `canticle secrets import`, set one by name from stdin with `canticle secrets set <name>`, and list stored names (never values) with `canticle secrets list`. The 32-byte master key is auto-generated as a `0600` key file on first use (the universal zero-setup default on all platforms including Docker). Set `MXLRC_MASTER_KEY` to an optional base64-encoded override for key/data separation (recommended when the threat model includes whole-volume theft). Losing the key makes the encrypted secrets unrecoverable by design; the remedy is to re-import or re-set them with the original plaintext. See the [Encrypted secrets guide](https://sydlexius.github.io/canticle/USER_GUIDE/#encrypted-secrets).
 
 ## Web UI access (serve mode)
 
@@ -124,8 +124,8 @@ When TLS is on, the session cookie's `Secure` flag is set automatically. An opti
 
 ## Legal
 
-- [Privacy Policy](https://sydlexius.github.io/mxlrcgo-svc/privacy-policy/) - what data leaves your machine during a lyrics lookup and what does not.
-- [Code Signing Policy](https://sydlexius.github.io/mxlrcgo-svc/code-signing-policy/) - SignPath attribution, team roles, and release approval process.
+- [Privacy Policy](https://sydlexius.github.io/canticle/privacy-policy/) - what data leaves your machine during a lyrics lookup and what does not.
+- [Code Signing Policy](https://sydlexius.github.io/canticle/code-signing-policy/) - SignPath attribution, team roles, and release approval process.
 
 ## License
 

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -3,7 +3,7 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 # KEEP IN SYNC with the runtime stage of the root Dockerfile (used by nightly.yml and the
 # ci.yml CVE scan): identical base digest, apk packages, user, ENV, EXPOSE, VOLUME, entrypoint.
 # The two differ only in how the binary arrives (copied here vs built in the root Dockerfile).
-LABEL org.opencontainers.image.source="https://github.com/sydlexius/mxlrcgo-svc" \
+LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
       org.opencontainers.image.description="Fetch synced lyrics from Musixmatch and save .lrc files" \
       org.opencontainers.image.licenses="GPL-3.0" \
       net.unraid.docker.webui="http://[IP]:[PORT:50705]/"

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -19,7 +19,7 @@ RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
 # each platform's binary under $TARGETPLATFORM/ in the build context.
 # extra_files (entrypoint.sh) keep their original relative path.
 ARG TARGETPLATFORM
-COPY $TARGETPLATFORM/mxlrcgo-svc /usr/local/bin/mxlrcgo-svc
+COPY $TARGETPLATFORM/canticle /usr/local/bin/canticle
 COPY build/docker/entrypoint.sh /entrypoint.sh
 # Make the entrypoint executable and pre-ship bash completion: generate the
 # static wrapper and source it from the system bashrc so interactive
@@ -28,8 +28,8 @@ COPY build/docker/entrypoint.sh /entrypoint.sh
 # one an interactive non-login shell reads here). We also write the conventional
 # /etc/bash.bashrc for robustness if the base image ever changes; both are guarded.
 RUN chmod +x /entrypoint.sh && \
-    mxlrcgo-svc completion bash > /etc/bash/mxlrcgo-svc.bash && \
-    printf '\n[ -f /etc/bash/mxlrcgo-svc.bash ] && . /etc/bash/mxlrcgo-svc.bash\n' \
+    canticle completion bash > /etc/bash/canticle.bash && \
+    printf '\n[ -f /etc/bash/canticle.bash ] && . /etc/bash/canticle.bash\n' \
       | tee -a /etc/bash/bashrc /etc/bash.bashrc > /dev/null
 
 ENV MXLRC_DOCKER=true \
@@ -42,4 +42,4 @@ VOLUME ["/config", "/music"]
 # USER is intentionally omitted so entrypoint.sh can perform PUID/PGID
 # remapping and volume ownership fixes as root before dropping to mxlrcgo.
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["mxlrcgo-svc", "serve"]
+CMD ["canticle", "serve"]

--- a/build/package/mxlrcgo-svc.openrc
+++ b/build/package/mxlrcgo-svc.openrc
@@ -1,8 +1,8 @@
 #!/sbin/openrc-run
 
-description="mxlrcgo-svc lyrics fetcher daemon"
+description="Canticle lyrics fetcher daemon"
 
-command=/usr/local/bin/mxlrcgo-svc
+command=/usr/local/bin/canticle
 command_args="serve"
 command_user=mxlrcgo-svc:mxlrcgo-svc
 command_background=yes

--- a/build/package/mxlrcgo-svc.service
+++ b/build/package/mxlrcgo-svc.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=mxlrcgo-svc lyrics fetcher daemon
-Documentation=https://sydlexius.github.io/mxlrcgo-svc/
+Description=Canticle lyrics fetcher daemon
+Documentation=https://sydlexius.github.io/canticle/
 After=network-online.target
 Wants=network-online.target
 
@@ -8,7 +8,7 @@ Wants=network-online.target
 Type=simple
 User=mxlrcgo-svc
 Group=mxlrcgo-svc
-ExecStart=/usr/local/bin/mxlrcgo-svc serve
+ExecStart=/usr/local/bin/canticle serve
 Restart=on-failure
 RestartSec=5s
 

--- a/cmd/mxlrcgo-svc/main_test.go
+++ b/cmd/mxlrcgo-svc/main_test.go
@@ -146,7 +146,7 @@ func TestRunWithOptions_HelpDoesNotStartApplication(t *testing.T) {
 	if rec.appCreated {
 		t.Fatal("app was created; want help to stop before startup")
 	}
-	if !strings.Contains(out.String(), "Usage: mxlrcgo-svc") {
+	if !strings.Contains(out.String(), "Usage: canticle") {
 		t.Fatalf("help output = %q; want usage", out.String())
 	}
 }
@@ -162,22 +162,22 @@ func TestRunWithOptions_SubcommandHelpShowsSelectedCommand(t *testing.T) {
 		{
 			name: "serve",
 			args: []string{"serve", "--help"},
-			want: []string{"Usage: mxlrcgo-svc serve", "--scan-interval", "--work-interval"},
+			want: []string{"Usage: canticle serve", "--scan-interval", "--work-interval"},
 		},
 		{
 			name: "scan",
 			args: []string{"scan", "--help"},
-			want: []string{"Usage: mxlrcgo-svc scan", "--upgrade", "--bfs"},
+			want: []string{"Usage: canticle scan", "--upgrade", "--bfs"},
 		},
 		{
 			name: "library",
 			args: []string{"library", "--help"},
-			want: []string{"Usage: mxlrcgo-svc library", "add", "list"},
+			want: []string{"Usage: canticle library", "add", "list"},
 		},
 		{
 			name: "library add",
 			args: []string{"library", "add", "--help"},
-			want: []string{"Usage: mxlrcgo-svc library add", "--name", "--config"},
+			want: []string{"Usage: canticle library add", "--name", "--config"},
 		},
 	}
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,4 @@
-# mxlrcgo-svc configuration file
+# Canticle configuration file
 # Copy to ~/.config/mxlrcgo-svc/config.toml and edit as needed.
 # Environment variable overrides (in precedence order): MUSIXMATCH_TOKEN,
 # MXLRC_API_TOKEN, MXLRC_API_COOLDOWN (or MXLRC_COOLDOWN),

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,6 @@
 # Canticle configuration file
 # Copy to ~/.config/mxlrcgo-svc/config.toml and edit as needed.
+# (config dir name retained as mxlrcgo-svc for in-place upgrade compatibility)
 # Environment variable overrides (in precedence order): MUSIXMATCH_TOKEN,
 # MXLRC_API_TOKEN, MXLRC_API_COOLDOWN (or MXLRC_COOLDOWN),
 # MXLRC_API_CIRCUIT_OPEN_DURATION, MXLRC_API_CIRCUIT_BACKOFF_BASE, MXLRC_OUTPUT_DIR,

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,7 +1,7 @@
 services:
-  mxlrcgo-svc:
-    image: ghcr.io/sydlexius/mxlrcgo-svc:latest
-    container_name: mxlrcgo-svc
+  canticle:
+    image: ghcr.io/sydlexius/canticle:latest
+    container_name: canticle
     restart: unless-stopped
     ports:
       - "50705:50705"
@@ -33,8 +33,8 @@ services:
       # /config/.mxlrcgo.key. See docs/USER_GUIDE.md "Encrypted secrets".
       MXLRC_MASTER_KEY: "${MXLRC_MASTER_KEY}"
     volumes:
-      - mxlrcgo-svc-config:/config
+      - canticle-config:/config
       - /path/to/your/data:/data:rw
 
 volumes:
-  mxlrcgo-svc-config:
+  canticle-config:

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5,7 +5,7 @@ This page documents every subcommand and flag. For operational guidance (running
 ## Usage
 
 ```text
-Usage: mxlrcgo-svc [fetch|serve|scan|library|keys|config|queue|provenance]
+Usage: canticle [fetch|serve|scan|library|keys|config|queue|provenance]
 
 Commands:
   fetch       fetch lyrics once without HTTP server or DB queue
@@ -22,13 +22,13 @@ Global flags:
   --help     show help for the program or a subcommand
 
 Legacy flag-only invocation is still supported:
-  mxlrcgo-svc [--outdir OUTDIR] [--cooldown COOLDOWN] [--depth DEPTH] [--update] [--upgrade] [--bfs] [--serve] [--listen LISTEN] [--token TOKEN] [--config CONFIG] [SONG ...]
+  canticle [--outdir OUTDIR] [--cooldown COOLDOWN] [--depth DEPTH] [--update] [--upgrade] [--bfs] [--serve] [--listen LISTEN] [--token TOKEN] [--config CONFIG] [SONG ...]
 ```
 
 ## Version
 
-`mxlrcgo-svc --version` prints the embedded build metadata, for example
-`mxlrcgo-svc v1.1.0 (commit 1a2b3c4, built 2026-06-05T00:00:00Z)`. Release
+`canticle --version` prints the embedded build metadata, for example
+`canticle v1.1.0 (commit 1a2b3c4, built 2026-06-05T00:00:00Z)`. Release
 binaries and the published Docker images carry the real tag; a `go build` or
 `go install` from source reports `dev` unless you inject the ldflags yourself.
 
@@ -39,26 +39,26 @@ One-shot lyric fetching without the HTTP server or DB queue.
 ### One song
 
 ```sh
-mxlrcgo-svc adele,hello
-mxlrcgo-svc fetch adele,hello
+canticle adele,hello
+canticle fetch adele,hello
 ```
 
 ### Multiple songs and a custom output directory
 
 ```sh
-mxlrcgo-svc adele,hello "the killers,mr. brightside" -o some_directory
+canticle adele,hello "the killers,mr. brightside" -o some_directory
 ```
 
 ### With a text file and a custom cooldown time
 
 ```sh
-mxlrcgo-svc example_input.txt -c 20
+canticle example_input.txt -c 20
 ```
 
 ### Directory mode (recursive)
 
 ```sh
-mxlrcgo-svc "Dream Theater"
+canticle "Dream Theater"
 ```
 
 > **_This option overrides the `-o/--outdir` argument which means the lyrics will be saved in the same directory as the given input._**
@@ -76,8 +76,8 @@ In directory mode, when audio tags carry ISRC, MusicBrainz recording ID, or dura
 Run the HTTP server, worker, and library scheduler. See the [User Guide](USER_GUIDE.md#lidarr-webhook-server) for full operational detail.
 
 ```sh
-mxlrcgo-svc serve --listen 127.0.0.1:3876
-mxlrcgo-svc serve --config path/to/config.toml
+canticle serve --listen 127.0.0.1:3876
+canticle serve --config path/to/config.toml
 ```
 
 Relevant serve flags: `--listen` (overrides `MXLRC_SERVER_ADDR`), `--scan-interval`, `--work-interval`, and `--config`.
@@ -85,12 +85,12 @@ Relevant serve flags: `--listen` (overrides `MXLRC_SERVER_ADDR`), `--scan-interv
 ## Library and key management
 
 ```sh
-mxlrcgo-svc library add /data/media/music --name Music
-mxlrcgo-svc library list
-mxlrcgo-svc scan
-mxlrcgo-svc keys create --name lidarr --scope webhook
-mxlrcgo-svc keys list
-mxlrcgo-svc config get db.path
+canticle library add /data/media/music --name Music
+canticle library list
+canticle scan
+canticle keys create --name lidarr --scope webhook
+canticle keys list
+canticle config get db.path
 ```
 
 ## Queue and scan inspection
@@ -99,7 +99,7 @@ The `queue` and `scan` subcommands expose the durable work queue and persisted s
 
 ## Provenance
 
-Synced `.lrc` files written by `mxlrcgo-svc` carry provenance tags in the header block that identify where and when each file came from. These tags appear after the standard metadata tags (`[by:]`, `[ar:]`, `[ti:]`, etc.) and before the first timestamped lyric line:
+Synced `.lrc` files written by `canticle` carry provenance tags in the header block that identify where and when each file came from. These tags appear after the standard metadata tags (`[by:]`, `[ar:]`, `[ti:]`, etc.) and before the first timestamped lyric line:
 
 ```text
 [source:musixmatch]
@@ -113,7 +113,7 @@ Synced `.lrc` files written by `mxlrcgo-svc` carry provenance tags in the header
 |---|---|---|
 | `[source:]` | provider lane name | e.g. `musixmatch`, `petitlyrics` |
 | `[fetched:]` | ISO 8601 fetch timestamp | UTC; absent on cache hits |
-| `[ve:]` | generating mxlrcgo-svc version | e.g. `v1.2.0`; `dev` on local builds |
+| `[ve:]` | generating canticle version | e.g. `v1.2.0`; `dev` on local builds |
 | `[isrc:]` | ISRC recording identifier | when available from the audio file or API response |
 | `[mbid:]` | MusicBrainz recording ID | when available from the audio file |
 
@@ -123,16 +123,16 @@ Existing `.lrc` files that predate this feature can have provenance tags injecte
 
 ```sh
 # Preview what would change (dry run)
-mxlrcgo-svc provenance backfill
+canticle provenance backfill
 
 # Target specific paths or directories
-mxlrcgo-svc provenance backfill /data/music/Artist
+canticle provenance backfill /data/music/Artist
 
 # Apply the changes
-mxlrcgo-svc provenance backfill --yes
+canticle provenance backfill --yes
 
 # Apply to specific paths
-mxlrcgo-svc provenance backfill --yes /data/music/Artist/Album
+canticle provenance backfill --yes /data/music/Artist/Album
 ```
 
 The backfill is idempotent: tags that already exist in a file are skipped; only genuinely absent tags are injected. The `[ve:]` tag is never injected on backfill (the originating version is not recorded in the database). Files for which the database has no matching row, or with only partial metadata, are reported as `partial` rather than `seeded`.
@@ -142,7 +142,7 @@ The backfill is idempotent: tags that already exist in a file are skipped; only 
 ## Shell completion
 
 ```sh
-mxlrcgo-svc completion <bash|zsh|fish>
+canticle completion <bash|zsh|fish>
 ```
 
 See [Shell completion](USER_GUIDE.md#shell-completion) for installation snippets.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,12 +10,12 @@ A Musixmatch API token is required. Supply it using any of the following methods
 
 1. **`--token` CLI flag** - highest priority.
    ```sh
-   mxlrcgo-svc --token YOUR_TOKEN adele,hello
+   canticle --token YOUR_TOKEN adele,hello
    ```
 2. **`MUSIXMATCH_TOKEN` environment variable** (`MXLRC_API_TOKEN` is accepted as a lower-precedence alias).
    ```sh
    export MUSIXMATCH_TOKEN=YOUR_TOKEN
-   mxlrcgo-svc adele,hello
+   canticle adele,hello
    ```
 3. **Config file / `.env` file** - place a `.env` in the working directory where you run the command, or set the token in the TOML config.
    ```sh
@@ -30,7 +30,7 @@ For all settings, precedence is **CLI flag > environment variable > config file 
 
 ## Storage paths
 
-`mxlrcgo-svc` resolves its config file and SQLite database using XDG base directories by default, with overrides for Docker and native packages.
+`canticle` resolves its config file and SQLite database using XDG base directories by default, with overrides for Docker and native packages.
 
 | Install method | Config file | Database |
 |----------------|-------------|----------|
@@ -53,7 +53,7 @@ The table below is the complete env-var surface; the watcher and verification se
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `MUSIXMATCH_TOKEN` | (required) | Musixmatch API token. `MXLRC_API_TOKEN` is accepted as a lower-precedence alias. |
-| `MXLRC_WEBHOOK_API_KEY` | (none) | Comma-separated webhook API key(s) accepted by the server. Generate with `mxlrcgo-svc keys create --scope webhook`. |
+| `MXLRC_WEBHOOK_API_KEY` | (none) | Comma-separated webhook API key(s) accepted by the server. Generate with `canticle keys create --scope webhook`. |
 | `MXLRC_SERVER_ADDR` | `127.0.0.1:3876` | HTTP listen address for `serve`. Docker images default this to `0.0.0.0:50705`. |
 | `MXLRC_WEB_UI_ENABLED` | `false` | Enable the browser UI on the serve listener. Env override of `web_ui_enabled` (precedence: env > file). Restart to apply. |
 | `MXLRC_TRUSTED_CIDRS` | (none) | Comma-separated CIDRs of trusted client networks (serve mode). Loopback is always trusted. Requests from listed CIDRs may scrape `GET /metrics` and bypass the web UI session requirement. |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-`mxlrcgo-svc` fetches synced lyrics from [Musixmatch](https://www.musixmatch.com/) and saves them as `.lrc` files (falling back to `.txt` for unsynced lyrics or instrumental markers). This guide gets you from nothing to working lyrics, then points you at the reference pages for detail.
+Canticle fetches synced lyrics from [Musixmatch](https://www.musixmatch.com/) and saves them as `.lrc` files (falling back to `.txt` for unsynced lyrics or instrumental markers). This guide gets you from nothing to working lyrics, then points you at the reference pages for detail.
 
 ## Which path is for you?
 
@@ -36,7 +36,7 @@ See [Configuration](CONFIGURATION.md#token-precedence) for the full token and co
 With the token exported, fetch a single song. The query is `artist,title` - a comma, no spaces:
 
 ```sh
-mxlrcgo-svc adele,hello
+canticle adele,hello
 ```
 
 On success, a lyric file is written to the current directory (or to the directory you pass with `-o/--outdir`). What you get depends on what Musixmatch has:
@@ -53,7 +53,7 @@ For multiple songs, a text-file batch, and every flag, see the [CLI Reference](C
 Point the tool at a folder and it walks the tree, writing a lyric file next to each audio file:
 
 ```sh
-mxlrcgo-svc /path/to/music
+canticle /path/to/music
 ```
 
 Notes:
@@ -63,7 +63,7 @@ Notes:
 - `--upgrade` re-fetches tracks that previously produced a `.txt` (unsynced) file, to promote them to `.lrc` once synced lyrics become available. **Instrumental `.txt` files are excluded from upgrade**; use `--update` to force a re-fetch of those.
 - When audio files contain ISRC, MusicBrainz recording ID, or duration tags, the scanner reads them automatically and passes them to Musixmatch to improve match precision - especially useful for albums with tracks that share the same title. See [Recording enrichment](USER_GUIDE.md#recording-enrichment) for controls.
 
-A bare argument that matches an existing directory triggers a recursive scan. That means `mxlrcgo-svc "Dream Theater"` scans a folder named `Dream Theater`; it is not interpreted as a song query. Use the `artist,title` form for one-shot fetches.
+A bare argument that matches an existing directory triggers a recursive scan. That means `canticle "Dream Theater"` scans a folder named `Dream Theater`; it is not interpreted as a song query. Use the `artist,title` form for one-shot fetches.
 
 Test on a single album first to confirm the result before scanning a whole library. See the [CLI Reference](CLI_REFERENCE.md#directory-mode-recursive) for the full flag list.
 
@@ -76,11 +76,11 @@ If you installed via a `.deb`, `.rpm`, or `.apk` package, the service is managed
 Register a library, then start the server:
 
 ```sh
-mxlrcgo-svc library add /path/to/music --name Music
-mxlrcgo-svc serve
+canticle library add /path/to/music --name Music
+canticle serve
 ```
 
-`serve` listens on `MXLRC_SERVER_ADDR` (default `127.0.0.1:3876`) unless you pass `--listen`. Registering and scanning your libraries first is what lets webhooks reuse the exact file paths a scan discovered, so they work even when Lidarr and `mxlrcgo-svc` see the media through different mount paths.
+`serve` listens on `MXLRC_SERVER_ADDR` (default `127.0.0.1:3876`) unless you pass `--listen`. Registering and scanning your libraries first is what lets webhooks reuse the exact file paths a scan discovered, so they work even when Lidarr and `canticle` see the media through different mount paths.
 
 ### Lidarr webhook
 
@@ -93,7 +93,7 @@ POST /api/v1/webhooks/lidarr
 Create a webhook-scoped key for it:
 
 ```sh
-mxlrcgo-svc keys create --name lidarr --scope webhook
+canticle keys create --name lidarr --scope webhook
 ```
 
 The endpoint authenticates the key in one of two ways (the server accepts either):
@@ -105,28 +105,28 @@ Configure whichever your client supports. See the [User Guide](USER_GUIDE.md#lid
 
 ### Docker
 
-The published image is `ghcr.io/sydlexius/mxlrcgo-svc`. It runs the server on container port `50705`, sets `MXLRC_DOCKER=true` automatically (so storage defaults resolve under `/config`), and honors `PUID`/`PGID` for file ownership. Mount your media data parent once (for example to `/data`):
+The published image is `ghcr.io/sydlexius/canticle`. It runs the server on container port `50705`, sets `MXLRC_DOCKER=true` automatically (so storage defaults resolve under `/config`), and honors `PUID`/`PGID` for file ownership. Mount your media data parent once (for example to `/data`):
 
 ```sh
 docker run -d \
-  --name mxlrcgo-svc \
+  --name canticle \
   -p 50705:50705 \
   -e MUSIXMATCH_TOKEN=YOUR_TOKEN \
   -e MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key \
-  -v mxlrcgo-svc-config:/config \
+  -v canticle-config:/config \
   -v /path/to/your/data:/data:rw \
-  ghcr.io/sydlexius/mxlrcgo-svc:latest
+  ghcr.io/sydlexius/canticle:latest
 ```
 
 See the [User Guide](USER_GUIDE.md#docker) for the full Docker, Compose, and Unraid setup.
 
 ### Windows
 
-Download the `.zip` from the [releases page](https://github.com/sydlexius/mxlrcgo-svc/releases), extract `mxlrcgo-svc.exe`, and add it to your `PATH`. For a quick test:
+Download the `.zip` from the [releases page](https://github.com/sydlexius/canticle/releases), extract `canticle.exe`, and add it to your `PATH`. For a quick test:
 
 ```cmd
 set MUSIXMATCH_TOKEN=YOUR_TOKEN
-mxlrcgo-svc.exe serve --listen 127.0.0.1:3876
+canticle.exe serve --listen 127.0.0.1:3876
 ```
 
 For an always-on background service, use NSSM to wrap the binary as a Windows service. See the [User Guide](USER_GUIDE.md#windows) for the full NSSM setup, environment variable configuration, and data paths.
@@ -136,7 +136,7 @@ For an always-on background service, use NSSM to wrap the binary as a Windows se
 Confirm the build and that work is flowing.
 
 ```sh
-mxlrcgo-svc --version
+canticle --version
 ```
 
 For one-shot and directory runs, check that the expected `.lrc`/`.txt` files were written.
@@ -150,10 +150,10 @@ For `serve`, the HTTP endpoints report health and status:
 The inspection subcommands show queue and scan state:
 
 ```sh
-mxlrcgo-svc queue list
-mxlrcgo-svc queue list --status pending --limit 100
-mxlrcgo-svc scan results
-mxlrcgo-svc scan results --library Music --status pending
+canticle queue list
+canticle queue list --status pending --limit 100
+canticle scan results
+canticle scan results --library Music --status pending
 ```
 
 See the [User Guide](USER_GUIDE.md#inspection-commands) for the full inspection command set.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,7 +17,7 @@ This page compares the available install methods and helps you pick one. For a q
 ## Native packages (Linux)
 
 Download the `.deb`, `.rpm`, or `.apk` for your distro from the
-[GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases) page.
+[GitHub Releases](https://github.com/sydlexius/canticle/releases) page.
 
 ```sh
 # Debian / Ubuntu
@@ -32,7 +32,7 @@ sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
 
 **What the package does:**
 
-- Installs the binary to `/usr/local/bin/mxlrcgo-svc`.
+- Installs the binary to `/usr/local/bin/canticle`.
 - Creates a `mxlrcgo-svc` system user and group (no login shell).
 - Creates `/var/lib/mxlrcgo-svc` (mode `0750`, owned by `mxlrcgo-svc:mxlrcgo-svc`) for the SQLite database and state.
 - Installs a systemd unit with hardening (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`), or an OpenRC script on Alpine (manages ownership and permissions via `start_pre`).
@@ -86,7 +86,7 @@ full operational reference.
 
 ## Docker
 
-The published image is `ghcr.io/sydlexius/mxlrcgo-svc`. It runs the server on
+The published image is `ghcr.io/sydlexius/canticle`. It runs the server on
 port `50705` and stores config and the SQLite database under the `/config`
 volume. Mount your media data parent to `/data`:
 
@@ -99,16 +99,16 @@ export MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key
 
 ```sh
 docker run -d \
-  --name mxlrcgo-svc \
+  --name canticle \
   -p 50705:50705 \
   -e MUSIXMATCH_TOKEN \
   -e MXLRC_WEBHOOK_API_KEY \
   -e PUID=99 -e PGID=100 \
   -e MXLRC_OUTPUT_DIR=/data/media/music \
-  -v mxlrcgo-svc-config:/config \
+  -v canticle-config:/config \
   -v /path/to/your/data:/data:rw \
   --restart unless-stopped \
-  ghcr.io/sydlexius/mxlrcgo-svc:latest
+  ghcr.io/sydlexius/canticle:latest
 ```
 
 For Docker Compose, copy `docker-compose.example.yml`, fill in the token and
@@ -125,7 +125,7 @@ setup.
 brew install sydlexius/tap/mxlrcgo-svc
 ```
 
-Upgrade with `brew upgrade mxlrcgo-svc`. Run as a background service with
+Upgrade with `brew upgrade canticle`. Run as a background service with
 `brew services start mxlrcgo-svc`. Storage defaults follow XDG base directories.
 
 ---
@@ -133,9 +133,9 @@ Upgrade with `brew upgrade mxlrcgo-svc`. Run as a background service with
 ## Tarball / zip
 
 Download the archive for your platform from the
-[GitHub Releases](https://github.com/sydlexius/mxlrcgo-svc/releases) page,
+[GitHub Releases](https://github.com/sydlexius/canticle/releases) page,
 extract the binary, and place it on your `PATH`. On Windows, the signed `.zip`
-extracts `mxlrcgo-svc.exe`; see the [Windows](USER_GUIDE.md#windows) section of
+extracts `canticle.exe`; see the [Windows](USER_GUIDE.md#windows) section of
 the User Guide for NSSM service installation.
 
 ---
@@ -145,14 +145,14 @@ the User Guide for NSSM service installation.
 Requires Go 1.26.4 or later.
 
 ```sh
-go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest
+go install github.com/sydlexius/canticle/cmd/mxlrcgo-svc@latest
 ```
 
 Or clone the repository and use `make`:
 
 ```sh
-git clone https://github.com/sydlexius/mxlrcgo-svc.git
-cd mxlrcgo-svc
+git clone https://github.com/sydlexius/canticle.git
+cd canticle
 make build
 ```
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,32 +1,32 @@
 # User Guide
 
-This guide covers running `mxlrcgo-svc` as a long-running service: the Lidarr webhook server, path resolution, health endpoints, Docker and Unraid deployment, the optional filesystem watcher, shell completion, and the inspection commands. For one-shot fetching and the full flag list, see the [CLI Reference](CLI_REFERENCE.md). For every setting, see [Configuration](CONFIGURATION.md).
+This guide covers running `canticle` as a long-running service: the Lidarr webhook server, path resolution, health endpoints, Docker and Unraid deployment, the optional filesystem watcher, shell completion, and the inspection commands. For one-shot fetching and the full flag list, see the [CLI Reference](CLI_REFERENCE.md). For every setting, see [Configuration](CONFIGURATION.md).
 
 ## Lidarr webhook server
 
 ```sh
-MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key mxlrcgo-svc --serve --listen 127.0.0.1:3876
-MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key mxlrcgo-svc serve --listen 127.0.0.1:3876
+MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key canticle --serve --listen 127.0.0.1:3876
+MUSIXMATCH_TOKEN=YOUR_TOKEN MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key canticle serve --listen 127.0.0.1:3876
 ```
 
-The server listens on `MXLRC_SERVER_ADDR` when `--listen` is not provided. Configure one or more webhook keys with `MXLRC_WEBHOOK_API_KEY`, use `mxlrcgo-svc keys create`, or put the server address and webhook keys in a config file and start with `mxlrcgo-svc serve --config path/to/config.toml`.
+The server listens on `MXLRC_SERVER_ADDR` when `--listen` is not provided. Configure one or more webhook keys with `MXLRC_WEBHOOK_API_KEY`, use `canticle keys create`, or put the server address and webhook keys in a config file and start with `canticle serve --config path/to/config.toml`.
 
 Webhook events are enqueued at high priority. If a webhook arrives for an artist/title that previously failed and is waiting out a retry backoff, the high-priority enqueue resets its retry timer so it becomes eligible immediately, jumping the queue. Scan-enqueued duplicates keep their existing backoff, so bulk scan traffic stays rate-limit protected. The worker's circuit breaker still pauses dequeuing globally when the upstream API signals rate limiting.
 
 ### Path resolution (Docker/Unraid)
 
-Configured library scans are the source of truth for filesystem paths. When a Lidarr webhook arrives, `mxlrcgo-svc` resolves the target file in this order:
+Configured library scans are the source of truth for filesystem paths. When a Lidarr webhook arrives, `canticle` resolves the target file in this order:
 
-1. **Scanned inventory.** The webhook artist/title is matched against persisted scan results (using the same normalization as the cache), and a match reuses the exact container-visible source path and output destination the scan recorded. This is why you should add and scan your libraries (`mxlrcgo-svc library add ...`, then `mxlrcgo-svc scan`) before relying on webhooks.
-2. **Direct payload path.** If there is no inventory match but the webhook payload carries a `trackFiles` path that, after cleaning, lies inside one of your configured library roots and exists inside the `mxlrcgo-svc` container, that path is used directly. Payload paths outside every configured root are never used as a write target; they fall back to metadata. This confinement is a security guard: it stops a webhook from directing a lyric write to an arbitrary location. As a result, raw payload-path resolution requires at least one configured library; with no libraries configured, step 2 is disabled and resolution goes straight from inventory to metadata.
+1. **Scanned inventory.** The webhook artist/title is matched against persisted scan results (using the same normalization as the cache), and a match reuses the exact container-visible source path and output destination the scan recorded. This is why you should add and scan your libraries (`canticle library add ...`, then `canticle scan`) before relying on webhooks.
+2. **Direct payload path.** If there is no inventory match but the webhook payload carries a `trackFiles` path that, after cleaning, lies inside one of your configured library roots and exists inside the `canticle` container, that path is used directly. Payload paths outside every configured root are never used as a write target; they fall back to metadata. This confinement is a security guard: it stops a webhook from directing a lyric write to an arbitrary location. As a result, raw payload-path resolution requires at least one configured library; with no libraries configured, step 2 is disabled and resolution goes straight from inventory to metadata.
 3. **Metadata fallback.** Otherwise the lyrics are written to the configured `output.dir` using the webhook metadata.
 
-On Unraid, Lidarr and `mxlrcgo-svc` often see the same media through different mount paths. Because resolution prefers the scanned inventory, you do not need to maintain host-to-container path mappings: a payload path that is not visible inside the container, or that falls outside your configured library roots, simply falls back to metadata rather than failing.
+On Unraid, Lidarr and `canticle` often see the same media through different mount paths. Because resolution prefers the scanned inventory, you do not need to maintain host-to-container path mappings: a payload path that is not visible inside the container, or that falls outside your configured library roots, simply falls back to metadata rather than failing.
 
 Two operational notes:
 
-- The library roots used to confine payload paths (step 2) are snapshotted when `serve` starts. A library added with `mxlrcgo-svc library add ...` while `serve` is running is not recognized for raw-payload-path resolution until `serve` is restarted. (The periodic scheduler and watcher still pick up new libraries without a restart; only the webhook payload-path confinement uses the startup snapshot.)
-- Inventory matching for tracks with non-ASCII artist/title metadata converges after one rescan following an upgrade. The key-backfill migration applies a best-effort ASCII fold to pre-existing rows; the exact normalized keys are written on the next library scan, so run `mxlrcgo-svc scan` once after upgrading to make non-ASCII webhook matches reliable.
+- The library roots used to confine payload paths (step 2) are snapshotted when `serve` starts. A library added with `canticle library add ...` while `serve` is running is not recognized for raw-payload-path resolution until `serve` is restarted. (The periodic scheduler and watcher still pick up new libraries without a restart; only the webhook payload-path confinement uses the startup snapshot.)
+- Inventory matching for tracks with non-ASCII artist/title metadata converges after one rescan following an upgrade. The key-backfill migration applies a best-effort ASCII fold to pre-existing rows; the exact normalized keys are written on the next library scan, so run `canticle scan` once after upgrading to make non-ASCII webhook matches reliable.
 
 The scheduler scan interval and worker poll interval are configurable for Docker/Unraid deployments. Set `scan_interval_seconds` and `work_interval_seconds` under `[server]` in the config file, or override with `MXLRC_SCAN_INTERVAL` and `MXLRC_WORK_INTERVAL`. Precedence is CLI flag (`--scan-interval`, `--work-interval`) > environment variable > config file > default. Defaults preserve current behavior: scan interval 900 seconds, and worker interval falls back to `api.cooldown` (clamped to a 15-second floor). A scan interval of 0 scans once without repeating.
 
@@ -90,17 +90,17 @@ Published GHCR tags:
 
 ```sh
 docker run -d \
-  --name mxlrcgo-svc \
+  --name canticle \
   -p 50705:50705 \
   -e MUSIXMATCH_TOKEN=YOUR_TOKEN \
   -e MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key \
   -e PUID=99 \
   -e PGID=100 \
   -e MXLRC_OUTPUT_DIR=/data/media/music \
-  -v mxlrcgo-svc-config:/config \
+  -v canticle-config:/config \
   -v /path/to/your/data:/data:rw \
   --restart unless-stopped \
-  ghcr.io/sydlexius/mxlrcgo-svc:latest
+  ghcr.io/sydlexius/canticle:latest
 ```
 
 For Compose, copy `docker-compose.example.yml`, set `MUSIXMATCH_TOKEN` and `MXLRC_WEBHOOK_API_KEY`, adjust the music volume, then run:
@@ -111,7 +111,7 @@ docker compose up -d
 
 `MXLRC_DOCKER=true` makes default storage paths resolve to `/config/config.toml` and `/config/mxlrcgo.db`.
 
-To inspect or maintain the queue and scan state inside the container, exec the same `mxlrcgo-svc queue` and `mxlrcgo-svc scan results` / `mxlrcgo-svc scan clear` commands documented in the [Inspection commands](#inspection-commands) section below (for example `docker exec mxlrcgo-svc mxlrcgo-svc queue failed`).
+To inspect or maintain the queue and scan state inside the container, exec the same `canticle queue` and `canticle scan results` / `canticle scan clear` commands documented in the [Inspection commands](#inspection-commands) section below (for example `docker exec canticle canticle queue failed`).
 
 ## Encrypted secrets
 
@@ -130,18 +130,18 @@ Three commands manage the encrypted store. None of them ever print a secret valu
 # the normal CLI/env/TOML precedence but skips the database itself as a source,
 # so it never copies the database onto itself. With no flag it imports both
 # currently-set secrets; scope it with --token or --webhook.
-mxlrcgo-svc secrets import
-mxlrcgo-svc secrets import --token
-mxlrcgo-svc secrets import --webhook
+canticle secrets import
+canticle secrets import --token
+canticle secrets import --webhook
 
 # Set one secret by name from stdin. The value is read from the terminal prompt
 # or a pipe, never from the command line (the command line lands in shell
 # history and ps). Valid names: musixmatch_token, webhook_api_key.
-mxlrcgo-svc secrets set musixmatch_token        # prompts for the value
-printf '%s' "$TOKEN" | mxlrcgo-svc secrets set musixmatch_token   # or pipe it
+canticle secrets set musixmatch_token        # prompts for the value
+printf '%s' "$TOKEN" | canticle secrets set musixmatch_token   # or pipe it
 
 # List stored secret names and their last-updated timestamps. Never prints values.
-mxlrcgo-svc secrets list
+canticle secrets list
 ```
 
 `secrets import` is idempotent: re-running overwrites the existing encrypted row. After a successful import, the command reminds you to remove the now-redundant plaintext from `config.toml` and your compose environment so it is no longer stored in the clear.
@@ -164,8 +164,8 @@ In Docker mode (storage paths resolve under `/config`), the daemon auto-creates 
 ```yaml
 # docker-compose.yml - optional hardening: key separated from the data volume
 services:
-  mxlrcgo-svc:
-    image: ghcr.io/sydlexius/mxlrcgo-svc:latest
+  canticle:
+    image: ghcr.io/sydlexius/canticle:latest
     environment:
       # Optional. Generate once: openssl rand -base64 32
       # Source from a .env file NOT inside the /config volume.
@@ -209,11 +209,11 @@ An Unraid Community Applications template is provided at `unraid/mxlrcgo-svc.xml
 Then register the library (or libraries) under it (paths are container-visible):
 
 ```sh
-docker exec mxlrcgo-svc mxlrcgo-svc library add /data/media/music --name Music
-docker exec mxlrcgo-svc mxlrcgo-svc scan
+docker exec canticle canticle library add /data/media/music --name Music
+docker exec canticle canticle scan
 ```
 
-(Unlike the *arr apps, mxlrcgo-svc never moves or hardlinks files; it only reads audio and writes a `.lrc`/`.txt` sibling. The single-mount convention is still worth following so paths match the rest of your stack.)
+(Unlike the *arr apps, Canticle never moves or hardlinks files; it only reads audio and writes a `.lrc`/`.txt` sibling. The single-mount convention is still worth following so paths match the rest of your stack.)
 
 If your music instead lives in several separate top-level shares, map their common parent once, or add one **Path** mapping per share beneath `/data/media` (for example `/mnt/user/<share>` to `/data/media/<share>`) and register each with `library add`. Lyrics are written next to each audio file, so libraries do not need a shared output root; set `MXLRC_OUTPUT_DIR` only for the webhook metadata-fallback case (step 3 under [Path resolution](#path-resolution-dockerunraid)).
 
@@ -283,25 +283,25 @@ Write operations use a double-submit cookie token (`mx-csrf-token`). This is tra
 
 ## Windows
 
-Download the signed `.zip` archive for `windows/amd64` from the [GitHub releases page](https://github.com/sydlexius/mxlrcgo-svc/releases). Extract `mxlrcgo-svc.exe` to one of:
+Download the signed `.zip` archive for `windows/amd64` from the [GitHub releases page](https://github.com/sydlexius/canticle/releases). Extract `canticle.exe` to one of:
 
 - **`%LOCALAPPDATA%\mxlrcgo-svc\`** - user-mode install; no administrator rights required.
 - **`C:\Program Files\mxlrcgo-svc\`** - system-wide install; requires administrator rights.
 
-Add the chosen directory to your `PATH` so `mxlrcgo-svc` is reachable from any shell.
+Add the chosen directory to your `PATH` so `canticle` is reachable from any shell.
 
 **Manual run.** To start the server from a terminal (useful for initial testing):
 
 ```cmd
 set MUSIXMATCH_TOKEN=YOUR_TOKEN
 set MXLRC_WEBHOOK_API_KEY=mxlrc_your_webhook_key
-mxlrcgo-svc serve --listen 127.0.0.1:3876
+canticle serve --listen 127.0.0.1:3876
 ```
 
 Or use a config file to keep credentials out of the shell environment:
 
 ```cmd
-mxlrcgo-svc serve --config C:\path\to\config.toml
+canticle serve --config C:\path\to\config.toml
 ```
 
 ### NSSM service installation
@@ -317,9 +317,9 @@ nssm install mxlrcgo-svc
 NSSM opens a GUI. Fill in the tabs:
 
 - **Application tab:**
-  - *Path*: full path to `mxlrcgo-svc.exe`, for example `C:\Program Files\mxlrcgo-svc\mxlrcgo-svc.exe`
+  - *Path*: full path to `canticle.exe`, for example `C:\Program Files\mxlrcgo-svc\canticle.exe`
   - *Arguments*: `serve --listen 0.0.0.0:3876` (or `serve --config C:\path\to\config.toml` if you use a config file)
-  - *Startup directory*: the directory containing `mxlrcgo-svc.exe`
+  - *Startup directory*: the directory containing `canticle.exe`
 
 - **Environment tab.** Add one variable per line:
 
@@ -353,7 +353,7 @@ To update the configuration after installation, run `nssm edit mxlrcgo-svc` from
 
 ### Data location
 
-Without an explicit `MXLRC_DB_PATH`, `mxlrcgo-svc` resolves storage paths via XDG base directories. On Windows these defaults resolve to:
+Without an explicit `MXLRC_DB_PATH`, `canticle` resolves storage paths via XDG base directories. On Windows these defaults resolve to:
 
 | Item | Default path |
 |------|-------------|
@@ -371,7 +371,7 @@ Even signed binaries can trigger the "Windows protected your PC" prompt on first
 1. Click **More info**.
 2. Click **Run anyway**.
 
-This prompt should not appear again after the first run. See [issue #183](https://github.com/sydlexius/mxlrcgo-svc/issues/183) for background on code signing.
+This prompt should not appear again after the first run. See [issue #183](https://github.com/sydlexius/canticle/issues/183) for background on code signing.
 
 ## Native packages
 
@@ -436,8 +436,8 @@ Recording enrichment reads the ISRC, MusicBrainz recording ID, and duration from
 You can control it at three levels, resolved with the precedence **CLI flag > per-library setting > global default**:
 
 - **Global default** (`config.toml`): `[enrichment] enabled = true` (env `MXLRC_ENRICHMENT_ENABLED`). Default `true`. Set `false` to skip enrichment everywhere unless a library or run opts back in.
-- **Per library**: `mxlrcgo-svc library add/update --enrich` (force on) or `--enrich=false` (force off). Omit the flag to inherit the global default.
-- **Per run**: `mxlrcgo-svc scan --enrich` or `--no-enrich` overrides both for that single scan (the two flags are mutually exclusive). The serve-mode scheduler has no per-run flag; it resolves per library against the global default.
+- **Per library**: `canticle library add/update --enrich` (force on) or `--enrich=false` (force off). Omit the flag to inherit the global default.
+- **Per run**: `canticle scan --enrich` or `--no-enrich` overrides both for that single scan (the two flags are mutually exclusive). The serve-mode scheduler has no per-run flag; it resolves per library against the global default.
 
 When enrichment is off for a track, the scanner skips ISRC, MBID, and duration extraction as a unit, and the track keeps the `duration_bucket = 0` cache fallback (no behavior regression). A per-library or global change only affects scans run after the change; it does not restamp already-scanned rows.
 
@@ -448,8 +448,8 @@ The optional instrumental-detection sidecar samples each track's audio with ffmp
 You control it at three levels, resolved with the precedence **CLI flag > per-library setting > global default**:
 
 - **Global default** (`config.toml`): `[instrumental_detector] enabled` (env `MXLRC_INSTRUMENTAL_DETECTOR_ENABLED`). Default `false`.
-- **Per library**: `mxlrcgo-svc library add/update --detect-instrumental` (force on) or `--detect-instrumental=false` (force off). Omit the flag to inherit the global default.
-- **Per run**: `mxlrcgo-svc scan --detect-instrumental` or `--no-detect-instrumental` overrides both for the tracks enqueued by that scan (the two flags are mutually exclusive). serve has no per-run flag; it resolves per library against the global default.
+- **Per library**: `canticle library add/update --detect-instrumental` (force on) or `--detect-instrumental=false` (force off). Omit the flag to inherit the global default.
+- **Per run**: `canticle scan --detect-instrumental` or `--no-detect-instrumental` overrides both for the tracks enqueued by that scan (the two flags are mutually exclusive). serve has no per-run flag; it resolves per library against the global default.
 
 The decision is resolved and stamped onto each work-queue item when it is enqueued (like the provider-set version), so a per-library or global change only affects tracks enqueued after the change. Tracks queued before per-library detection existed carry no decision and fall back to the global default at processing time. If an item requests detection but no `classifier_url` is configured, the worker logs an error and proceeds without detection (it never silently skips).
 
@@ -488,12 +488,12 @@ The watcher emits `INFO "watcher started"` at boot (with library and directory c
 
 ## Shell completion
 
-`mxlrcgo-svc completion <bash|zsh|fish>` prints a sourceable completion script that completes subcommands, flags, and configured library names (the last queried live from the database, degrading gracefully when it is absent):
+`canticle completion <bash|zsh|fish>` prints a sourceable completion script that completes subcommands, flags, and configured library names (the last queried live from the database, degrading gracefully when it is absent):
 
 ```bash
-source <(mxlrcgo-svc completion bash)                 # bash (e.g. in ~/.bashrc)
-source <(mxlrcgo-svc completion zsh)                  # zsh  (e.g. in ~/.zshrc)
-mxlrcgo-svc completion fish > ~/.config/fish/completions/mxlrcgo-svc.fish
+source <(canticle completion bash)                 # bash (e.g. in ~/.bashrc)
+source <(canticle completion zsh)                  # zsh  (e.g. in ~/.zshrc)
+canticle completion fish > ~/.config/fish/completions/canticle.fish
 ```
 
 The scripts call a hidden `__complete` handler; library-name completion never creates the database.
@@ -512,34 +512,34 @@ SQLite database by hand.
 
 ```sh
 # List the next 50 work_queue rows.
-mxlrcgo-svc queue list
+canticle queue list
 
 # Filter by status; failed and deferred are also exposed as convenience subcommands.
-mxlrcgo-svc queue list --status pending --limit 100
-mxlrcgo-svc queue failed
+canticle queue list --status pending --limit 100
+canticle queue failed
 
 # List deferred rows: benign misses (a track Musixmatch has no lyrics for yet)
 # waiting out a fixed cooldown before re-check. These are NOT failures and are
 # kept out of `queue failed`.
-mxlrcgo-svc queue deferred
+canticle queue deferred
 
 # Reset a single failed row back to pending. Refused if the row is not failed
 # (a deferred row is refused; let it re-check on its own, or re-trigger via webhook).
-mxlrcgo-svc queue retry 42
+canticle queue retry 42
 
 # Delete completed rows. Without --yes, prints what would be deleted.
-mxlrcgo-svc queue clear --done
-mxlrcgo-svc queue clear --done --yes
+canticle queue clear --done
+canticle queue clear --done --yes
 
 # List persisted scan_results, optionally filtered by library (name or id) and status.
-mxlrcgo-svc scan results
-mxlrcgo-svc scan results --library Music --status pending
-mxlrcgo-svc scan results --library 1 --limit 200
+canticle scan results
+canticle scan results --library Music --status pending
+canticle scan results --library 1 --limit 200
 
 # Delete every scan_results row for a single library. Without --yes, prints what would be deleted.
 # The library row itself is left intact.
-mxlrcgo-svc scan clear --library Music
-mxlrcgo-svc scan clear --library Music --yes
+canticle scan clear --library Music
+canticle scan clear --library Music --yes
 ```
 
 ## Reports workspace
@@ -577,4 +577,4 @@ Use this to audit which tracks the detector marked instrumental and whether they
 
 ### Failure analysis
 
-Lists failed and deferred work queue items grouped by status and error reason, with a count per group, ordered most-frequent first. "Failed" rows hit a hard error; "deferred" rows are benign misses waiting for a retry. Grouping keeps the two separate because they require different responses - deferred rows self-resolve on their retry schedule, while failed rows may need manual intervention (`mxlrcgo-svc queue retry <id>`).
+Lists failed and deferred work queue items grouped by status and error reason, with a count per group, ordered most-frequent first. "Failed" rows hit a hard error; "deferred" rows are benign misses waiting for a retry. Grouping keeps the two separate because they require different responses - deferred rows self-resolve on their retry schedule, while failed rows may need manual intervention (`canticle queue retry <id>`).

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -5,7 +5,7 @@ by [SignPath Foundation](https://signpath.org/).
 
 ## Scope
 
-All `mxlrcgo-svc` release binaries published to GitHub Releases are signed
+All Canticle release binaries published to GitHub Releases are signed
 using the SignPath free open-source program. Signing applies to the final
 binaries produced by the GoReleaser release pipeline.
 
@@ -45,4 +45,4 @@ signing workflow. For details on what SignPath processes during signing, see the
 
 - [SignPath.io](https://signpath.io/) - code signing provider
 - [SignPath Foundation](https://signpath.org/) - certificate authority for the free open-source program
-- [Privacy Policy](privacy-policy.md) - data handling policy for `mxlrcgo-svc`
+- [Privacy Policy](privacy-policy.md) - data handling policy for Canticle

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# mxlrcgo-svc
+# Canticle
 
-`mxlrcgo-svc` is a Go command-line tool and webhook service that fetches synced lyrics from [Musixmatch](https://www.musixmatch.com/) and saves them as `.lrc` files (falling back to `.txt` for unsynced lyrics or instrumental markers). It runs one-shot from the CLI, recursively over a media directory, or as a long-running Lidarr webhook server with a durable work queue, scheduled library scans, and an optional filesystem watcher.
+Canticle is a Go command-line tool and webhook service that fetches synced lyrics from [Musixmatch](https://www.musixmatch.com/) and saves them as `.lrc` files (falling back to `.txt` for unsynced lyrics or instrumental markers). It runs one-shot from the CLI, recursively over a media directory, or as a long-running Lidarr webhook server with a durable work queue, scheduled library scans, and an optional filesystem watcher.
 
 New here? Start with the [Getting Started](GETTING_STARTED.md) guide - it picks a path for you (one-shot, directory, or daemon) and gets you to working lyrics.
 

--- a/docs/multi-provider-orchestration.md
+++ b/docs/multi-provider-orchestration.md
@@ -335,10 +335,10 @@ record:
 
 ## Cross-references
 
-- Issue [#148](https://github.com/sydlexius/mxlrcgo-svc/issues/148) - this design record
-- Issue [#146](https://github.com/sydlexius/mxlrcgo-svc/issues/146) - multilingual output policy (the suitability quality bar interacts with bilingual output)
-- Issue [#149](https://github.com/sydlexius/mxlrcgo-svc/issues/149) - second lyrics source; deferred per-provider cache handling to this design (resolved in Gap 1)
-- Issue [#163](https://github.com/sydlexius/mxlrcgo-svc/issues/163) - langguard wired into config and the worker pipeline (supplies the suitability script gate)
+- Issue [#148](https://github.com/sydlexius/canticle/issues/148) - this design record
+- Issue [#146](https://github.com/sydlexius/canticle/issues/146) - multilingual output policy (the suitability quality bar interacts with bilingual output)
+- Issue [#149](https://github.com/sydlexius/canticle/issues/149) - second lyrics source; deferred per-provider cache handling to this design (resolved in Gap 1)
+- Issue [#163](https://github.com/sydlexius/canticle/issues/163) - langguard wired into config and the worker pipeline (supplies the suitability script gate)
 - `internal/queue/queue.go` - `Complete` CAS guard, `Enqueue` busy-retry upserts, `providers_version` column
 - `internal/worker/worker.go` - current circuit-breaker fields and `tripCircuitIfRateLimited`
 - `internal/langguard/guard.go` - `Guard.Accept` suitability decision

--- a/docs/multilingual-output-policy.md
+++ b/docs/multilingual-output-policy.md
@@ -97,8 +97,8 @@ integration issue).
 
 ## Cross-references
 
-- Issue [#146](https://github.com/sydlexius/mxlrcgo-svc/issues/146) - decision record
-- Issue [#149](https://github.com/sydlexius/mxlrcgo-svc/issues/149) - CJK provider adapter (depends on this policy)
+- Issue [#146](https://github.com/sydlexius/canticle/issues/146) - decision record
+- Issue [#149](https://github.com/sydlexius/canticle/issues/149) - CJK provider adapter (depends on this policy)
 - `internal/langguard` - script classifier and guard
 - `internal/lyrics/writer.go` - current writer (single-track, no translation)
 - `internal/models/models.go` - `Song`, `Synced` types

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-This page documents what data leaves your machine when you run `mxlrcgo-svc`,
+This page documents what data leaves your machine when you run `canticle`,
 and what does not.
 
 ## Musixmatch (default provider)
@@ -36,7 +36,7 @@ for this provider.
 
 ## Network metadata
 
-Like any application that makes internet requests, `mxlrcgo-svc` does not
+Like any application that makes internet requests, Canticle does not
 control what standard network metadata a remote server or intermediary receives.
 When the app contacts a lyrics provider, that provider - and any network
 intermediary on the path - inherently receives the request's source IP address
@@ -52,7 +52,7 @@ without contacting any external API.
 
 ## Telemetry, analytics, and crash reporting
 
-**None.** `mxlrcgo-svc` does not collect telemetry, analytics, or crash
+**None.** Canticle does not collect telemetry, analytics, or crash
 reports. No data is ever sent to the project maintainers or any third party
 other than the lyrics providers listed above.
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -87,7 +87,7 @@ func TestRunFetchesAndWritesSyncedLyrics(t *testing.T) {
 		t.Fatalf("reading LRC output: %v", err)
 	}
 	want := strings.Join([]string{
-		"[by:mxlrcgo-svc]",
+		"[by:canticle]",
 		"[ar:Test Artist]",
 		"[ti:Test Song]",
 		"[al:Test Album]",

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -364,7 +364,7 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 	if !usesSubcommand(rawArgs) {
 		parseTarget = &legacy
 	}
-	parser, err := arg.NewParser(arg.Config{Program: "mxlrcgo-svc", Out: out}, parseTarget)
+	parser, err := arg.NewParser(arg.Config{Program: "canticle", Out: out}, parseTarget)
 	if err != nil {
 		_, _ = fmt.Fprintln(out, err)
 		return 2

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -334,22 +334,22 @@ func TestRunSubcommandHelpShowsSelectedCommand(t *testing.T) {
 		{
 			name: "serve",
 			args: []string{"serve", "--help"},
-			want: []string{"Usage: mxlrcgo-svc serve", "--scan-interval", "--work-interval"},
+			want: []string{"Usage: canticle serve", "--scan-interval", "--work-interval"},
 		},
 		{
 			name: "scan",
 			args: []string{"scan", "--help"},
-			want: []string{"Usage: mxlrcgo-svc scan", "--upgrade", "--bfs"},
+			want: []string{"Usage: canticle scan", "--upgrade", "--bfs"},
 		},
 		{
 			name: "library",
 			args: []string{"library", "--help"},
-			want: []string{"Usage: mxlrcgo-svc library", "add", "list"},
+			want: []string{"Usage: canticle library", "add", "list"},
 		},
 		{
 			name: "library add",
 			args: []string{"library", "add", "--help"},
-			want: []string{"Usage: mxlrcgo-svc library add", "--name", "--config"},
+			want: []string{"Usage: canticle library add", "--name", "--config"},
 		},
 	}
 
@@ -375,10 +375,10 @@ func TestRunSubcommandParseErrorShowsSelectedUsage(t *testing.T) {
 	if code != 2 {
 		t.Fatalf("Run exit code = %d; want 2", code)
 	}
-	if !strings.Contains(out.String(), "Usage: mxlrcgo-svc serve") {
+	if !strings.Contains(out.String(), "Usage: canticle serve") {
 		t.Fatalf("usage output = %q; want serve usage", out.String())
 	}
-	if strings.Contains(out.String(), "Usage: mxlrcgo-svc <command>") {
+	if strings.Contains(out.String(), "Usage: canticle <command>") {
 		t.Fatalf("usage output = %q; want selected subcommand usage, not top-level usage", out.String())
 	}
 }

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -133,34 +133,34 @@ func completionLibraryNames(ctx context.Context) []string {
 	return names
 }
 
-const bashCompletion = `# mxlrcgo-svc bash completion. Source this file (e.g. from ~/.bashrc):
-#   source <(mxlrcgo-svc completion bash)
-_mxlrcgo_svc_complete() {
+const bashCompletion = `# canticle bash completion. Source this file (e.g. from ~/.bashrc):
+#   source <(canticle completion bash)
+_canticle_complete() {
     local cur words
     cur="${COMP_WORDS[COMP_CWORD]}"
     words=("${COMP_WORDS[@]:1:COMP_CWORD}")
     local IFS=$'\n'
-    COMPREPLY=( $(mxlrcgo-svc __complete "${words[@]}") )
+    COMPREPLY=( $(canticle __complete "${words[@]}") )
 }
-complete -F _mxlrcgo_svc_complete mxlrcgo-svc
+complete -F _canticle_complete canticle
 `
 
-const zshCompletion = `#compdef mxlrcgo-svc
-# mxlrcgo-svc zsh completion. Source this file (e.g. from ~/.zshrc):
-#   source <(mxlrcgo-svc completion zsh)
-_mxlrcgo_svc_complete() {
+const zshCompletion = `#compdef canticle
+# canticle zsh completion. Source this file (e.g. from ~/.zshrc):
+#   source <(canticle completion zsh)
+_canticle_complete() {
     local -a completions
-    completions=("${(@f)$(mxlrcgo-svc __complete "${words[@]:1}")}")
+    completions=("${(@f)$(canticle __complete "${words[@]:1}")}")
     compadd -- "${completions[@]}"
 }
-compdef _mxlrcgo_svc_complete mxlrcgo-svc
+compdef _canticle_complete canticle
 `
 
-const fishCompletion = `# mxlrcgo-svc fish completion. Save to ~/.config/fish/completions/mxlrcgo-svc.fish:
-#   mxlrcgo-svc completion fish > ~/.config/fish/completions/mxlrcgo-svc.fish
-function __mxlrcgo_svc_complete
+const fishCompletion = `# canticle fish completion. Save to ~/.config/fish/completions/canticle.fish:
+#   canticle completion fish > ~/.config/fish/completions/canticle.fish
+function __canticle_complete
     set -l tokens (commandline -opc) (commandline -ct)
-    mxlrcgo-svc __complete $tokens[2..-1]
+    canticle __complete $tokens[2..-1]
 end
-complete -c mxlrcgo-svc -f -a '(__mxlrcgo_svc_complete)'
+complete -c canticle -f -a '(__canticle_complete)'
 `

--- a/internal/commands/version_test.go
+++ b/internal/commands/version_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestVersionStringUsesBuildDefaults(t *testing.T) {
 	got := VersionString()
-	for _, want := range []string{"mxlrcgo-svc", version, commit, date} {
+	for _, want := range []string{"canticle", version, commit, date} {
 		if !strings.Contains(got, want) {
 			t.Errorf("VersionString() = %q, missing %q", got, want)
 		}

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -171,7 +171,7 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	var tags []string
 	if writeTags {
 		tags = []string{
-			"[by:mxlrcgo-svc]",
+			"[by:canticle]",
 			fmt.Sprintf("[ar:%s]", song.Track.ArtistName),
 			fmt.Sprintf("[ti:%s]", song.Track.TrackName),
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,5 +14,5 @@ var (
 
 // VersionString renders the single line printed for --version.
 func VersionString() string {
-	return fmt.Sprintf("mxlrcgo-svc %s (commit %s, built %s)", Version, Commit, Date)
+	return fmt.Sprintf("canticle %s (commit %s, built %s)", Version, Commit, Date)
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestVersionString(t *testing.T) {
 	got := VersionString()
-	if !strings.HasPrefix(got, "mxlrcgo-svc ") {
-		t.Errorf("VersionString() = %q, want prefix \"mxlrcgo-svc \"", got)
+	if !strings.HasPrefix(got, "canticle ") {
+		t.Errorf("VersionString() = %q, want prefix \"canticle \"", got)
 	}
 	for _, sub := range []string{Version, Commit, Date} {
 		if !strings.Contains(got, sub) {

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -1,8 +1,8 @@
-site_name: mxlrcgo-svc
+site_name: Canticle
 site_description: Command line tool and webhook service to fetch synced lyrics from Musixmatch and save them as .lrc files.
-site_url: https://sydlexius.github.io/mxlrcgo-svc/
-repo_url: https://github.com/sydlexius/mxlrcgo-svc
-repo_name: sydlexius/mxlrcgo-svc
+site_url: https://sydlexius.github.io/canticle/
+repo_url: https://github.com/sydlexius/canticle
+repo_name: sydlexius/canticle
 edit_uri: edit/main/docs/
 
 # Built with ProperDocs (a maintained, drop-in continuation of MkDocs 1.x) plus
@@ -73,7 +73,7 @@ extra:
   generator: false
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/sydlexius/mxlrcgo-svc
+      link: https://github.com/sydlexius/canticle
 
 nav:
   - Home: index.md

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/mxlrcgo-svc-smoke.XXXXXX")"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/canticle-smoke.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 BIN="$TMPDIR/canticle"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/mxlrcgo-svc-smoke.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-BIN="$TMPDIR/mxlrcgo-svc"
+BIN="$TMPDIR/canticle"
 CONFIG_HOME="$TMPDIR/config"
 DATA_HOME="$TMPDIR/data"
 OUTDIR="$TMPDIR/out"
@@ -15,7 +15,7 @@ mkdir -p "$CONFIG_HOME" "$DATA_HOME" "$OUTDIR"
 CGO_ENABLED=0 go build -o "$BIN" "$ROOT/cmd/mxlrcgo-svc"
 
 help_output="$("$BIN" --help)"
-if [[ "$help_output" != *"Usage: mxlrcgo-svc"* ]]; then
+if [[ "$help_output" != *"Usage: canticle"* ]]; then
   echo "smoke: --help output did not include usage" >&2
   exit 1
 fi

--- a/unraid/mxlrcgo-svc.xml
+++ b/unraid/mxlrcgo-svc.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>mxlrcgo-svc</Name>
-  <Repository>ghcr.io/sydlexius/mxlrcgo-svc</Repository>
-  <Registry>https://github.com/sydlexius/mxlrcgo-svc/pkgs/container/mxlrcgo-svc</Registry>
-  <TemplateURL>https://raw.githubusercontent.com/sydlexius/mxlrcgo-svc/main/unraid/mxlrcgo-svc.xml</TemplateURL>
+  <Name>Canticle</Name>
+  <Repository>ghcr.io/sydlexius/canticle</Repository>
+  <Registry>https://github.com/sydlexius/canticle/pkgs/container/canticle</Registry>
+  <TemplateURL>https://raw.githubusercontent.com/sydlexius/canticle/main/unraid/mxlrcgo-svc.xml</TemplateURL>
   <Branch>
     <Tag>latest</Tag>
     <TagDescription>Latest stable release</TagDescription>
@@ -11,10 +11,10 @@
   <Network>bridge</Network>
   <Shell>bash</Shell>
   <Privileged>false</Privileged>
-  <Support>https://github.com/sydlexius/mxlrcgo-svc/issues</Support>
-  <Project>https://github.com/sydlexius/mxlrcgo-svc</Project>
+  <Support>https://github.com/sydlexius/canticle/issues</Support>
+  <Project>https://github.com/sydlexius/canticle</Project>
   <Overview>Fetch synced lyrics from Musixmatch and save them as .lrc files for music libraries.</Overview>
-  <Description>mxlrcgo-svc fetches synced lyrics from the Musixmatch API, writes .lrc files, and can run as a small HTTP service for Lidarr webhook-driven lyric fetching.</Description>
+  <Description>Canticle fetches synced lyrics from the Musixmatch API, writes .lrc files, and can run as a small HTTP service for Lidarr webhook-driven lyric fetching.</Description>
   <Category>MediaApp:Music</Category>
   <WebUI>http://[IP]:[PORT:50705]/</WebUI>
   <Icon>https://raw.githubusercontent.com/sydlexius/unraid-templates/main/icon.svg</Icon>
@@ -25,9 +25,9 @@
   <Requires/>
   <Config Name="Webhook Port" Target="50705" Default="50705" Mode="tcp" Description="HTTP webhook server port." Type="Port" Display="always" Required="true" Mask="false">50705</Config>
   <Config Name="Appdata" Target="/config" Default="" Mode="rw" Description="Stores configuration and the SQLite database." Type="Path" Display="always" Required="true" Mask="false"/>
-  <Config Name="Media Library" Target="/data" Default="/mnt/user/data" Mode="rw" Description="Your media parent, mapped to /data inside the container following the TRaSH Guides single-mount convention. Register libraries under it (for example /data/media/music) with 'mxlrcgo-svc library add'. For multiple shares, add one more Path mapping per share beneath /data/media." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/data</Config>
+  <Config Name="Media Library" Target="/data" Default="/mnt/user/data" Mode="rw" Description="Your media parent, mapped to /data inside the container following the TRaSH Guides single-mount convention. Register libraries under it (for example /data/media/music) with 'canticle library add'. For multiple shares, add one more Path mapping per share beneath /data/media." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/data</Config>
   <Config Name="Musixmatch Token" Target="MUSIXMATCH_TOKEN" Default="" Description="Musixmatch API token used to fetch lyrics." Type="Variable" Display="always" Required="true" Mask="true"/>
-  <Config Name="Webhook API Key" Target="MXLRC_WEBHOOK_API_KEY" Default="" Description="API key accepted by webhook endpoints. Generate one with mxlrcgo-svc keys create --scope webhook." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Webhook API Key" Target="MXLRC_WEBHOOK_API_KEY" Default="" Description="API key accepted by webhook endpoints. Generate one with canticle keys create --scope webhook." Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="PUID" Target="PUID" Default="99" Description="User ID for file permissions. Default 99 maps to nobody on Unraid." Type="Variable" Display="advanced" Required="false" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="100" Description="Group ID for file permissions. Default 100 maps to users on Unraid." Type="Variable" Display="advanced" Required="false" Mask="false">100</Config>
   <Config Name="Docker Mode" Target="MXLRC_DOCKER" Default="true" Description="Use Docker storage defaults under /config." Type="Variable" Display="advanced" Required="true" Mask="false">true</Config>

--- a/unraid/mxlrcgo-svc.xml
+++ b/unraid/mxlrcgo-svc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>Canticle</Name>
+  <Name>mxlrcgo-svc</Name>
   <Repository>ghcr.io/sydlexius/canticle</Repository>
   <Registry>https://github.com/sydlexius/canticle/pkgs/container/canticle</Registry>
   <TemplateURL>https://raw.githubusercontent.com/sydlexius/canticle/main/unraid/mxlrcgo-svc.xml</TemplateURL>


### PR DESCRIPTION
## What

Partial rebrand mxlrcgo-svc -> **Canticle** (Option A: brand/display surfaces only; OS deploy identity stays `mxlrcgo-svc` for in-place upgrade). References #330.

## Renamed to Canticle (brand/display)
- Binary -> `canticle`; CLI command, `--help`/usage text, shell completions (`canticle.fish` etc.).
- `.goreleaser.yml`, both Dockerfiles (incl. OCI `org.opencontainers.image.source`), `docker-compose.example.yml`, Makefile `BINARY`.
- Docs (README, CLI_REFERENCE, CONFIGURATION, GETTING_STARTED, INSTALL, USER_GUIDE, index, privacy, code-signing, multi-provider, multilingual, properdocs.yml): brand/display -> Canticle, command examples -> `canticle`, Pages/repo/codecov URLs -> `.../canticle`, Windows binary -> `canticle.exe`.
- `writer.go` LRC tag `[by:mxlrcgo-svc]` -> `[by:canticle]`.
- systemd/openrc **ExecStart/command** -> `/usr/local/bin/canticle` (the renamed binary).

## Intentionally KEPT `mxlrcgo-svc` (deploy identity — upgrade-in-place stability)
Install paths (`/etc`, `/var/lib`, `/run`), unit/service **filenames + unit name**, `User=`/`Group=` system user, nfpm `package_name`, homebrew cask token `sydlexius/tap/mxlrcgo-svc`, `mxlrcgo.db` / `.mxlrcgo.key`, `mxlrcgo_*` metrics + Prometheus job/target, self-signed cert CN, `cmd/mxlrcgo-svc` source dir, `MXLRC_*`/`MXLRCGO_*` env vars, Go module path. Unraid `<Name>` kept `mxlrcgo-svc` (it seeds container/appdata identity in Unraid CA; the template's brand/Overview text reads Canticle).

## Deferred to a follow-up (NOT in this PR), #330 stays open to track
- Web UI templates (`web/templates/{layout,login,setup,sidebar}.templ` + generated `*_templ.go`), `design-tokens.css`, the `mx-` CSS class prefix. **Sequenced after #318 + #367 merge** to avoid colliding with #318's dashboard work in the same templates.
- **Heads-up:** until that pass lands, the served web UI still shows the old brand (page title `- mxlrcgo-svc`, `mxlrcgo` wordmark) while the favicon already points at `canticle-mark.svg` — a temporary mixed state by design.
- Repo rename + ghcr + Pages = post-merge admin (module path + env vars stay; redirect covers `go get`).

## Verification
`make gate` GREEN at HEAD: build, race tests, patch coverage 100%, golangci-lint 0, actionlint, govulncheck, `ui-check` confirms UI templates untouched. `make build` -> `canticle`; `canticle --version` -> `canticle dev`. A read-only diff audit confirmed zero identity tokens wrongly flipped to canticle and no missed user-facing brand refs (deferred UI surfaces excluded).
