### PR TITLE
chore: add explicit .gates.toml for cc-orchestrator gate-runner (#372)

### DIFF
--- a/.gates.toml
+++ b/.gates.toml
@@ -1,0 +1,6 @@
+# Read by gate-runner.py (cc-orchestrator >= v0.49.0).
+[prep_pr]
+gate = "make gate"   # -> scripts/pre-push-gate.sh
+
+[merge_pr]
+coverage_advisory = true   # codecov.yml present


### PR DESCRIPTION
## What

Add an explicit `.gates.toml` at the repo root so cc-orchestrator's `gate-runner.py` (>= v0.49.0) runs the same checks for `/prep-pr` and the pre-push hook. We already have the `make gate` umbrella (`scripts/pre-push-gate.sh`); this declares it explicitly and adds the merge-time coverage signal.

```toml
[prep_pr]
gate = "make gate"   # -> scripts/pre-push-gate.sh

[merge_pr]
coverage_advisory = true   # codecov.yml present
```

## Why it's safe

- **Inert / no behavior change:** without the file the runner already auto-detects `make gate` via fallback, and the file does nothing until the runner is deployed here. This just makes the gate explicit and declares the coverage signal.
- Verified locally with `python3 ~/.claude/scripts/gate-runner.py` (clean exit).

Closes #372.
