### PR TITLE
feat(web): manage webhook API keys in settings (masked list / revoke / generate) (#300)

### DIFF
--- a/internal/auth/memory.go
+++ b/internal/auth/memory.go
@@ -67,6 +67,32 @@ func (s *MemoryStore) RevokeByHash(ctx context.Context, hash string, revokedAt t
 	return cloneKey(key), nil
 }
 
+// RevokeByID records a revocation timestamp for the key with the given public ID
+// (Key.ID). IDs are unique (the SQL primary key), so the in-memory store mirrors
+// that by revoking the single matching entry.
+func (s *MemoryStore) RevokeByID(ctx context.Context, id string, revokedAt time.Time) (Key, error) {
+	if err := ctx.Err(); err != nil {
+		return Key{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for hash, key := range s.keys {
+		if key.ID != id {
+			continue
+		}
+		// Idempotent: re-revoking an already-revoked key preserves the original
+		// revocation timestamp rather than re-stamping it to now.
+		if key.RevokedAt != nil {
+			return cloneKey(key), nil
+		}
+		at := revokedAt.UTC()
+		key.RevokedAt = &at
+		s.keys[hash] = cloneKey(key)
+		return cloneKey(key), nil
+	}
+	return Key{}, ErrInvalidKey
+}
+
 // List returns all key metadata in stable creation order.
 func (s *MemoryStore) List(ctx context.Context) ([]Key, error) {
 	if err := ctx.Err(); err != nil {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -66,6 +66,7 @@ type Store interface {
 	Create(ctx context.Context, key Key) error
 	FindByHash(ctx context.Context, hash string) (Key, error)
 	RevokeByHash(ctx context.Context, hash string, revokedAt time.Time) (Key, error)
+	RevokeByID(ctx context.Context, id string, revokedAt time.Time) (Key, error)
 	List(ctx context.Context) ([]Key, error)
 }
 
@@ -169,6 +170,24 @@ func (s *Service) RevokeKey(ctx context.Context, raw string) (Key, error) {
 		return Key{}, err
 	}
 	return s.store.RevokeByHash(ctx, hash, s.now().UTC())
+}
+
+// RevokeKeyByID revokes the key identified by id (the public Key.ID) and returns
+// the updated metadata. It exists so the management UI can revoke a key it only
+// knows by its displayed ID: the raw key is never recoverable after creation, so
+// RevokeKey (which derives the hash from the raw key) cannot be used there. The
+// nil-dependency guards mirror RevokeKey.
+func (s *Service) RevokeKeyByID(ctx context.Context, id string) (Key, error) {
+	if s.store == nil {
+		return Key{}, fmt.Errorf("auth: store dependency is nil")
+	}
+	if s.now == nil {
+		return Key{}, fmt.Errorf("auth: now dependency is nil")
+	}
+	if strings.TrimSpace(id) == "" {
+		return Key{}, ErrInvalidKey
+	}
+	return s.store.RevokeByID(ctx, id, s.now().UTC())
 }
 
 // ListKeys returns stored key metadata without raw key material.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -105,6 +105,59 @@ func TestService_RevokeKeyPreventsValidation(t *testing.T) {
 	}
 }
 
+func TestService_RevokeKeyByID(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	svc := NewService(store)
+	svc.rand = bytes.NewReader(bytes.Repeat([]byte{0x07}, keyBytes))
+	revokedAt := time.Date(2026, 4, 27, 13, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return revokedAt }
+
+	created, err := svc.CreateKey(ctx, "webhook", []Scope{ScopeWebhook})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	revoked, err := svc.RevokeKeyByID(ctx, created.Key.ID)
+	if err != nil {
+		t.Fatalf("RevokeKeyByID: %v", err)
+	}
+	if revoked.RevokedAt == nil || !revoked.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("RevokedAt = %v; want %s", revoked.RevokedAt, revokedAt)
+	}
+	// Validation by the raw key now fails: revocation by ID reached the same row.
+	if _, err := svc.ValidateKey(ctx, created.Raw, ScopeWebhook); !errors.Is(err, ErrRevokedKey) {
+		t.Fatalf("ValidateKey after RevokeKeyByID = %v; want ErrRevokedKey", err)
+	}
+
+	// Idempotent: re-revoking at a later time preserves the original timestamp.
+	svc.now = func() time.Time { return revokedAt.Add(time.Hour) }
+	again, err := svc.RevokeKeyByID(ctx, created.Key.ID)
+	if err != nil {
+		t.Fatalf("RevokeKeyByID (second): %v", err)
+	}
+	if again.RevokedAt == nil || !again.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("re-revoke RevokedAt = %v; want preserved %s", again.RevokedAt, revokedAt)
+	}
+
+	// A blank or unknown ID is a clean ErrInvalidKey, never a panic.
+	if _, err := svc.RevokeKeyByID(ctx, "  "); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("RevokeKeyByID blank = %v; want ErrInvalidKey", err)
+	}
+	if _, err := svc.RevokeKeyByID(ctx, "nope"); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("RevokeKeyByID unknown = %v; want ErrInvalidKey", err)
+	}
+}
+
+func TestService_RevokeKeyByIDNilDeps(t *testing.T) {
+	ctx := context.Background()
+	if _, err := (&Service{}).RevokeKeyByID(ctx, "id"); err == nil {
+		t.Fatal("RevokeKeyByID with nil store returned nil error")
+	}
+	if _, err := (&Service{store: NewMemoryStore()}).RevokeKeyByID(ctx, "id"); err == nil {
+		t.Fatal("RevokeKeyByID with nil now returned nil error")
+	}
+}
+
 func TestService_InvalidKeysAndScopes(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -121,25 +121,21 @@ func (s *SQLStore) findByID(ctx context.Context, id string) (Key, error) {
 // RevokeByID records a revocation timestamp for the key with the given public ID.
 // id is the table's primary key, so it matches at most one row.
 func (s *SQLStore) RevokeByID(ctx context.Context, id string, revokedAt time.Time) (Key, error) {
-	key, err := s.findByID(ctx, id)
-	if err != nil {
-		return Key{}, err
-	}
-	// Idempotent: re-revoking an already-revoked key is a no-op that preserves the
-	// original revocation timestamp rather than re-stamping it to now.
-	if key.RevokedAt != nil {
-		return key, nil
-	}
-	_, err = s.db.ExecContext(ctx,
-		`UPDATE api_key_metadata SET revoked_at = ? WHERE id = ?`,
-		formatTime(revokedAt),
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE api_key_metadata
+         SET revoked_at = ?
+         WHERE id = ? AND revoked_at IS NULL`,
+		formatTime(revokedAt.UTC()),
 		id,
 	)
 	if err != nil {
 		return Key{}, fmt.Errorf("auth: revoke key by id: %w", err)
 	}
-	key.RevokedAt = ptrTime(revokedAt.UTC())
-	return key, nil
+	// The WHERE ... AND revoked_at IS NULL makes this atomically idempotent: a
+	// second revoke matches 0 rows and leaves the original timestamp intact,
+	// with no read-then-write race between concurrent revokes. findByID maps a
+	// missing id to ErrInvalidKey (the caller already handles that).
+	return s.findByID(ctx, id)
 }
 
 // List returns all key metadata in stable creation order.

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -100,6 +100,48 @@ func (s *SQLStore) RevokeByHash(ctx context.Context, hash string, revokedAt time
 	return key, nil
 }
 
+// findByID returns key metadata by its public ID (hash[:16], the table's primary
+// key), mapping a missing row to ErrInvalidKey like FindByHash.
+func (s *SQLStore) findByID(ctx context.Context, id string) (Key, error) {
+	key, err := s.scanKey(s.db.QueryRowContext(ctx,
+		`SELECT id, name, hash, scopes, created_at, revoked_at
+         FROM api_key_metadata
+         WHERE id = ?`,
+		id,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Key{}, ErrInvalidKey
+	}
+	if err != nil {
+		return Key{}, fmt.Errorf("auth: find key by id: %w", err)
+	}
+	return key, nil
+}
+
+// RevokeByID records a revocation timestamp for the key with the given public ID.
+// id is the table's primary key, so it matches at most one row.
+func (s *SQLStore) RevokeByID(ctx context.Context, id string, revokedAt time.Time) (Key, error) {
+	key, err := s.findByID(ctx, id)
+	if err != nil {
+		return Key{}, err
+	}
+	// Idempotent: re-revoking an already-revoked key is a no-op that preserves the
+	// original revocation timestamp rather than re-stamping it to now.
+	if key.RevokedAt != nil {
+		return key, nil
+	}
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE api_key_metadata SET revoked_at = ? WHERE id = ?`,
+		formatTime(revokedAt),
+		id,
+	)
+	if err != nil {
+		return Key{}, fmt.Errorf("auth: revoke key by id: %w", err)
+	}
+	key.RevokedAt = ptrTime(revokedAt.UTC())
+	return key, nil
+}
+
 // List returns all key metadata in stable creation order.
 func (s *SQLStore) List(ctx context.Context) (keys []Key, retErr error) {
 	rows, err := s.db.QueryContext(ctx,

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -67,6 +67,63 @@ func TestSQLStore_CreateListFindAndRevoke(t *testing.T) {
 	}
 }
 
+func TestSQLStore_RevokeByID(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "auth.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	store := NewSQLStore(sqlDB)
+	key := Key{
+		ID:        "key-id",
+		Name:      "webhook",
+		Hash:      "0123456789abcdef",
+		Scopes:    []Scope{ScopeWebhook},
+		CreatedAt: time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC),
+	}
+	if err := store.Create(ctx, key); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	revokedAt := time.Date(2026, 4, 27, 13, 0, 0, 0, time.UTC)
+	revoked, err := store.RevokeByID(ctx, key.ID, revokedAt)
+	if err != nil {
+		t.Fatalf("RevokeByID: %v", err)
+	}
+	if revoked.RevokedAt == nil || !revoked.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("RevokedAt = %v; want %s", revoked.RevokedAt, revokedAt)
+	}
+	// The persisted row reflects the revocation.
+	got, err := store.FindByHash(ctx, key.Hash)
+	if err != nil {
+		t.Fatalf("FindByHash: %v", err)
+	}
+	if got.RevokedAt == nil || !got.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("persisted RevokedAt = %v; want %s", got.RevokedAt, revokedAt)
+	}
+
+	if _, err := store.RevokeByID(ctx, "missing-id", revokedAt); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("RevokeByID missing error = %v; want ErrInvalidKey", err)
+	}
+
+	// Idempotent: a second revoke at a LATER time preserves the original
+	// revoked_at rather than re-stamping it.
+	later := revokedAt.Add(time.Hour)
+	again, err := store.RevokeByID(ctx, key.ID, later)
+	if err != nil {
+		t.Fatalf("RevokeByID (second) : %v", err)
+	}
+	if again.RevokedAt == nil || !again.RevokedAt.Equal(revokedAt) {
+		t.Fatalf("re-revoke RevokedAt = %v; want preserved original %s", again.RevokedAt, revokedAt)
+	}
+}
+
 func TestSQLStore_InvalidRows(t *testing.T) {
 	ctx := context.Background()
 	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "auth.db"))

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -959,6 +959,10 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 			// Back the dashboard cache hit-rate tile (#308) with the same shared
 			// cache repo the worker/scheduler/watcher read through.
 			server.WithCacheStatsUI(cacheRepo),
+			// Back the webhook key management page (#300) with the same managed key
+			// service that authenticates webhook calls, so keys created in the UI are
+			// immediately usable for webhook auth.
+			server.WithKeyManagerUI(authSvc),
 		)
 	}
 	srv := &http.Server{

--- a/internal/server/keys_ui_test.go
+++ b/internal/server/keys_ui_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+)
+
+// TestWithKeyManagerUIWiring verifies the server-level wiring: WithWebUI +
+// WithKeyManagerUI mounts the webhook key management page in a manageable state
+// (the create form renders), and omitting the option leaves it unavailable.
+func TestWithKeyManagerUIWiring(t *testing.T) {
+	km := auth.NewService(auth.NewMemoryStore())
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithWebUI(config.Config{}, "vtest"),
+		WithKeyManagerUI(km),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "Generate a new key") {
+		t.Error("key management page is not manageable when WithKeyManagerUI is wired")
+	}
+}
+
+func TestWithoutKeyManagerUIUnavailable(t *testing.T) {
+	h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+		WithWebUI(config.Config{}, "vtest"),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "unavailable") {
+		t.Error("expected the unavailable notice when no key manager is wired")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,6 +91,7 @@ type Handler struct {
 	settingsConfigPath string
 	settingsStore      secrets.Store
 	cacheStats         web.CacheStatsProvider
+	keyManager         web.KeyManager
 	trusted            *trustnet.Policy
 	mux                *http.ServeMux
 }
@@ -219,6 +220,14 @@ func WithCacheStatsUI(p web.CacheStatsProvider) Option {
 	return func(h *Handler) { h.cacheStats = p }
 }
 
+// WithKeyManagerUI wires the managed webhook API key store that backs the key
+// management page (#300). The handler attaches it to the mounted web UI (see
+// NewHandler). Meaningful only alongside a mounted web UI; with no UI, or a nil
+// manager, it is a no-op (the page renders an unavailable notice).
+func WithKeyManagerUI(km web.KeyManager) Option {
+	return func(h *Handler) { h.keyManager = km }
+}
+
 // WithWebUIIf conditionally mounts the web UI. When enabled is false it
 // returns a no-op option so callers do not need an inline if-branch.
 func WithWebUIIf(enabled bool, cfg config.Config, version string) Option {
@@ -259,6 +268,9 @@ func NewHandler(a Authenticator, q WorkQueue, outdir string, opts ...Option) *Ha
 		}
 		if h.cacheStats != nil {
 			h.webui.AttachCacheStats(h.cacheStats)
+		}
+		if h.keyManager != nil {
+			h.webui.AttachKeyManager(h.keyManager)
 		}
 		h.webui.Register(h.mux)
 	}

--- a/internal/web/keys.go
+++ b/internal/web/keys.go
@@ -1,0 +1,274 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
+	"github.com/sydlexius/mxlrcgo-svc/web/templates"
+)
+
+// keyIDDisplayLen is how many leading characters of the public key ID are shown
+// in the masked list (the rest is elided). The full ID is a non-secret public
+// identifier, but truncating keeps the table compact while staying unambiguous.
+const keyIDDisplayLen = 8
+
+// maxKeyNameLen bounds the operator-supplied key name server-side. It matches the
+// create form's client-side maxlength so a normal submission is never rejected,
+// while a forged over-long name cannot be persisted.
+const maxKeyNameLen = 120
+
+// handleWebhookKeys renders the webhook API key management page (#300): the
+// masked list of managed keys plus the create form. It never renders raw key
+// material or a full hash. The response is no-store (it exposes key metadata).
+func (u *UI) handleWebhookKeys(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	view := u.buildWebhookKeysView(r.Context())
+	u.attachKeysCSRF(w, r, &view)
+	render(w, r, templates.WebhookKeysPage(u.version, view, u.buildRail("")))
+}
+
+// handleCreateWebhookKey creates a new managed key and returns the panel fragment
+// with the raw key revealed exactly once (#300). Order mirrors the settings save
+// path: same-origin, then CSRF, then the backend check, then the work.
+func (u *UI) handleCreateWebhookKey(w http.ResponseWriter, r *http.Request) {
+	// The success response carries the one-time RAW key, so it must never be
+	// cached - same threat model as the list page's no-store (which only carries
+	// metadata). Set it first so even an early error response stays uncached.
+	w.Header().Set("Cache-Control", "no-store")
+	if !enforceSameOrigin(w, r) {
+		return
+	}
+	if !enforceCSRFToken(w, r) {
+		return
+	}
+	if u.keys == nil {
+		http.Error(w, "key management unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	scopes, err := parseScopeForm(r.PostForm["scope"])
+	if err != nil {
+		// The form only offers valid scopes, so this is a forged/garbled request.
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	name := strings.TrimSpace(r.PostFormValue("name"))
+	// The form caps the name client-side (maxlength), but a forged POST could send
+	// an arbitrarily large value and have it persisted. Bound it server-side and
+	// refuse with a friendly re-render rather than storing it.
+	if utf8.RuneCountInString(name) > maxKeyNameLen {
+		view := u.buildWebhookKeysView(r.Context())
+		u.attachKeysCSRF(w, r, &view)
+		view.Error = fmt.Sprintf("Key name is too long (maximum %d characters).", maxKeyNameLen)
+		render(w, r, templates.WebhookKeysPanel(view))
+		return
+	}
+
+	created, err := u.keys.CreateKey(r.Context(), name, scopes)
+	if err != nil {
+		slog.Error("settings: create webhook key failed", "error", err)
+		http.Error(w, "failed to create key", http.StatusInternalServerError)
+		return
+	}
+
+	view := u.buildWebhookKeysView(r.Context())
+	u.attachKeysCSRF(w, r, &view)
+	view.NewKey = &templates.NewWebhookKey{
+		Raw:  created.Raw,
+		Name: created.Key.Name,
+		ID:   created.Key.ID,
+	}
+	render(w, r, templates.WebhookKeysPanel(view))
+}
+
+// handleRevokeWebhookKey revokes a managed key by its public ID and returns the
+// re-rendered panel fragment (#300). The raw key is unrecoverable after creation,
+// so revocation is by ID. A revoke re-renders the panel WITHOUT NewKey, so a
+// previously revealed raw key is never shown again.
+func (u *UI) handleRevokeWebhookKey(w http.ResponseWriter, r *http.Request) {
+	// The re-rendered panel carries key metadata; keep it out of caches like the
+	// list page (set first so an early error response is uncached too).
+	w.Header().Set("Cache-Control", "no-store")
+	if !enforceSameOrigin(w, r) {
+		return
+	}
+	if !enforceCSRFToken(w, r) {
+		return
+	}
+	if u.keys == nil {
+		http.Error(w, "key management unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	id := strings.TrimSpace(r.PostFormValue("id"))
+	if id == "" {
+		http.Error(w, "missing key id", http.StatusBadRequest)
+		return
+	}
+
+	_, err := u.keys.RevokeKeyByID(r.Context(), id)
+	if err != nil && !errors.Is(err, auth.ErrInvalidKey) {
+		slog.Error("settings: revoke webhook key failed", "error", err)
+		http.Error(w, "failed to revoke key", http.StatusInternalServerError)
+		return
+	}
+	// Build the result view exactly once, after the revoke, so the rows reflect
+	// the new state. ErrInvalidKey means the key was already gone (concurrent
+	// revoke, stale page): render the current list with a converge notice rather
+	// than erroring.
+	view := u.buildWebhookKeysView(r.Context())
+	u.attachKeysCSRF(w, r, &view)
+	if errors.Is(err, auth.ErrInvalidKey) {
+		view.Error = "That key no longer exists; the list has been refreshed."
+	}
+	render(w, r, templates.WebhookKeysPanel(view))
+}
+
+// attachKeysCSRF embeds a double-submit CSRF token in the view when the page is
+// manageable (a key backend is wired). On token-generation failure the page
+// stays read-only: Manageable is forced false so no create/revoke controls
+// render, matching the settings page's fail-safe behavior.
+func (u *UI) attachKeysCSRF(w http.ResponseWriter, r *http.Request, view *templates.WebhookKeysView) {
+	if !view.Manageable {
+		return
+	}
+	token, err := ensureCSRFToken(w, r, u.secureRequest(r))
+	if err != nil {
+		slog.Error("settings: CSRF token generation failed; key management disabled", "error", err)
+		view.Manageable = false
+		return
+	}
+	view.CSRFToken = token
+}
+
+// buildWebhookKeysView assembles the page view model from the managed key store.
+// It carries only metadata (never raw key material or the full hash). When no key
+// backend is wired the view is not Manageable and the page renders an unavailable
+// notice.
+func (u *UI) buildWebhookKeysView(ctx context.Context) templates.WebhookKeysView {
+	view := templates.WebhookKeysView{ScopeOptions: defaultScopeOptions()}
+	if u.keys == nil {
+		return view
+	}
+	view.Manageable = true
+
+	keys, err := u.keys.ListKeys(ctx)
+	if err != nil {
+		slog.Error("settings: list webhook keys failed", "error", err)
+		view.Error = "The existing keys could not be loaded."
+		return view
+	}
+	loc := serverDisplayLocation()
+	view.Keys = make([]templates.WebhookKeyRow, 0, len(keys))
+	for _, k := range keys {
+		view.Keys = append(view.Keys, keyRow(k, loc))
+	}
+	return view
+}
+
+// keyRow maps one stored key onto its masked display row. The full hash and any
+// raw material are intentionally never read here. Timestamps use the dashboard
+// pattern (formatDashboardTime): the server renders a labeled value and emits the
+// RFC3339 UTC for keys.js to reformat into the viewer's local zone, so the cell
+// never shows bare UTC when the viewer is elsewhere.
+func keyRow(k auth.Key, loc *time.Location) templates.WebhookKeyRow {
+	created, createdISO, createdTZ := formatDashboardTime(k.CreatedAt, loc)
+	row := templates.WebhookKeyRow{
+		ID:               truncateKeyID(k.ID),
+		FullID:           k.ID,
+		Name:             keyDisplayName(k.Name),
+		Scopes:           scopesDisplay(k.Scopes),
+		Created:          created,
+		CreatedISO:       createdISO,
+		CreatedTZApplied: createdTZ,
+	}
+	if k.RevokedAt != nil {
+		row.Revoked = true
+		row.RevokedAt, row.RevokedAtISO, row.RevokedAtTZApplied = formatDashboardTime(*k.RevokedAt, loc)
+	}
+	return row
+}
+
+// truncateKeyID shortens the public key ID for display, eliding the tail. The ID
+// is a public identifier (hash prefix), so this is presentation, not redaction.
+func truncateKeyID(id string) string {
+	if len(id) <= keyIDDisplayLen {
+		return id
+	}
+	return id[:keyIDDisplayLen] + "…"
+}
+
+// keyDisplayName returns a placeholder for an unnamed key so the column never
+// renders blank.
+func keyDisplayName(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "(unnamed)"
+	}
+	return name
+}
+
+// scopesDisplay renders a key's scopes as a comma-joined string, or a placeholder
+// when somehow empty.
+func scopesDisplay(scopes []auth.Scope) string {
+	if len(scopes) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		parts = append(parts, string(s))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// defaultScopeOptions are the scope checkboxes offered on the create form, with
+// webhook pre-checked (the common case for a Lidarr key).
+func defaultScopeOptions() []templates.WebhookScopeOption {
+	return []templates.WebhookScopeOption{
+		{Value: string(auth.ScopeWebhook), Label: "Webhook (accept Lidarr webhook calls)", Checked: true},
+		{Value: string(auth.ScopeAdmin), Label: "Admin (full access, including status and metrics)", Checked: false},
+	}
+}
+
+// parseScopeForm validates and normalizes the scope checkbox values from the
+// create form. With nothing selected it defaults to the webhook scope so the
+// common case needs no choice; an unknown value is rejected (forged request).
+func parseScopeForm(values []string) ([]auth.Scope, error) {
+	cleaned := make([]auth.Scope, 0, len(values))
+	for _, v := range values {
+		if v = strings.TrimSpace(v); v != "" {
+			cleaned = append(cleaned, auth.Scope(v))
+		}
+	}
+	if len(cleaned) == 0 {
+		cleaned = []auth.Scope{auth.ScopeWebhook}
+	}
+	return auth.NormalizeScopes(cleaned)
+}
+
+// serverDisplayLocation resolves the timezone for created/revoked timestamps,
+// mirroring buildReportView: the TZ env var when set and valid, otherwise nil
+// (formatReportTime then normalizes to UTC).
+func serverDisplayLocation() *time.Location {
+	if tz := os.Getenv("TZ"); tz != "" {
+		if loc, err := time.LoadLocation(tz); err == nil {
+			return loc
+		}
+	}
+	return nil
+}

--- a/internal/web/keys_test.go
+++ b/internal/web/keys_test.go
@@ -1,0 +1,420 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
+	"github.com/sydlexius/mxlrcgo-svc/internal/config"
+)
+
+// errTest is a sentinel returned by errKeyManager to drive the handler error
+// branches.
+var errTest = errors.New("test error")
+
+// keysTestUI builds a UI with the given key manager wired and returns the mounted
+// handler. Built without auth, so routes are public and the same-origin check
+// passes for a header-less test request.
+func keysTestUI(t *testing.T, km KeyManager) http.Handler {
+	t.Helper()
+	u := NewUI(config.Config{}, "v0", WithKeyManager(km))
+	mux := http.NewServeMux()
+	u.Register(mux)
+	return mux
+}
+
+// seedKey creates a key in the manager and returns its raw value and metadata.
+func seedKey(t *testing.T, km KeyManager, name string, scopes ...auth.Scope) auth.CreatedKey {
+	t.Helper()
+	if len(scopes) == 0 {
+		scopes = []auth.Scope{auth.ScopeWebhook}
+	}
+	created, err := km.CreateKey(context.Background(), name, scopes)
+	if err != nil {
+		t.Fatalf("seed CreateKey: %v", err)
+	}
+	return created
+}
+
+func newKeyManager() KeyManager {
+	return auth.NewService(auth.NewMemoryStore())
+}
+
+// postKeys issues a POST to path with a valid double-submit CSRF token.
+func postKeys(t *testing.T, h http.Handler, path string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	form.Set("csrf_token", testCSRFToken)
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: testCSRFToken})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestWebhookKeysListNeverExposesSecrets is the core security assertion: the
+// masked list page renders metadata but never the raw key and never the full
+// PBKDF2 hash.
+func TestWebhookKeysListNeverExposesSecrets(t *testing.T) {
+	km := newKeyManager()
+	created := seedKey(t, km, "lidarr-main")
+
+	h := keysTestUI(t, km)
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /settings/keys status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if strings.Contains(body, created.Raw) {
+		t.Error("list page leaked the raw key")
+	}
+	if strings.Contains(body, created.Key.Hash) {
+		t.Error("list page leaked the full key hash")
+	}
+	// The masked public ID (and the key name) are expected metadata.
+	if !strings.Contains(body, "lidarr-main") {
+		t.Error("list page is missing the key name")
+	}
+	if !strings.Contains(body, created.Key.ID[:keyIDDisplayLen]) {
+		t.Error("list page is missing the truncated key ID")
+	}
+	// The Created cell uses the dashboard viewer-local pattern: a <time
+	// data-tz="pending"> element keys.js reformats, not a bare UTC string.
+	if !strings.Contains(body, `data-tz="pending"`) {
+		t.Error("Created timestamp is not the viewer-local <time data-tz=pending> element")
+	}
+	if strings.Contains(body, "@keyTime") {
+		t.Error("list page leaked a literal templ component call")
+	}
+}
+
+// TestWebhookKeysCreateShowsRawOnce asserts the create response reveals the raw
+// key exactly once, and that a subsequent plain list render never shows it.
+func TestWebhookKeysCreateShowsRawOnce(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+
+	rec := postKeys(t, h, "/settings/keys", url.Values{"name": {"created-in-ui"}, "scope": {"webhook"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	// The create response carries the one-time raw key - it must never be cached.
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("create Cache-Control = %q, want no-store", cc)
+	}
+	body := rec.Body.String()
+
+	// The raw key appears in the create response (it is the one-time reveal).
+	keys, err := km.ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want 1 key after create, got %d", len(keys))
+	}
+	if !strings.Contains(body, auth.KeyPrefix) {
+		t.Error("create response does not contain the raw key prefix")
+	}
+	if strings.Contains(body, keys[0].Hash) {
+		t.Error("create response leaked the full key hash")
+	}
+
+	// A fresh list render (GET) must NOT contain any raw key material.
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	listBody := rec2.Body.String()
+	// The raw key is prefix + 64 hex chars; the prefix may appear in form
+	// placeholders, but a full raw key value must not. Assert the readonly reveal
+	// input is absent from the plain list.
+	if strings.Contains(listBody, `id="mx-newkey-value"`) {
+		t.Error("plain list render still shows the one-time raw key field")
+	}
+	if strings.Contains(listBody, keys[0].Hash) {
+		t.Error("plain list render leaked the full key hash")
+	}
+}
+
+// TestWebhookKeysRevoke marks a key revoked through the handler and confirms the
+// re-rendered panel reflects the revoked status.
+func TestWebhookKeysRevoke(t *testing.T) {
+	km := newKeyManager()
+	created := seedKey(t, km, "to-revoke")
+	h := keysTestUI(t, km)
+
+	rec := postKeys(t, h, "/settings/keys/revoke", url.Values{"id": {created.Key.ID}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("revoke Cache-Control = %q, want no-store", cc)
+	}
+	revokeBody := rec.Body.String()
+	if !strings.Contains(revokeBody, "mx-keys-status-revoked") {
+		t.Error("revoke response does not show the revoked status")
+	}
+	// The revoked timestamp must render as a real <time> element (viewer-local
+	// reformat), not the literal templ call text - guards the inline-@component
+	// regression where "Revoked @keyTime(...)" emitted as plain text.
+	if !strings.Contains(revokeBody, "<time ") {
+		t.Error("revoke response is missing the <time> timestamp element")
+	}
+	if strings.Contains(revokeBody, "@keyTime") {
+		t.Error("revoke response leaked a literal templ component call")
+	}
+
+	keys, err := km.ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].RevokedAt == nil {
+		t.Fatalf("key was not revoked in the store: %+v", keys)
+	}
+}
+
+// TestWebhookKeysRevokeUnknownIDConverges asserts revoking a missing id is not a
+// hard error: the panel re-renders with a soft notice.
+func TestWebhookKeysRevokeUnknownID(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	rec := postKeys(t, h, "/settings/keys/revoke", url.Values{"id": {"deadbeefdeadbeef"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke unknown status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "no longer exists") {
+		t.Error("revoke unknown id should render the converge notice")
+	}
+}
+
+// TestWebhookKeysCreateCSRFRejected asserts a create POST without a valid CSRF
+// token is rejected and creates nothing.
+func TestWebhookKeysCreateCSRFRejected(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+
+	// No cookie -> 403.
+	req := httptest.NewRequest(http.MethodPost, "/settings/keys",
+		strings.NewReader(url.Values{"csrf_token": {testCSRFToken}, "scope": {"webhook"}}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("create without CSRF cookie status = %d, want 403", rec.Code)
+	}
+	keys, err := km.ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("a key was created despite the CSRF failure: %+v", keys)
+	}
+}
+
+// TestWebhookKeysUnavailable asserts that without a key manager wired the page
+// renders the unavailable notice and the POSTs return 503.
+func TestWebhookKeysUnavailable(t *testing.T) {
+	u := NewUI(config.Config{}, "v0") // no WithKeyManager
+	mux := http.NewServeMux()
+	u.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "unavailable") {
+		t.Error("expected an unavailable notice when no key manager is wired")
+	}
+
+	rec2 := postKeys(t, mux, "/settings/keys", url.Values{"scope": {"webhook"}})
+	if rec2.Code != http.StatusServiceUnavailable {
+		t.Fatalf("create with no manager status = %d, want 503", rec2.Code)
+	}
+}
+
+// errKeyManager is a KeyManager whose operations fail, exercising the handler
+// error branches.
+type errKeyManager struct {
+	listErr, createErr, revokeErr error
+}
+
+func (e errKeyManager) ListKeys(context.Context) ([]auth.Key, error) {
+	return nil, e.listErr
+}
+
+func (e errKeyManager) CreateKey(context.Context, string, []auth.Scope) (auth.CreatedKey, error) {
+	return auth.CreatedKey{}, e.createErr
+}
+
+func (e errKeyManager) RevokeKeyByID(context.Context, string) (auth.Key, error) {
+	return auth.Key{}, e.revokeErr
+}
+
+// TestWebhookKeysListError asserts a List failure surfaces a soft error on the
+// page rather than a 500 or a misleading empty list.
+func TestWebhookKeysListError(t *testing.T) {
+	h := keysTestUI(t, errKeyManager{listErr: errTest})
+	req := httptest.NewRequest(http.MethodGet, "/settings/keys", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "could not be loaded") {
+		t.Error("expected a list-load error notice")
+	}
+}
+
+// TestWebhookKeysCreateBackendError asserts a CreateKey failure returns 500.
+func TestWebhookKeysCreateBackendError(t *testing.T) {
+	h := keysTestUI(t, errKeyManager{createErr: errTest})
+	rec := postKeys(t, h, "/settings/keys", url.Values{"scope": {"webhook"}})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestWebhookKeysRevokeBackendError asserts a non-"missing" revoke failure 500s.
+func TestWebhookKeysRevokeBackendError(t *testing.T) {
+	h := keysTestUI(t, errKeyManager{revokeErr: errTest})
+	rec := postKeys(t, h, "/settings/keys/revoke", url.Values{"id": {"abc"}})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestWebhookKeysCrossSiteRejected asserts a cross-site POST is blocked before
+// any mutation, for both create and revoke.
+func TestWebhookKeysCrossSiteRejected(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	for _, path := range []string{"/settings/keys", "/settings/keys/revoke"} {
+		form := url.Values{"csrf_token": {testCSRFToken}, "scope": {"webhook"}, "id": {"x"}}
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: testCSRFToken})
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s cross-site status = %d, want 403", path, rec.Code)
+		}
+	}
+}
+
+// TestWebhookKeysRevokeMissingID asserts a revoke with no id is a 400.
+func TestWebhookKeysRevokeMissingID(t *testing.T) {
+	h := keysTestUI(t, newKeyManager())
+	rec := postKeys(t, h, "/settings/keys/revoke", url.Values{})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestWebhookKeysCreateInvalidScope asserts a forged unknown scope is rejected.
+func TestWebhookKeysCreateInvalidScope(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	rec := postKeys(t, h, "/settings/keys", url.Values{"scope": {"root"}})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	keys, _ := km.ListKeys(context.Background())
+	if len(keys) != 0 {
+		t.Errorf("a key was created for an invalid scope: %+v", keys)
+	}
+}
+
+// TestWebhookKeysAdminScope asserts the admin scope checkbox creates an
+// admin-scoped key.
+func TestWebhookKeysAdminScope(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	rec := postKeys(t, h, "/settings/keys", url.Values{"scope": {"webhook", "admin"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	keys, _ := km.ListKeys(context.Background())
+	if len(keys) != 1 || !auth.HasScope(keys[0].Scopes, auth.ScopeAdmin) {
+		t.Fatalf("admin scope not applied: %+v", keys)
+	}
+}
+
+// TestWebhookKeysCreateRejectsOverlongName asserts a forged over-length name is
+// refused server-side (friendly re-render) and no key is created, even though the
+// client form caps it.
+func TestWebhookKeysCreateRejectsOverlongName(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	longName := strings.Repeat("a", maxKeyNameLen+1)
+	rec := postKeys(t, h, "/settings/keys", url.Values{"name": {longName}, "scope": {"webhook"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (friendly re-render)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "too long") {
+		t.Error("expected an over-long-name notice")
+	}
+	keys, _ := km.ListKeys(context.Background())
+	if len(keys) != 0 {
+		t.Errorf("a key was created despite the over-long name: %+v", keys)
+	}
+	// A name exactly at the limit is accepted.
+	rec2 := postKeys(t, h, "/settings/keys", url.Values{"name": {strings.Repeat("a", maxKeyNameLen)}, "scope": {"webhook"}})
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("at-limit name status = %d, want 200", rec2.Code)
+	}
+	keys2, _ := km.ListKeys(context.Background())
+	if len(keys2) != 1 {
+		t.Fatalf("at-limit name should have been created: %+v", keys2)
+	}
+}
+
+// TestKeyRowHelpers covers the small display-mapping helpers directly.
+func TestKeyRowHelpers(t *testing.T) {
+	if got := truncateKeyID("abc"); got != "abc" {
+		t.Errorf("truncateKeyID short = %q, want abc", got)
+	}
+	if got := truncateKeyID("0123456789abcdef"); got != "01234567…" {
+		t.Errorf("truncateKeyID = %q", got)
+	}
+	if got := keyDisplayName("   "); got != "(unnamed)" {
+		t.Errorf("keyDisplayName blank = %q", got)
+	}
+	if got := keyDisplayName("x"); got != "x" {
+		t.Errorf("keyDisplayName = %q", got)
+	}
+	if got := scopesDisplay(nil); got != "(none)" {
+		t.Errorf("scopesDisplay nil = %q", got)
+	}
+	if got := scopesDisplay([]auth.Scope{auth.ScopeWebhook, auth.ScopeAdmin}); got != "webhook, admin" {
+		t.Errorf("scopesDisplay = %q", got)
+	}
+}
+
+// TestWebhookKeysCreateDefaultsToWebhookScope asserts an empty scope selection
+// defaults to the webhook scope rather than erroring.
+func TestWebhookKeysCreateDefaultsToWebhookScope(t *testing.T) {
+	km := newKeyManager()
+	h := keysTestUI(t, km)
+	rec := postKeys(t, h, "/settings/keys", url.Values{"name": {"no-scope"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	keys, err := km.ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 || len(keys[0].Scopes) != 1 || keys[0].Scopes[0] != auth.ScopeWebhook {
+		t.Fatalf("default scope not applied: %+v", keys)
+	}
+}

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/a-h/templ"
 
+	"github.com/sydlexius/mxlrcgo-svc/internal/auth"
 	"github.com/sydlexius/mxlrcgo-svc/internal/config"
 	"github.com/sydlexius/mxlrcgo-svc/internal/reports"
 	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
@@ -90,6 +91,24 @@ type UI struct {
 	// is attached (e.g. some tests, or the web UI built without serve wiring), in
 	// which case the dashboard omits the cache tile rather than rendering zeros.
 	cacheStats CacheStatsProvider
+
+	// keys is the managed (DB-backed) webhook API key store the key-management
+	// page (#300) lists, creates, and revokes against. Nil when no key seam is
+	// wired (e.g. some tests, or the web UI built without serve wiring), in which
+	// case the page renders an "unavailable" notice and the create/revoke POSTs
+	// return 503 rather than panicking.
+	keys KeyManager
+}
+
+// KeyManager is the subset of *auth.Service the webhook key management page
+// (#300) needs: list existing keys (metadata only), create a key (returning the
+// one-time raw material), and revoke a key by its public ID (the raw key is not
+// recoverable after creation, so revocation is by ID). *auth.Service satisfies
+// it.
+type KeyManager interface {
+	ListKeys(ctx context.Context) ([]auth.Key, error)
+	CreateKey(ctx context.Context, name string, scopes []auth.Scope) (auth.CreatedKey, error)
+	RevokeKeyByID(ctx context.Context, id string) (auth.Key, error)
 }
 
 // CacheStatsProvider supplies the process-lifetime lyrics-cache hit and lookup
@@ -146,6 +165,19 @@ func WithCacheStats(p CacheStatsProvider) UIOption {
 // post-construction equivalent of WithCacheStats used by the server layer where
 // the UI is built first (WithWebUIAuth) and the seam attached after.
 func (u *UI) AttachCacheStats(p CacheStatsProvider) { u.cacheStats = p }
+
+// WithKeyManager wires the managed webhook API key store the key-management page
+// (#300) operates on. Omitting it leaves the page reachable but renders an
+// "unavailable" notice (no key backend wired); the create/revoke POSTs return
+// 503.
+func WithKeyManager(km KeyManager) UIOption {
+	return func(u *UI) { u.keys = km }
+}
+
+// AttachKeyManager wires the key store onto an already-constructed UI, the
+// post-construction equivalent of WithKeyManager used by the server layer where
+// the UI is built first (WithWebUIAuth) and the seam attached after.
+func (u *UI) AttachKeyManager(km KeyManager) { u.keys = km }
 
 // WithConfigPath sets the resolved config file path the settings save handlers
 // write through. Without it the settings page stays read-only (no write path).
@@ -264,6 +296,9 @@ func (u *UI) Register(mux *http.ServeMux) {
 		mux.Handle("GET /settings", guard(http.HandlerFunc(u.handleSettings)))
 		mux.Handle("POST /settings/field", guard(http.HandlerFunc(u.handleSaveField)))
 		mux.Handle("POST /settings/section", guard(http.HandlerFunc(u.handleSaveSection)))
+		mux.Handle("GET /settings/keys", guard(http.HandlerFunc(u.handleWebhookKeys)))
+		mux.Handle("POST /settings/keys", guard(http.HandlerFunc(u.handleCreateWebhookKey)))
+		mux.Handle("POST /settings/keys/revoke", guard(http.HandlerFunc(u.handleRevokeWebhookKey)))
 		return
 	}
 	mux.HandleFunc("GET /{$}", u.handleRoot)
@@ -274,6 +309,9 @@ func (u *UI) Register(mux *http.ServeMux) {
 	mux.HandleFunc("GET /settings", u.handleSettings)
 	mux.HandleFunc("POST /settings/field", u.handleSaveField)
 	mux.HandleFunc("POST /settings/section", u.handleSaveSection)
+	mux.HandleFunc("GET /settings/keys", u.handleWebhookKeys)
+	mux.HandleFunc("POST /settings/keys", u.handleCreateWebhookKey)
+	mux.HandleFunc("POST /settings/keys/revoke", u.handleRevokeWebhookKey)
 }
 
 // settingsPath is the single config destination. Settings replaced the old

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -37,6 +37,20 @@ body {
   min-height: 100vh;
 }
 
+/* htmx loading indicators. We disable htmx's built-in injected <style> via the
+   htmx-config meta (includeIndicatorStyles:false) because that inline style
+   violates our strict CSP (style-src 'self'); these are the equivalent rules,
+   now served from our own embedded stylesheet instead of inline. */
+.htmx-indicator {
+  opacity: 0;
+}
+.htmx-request .htmx-indicator {
+  opacity: 1;
+}
+.htmx-request.htmx-indicator {
+  opacity: 1;
+}
+
 /* -- App shell ------------------------------------------------------------- */
 .mx-shell {
   display: flex;
@@ -204,6 +218,32 @@ body {
   font-size: 0.9rem;
   color: var(--mx-content-text-secondary);
   margin: 0 0 1.75rem;
+}
+
+/* Settings sub-area link (e.g. Webhook keys): a labeled jump to a related
+   management page surfaced from within Settings, #300. */
+.mx-settings-subnav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  margin: 0 0 1.75rem;
+}
+
+.mx-settings-subnav-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--mx-sidebar-active-text);
+  text-decoration: none;
+  width: fit-content;
+}
+
+.mx-settings-subnav-link:hover {
+  text-decoration: underline;
+}
+
+.mx-settings-subnav-hint {
+  font-size: 0.8rem;
+  color: var(--mx-content-text-secondary);
 }
 
 /* -- Config view ----------------------------------------------------------- */

--- a/web/static/css/keys.css
+++ b/web/static/css/keys.css
@@ -1,0 +1,176 @@
+/* Webhook API key management page (#300). Hand-written component CSS served as a
+ * per-page stylesheet (issue #322 pattern) so it ships only on /settings/keys
+ * and does not need the Tailwind build to pick up new utility classes. It reuses
+ * the design tokens (design-tokens.css) so it matches the rest of the dark UI. */
+
+.mx-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mx-keys-unavailable,
+.mx-keys-error {
+  font-size: 0.875rem;
+  color: #fca5a5; /* red-300 */
+  background-color: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: var(--mx-radius-md);
+  padding: 0.75rem 1rem;
+  margin: 0 0 1.25rem;
+}
+
+/* -- One-time raw key reveal ---------------------------------------------- */
+.mx-key-reveal {
+  background-color: rgba(59, 130, 246, 0.08);
+  border: 1px solid var(--mx-accent);
+  border-radius: var(--mx-radius-md);
+  padding: 1rem 1.25rem;
+  margin: 0 0 1.75rem;
+}
+
+.mx-key-reveal-title {
+  font-weight: 700;
+  color: #f1f5f9; /* slate-100 */
+  margin: 0 0 0.5rem;
+}
+
+.mx-key-reveal-meta {
+  font-size: 0.85rem;
+  color: var(--mx-content-text-secondary);
+  margin: 0 0 0.75rem;
+}
+
+.mx-key-reveal-meta code {
+  font-family: var(--mx-font-mono);
+  color: var(--mx-content-text);
+}
+
+.mx-key-reveal-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.mx-key-reveal-value {
+  flex: 1 1 auto;
+  font-family: var(--mx-font-mono);
+}
+
+.mx-key-reveal-hint {
+  font-size: 0.8rem;
+  color: var(--mx-content-text-secondary);
+  margin: 0.75rem 0 0;
+}
+
+/* -- Create form ----------------------------------------------------------- */
+.mx-keys-create,
+.mx-keys-list-section {
+  margin: 0 0 2rem;
+}
+
+.mx-keys-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 32rem;
+}
+
+.mx-keys-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.mx-keys-scopes {
+  border: 1px solid var(--mx-surface-border);
+  border-radius: var(--mx-radius-md);
+  padding: 0.75rem 1rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mx-keys-scopes legend {
+  padding: 0 0.375rem;
+}
+
+.mx-keys-generate {
+  align-self: flex-start;
+}
+
+/* -- Key list table -------------------------------------------------------- */
+.mx-keys-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mx-keys-table th,
+.mx-keys-table td {
+  text-align: left;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--mx-surface-border);
+  vertical-align: middle;
+}
+
+.mx-keys-table th {
+  font-weight: 600;
+  color: var(--mx-content-text-secondary);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.mx-keys-table td code {
+  font-family: var(--mx-font-mono);
+}
+
+.mx-keys-row-revoked td {
+  color: var(--mx-content-text-secondary);
+}
+
+.mx-keys-status {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--mx-radius-sm);
+}
+
+.mx-keys-status-active {
+  color: #6ee7b7; /* emerald-300 */
+  background-color: rgba(16, 185, 129, 0.12);
+}
+
+.mx-keys-status-revoked {
+  color: var(--mx-content-text-secondary);
+  background-color: rgba(148, 163, 184, 0.12);
+}
+
+.mx-keys-revoke {
+  font-family: var(--mx-font-sans);
+  font-size: 0.8125rem;
+  color: #fca5a5; /* red-300 */
+  background-color: transparent;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  border-radius: var(--mx-radius-sm);
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+}
+
+.mx-keys-revoke:hover {
+  background-color: rgba(239, 68, 68, 0.12);
+}
+
+.mx-keys-revoke:focus-visible {
+  outline: 2px solid var(--mx-accent);
+  outline-offset: 2px;
+}

--- a/web/static/js/keys.js
+++ b/web/static/js/keys.js
@@ -1,0 +1,106 @@
+// keys.js powers the one client-side affordance on the webhook keys page (#300):
+// the "Copy" button next to a freshly revealed raw key. Everything else (create,
+// revoke) is plain htmx form posts, so the page works with this script absent.
+// CSP-safe: external file, event-delegated listener, no inline handlers. Capability
+// gaps fail loudly (console.error), never silently.
+(function () {
+  "use strict";
+
+  // copyFromTarget copies the value of the input named by the button's
+  // data-copy-target into the clipboard. It prefers the async Clipboard API and
+  // falls back to selecting the field + execCommand so an http (non-secure)
+  // context, where navigator.clipboard is unavailable, still copies.
+  function copyFromTarget(btn) {
+    var targetId = btn.getAttribute("data-copy-target");
+    var input = targetId ? document.getElementById(targetId) : null;
+    if (!input) {
+      console.error("keys.js: copy target not found:", targetId);
+      return;
+    }
+    var value = input.value;
+    var done = function () {
+      var original = btn.textContent;
+      btn.textContent = "Copied";
+      window.setTimeout(function () {
+        btn.textContent = original;
+      }, 1500);
+    };
+
+    if (window.navigator && window.navigator.clipboard && typeof window.navigator.clipboard.writeText === "function") {
+      window.navigator.clipboard.writeText(value).then(done).catch(function (err) {
+        console.error("keys.js: clipboard write failed; falling back to select", err);
+        selectFallback(input, done);
+      });
+      return;
+    }
+    selectFallback(input, done);
+  }
+
+  // selectFallback selects the field's text and tries the legacy copy command,
+  // leaving the value selected for a manual copy if that is unavailable too.
+  function selectFallback(input, done) {
+    input.focus();
+    input.select();
+    var copied = false;
+    try {
+      copied = document.execCommand && document.execCommand("copy");
+    } catch (err) {
+      console.error("keys.js: execCommand copy failed", err);
+    }
+    if (copied) {
+      done();
+    } else {
+      console.error("keys.js: no clipboard mechanism available; key left selected for manual copy");
+    }
+  }
+
+  document.addEventListener("click", function (event) {
+    var btn = event.target.closest("[data-copy-target]");
+    if (btn) {
+      event.preventDefault();
+      copyFromTarget(btn);
+    }
+  });
+
+  // --- Viewer-local timestamps --------------------------------------------
+  // Reformat <time data-tz="pending"> cells (Created / Revoked) into the
+  // browser's local timezone with a 3-letter abbreviation (e.g. "PDT"), matching
+  // the dashboard. The dashboard does this with an inline script; this page is
+  // CSP script-src 'self', so the same logic lives here in the external file.
+  // Elements marked data-tz-applied (server already applied a TZ-env zone) are
+  // left untouched. Re-run after every htmx swap so the re-rendered key list (on
+  // create/revoke) gets reformatted too.
+  function reformatTimes(root) {
+    var scope = root && root.querySelectorAll ? root : document;
+    scope.querySelectorAll('time[data-tz="pending"]').forEach(function (el) {
+      var iso = el.getAttribute("datetime");
+      if (!iso) {
+        return;
+      }
+      try {
+        var d = new Date(iso);
+        var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        el.textContent = d.toLocaleString("en-US", {
+          year: "numeric", month: "2-digit", day: "2-digit",
+          hour: "2-digit", minute: "2-digit",
+          timeZone: tz,
+          timeZoneName: "short"
+        });
+        // Mark done so a later swap that re-scopes to document does not
+        // re-process an already-localized cell.
+        el.setAttribute("data-tz", "applied");
+      } catch (err) {
+        console.error("keys.js: timestamp reformat failed", err);
+      }
+    });
+  }
+
+  // The script is deferred, so the DOM is parsed when this runs.
+  reformatTimes(document);
+  // htmx swaps the key-list panel on create/revoke; reformat the swapped-in nodes.
+  if (document.body) {
+    document.body.addEventListener("htmx:afterSwap", function (event) {
+      reformatTimes(event.target || document);
+    });
+  }
+})();

--- a/web/static/js/keys.js
+++ b/web/static/js/keys.js
@@ -100,7 +100,8 @@
   // htmx swaps the key-list panel on create/revoke; reformat the swapped-in nodes.
   if (document.body) {
     document.body.addEventListener("htmx:afterSwap", function (event) {
-      reformatTimes(event.target || document);
+      var root = (event.detail && event.detail.target) ? event.detail.target : (event.target || document);
+      reformatTimes(root);
     });
   }
 })();

--- a/web/templates/keys.templ
+++ b/web/templates/keys.templ
@@ -1,0 +1,197 @@
+package templates
+
+// WebhookKeysPage renders the webhook API key management page (#300): a masked
+// list of the keys held in the managed (DB-backed) store, a per-key revoke
+// control, and a "Generate new key" form that shows the raw key exactly once.
+//
+// The create and revoke forms POST via htmx and swap the #mx-keys-panel content
+// with the re-rendered panel fragment (WebhookKeysPanel). The raw key is only
+// ever present in the immediate create response (view.NewKey); a later revoke
+// re-renders the panel without it, so it is never shown twice and never persists
+// in the rendered list.
+templ WebhookKeysPage(version string, view WebhookKeysView, reports []RailItem) {
+	@Layout("Webhook keys", "/settings/keys", version, reports, "/static/css/keys.css") {
+		// keys.js adds the one-time raw key's Copy button. Served from the embedded
+		// /static; the page works without it (the key sits in a selectable field).
+		<script src="/static/js/keys.js" defer></script>
+		<h1 class="mx-page-title">Webhook keys</h1>
+		<p class="mx-page-subtitle">
+			These keys authenticate Lidarr webhook calls to this server. Generate a key, copy it once,
+			and paste it into Lidarr. The key itself is never stored or shown again - only its name and
+			ID are kept here, so revoke and replace it if it is ever lost or leaked.
+		</p>
+		if !view.Manageable {
+			<p class="mx-keys-unavailable" role="alert">
+				Key management is unavailable: the server is running without a key store wired.
+			</p>
+		} else {
+			<div id="mx-keys-panel">
+				@WebhookKeysPanel(view)
+			</div>
+		}
+	}
+}
+
+// WebhookKeysPanel is the swappable inner content of #mx-keys-panel: an optional
+// error notice, the one-time raw-key reveal (only on a create response), the
+// create form, and the masked key list. Both POST handlers render this fragment
+// so an htmx innerHTML swap replaces the whole panel in place.
+templ WebhookKeysPanel(view WebhookKeysView) {
+	if view.Error != "" {
+		<p class="mx-keys-error" role="alert">{ view.Error }</p>
+	}
+	if view.NewKey != nil {
+		@keyReveal(view.NewKey)
+	}
+	@keyCreateForm(view)
+	@keyList(view)
+}
+
+// keyReveal shows a freshly created raw key once, with a copy affordance and a
+// blunt "won't be shown again" warning. The value sits in a readonly input so it
+// is selectable and copyable without JavaScript; keys.js adds a copy button.
+templ keyReveal(key *NewWebhookKey) {
+	<div class="mx-key-reveal" role="alert">
+		<p class="mx-key-reveal-title">Key created. Copy it now - it will not be shown again.</p>
+		if key.Name != "" {
+			<p class="mx-key-reveal-meta">Name: <span class="mx-key-reveal-name">{ key.Name }</span> &middot; ID: <code>{ key.ID }</code></p>
+		} else {
+			<p class="mx-key-reveal-meta">ID: <code>{ key.ID }</code></p>
+		}
+		<div class="mx-key-reveal-row">
+			<input
+				class="mx-settings-input mx-key-reveal-value"
+				id="mx-newkey-value"
+				type="text"
+				readonly
+				value={ key.Raw }
+				aria-label="New webhook key (copy now)"
+			/>
+			<button type="button" class="mx-settings-genbtn" data-copy-target="mx-newkey-value">Copy</button>
+		</div>
+		<p class="mx-key-reveal-hint">Store it in Lidarr's webhook settings. If you lose it, revoke this key and generate a new one.</p>
+	</div>
+}
+
+// keyCreateForm is the "Generate new key" form. It posts to /settings/keys; the
+// server generates the raw key, stores only its hash, and returns the panel with
+// the raw key revealed once.
+templ keyCreateForm(view WebhookKeysView) {
+	<section class="mx-keys-create" aria-labelledby="mx-keys-create-heading">
+		<h2 class="mx-settings-section-title" id="mx-keys-create-heading">Generate a new key</h2>
+		<form
+			class="mx-keys-create-form"
+			hx-post="/settings/keys"
+			hx-target="#mx-keys-panel"
+			hx-swap="innerHTML"
+		>
+			<input type="hidden" name="csrf_token" value={ view.CSRFToken }/>
+			<div class="mx-keys-field">
+				<label class="mx-settings-field-label" for="mx-keys-name">Name (optional)</label>
+				<input
+					class="mx-settings-input"
+					id="mx-keys-name"
+					name="name"
+					type="text"
+					maxlength="120"
+					autocomplete="off"
+					placeholder="e.g. lidarr-main"
+				/>
+			</div>
+			<fieldset class="mx-keys-scopes">
+				<legend class="mx-settings-field-label">Scopes</legend>
+				for i, opt := range view.ScopeOptions {
+					<label class="mx-settings-checkbox-row">
+						<input
+							type="checkbox"
+							class="mx-settings-checkbox"
+							name="scope"
+							id={ OptionID("mx-keys-scope", i) }
+							value={ opt.Value }
+							if opt.Checked {
+								checked
+							}
+						/>
+						<span>{ opt.Label }</span>
+					</label>
+				}
+			</fieldset>
+			<button type="submit" class="mx-settings-genbtn mx-keys-generate">Generate key</button>
+		</form>
+	</section>
+}
+
+// keyTime renders a timestamp cell using the dashboard's viewer-local pattern: a
+// <time data-tz="pending"> element carrying the RFC3339 value, which keys.js
+// reformats to the browser's local zone with a 3-letter abbreviation. When the
+// server already applied a TZ-env zone (tzApplied) the element is marked
+// data-tz-applied so the client leaves it as-is; an empty ISO (zero time) renders
+// the plain display string.
+templ keyTime(display string, iso string, tzApplied bool) {
+	if iso == "" {
+		{ display }
+	} else if tzApplied {
+		<time datetime={ iso } data-tz-applied="1">{ display }</time>
+	} else {
+		<time datetime={ iso } data-tz="pending">{ display }</time>
+	}
+}
+
+// keyList renders the masked table of existing keys. It shows only metadata -
+// name, truncated public ID, scopes, created timestamp, and active/revoked
+// status - never the raw key or the full hash. An active key carries an inline
+// revoke form; a revoked key shows when it was revoked.
+templ keyList(view WebhookKeysView) {
+	<section class="mx-keys-list-section" aria-labelledby="mx-keys-list-heading">
+		<h2 class="mx-settings-section-title" id="mx-keys-list-heading">Existing keys</h2>
+		if len(view.Keys) == 0 {
+			<p class="mx-settings-field-desc">No keys yet. Generate one above to authenticate Lidarr webhooks.</p>
+		} else {
+			<table class="mx-keys-table">
+				<thead>
+					<tr>
+						<th scope="col">Name</th>
+						<th scope="col">ID</th>
+						<th scope="col">Scopes</th>
+						<th scope="col">Created</th>
+						<th scope="col">Status</th>
+						<th scope="col"><span class="mx-visually-hidden">Actions</span></th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, row := range view.Keys {
+						<tr class={ "mx-keys-row", templ.KV("mx-keys-row-revoked", row.Revoked) }>
+							<td>{ row.Name }</td>
+							<td><code class="mx-field-value">{ row.ID }</code></td>
+							<td>{ row.Scopes }</td>
+							<td>@keyTime(row.Created, row.CreatedISO, row.CreatedTZApplied)</td>
+							<td>
+								if row.Revoked {
+									<span class="mx-keys-status mx-keys-status-revoked">Revoked</span>
+									{ " " }
+									@keyTime(row.RevokedAt, row.RevokedAtISO, row.RevokedAtTZApplied)
+								} else {
+									<span class="mx-keys-status mx-keys-status-active">Active</span>
+								}
+							</td>
+							<td>
+								if !row.Revoked {
+									<form
+										hx-post="/settings/keys/revoke"
+										hx-target="#mx-keys-panel"
+										hx-swap="innerHTML"
+										hx-confirm="Revoke this key? Any client using it will immediately stop working."
+									>
+										<input type="hidden" name="csrf_token" value={ view.CSRFToken }/>
+										<input type="hidden" name="id" value={ row.FullID }/>
+										<button type="submit" class="mx-keys-revoke">Revoke</button>
+									</form>
+								}
+							</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		}
+	</section>
+}

--- a/web/templates/keys.templ
+++ b/web/templates/keys.templ
@@ -43,7 +43,13 @@ templ WebhookKeysPanel(view WebhookKeysView) {
 	if view.NewKey != nil {
 		@keyReveal(view.NewKey)
 	}
-	@keyCreateForm(view)
+	if !view.Manageable {
+		<p class="mx-keys-unavailable" role="alert">
+			Key management is unavailable: the server is running without a key store wired.
+		</p>
+	} else {
+		@keyCreateForm(view)
+	}
 	@keyList(view)
 }
 

--- a/web/templates/keys_view.go
+++ b/web/templates/keys_view.go
@@ -1,0 +1,81 @@
+package templates
+
+// Presentation models for the webhook API key management page (#300). The
+// handler maps auth.Key metadata onto these string-bearing view structs so the
+// templ file stays free of formatting and auth-package concerns.
+//
+// Security invariant: a key's raw material is shown EXACTLY ONCE, in NewKey,
+// immediately after creation. The persisted list (Keys) carries only metadata -
+// never the raw key and never the full PBKDF2 hash. The displayed ID is the
+// public Key.ID (the hash prefix), the same identifier the `keys list` CLI
+// prints.
+
+// WebhookKeysView is the top-level view model for the webhook keys page.
+type WebhookKeysView struct {
+	// Keys is the masked list of existing keys, newest activity last (creation
+	// order), each carrying only display metadata.
+	Keys []WebhookKeyRow
+	// NewKey is non-nil only on the response that just created a key: it carries
+	// the one-time raw key to display once. It is never set when rendering the
+	// list on its own, so the raw key is shown exactly once and never re-rendered.
+	NewKey *NewWebhookKey
+	// ScopeOptions are the scope checkboxes offered on the create form.
+	ScopeOptions []WebhookScopeOption
+	// CSRFToken is the double-submit token embedded in the create/revoke forms.
+	// Empty when key management is not wired (the page is then read-only).
+	CSRFToken string
+	// Manageable is true when the key-management backend is wired, so the create
+	// and revoke controls render. False renders an unavailable notice instead.
+	Manageable bool
+	// Error is a user-facing message shown when listing, creating, or revoking
+	// failed. Empty on success.
+	Error string
+}
+
+// WebhookKeyRow is one existing key's masked display row. It deliberately omits
+// the full hash and any raw material.
+type WebhookKeyRow struct {
+	// ID is the truncated public ID for display (e.g. "a1b2c3d4…").
+	ID string
+	// FullID is the complete public ID (auth.Key.ID), used as the revoke target.
+	// It is NOT the hash and carries no secret material.
+	FullID string
+	// Name is the operator-assigned label, or a placeholder when unnamed.
+	Name string
+	// Scopes is the comma-joined scope list (e.g. "webhook").
+	Scopes string
+	// Created is the server-side formatted creation timestamp (display string).
+	Created string
+	// CreatedISO is the RFC3339 UTC value for the <time datetime=> attribute, so
+	// the client reformats it to the viewer's local zone (empty for a zero time).
+	CreatedISO string
+	// CreatedTZApplied is true when the server already applied a TZ-env zone, so
+	// the client should not reformat (mirrors the dashboard pattern).
+	CreatedTZApplied bool
+	// Revoked is true once the key has been revoked.
+	Revoked bool
+	// RevokedAt / RevokedAtISO / RevokedAtTZApplied are the revocation timestamp's
+	// display string, ISO value, and tz-applied flag, shown when Revoked.
+	RevokedAt          string
+	RevokedAtISO       string
+	RevokedAtTZApplied bool
+}
+
+// NewWebhookKey carries the one-time raw key shown immediately after creation.
+type NewWebhookKey struct {
+	// Raw is the full raw key string. Shown once; never persisted to the rendered
+	// list afterwards.
+	Raw string
+	// Name is the label the key was created with (may be empty).
+	Name string
+	// ID is the new key's public ID, so the operator can correlate it with the
+	// list row.
+	ID string
+}
+
+// WebhookScopeOption is one scope checkbox on the create form.
+type WebhookScopeOption struct {
+	Value   string
+	Label   string
+	Checked bool
+}

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -17,6 +17,13 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 	<html lang="en">
 		<head>
 			<meta charset="utf-8"/>
+				// Tell htmx NOT to inject its default .htmx-indicator <style> block on
+				// load: that inline <style> violates our strict CSP (style-src 'self',
+				// no 'unsafe-inline') and logs a console error on every htmx page. htmx
+				// reads this config before it would inject the style, so nothing inline
+				// is added; the equivalent rules ship in our own output.css instead.
+				// Must precede the htmx script so the config is set before htmx runs.
+				<meta name="htmx-config" content='{&#34;includeIndicatorStyles&#34;:false}'/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<title>{ title } - mxlrcgo-svc</title>
 			<link rel="icon" type="image/svg+xml" href="/static/img/canticle-mark.svg"/>

--- a/web/templates/settings.templ
+++ b/web/templates/settings.templ
@@ -16,6 +16,13 @@ templ SettingsPage(version string, view SettingsView, reports []RailItem) {
 			Edit the daemon configuration. Changes are written to the config file and take effect on restart.
 			A field set by an environment variable or command-line flag is locked here; clear the override to edit it.
 		</p>
+		// Webhook keys live on their own page (managed in the database, not the
+		// config file), surfaced here as a Settings sub-area rather than a
+		// top-level nav entry (#300 UAT).
+		<p class="mx-settings-subnav">
+			<a class="mx-settings-subnav-link" href="/settings/keys">Manage webhook API keys &rarr;</a>
+			<span class="mx-settings-subnav-hint">Generate, view, and revoke the keys that authenticate Lidarr webhooks.</span>
+		</p>
 		// settings.js powers the guided controls, the reactive grey-out, and the
 		// save POSTs (#288 Phase 2). Served from the embedded /static.
 		<script src="/static/js/settings.js" defer></script>


### PR DESCRIPTION
## What

Adds a webhook API key management page to the settings UI (#300, follow-up from #288 UAT). Closes #300.

New page **`GET /settings/keys`** (reached via a "Manage webhook API keys →" link on `/settings`), backed by the existing DB-backed `auth.Service` — the same store that authenticates Lidarr webhooks, so keys created here work immediately.

- **Masked list** of existing keys: name, truncated public ID, scopes, created time, Active/Revoked status. Never renders the raw key or the full PBKDF2 hash.
- **Generate** a new key: optional name + scope checkboxes; the raw key is shown **exactly once** in an htmx fragment with a copy button + "won't be shown again" banner.
- **Revoke** per key: new `auth.Service.RevokeKeyByID` / `Store.RevokeByID` (revoke without the raw key, which is unrecoverable after creation).
- CSP-safe: external `keys.js` (event-delegated, no inline handlers), per-page `keys.css`; same-origin + double-submit CSRF on both POSTs (mirrors the settings save path); `Cache-Control: no-store` on both POST responses.

## Also fixes a pre-existing app-wide CSP bug

The strict CSP (`style-src 'self'`) was blocking htmx's runtime-injected `.htmx-indicator` inline `<style>` — a console error on **every** htmx page (settings, dashboard, reports, keys). Fixed in the shared layout: `<meta name="htmx-config" content='{"includeIndicatorStyles":false}'>` so htmx doesn't inject the style, with the indicator rules moved into our own embedded stylesheet. Verified zero console errors after.

## Verification

- Maintainer UAT accepted (sidebar placement, viewer-local PDT timestamps, clean console — verified live in Playwright).
- Adversarial review: no Critical/High; folded in all findings — `Cache-Control: no-store` on POSTs, single view build on revoke, server-side key-name cap (120), idempotent re-revoke preserving `revoked_at`.
- `make gate` green; patch coverage 85.04%. Generated `*_templ.go`/`output.css` are build-time (gitignored per #371), not committed.

## Notes / possible follow-ups (not in this PR)

- The pre-existing inline `server.webhook_api_keys` config field still lives on `/settings` alongside the new link (the bootstrap config-list editor vs the managed DB store).
- Key "last-used" timestamp deferred (no schema column; would touch the webhook auth hot path).
- `script-src 'unsafe-inline'` could be dropped by externalizing the dashboard's one inline script (keys.js already has that logic externalized).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a webhook API key management page in settings to generate keys (selectable scopes), view masked key metadata/status, and revoke active keys by identifier.
  * Newly created keys reveal the raw key once (with one-click copy) and show timestamps in the local timezone.
  * When key management isn’t wired, the page and actions report as unavailable.
* **Security & Access**
  * Creation/revocation POST requests are protected with CSRF checks and respond with `no-store`; secret material is never exposed in the key list.
* **Style**
  * Added dedicated UI styling plus improved HTMX loading indicator behavior and settings sub-navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->