### PR TITLE
feat(scanner): skip files that consistently fail metadata read (#376)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,12 +159,13 @@ Every package is listed with a one-line purpose and its location. `cmd/mxlrcgo-s
 - `internal/lyrics` - LRC/TXT/instrumental writer (`Writer` interface, `LRCWriter`), `Slugify`, an `.lrc` parser, provenance-tag embedding, and fsync helpers. Location: `internal/lyrics/`.
 - `internal/normalize` - NFKC cache-key normalization, duration bucketing, fuzzy match confidence, and album-artist resolution. Location: `internal/normalize/`.
 - `internal/langguard` - Unicode-script classification/filtering of lyric text against a configured language allowlist. Location: `internal/langguard/`.
-- `internal/scanner` - Parses CLI/text-file/directory input into the in-memory queue (`Scanner`, `ScanOptions`). Location: `internal/scanner/scanner.go`.
+- `internal/scanner` - Parses CLI/text-file/directory input into the in-memory queue (`Scanner`, `ScanOptions`). Skips files that consistently fail metadata read via the injected `MetadataFailureStore` (issue #376). Location: `internal/scanner/scanner.go`.
 - `internal/app` - One-shot `fetch`-mode orchestration loop over the in-memory `InputsQueue`; depends on the `Fetcher` and `Writer` interfaces. Location: `internal/app/app.go`.
 
 ### Persistence and stateful services
 - `internal/db` - Pure-Go SQLite (`modernc.org/sqlite`) open/migrate (goose), WAL mode, foreign keys, busy-retry, and a read-only open path. Migrations live in `internal/db/migrations/`. Location: `internal/db/`.
 - `internal/cache` - Lyrics cache repository (`CacheRepo`) over the SQLite DB. Location: `internal/cache/cache.go`.
+- `internal/scanfail` - `Store` over the SQLite DB recording files that consistently fail metadata read, so the scanner skips re-reading them until their mtime/size changes (issue #376). Satisfies `scanner.MetadataFailureStore`. Location: `internal/scanfail/scanfail.go`.
 - `internal/queue` - Two queues: the in-memory `InputsQueue` (fetch mode) and the durable SQLite `DBQueue` (serve/worker mode) with priority tiers and randomized within-tier dequeue. Location: `internal/queue/`.
 - `internal/library` - Library-root CRUD repository (`Repo`: `Add`/`List`/`Get`/`GetByName`/`Update`/`Remove`). Location: `internal/library/repository.go`.
 - `internal/scan` - Library scanning: `Enqueuer`, the `scan_results` `Repo`, and the periodic scheduler that enqueues missing lyrics. Location: `internal/scan/`.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sydlexius/mxlrcgo-svc/internal/providers"
 	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scan"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scanfail"
 	"github.com/sydlexius/mxlrcgo-svc/internal/scanner"
 	"github.com/sydlexius/mxlrcgo-svc/internal/secrets"
 	"github.com/sydlexius/mxlrcgo-svc/internal/server"
@@ -1609,8 +1610,10 @@ func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, gl
 	return scan.Scheduler{
 		Libraries: library.New(sqlDB),
 		Results:   results,
-		Scanner:   scanner.NewScanner(),
-		Options:   opts,
+		// Persist metadata-read failures so a permanently-malformed file is not
+		// re-read (and re-warned about) on every scheduled/watched scan (#376).
+		Scanner: scanner.NewScanner(scanner.WithMetadataFailureStore(scanfail.New(sqlDB))),
+		Options: opts,
 		OnScanComplete: func(ctx context.Context, lib models.Library, found []models.ScanResult) error {
 			enqueued, cacheHits, err := enq.EnqueuePending(ctx, lib)
 			if err != nil {

--- a/internal/db/migrations/023_scanner_metadata_failures.sql
+++ b/internal/db/migrations/023_scanner_metadata_failures.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Files that consistently fail audio metadata read (malformed tag frames, e.g.
+-- "compression without data length indicator"). The scanner records a row here
+-- on a metadata-read failure and skips re-reading the file on later scans while
+-- mtime_unix and size_bytes are unchanged, so a permanently-malformed file is
+-- not re-read (and re-warned about) on every scan. The row is keyed by absolute
+-- file_path; an upsert overwrites it when the file changes and fails again. A
+-- file that later reads cleanly simply stops matching (its mtime/size moved on),
+-- so the stale row is inert and harmless. See issue #376.
+CREATE TABLE scanner_metadata_failures (
+    file_path  TEXT    PRIMARY KEY,
+    mtime_unix INTEGER NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    error_text TEXT    NOT NULL DEFAULT ''
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS scanner_metadata_failures;
+-- +goose StatementEnd

--- a/internal/db/migrations/023_scanner_metadata_failures.sql
+++ b/internal/db/migrations/023_scanner_metadata_failures.sql
@@ -3,14 +3,16 @@
 -- Files that consistently fail audio metadata read (malformed tag frames, e.g.
 -- "compression without data length indicator"). The scanner records a row here
 -- on a metadata-read failure and skips re-reading the file on later scans while
--- mtime_unix and size_bytes are unchanged, so a permanently-malformed file is
+-- mtime_nsec and size_bytes are unchanged, so a permanently-malformed file is
 -- not re-read (and re-warned about) on every scan. The row is keyed by absolute
 -- file_path; an upsert overwrites it when the file changes and fails again. A
 -- file that later reads cleanly simply stops matching (its mtime/size moved on),
--- so the stale row is inert and harmless. See issue #376.
+-- so the stale row is inert and harmless. mtime is stored at nanosecond
+-- precision (ModTime().UnixNano()) so a file rewritten within the same wall-clock
+-- second to the same byte size is still detected as changed. See issue #376.
 CREATE TABLE scanner_metadata_failures (
     file_path  TEXT    PRIMARY KEY,
-    mtime_unix INTEGER NOT NULL,
+    mtime_nsec INTEGER NOT NULL,
     size_bytes INTEGER NOT NULL,
     error_text TEXT    NOT NULL DEFAULT ''
 );

--- a/internal/scanfail/scanfail.go
+++ b/internal/scanfail/scanfail.go
@@ -24,11 +24,13 @@ func New(db *sql.DB) *Store {
 
 // ShouldSkip reports whether path previously failed metadata read at the same
 // mtime and size, meaning a re-read would fail identically and can be skipped.
-func (s *Store) ShouldSkip(ctx context.Context, path string, mtimeUnix, size int64) (bool, error) {
+// mtimeNano is ModTime().UnixNano() so a same-second rewrite to the same size
+// still reads as changed.
+func (s *Store) ShouldSkip(ctx context.Context, path string, mtimeNano, size int64) (bool, error) {
 	var one int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT 1 FROM scanner_metadata_failures WHERE file_path=? AND mtime_unix=? AND size_bytes=? LIMIT 1`,
-		path, mtimeUnix, size,
+		`SELECT 1 FROM scanner_metadata_failures WHERE file_path=? AND mtime_nsec=? AND size_bytes=? LIMIT 1`,
+		path, mtimeNano, size,
 	).Scan(&one)
 	if err == nil {
 		return true, nil
@@ -40,20 +42,21 @@ func (s *Store) ShouldSkip(ctx context.Context, path string, mtimeUnix, size int
 }
 
 // RecordFailure remembers that path failed metadata read at the given mtime and
-// size, so subsequent scans skip it until the file changes.
-func (s *Store) RecordFailure(ctx context.Context, path string, mtimeUnix, size int64, readErr error) error {
+// size, so subsequent scans skip it until the file changes. mtimeNano is
+// ModTime().UnixNano().
+func (s *Store) RecordFailure(ctx context.Context, path string, mtimeNano, size int64, readErr error) error {
 	var errText string
 	if readErr != nil {
 		errText = readErr.Error()
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO scanner_metadata_failures (file_path, mtime_unix, size_bytes, error_text)
+		`INSERT INTO scanner_metadata_failures (file_path, mtime_nsec, size_bytes, error_text)
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(file_path) DO UPDATE SET
-		     mtime_unix = excluded.mtime_unix,
+		     mtime_nsec = excluded.mtime_nsec,
 		     size_bytes = excluded.size_bytes,
 		     error_text = excluded.error_text`,
-		path, mtimeUnix, size, errText,
+		path, mtimeNano, size, errText,
 	)
 	if err != nil {
 		return fmt.Errorf("scanfail: record %q: %w", path, err)

--- a/internal/scanfail/scanfail.go
+++ b/internal/scanfail/scanfail.go
@@ -1,0 +1,62 @@
+// Package scanfail persists files that consistently fail audio metadata read so
+// the scanner can skip re-reading (and re-warning about) malformed files until
+// they change on disk. See issue #376.
+package scanfail
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Store records and queries metadata-read failures in the
+// scanner_metadata_failures table. It is safe for concurrent use because the
+// underlying *sql.DB is.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store backed by db.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// ShouldSkip reports whether path previously failed metadata read at the same
+// mtime and size, meaning a re-read would fail identically and can be skipped.
+func (s *Store) ShouldSkip(ctx context.Context, path string, mtimeUnix, size int64) (bool, error) {
+	var one int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT 1 FROM scanner_metadata_failures WHERE file_path=? AND mtime_unix=? AND size_bytes=? LIMIT 1`,
+		path, mtimeUnix, size,
+	).Scan(&one)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, fmt.Errorf("scanfail: lookup %q: %w", path, err)
+}
+
+// RecordFailure remembers that path failed metadata read at the given mtime and
+// size, so subsequent scans skip it until the file changes.
+func (s *Store) RecordFailure(ctx context.Context, path string, mtimeUnix, size int64, readErr error) error {
+	var errText string
+	if readErr != nil {
+		errText = readErr.Error()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO scanner_metadata_failures (file_path, mtime_unix, size_bytes, error_text)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(file_path) DO UPDATE SET
+		     mtime_unix = excluded.mtime_unix,
+		     size_bytes = excluded.size_bytes,
+		     error_text = excluded.error_text`,
+		path, mtimeUnix, size, errText,
+	)
+	if err != nil {
+		return fmt.Errorf("scanfail: record %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/scanfail/scanfail_test.go
+++ b/internal/scanfail/scanfail_test.go
@@ -1,0 +1,106 @@
+package scanfail_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/scanfail"
+)
+
+func openTestStore(t *testing.T) *scanfail.Store {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return scanfail.New(sqlDB)
+}
+
+func TestShouldSkip_UnknownPathIsNotSkipped(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	skip, err := s.ShouldSkip(ctx, "/music/never-seen.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("ShouldSkip: %v", err)
+	}
+	if skip {
+		t.Fatal("an unrecorded file must not be skipped")
+	}
+}
+
+func TestRecordedFailureIsSkippedWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.RecordFailure(ctx, "/music/bad.mp3", 100, 200, errors.New("compression without data length indicator")); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+	skip, err := s.ShouldSkip(ctx, "/music/bad.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("ShouldSkip: %v", err)
+	}
+	if !skip {
+		t.Fatal("a recorded failure with unchanged mtime+size must be skipped")
+	}
+}
+
+func TestChangedMtimeOrSizeIsNotSkipped(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.RecordFailure(ctx, "/music/bad.mp3", 100, 200, errors.New("bad")); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	changedMtime, err := s.ShouldSkip(ctx, "/music/bad.mp3", 101, 200)
+	if err != nil {
+		t.Fatalf("ShouldSkip changed mtime: %v", err)
+	}
+	if changedMtime {
+		t.Error("a file whose mtime changed must be re-read, not skipped")
+	}
+
+	changedSize, err := s.ShouldSkip(ctx, "/music/bad.mp3", 100, 201)
+	if err != nil {
+		t.Fatalf("ShouldSkip changed size: %v", err)
+	}
+	if changedSize {
+		t.Error("a file whose size changed must be re-read, not skipped")
+	}
+}
+
+func TestRecordFailureUpsertsOnRefailure(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	// First failure at one version, then the file changes and fails again at a
+	// new version. The new version must be the one that is skipped; the old
+	// version must no longer match.
+	if err := s.RecordFailure(ctx, "/music/bad.mp3", 100, 200, errors.New("v1")); err != nil {
+		t.Fatalf("RecordFailure v1: %v", err)
+	}
+	if err := s.RecordFailure(ctx, "/music/bad.mp3", 101, 250, errors.New("v2")); err != nil {
+		t.Fatalf("RecordFailure v2: %v", err)
+	}
+
+	skipNew, err := s.ShouldSkip(ctx, "/music/bad.mp3", 101, 250)
+	if err != nil {
+		t.Fatalf("ShouldSkip new: %v", err)
+	}
+	if !skipNew {
+		t.Error("the latest recorded version must be skipped")
+	}
+
+	skipOld, err := s.ShouldSkip(ctx, "/music/bad.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("ShouldSkip old: %v", err)
+	}
+	if skipOld {
+		t.Error("the superseded version must not be skipped after upsert")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -52,10 +52,12 @@ func audioFileTypeForExt(ext string) (int, bool) {
 type MetadataFailureStore interface {
 	// ShouldSkip reports whether path previously failed metadata read at the same
 	// mtime and size, meaning a re-read would fail identically and can be skipped.
-	ShouldSkip(ctx context.Context, path string, mtimeUnix, size int64) (bool, error)
+	// mtimeNano is ModTime().UnixNano() (nanosecond precision so a same-second
+	// rewrite to the same size is still detected as changed).
+	ShouldSkip(ctx context.Context, path string, mtimeNano, size int64) (bool, error)
 	// RecordFailure remembers that path failed metadata read at the given mtime
 	// and size, so subsequent scans skip it until the file changes.
-	RecordFailure(ctx context.Context, path string, mtimeUnix, size int64, readErr error) error
+	RecordFailure(ctx context.Context, path string, mtimeNano, size int64, readErr error) error
 }
 
 // Scanner handles parsing input sources and populating the work queue.
@@ -303,12 +305,12 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		// same (mtime, size) means re-reading is wasted work and repeat log noise.
 		// info() can fail (race with a delete) -- when it does we skip the feature
 		// for this file and read as usual rather than guessing an identity.
-		var mtimeUnix, size int64
+		var mtimeNano, size int64
 		haveIdentity := false
 		if sc.failures != nil {
 			if info, ierr := file.Info(); ierr == nil {
-				mtimeUnix, size, haveIdentity = info.ModTime().Unix(), info.Size(), true
-				skip, serr := sc.failures.ShouldSkip(ctx, fullPath, mtimeUnix, size)
+				mtimeNano, size, haveIdentity = info.ModTime().UnixNano(), info.Size(), true
+				skip, serr := sc.failures.ShouldSkip(ctx, fullPath, mtimeNano, size)
 				if serr != nil {
 					slog.Warn("metadata-failure lookup failed; reading file anyway", "file", file.Name(), "error", serr)
 				} else if skip {
@@ -332,7 +334,7 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			// re-warn) until it changes on disk. A record/store error is logged
 			// but never fatal -- the scan continues exactly as before.
 			if sc.failures != nil && haveIdentity {
-				if rerr := sc.failures.RecordFailure(ctx, fullPath, mtimeUnix, size, err); rerr != nil {
+				if rerr := sc.failures.RecordFailure(ctx, fullPath, mtimeNano, size, err); rerr != nil {
 					slog.Warn("failed to record metadata-read failure", "file", file.Name(), "error", rerr)
 				}
 			}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -45,11 +45,36 @@ func audioFileTypeForExt(ext string) (int, bool) {
 	}
 }
 
+// MetadataFailureStore remembers files that consistently fail audio metadata
+// read so the scanner can skip re-reading (and re-warning about) malformed files
+// until they change on disk. A nil store disables the feature: every file is
+// read and every failure warns, the historical behavior. See issue #376.
+type MetadataFailureStore interface {
+	// ShouldSkip reports whether path previously failed metadata read at the same
+	// mtime and size, meaning a re-read would fail identically and can be skipped.
+	ShouldSkip(ctx context.Context, path string, mtimeUnix, size int64) (bool, error)
+	// RecordFailure remembers that path failed metadata read at the given mtime
+	// and size, so subsequent scans skip it until the file changes.
+	RecordFailure(ctx context.Context, path string, mtimeUnix, size int64, readErr error) error
+}
+
 // Scanner handles parsing input sources and populating the work queue.
 type Scanner struct {
 	// probeFunc, when set, is used as the duration probe instead of audioduration
 	// (tests only -- lets tests inject a known duration without real audio fixtures).
 	probeFunc func(string) (int, error)
+	// failures, when set, lets the scanner skip files that previously failed
+	// metadata read (and warn only once per file-version). Nil disables it.
+	failures MetadataFailureStore
+}
+
+// Option configures a Scanner at construction.
+type Option func(*Scanner)
+
+// WithMetadataFailureStore wires a store so the scanner skips files that
+// consistently fail metadata read until they change on disk (issue #376).
+func WithMetadataFailureStore(s MetadataFailureStore) Option {
+	return func(sc *Scanner) { sc.failures = s }
 }
 
 // ScanOptions controls library directory traversal and queue eligibility.
@@ -74,9 +99,13 @@ type ScanOptions struct {
 	EnrichRecording bool
 }
 
-// NewScanner creates a new Scanner.
-func NewScanner() *Scanner {
-	return &Scanner{}
+// NewScanner creates a new Scanner with the supplied options.
+func NewScanner(opts ...Option) *Scanner {
+	sc := &Scanner{}
+	for _, o := range opts {
+		o(sc)
+	}
+	return sc
 }
 
 // audioDuration reads the header of r to determine duration in seconds.
@@ -267,7 +296,29 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			continue
 		}
 
-		f, err := os.Open(filepath.Join(dir, file.Name())) //nolint:gosec // path from directory scan
+		fullPath := filepath.Join(dir, file.Name())
+
+		// Identity for the metadata-failure skip list: a malformed file reads
+		// identically until its mtime or size changes, so a prior failure at the
+		// same (mtime, size) means re-reading is wasted work and repeat log noise.
+		// info() can fail (race with a delete) -- when it does we skip the feature
+		// for this file and read as usual rather than guessing an identity.
+		var mtimeUnix, size int64
+		haveIdentity := false
+		if sc.failures != nil {
+			if info, ierr := file.Info(); ierr == nil {
+				mtimeUnix, size, haveIdentity = info.ModTime().Unix(), info.Size(), true
+				skip, serr := sc.failures.ShouldSkip(ctx, fullPath, mtimeUnix, size)
+				if serr != nil {
+					slog.Warn("metadata-failure lookup failed; reading file anyway", "file", file.Name(), "error", serr)
+				} else if skip {
+					slog.Debug("skipping file, metadata read previously failed (unchanged)", "file", file.Name())
+					continue
+				}
+			}
+		}
+
+		f, err := os.Open(fullPath) //nolint:gosec // path from directory scan
 		if err != nil {
 			slog.Warn("error reading file", "error", err)
 			continue
@@ -277,6 +328,14 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		if err != nil {
 			_ = f.Close()
 			slog.Warn("error reading metadata", "file", file.Name(), "error", err)
+			// Remember this failure so later scans skip the file (and do not
+			// re-warn) until it changes on disk. A record/store error is logged
+			// but never fatal -- the scan continues exactly as before.
+			if sc.failures != nil && haveIdentity {
+				if rerr := sc.failures.RecordFailure(ctx, fullPath, mtimeUnix, size, err); rerr != nil {
+					slog.Warn("failed to record metadata-read failure", "file", file.Name(), "error", rerr)
+				}
+			}
 			continue
 		}
 

--- a/internal/scanner/skip_malformed_test.go
+++ b/internal/scanner/skip_malformed_test.go
@@ -1,0 +1,73 @@
+package scanner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// recordedFail captures a RecordFailure call for assertions.
+type recordedFail struct {
+	path  string
+	mtime int64
+	size  int64
+}
+
+// fakeFailStore is an in-memory MetadataFailureStore for scanner tests.
+type fakeFailStore struct {
+	skip     map[string]bool
+	recorded []recordedFail
+}
+
+func (f *fakeFailStore) ShouldSkip(_ context.Context, path string, _, _ int64) (bool, error) {
+	return f.skip[path], nil
+}
+
+func (f *fakeFailStore) RecordFailure(_ context.Context, path string, mtime, size int64, _ error) error {
+	f.recorded = append(f.recorded, recordedFail{path: path, mtime: mtime, size: size})
+	return nil
+}
+
+// TestScanLibrary_RecordsMetadataFailure verifies that a file which fails
+// metadata read is recorded in the failure store (so later scans can skip it).
+func TestScanLibrary_RecordsMetadataFailure(t *testing.T) {
+	dir := t.TempDir()
+	touchFile(t, dir, "bad.mp3") // empty file -> tag.ReadFrom fails
+
+	store := &fakeFailStore{skip: map[string]bool{}}
+	sc := &Scanner{probeFunc: func(string) (int, error) { return 0, nil }, failures: store}
+
+	if _, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 0}); err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+
+	if len(store.recorded) != 1 {
+		t.Fatalf("want 1 recorded metadata failure, got %d", len(store.recorded))
+	}
+	want := filepath.Join(dir, "bad.mp3")
+	if store.recorded[0].path != want {
+		t.Errorf("recorded path = %q, want %q", store.recorded[0].path, want)
+	}
+	if store.recorded[0].size != 0 {
+		t.Errorf("recorded size = %d, want 0 for the empty fixture", store.recorded[0].size)
+	}
+}
+
+// TestScanLibrary_SkipsKnownBadFile verifies that a file the store reports as
+// previously-failed is not re-read (and so not re-recorded or re-warned).
+func TestScanLibrary_SkipsKnownBadFile(t *testing.T) {
+	dir := t.TempDir()
+	touchFile(t, dir, "bad.mp3")
+	path := filepath.Join(dir, "bad.mp3")
+
+	store := &fakeFailStore{skip: map[string]bool{path: true}}
+	sc := &Scanner{probeFunc: func(string) (int, error) { return 0, nil }, failures: store}
+
+	if _, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 0}); err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+
+	if len(store.recorded) != 0 {
+		t.Errorf("a known-bad file must be skipped, not re-read; got %d new records", len(store.recorded))
+	}
+}


### PR DESCRIPTION
## Summary

- Persist metadata-read failures so a permanently-malformed audio file (e.g. an ID3 frame with `compression without data length indicator`) is no longer re-read and re-warned on every scheduled scan - the recurring prod log-noise reported in #376.
- New `scanner_metadata_failures` table (migration 023), keyed by absolute path with `mtime`+`size` as the change-detector. A prior failure at the same mtime/size is skipped (Debug, not Warn). On a fresh failure the file is recorded and warned once. When the file changes it stops matching and is read once more, so the `error reading metadata` WARN fires **at most once per file-version**.
- Architecture preserved: `scanner` defines a consumer `MetadataFailureStore` interface and never imports the DB; the concrete `scanfail.Store` (repository pattern over SQLite) is injected at the composition root via `WithMetadataFailureStore`. A nil store keeps the historical always-read/always-warn behavior.

## Scope

Wired into the serve scheduler/watcher path (the recurring daily scan). The one-shot `fetch` CLI is intentionally unchanged - it is a manual, on-demand invocation where a single warn per run is expected, and it can run DB-less.

## Linked issue

Closes #376

## Test plan

- [x] `internal/scanfail` integration tests against real SQLite: record/skip-when-unchanged, changed-mtime/size re-reads, upsert-on-refailure, unknown-path-not-skipped.
- [x] `internal/scanner` tests with a fake store: a malformed file is recorded; a known-bad file is skipped (not re-read/re-recorded).
- [x] `make gate` green (race tests, golangci-lint 0 issues, govulncheck clean, actionlint).
- [x] Patch coverage 78.9% (above the 70% threshold).