### PR TITLE
docs(readme): use the Canticle wordmark in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
-  <img src="web/static/img/canticle-mark.svg" alt="Canticle" width="150" height="150"/>
+  <img src="docs/img/canticle-wordmark.svg" alt="Canticle" width="380"/>
 </p>
-
-<h1 align="center">Canticle</h1>
 
 [![CI](https://github.com/sydlexius/canticle/actions/workflows/ci.yml/badge.svg)](https://github.com/sydlexius/canticle/actions/workflows/ci.yml)
 [![Release](https://github.com/sydlexius/canticle/actions/workflows/release.yml/badge.svg)](https://github.com/sydlexius/canticle/actions/workflows/release.yml)


### PR DESCRIPTION
## Summary

Swap the README header from the fermata-C **mark** + a text `<h1>Canticle</h1>` to the **wordmark** (`docs/img/canticle-wordmark.svg`).

The OS-themed wordmark adapts to the viewer's GitHub theme via `@media(prefers-color-scheme)` — indigo `#3B2F77` on light, lavender `#B3A4E6` on dark. Verified by rendered evidence (both themes render crisp at 380px); a fixed-color wordmark fails contrast on one theme, which is why the header originally used the mark + text title.

## Issue

Closes #382 (follow-up to the #330 rebrand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)