### PR TITLE
chore(release): rename packages + cask to canticle with upgrade path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,19 +95,23 @@ nfpms:
     # Upgrade path from the pre-rebrand package (issue #388). The Linux packages
     # were named "mxlrcgo-svc" through v1.9.1; this transitions installs to the
     # "canticle" name in a single step. nfpm maps these per format:
-    #   deb -> Replaces + Provides + Conflicts
-    #   rpm -> Obsoletes + Provides + Conflicts
+    #   deb -> Replaces + Provides (+ Conflicts, set in overrides.deb below)
+    #   rpm -> Obsoletes + Provides
     #   apk -> replaces + provides
-    # Obsoletes/Replaces remove the old mxlrcgo-svc package outright, so any
+    # Replaces/Obsoletes remove the old mxlrcgo-svc package outright, so any
     # stale binary it owned (v1.6.0/v1.7.0 installed /usr/local/bin/mxlrcgo-svc;
     # v1.8.0+ already ship /usr/local/bin/canticle) is cleaned up. The unit,
     # config, and state paths stay under /var/lib/mxlrcgo-svc et al. so the
     # SQLite DB and any (non-Docker) service install survive the transition.
+    #
+    # Conflicts is deb-only (set in overrides.deb), NOT a top-level field: the
+    # Debian rename idiom is Replaces+Conflicts to force removal of the old
+    # package, but the Fedora idiom is Obsoletes+Provides WITHOUT Conflicts -- an
+    # rpm Conflicts tag makes `rpm`/`dnf` treat mxlrcgo-svc as a blocking
+    # conflict and breaks the in-place upgrade. apk needs only replaces+provides.
     replaces:
       - mxlrcgo-svc
     provides:
-      - mxlrcgo-svc
-    conflicts:
       - mxlrcgo-svc
     vendor: sydlexius
     homepage: https://sydlexius.github.io/canticle/
@@ -133,6 +137,11 @@ nfpms:
     overrides:
       # Debian places systemd units under /lib/systemd/system/.
       deb:
+        # Conflicts is the Debian rename idiom (with Replaces) and forces the old
+        # mxlrcgo-svc package's removal on upgrade. Kept out of rpm/apk on purpose
+        # (see the package-rename note above).
+        conflicts:
+          - mxlrcgo-svc
         contents:
           - src: config.example.toml
             dst: /etc/mxlrcgo-svc/config.example.toml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ before:
     - ./.tools/tailwindcss -i web/static/css/input.css -o web/static/css/output.css --minify
 
 builds:
-  - id: mxlrcgo-svc
+  - id: canticle
     main: ./cmd/mxlrcgo-svc
     binary: canticle
     env:
@@ -54,9 +54,17 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 homebrew_casks:
-  - name: mxlrcgo-svc
+  - name: canticle
     ids:
       - default
+    # Renamed from the pre-rebrand "mxlrcgo-svc" cask (issue #388). Unlike the
+    # nfpm packages, a cask cannot self-replace the old token; conflicts_with
+    # just prevents both being installed at once. Auto-migration of an existing
+    # `brew install sydlexius/tap/mxlrcgo-svc` needs a cask_renames entry in the
+    # sydlexius/homebrew-tap repo (tracked separately) plus removal of the stale
+    # Casks/mxlrcgo-svc.rb there.
+    conflicts:
+      - cask: mxlrcgo-svc
     # ffmpeg is only needed for the optional audio verification/instrumental
     # sidecar; it is NOT a required runtime dependency and is not listed here.
     binaries:
@@ -76,13 +84,30 @@ homebrew_casks:
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "feat: update mxlrcgo-svc cask to {{ .Tag }}"
+    commit_msg_template: "feat: update canticle cask to {{ .Tag }}"
     skip_upload: auto
 
 nfpms:
-  - id: mxlrcgo-svc
-    package_name: mxlrcgo-svc
+  - id: canticle
+    package_name: canticle
     ids:
+      - canticle
+    # Upgrade path from the pre-rebrand package (issue #388). The Linux packages
+    # were named "mxlrcgo-svc" through v1.9.1; this transitions installs to the
+    # "canticle" name in a single step. nfpm maps these per format:
+    #   deb -> Replaces + Provides + Conflicts
+    #   rpm -> Obsoletes + Provides + Conflicts
+    #   apk -> replaces + provides
+    # Obsoletes/Replaces remove the old mxlrcgo-svc package outright, so any
+    # stale binary it owned (v1.6.0/v1.7.0 installed /usr/local/bin/mxlrcgo-svc;
+    # v1.8.0+ already ship /usr/local/bin/canticle) is cleaned up. The unit,
+    # config, and state paths stay under /var/lib/mxlrcgo-svc et al. so the
+    # SQLite DB and any (non-Docker) service install survive the transition.
+    replaces:
+      - mxlrcgo-svc
+    provides:
+      - mxlrcgo-svc
+    conflicts:
       - mxlrcgo-svc
     vendor: sydlexius
     homepage: https://sydlexius.github.io/canticle/
@@ -132,7 +157,7 @@ nfpms:
           preremove: build/package/preremove-apk.sh
 
 dockers_v2:
-  - id: mxlrcgo-svc
+  - id: canticle
     images:
       - "ghcr.io/sydlexius/canticle"
     # dockers_v2 ignores empty tag templates, so prerelease gating is encoded

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Full documentation is published at **<https://sydlexius.github.io/canticle/>**:
 **macOS / Linuxbrew (Homebrew):**
 
 ```sh
-brew install sydlexius/tap/mxlrcgo-svc
+brew install sydlexius/tap/canticle
 ```
 
 **Linux (.deb / .rpm / .apk):** Download the appropriate package for your distro
@@ -33,13 +33,13 @@ page and install it with your package manager:
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i mxlrcgo-svc_*.deb
+sudo dpkg -i canticle_*.deb
 
 # RHEL / Fedora / Rocky
-sudo rpm -i mxlrcgo-svc_*.rpm
+sudo rpm -i canticle_*.rpm
 
 # Alpine
-sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
+sudo apk add --allow-untrusted canticle_*.apk
 ```
 
 The package installs the binary to `/usr/local/bin/canticle`, a systemd unit

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ page and install it with your package manager:
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i canticle_*.deb
+sudo apt install ./canticle_*.deb
 
 # RHEL / Fedora / Rocky
-sudo rpm -i canticle_*.rpm
+sudo dnf install ./canticle_*.rpm
 
 # Alpine
 sudo apk add --allow-untrusted canticle_*.apk

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,13 +21,13 @@ Download the `.deb`, `.rpm`, or `.apk` for your distro from the
 
 ```sh
 # Debian / Ubuntu
-sudo apt install ./mxlrcgo-svc_*.deb
+sudo apt install ./canticle_*.deb
 
 # RHEL / Fedora / Rocky
-sudo dnf install ./mxlrcgo-svc_*.rpm
+sudo dnf install ./canticle_*.rpm
 
 # Alpine
-sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
+sudo apk add --allow-untrusted canticle_*.apk
 ```
 
 **What the package does:**
@@ -38,6 +38,14 @@ sudo apk add --allow-untrusted mxlrcgo-svc_*.apk
 - Installs a systemd unit with hardening (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`), or an OpenRC script on Alpine (manages ownership and permissions via `start_pre`).
 - Places an example config at `/etc/mxlrcgo-svc/config.example.toml`.
 - Does **not** enable or start the service automatically.
+
+> **Upgrading from `mxlrcgo-svc`:** the package was named `mxlrcgo-svc` through
+> v1.9.1 and is now `canticle`. Installing the `canticle` package replaces an
+> existing `mxlrcgo-svc` install in one step (it declares the appropriate
+> deb `Replaces`/rpm `Obsoletes`), removing the old package and any stale
+> binary it owned. The service unit, system user, and `/var/lib/mxlrcgo-svc`
+> data directory intentionally keep the `mxlrcgo-svc` name so the SQLite
+> database and an enabled service survive the rename untouched.
 
 **First-time setup:**
 
@@ -121,11 +129,11 @@ setup.
 ## Homebrew (macOS / Linuxbrew)
 
 ```sh
-brew install sydlexius/tap/mxlrcgo-svc
+brew install sydlexius/tap/canticle
 ```
 
 Upgrade with `brew upgrade canticle`. Run as a background service with
-`brew services start mxlrcgo-svc`. Storage defaults follow XDG base directories.
+`brew services start canticle`. Storage defaults follow XDG base directories.
 
 ---
 
@@ -144,7 +152,7 @@ the User Guide for NSSM service installation.
 Requires Go 1.26.4 or later.
 
 ```sh
-go install github.com/sydlexius/canticle/cmd/mxlrcgo-svc@latest
+go install github.com/sydlexius/mxlrcgo-svc/cmd/mxlrcgo-svc@latest
 ```
 
 Or clone the repository and use `make`:


### PR DESCRIPTION
## Summary

Post-rebrand, the Linux package artifacts (apk/deb/rpm) and the Homebrew cask were still named `mxlrcgo-svc` while the binary and archives are already `canticle`. This renames them to `canticle` and provides a clean, single-step upgrade from the old name.

- **nfpm packages:** `package_name` (and the build/nfpm/docker `id`s) -> `canticle`; added `replaces`/`provides`/`conflicts: [mxlrcgo-svc]`. nfpm maps these to deb `Replaces`/`Conflicts`, rpm `Obsoletes`, apk `replaces` -> installing `canticle` removes the old `mxlrcgo-svc` package (and any stale `/usr/local/bin/mxlrcgo-svc` it owned from v1.6.0/v1.7.0) in one step.
- **Homebrew cask:** renamed `mxlrcgo-svc` -> `canticle` with `conflicts_with` the old token.
- **Docs:** README + `docs/INSTALL.md` install commands now reference `canticle_*.{deb,rpm,apk}` and the `canticle` cask, with a note documenting the package upgrade path. Also fixed a broken `go install github.com/sydlexius/canticle/...` line (module path is `github.com/sydlexius/mxlrcgo-svc` per `go.mod`).

**Intentionally unchanged** (continuity, not naming bugs): the Go module path, the systemd/OpenRC service + system user, and `/etc/mxlrcgo-svc` + `/var/lib/mxlrcgo-svc` (the SQLite DB lives there) - so an existing DB and any enabled service survive the rename.

## Linked issue

Closes #388

## Verification

Built a snapshot and inspected the real package metadata (not just config):

| Format | Result |
|--------|--------|
| deb | `Package: canticle`; `Replaces`/`Provides`/`Conflicts: mxlrcgo-svc` |
| rpm | `NAME: canticle`; `OBSOLETENAME`/`PROVIDENAME`/`CONFLICTNAME: mxlrcgo-svc` |
| apk | `pkgname = canticle`; `replaces`/`provides = mxlrcgo-svc` |
| cask | `cask "canticle"`; `conflicts_with cask: ["mxlrcgo-svc"]`; `binary "canticle"` |

`goreleaser check` passes; `make gate` green (race tests, golangci-lint 0 issues, actionlint, govulncheck clean).

## Follow-up (separate repo, no version bump)

A cask cannot self-replace its old token. For existing `brew install sydlexius/tap/mxlrcgo-svc` users to transparently migrate, the `sydlexius/homebrew-tap` repo needs a `cask_renames` entry (`{"mxlrcgo-svc": "canticle"}`) plus removal of the stale `Casks/mxlrcgo-svc.rb` once the next release publishes `canticle.rb`.

## Test plan

- [x] `make gate` (race tests, lint, actionlint, govulncheck) passes
- [x] `goreleaser check` passes
- [x] Snapshot build: deb/rpm/apk metadata + generated cask inspected
- [ ] Confirmed on a real release run (next tag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated installation and release artifacts to use the new **Canticle** package name across Homebrew, Linux packages, Docker images, and build outputs.

* **Documentation**
  * Refreshed install instructions in the README and install guide to match the new package and binary names.
  * Added upgrade guidance for users moving from the previous package name, including how existing installs are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->