### PR TITLE
chore(yamnet): pin setuptools<81 so tensorflow-hub keeps pkg_resources

### DIFF
--- a/deploy/yamnet-detector/requirements.in
+++ b/deploy/yamnet-detector/requirements.in
@@ -6,5 +6,7 @@ tensorflow-hub==0.16.1
 soundfile==0.12.1
 numpy==2.0.2
 # tensorflow-hub 0.16.1 imports pkg_resources at runtime, which setuptools
-# removed in 81.0. Pin below that so pkg_resources remains available.
-setuptools<81
+# removed in 81.0. Constrain to the latest 80.x so pkg_resources remains
+# available (explicit floor documents the intent; the lock pins the exact
+# version + hash, so this band only steers regen).
+setuptools>=80.10.2,<81

--- a/deploy/yamnet-detector/requirements.in
+++ b/deploy/yamnet-detector/requirements.in
@@ -5,3 +5,6 @@ tensorflow-cpu==2.18.1
 tensorflow-hub==0.16.1
 soundfile==0.12.1
 numpy==2.0.2
+# tensorflow-hub 0.16.1 imports pkg_resources at runtime, which setuptools
+# removed in 81.0. Pin below that so pkg_resources remains available.
+setuptools<81

--- a/deploy/yamnet-detector/requirements.txt
+++ b/deploy/yamnet-detector/requirements.txt
@@ -1042,10 +1042,11 @@ rich==15.0.0 \
     --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
     --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
     # via keras
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.10.2 \
+    --hash=sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70 \
+    --hash=sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173
     # via
+    #   -r requirements.in
     #   tensorboard
     #   tensorflow
     #   tensorflow-cpu


### PR DESCRIPTION
## Summary

Fix-forward for #391. That PR's lock regen pulled **setuptools 82.0.1**, which **removed `pkg_resources`** (dropped in setuptools 81.0). `tensorflow-hub 0.16.1` (the latest, now frozen) imports `pkg_resources` at runtime, so building the sidecar fails at the YAMNet model-load step:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Pin `setuptools<81` in `requirements.in` (resolves to **80.10.2**) and regenerate the hash-pinned lock so `pkg_resources` stays available. Single transitive version change in the lock.

## Validation (the on-host check #391 deferred)

#391 couldn't validate the YAMNet load locally (TF 2.18 needs AVX, unavailable under QEMU on Apple Silicon). This was validated **end-to-end on the x86_64 host**:

- ✅ Sidecar image builds (deps install under `--require-hashes`).
- ✅ `hub.load(yamnet)` succeeds under **TF 2.18.1 / numpy 2.0.2 / keras 3.15 / setuptools 80.10.2**.
- ✅ Container recreated, reaches `healthy`; `POST /classify` returns HTTP 200 with the `{mean, max}` contract (**521 classes** each, real per-class scores).
- ✅ grype on the lock stays clean (still 0 vulnerabilities; setuptools 80.10.2 has no advisories).

The live sidecar on the host has been updated to this build and verified.

## Scope

`deploy/yamnet-detector/` only - not a release artifact. No Canticle version bump.