### PR TITLE
docs: add dedicated instrumental-detection page (#394)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -285,7 +285,7 @@ min_similarity = 0.35
 # AudioSet vocal-class names whose peak score blocks an instrumental marking.
 # Defaults to the verified singing/vocal set. Env (CSV):
 # MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_CLASSES.
-# vocal_classes = ["Singing", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
+# vocal_classes = ["Singing", "Speech", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
 
 # Maximum vocal-class peak (0-1) tolerated before a track is excluded from being
 # instrumental. Conservative: biased toward "not instrumental". Default 0.03

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -280,7 +280,7 @@ ffmpeg (used to extract the audio sample) is resolved automatically: see [ffmpeg
 # sample_duration_seconds = 30
 # min_confidence = 0.90
 # instrumental_classes = ["Music", "Musical instrument"]
-# vocal_classes = ["Singing", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
+# vocal_classes = ["Singing", "Speech", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
 # vocal_max_confidence = 0.03
 # spread_samples = 6
 # ffprobe_path = ""
@@ -293,7 +293,7 @@ When enabled and a `classifier_url` is set, the detector samples each track's au
 
 To catch vocals that enter after an instrumental intro (arias, jazz, classical), the detector samples `spread_samples` short windows spread across the **whole** track, concatenated into one sample, and gates on the per-class **max-over-frames** peak (the loudest singing moment), which the frame mean dilutes. This requires the sidecar to return `{"mean": {...}, "max": {...}}`; a legacy mean-only sidecar degrades safely to never-instrumental.
 
-`sample_duration_seconds` is clamped to [30, 60]. `min_confidence` and `vocal_max_confidence` values outside (0, 1] reset to `0.90` and `0.03` respectively. `cooldown_seconds` is the minimum gap between consecutive inference calls; `0` disables the cooldown. Track-duration probing needs `ffprobe`; the auto-provisioned ffmpeg ships none, so set `ffprobe_path` (or rely on a PATH ffprobe) or the detector falls back to a single window. **Deploy order:** upgrade Canticle before the sidecar (new Canticle tolerates the old flat-map response; old Canticle cannot parse `{mean,max}`). See the [Instrumental detection](USER_GUIDE.md#instrumental-detection) guide for the per-library and per-run override controls.
+`sample_duration_seconds` is clamped to [30, 60]. `min_confidence` and `vocal_max_confidence` values outside (0, 1] reset to `0.90` and `0.03` respectively. `cooldown_seconds` is the minimum gap between consecutive inference calls; `0` disables the cooldown. Track-duration probing needs `ffprobe`; the auto-provisioned ffmpeg ships none, so set `ffprobe_path` (or rely on a PATH ffprobe) or the detector falls back to a single window. **Deploy order:** upgrade Canticle before the sidecar (new Canticle tolerates the old flat-map response; old Canticle cannot parse `{mean,max}`). See **[Instrumental Detection](instrumental-detection.md)** for the full reference (decision model, sidecar setup, and tuning), and the [Instrumental detection](USER_GUIDE.md#instrumental-detection) guide for the per-library and per-run override controls.
 
 ffmpeg resolution is shared with `[verification]`; see [ffmpeg resolution](#ffmpeg-resolution) below. Set `ffmpeg_path` here only to pin a binary separately from the verification path.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -493,6 +493,8 @@ When enrichment is off for a track, the scanner skips ISRC, MBID, and duration e
 
 The optional instrumental-detection sidecar samples each track's audio with ffmpeg and asks an external classifier whether it is instrumental, writing an instrumental marker on a provider miss. It runs only when a classifier URL is configured (`[instrumental_detector] classifier_url`). Because it costs an ffmpeg sample plus an inference call per track, you may want it on a small curated or soundtrack-heavy library but off on a large bulk one.
 
+For how the detector decides (the two-gate model), the YAMNet sidecar setup and `{mean,max}` contract, deploy ordering, and threshold tuning, see the dedicated [Instrumental Detection](instrumental-detection.md) reference. This section covers only the enable/override controls.
+
 You control it at three levels, resolved with the precedence **CLI flag > per-library setting > global default**:
 
 - **Global default** (`config.toml`): `[instrumental_detector] enabled` (env `MXLRC_INSTRUMENTAL_DETECTOR_ENABLED`). Default `false`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ New here? Start with the [Getting Started](GETTING_STARTED.md) guide - it picks 
 - [User Guide](USER_GUIDE.md) - run the webhook server, Docker and Unraid deployment, native-package service management, path resolution, health endpoints, the filesystem watcher, shell completion, and inspection commands.
 - [CLI Reference](CLI_REFERENCE.md) - the full usage text, every subcommand and flag, `--version` output, and the library/key-management commands.
 - [Configuration](CONFIGURATION.md) - the complete environment-variable table, the TOML config keys, token precedence, and XDG/Docker/native-package path defaults.
+- [Instrumental Detection](instrumental-detection.md) - the optional audio-based instrumental detector: the two-gate decision model, the YAMNet sidecar setup and `{mean,max}` contract, deploy ordering, and threshold tuning.
 - [Developer Guide](DEVELOPER.md) - development setup, make targets, the quality gate, contributing notes, and design decisions.
 
 ## Legal

--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -1,0 +1,185 @@
+# Instrumental Detection
+
+Canticle can optionally recognize that a track is **instrumental** (no lyrics to
+find) by listening to the audio, so it writes an instrumental marker instead of
+re-querying providers forever for lyrics that do not exist. This page is the
+single reference for how that works, how to deploy it, and how to tune it.
+
+It is **disabled by default**. Nothing in this page applies unless you set
+`enabled = true` and a `classifier_url` under `[instrumental_detector]`.
+
+## What it does and when it runs
+
+When enabled, the detector samples a track's audio with `ffmpeg`, sends the
+sample to an external [AudioSet](https://research.google.com/audioset/)
+classifier (a YAMNet sidecar, vendored at `deploy/yamnet-detector/`), and decides
+whether the track is instrumental. If it is, the worker writes the usual
+instrumental marker (`.txt`) for that track.
+
+Two rules bound when it can act:
+
+- **Only on provider misses.** The detector runs *after* every lyrics provider
+  has come back empty. If a provider returns lyrics, the track is never
+  classified - the audio model never overrides provider-supplied data.
+- **Never destructive.** It only writes a marker where there would otherwise be a
+  miss. Instrumental markers are excluded from `--upgrade` (re-fetching an
+  instrumental just reproduces the marker); force a re-check with `--update`
+  (full re-fetch) after a catalog change.
+
+## The decision model (the core)
+
+A track is marked instrumental only when **both** gates pass. Either gate failing
+means "not instrumental", and the track is left as a normal miss.
+
+| Gate | Condition | Default |
+|------|-----------|---------|
+| **Music gate** | The **mean** over frames of the summed `instrumental_classes` probabilities is at least `min_confidence`. | `min_confidence = 0.90`, `instrumental_classes = ["Music", "Musical instrument"]` |
+| **Vocal gate** (#384) | The **peak** (max over frames) of *every* `vocal_classes` score stays **below** `vocal_max_confidence`. | `vocal_max_confidence = 0.03`, `vocal_classes` = the singing/vocal set below |
+
+The default `vocal_classes` set is:
+
+```
+Singing, Speech, Vocal music, Choir, A capella, Chant, Rapping,
+Child singing, Synthetic singing, Yodeling, Humming
+```
+
+Note that `Speech` is included on purpose: a spoken-vocal-over-music track (an
+intro, a monologue over a bed) should not be marked instrumental.
+
+### Why mean for music but max for vocals
+
+This asymmetry is the heart of the design:
+
+- **Music** is gated on the frame **mean**, because instrumental backing is
+  present throughout the track - a sustained, track-wide property.
+- **Vocals** are gated on the frame **max**, because singing can be *brief*. A
+  short sung passage is diluted to near-nothing by the mean but preserved by the
+  max. Gating vocals on their loudest single moment is what stops an
+  otherwise-instrumental aria from slipping through.
+
+### Spread sampling
+
+Late-entering vocals (an aria after a long instrumental intro, a vocal that
+arrives two minutes in) would be missed by sampling only the start of the track.
+So the detector builds **one** sample from `spread_samples` short windows
+(default **6**) distributed evenly across the **whole** track, concatenated into a
+single `sample_duration_seconds` clip, and runs one inference on it. The vocal
+peak is then taken across that whole spread.
+
+This requires the sidecar to return both reductions - `{"mean": {...}, "max":
+{...}}` - on the one forward pass. A value of `spread_samples < 2` disables
+spreading and uses a single contiguous window from the start.
+
+### Conservative by construction
+
+Any doubt resolves to **not instrumental**. A false instrumental is strictly
+worse than a missed one: it permanently suppresses a real lyrics fetch, whereas a
+missed instrumental just gets retried. Every threshold default is chosen to fail
+safe in that direction.
+
+### Calibration evidence
+
+The `vocal_max_confidence = 0.03` default was pinned by a sweep over real library
+tracks plus known-vocal controls (issue #384). The separation between
+instrumentals and vocals on the production metric (`vocal_peak` = max over vocal
+classes of each class's max-over-frames):
+
+| Track type | `vocal_peak` | Verdict |
+|------------|-------------|---------|
+| Baroque oratorio aria | ~0.39 | vocal (scored ~0.004 at a single 30s intro window - a false instrumental that spread sampling fixes) |
+| Jazz vocal | ~0.087 | vocal |
+| Country vocal | ~0.059 | vocal |
+| Orchestral ballet (instr.) | ~0.021 | instrumental |
+| Solo guitar (instr.) | ~0.013 | instrumental |
+| Baroque concerto (instr.) | ~0.005 | instrumental |
+
+Instrumentals top out near `0.021` and vocals floor near `0.059` - roughly a 3x
+margin - so `0.03` sits comfortably between them.
+
+## Sidecar setup
+
+The classifier is a small YAMNet HTTP service. Canticle does not publish an image
+for it; you build it on the host from the vendored source.
+
+- **Source:** `deploy/yamnet-detector/` in this repo (Dockerfile + FastAPI app).
+- **Response contract:** `POST /classify` returns
+  `{"mean": {<class>: <prob>, ...}, "max": {<class>: <prob>, ...}}` - both the
+  mean and the max-over-frames reduction for every AudioSet class. The vocal gate
+  needs the `max` map; a legacy mean-only sidecar degrades safely to
+  never-instrumental rather than producing wrong markers.
+- **Wire it up:** point `classifier_url` at the service, e.g.
+  `http://yamnet:8080`.
+
+### ffmpeg and ffprobe are both required
+
+The app container needs **both** `ffmpeg` and `ffprobe` on PATH:
+
+- `ffmpeg` extracts and concatenates the audio sample.
+- `ffprobe` reads each track's **duration** so spread sampling can place its
+  windows.
+
+If `ffmpeg` was auto-provisioned by Canticle it ships **no** `ffprobe`; set
+`ffprobe_path` (or install `ffprobe` on PATH) or the detector silently falls back
+to a single window from the start and loses late-vocal protection. See
+[Configuration -> ffmpeg resolution](CONFIGURATION.md) for how `ffmpeg` is
+located.
+
+### Upgrade ordering (important)
+
+When upgrading a running deployment, **upgrade Canticle before the sidecar.** The
+new Canticle tolerates an old flat-map (mean-only) sidecar response and degrades
+safely; an old Canticle **cannot** parse the new `{mean, max}` response. Upgrading
+the sidecar first can break classification until the app catches up.
+
+## Configuration reference and tuning
+
+All keys live under `[instrumental_detector]`; each has an
+`MXLRC_INSTRUMENTAL_DETECTOR_*` environment equivalent (see the full table in
+[Configuration](CONFIGURATION.md)).
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `enabled` | `false` | Master switch. |
+| `classifier_url` | (none) | Sidecar base URL. Required when enabled. |
+| `ffmpeg_path` | `ffmpeg` | ffmpeg binary (PATH or auto-provisioned). |
+| `ffprobe_path` | (auto-discover) | ffprobe binary for duration probing. Sibling of ffmpeg, then PATH. |
+| `sample_duration_seconds` | `30` | Total sample length, clamped to [30, 60]. |
+| `spread_samples` | `6` | Windows spread across the track. `< 2` disables spreading. |
+| `min_confidence` | `0.90` | Music-gate threshold (mean). Values outside (0, 1] reset to `0.90`. |
+| `instrumental_classes` | `["Music", "Musical instrument"]` | Classes summed for the music gate. |
+| `vocal_max_confidence` | `0.03` | Vocal-gate threshold (peak). Values outside (0, 1] reset to `0.03`. |
+| `vocal_classes` | (the singing/vocal set above) | Classes whose peak blocks an instrumental marking. |
+| `cooldown_seconds` | `5` | Minimum gap between inference calls. `0` disables. |
+
+**The defaults are the calibrated values - do not change the thresholds without a
+specific reason.** They were tuned against real audio (#384) to maximize the
+margin between instrumentals and vocals.
+
+If you do tune:
+
+- **`vocal_max_confidence`** is the dial that matters. **Raising** it lets more
+  tracks pass as instrumental (more false instrumentals - the dangerous
+  direction). **Lowering** it marks fewer tracks instrumental (safer, but you may
+  re-query genuine instrumentals).
+- **`min_confidence`** rarely needs changing; lowering it admits non-music audio
+  (field recordings, spoken word) as "instrumental".
+- **`spread_samples`** trades inference cost for coverage. Fewer windows risks
+  missing a late vocal entry; more windows dilutes each one's audio share within
+  the fixed `sample_duration_seconds`.
+
+## Operations and troubleshooting
+
+The decision is logged. Look for the detector decision line, which reports the
+computed `music_sum`, the `vocal_peak`, and the resulting verdict, so you can see
+*why* a track was or was not marked.
+
+- **The borderline band.** A `vocal_peak` of roughly `0.03-0.05` is genuinely
+  mixed material (quiet backing vocals, sparse vocal samples). The default
+  `0.03` deliberately keeps these on the "not instrumental" side.
+- **A false instrumental** (a vocal track wrongly marked) usually means a vocal
+  that the sample under-weighted - check that `ffprobe` is present and spread
+  sampling is actually running (a single-window fallback is the common culprit).
+- **Re-classifying / clearing stale markers.** After changing thresholds or
+  fixing the sidecar, force a re-check of affected tracks with `--update` (a full
+  re-fetch). Instrumental markers are otherwise sticky - `--upgrade` skips them
+  by design.

--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -121,8 +121,8 @@ The app container needs **both** `ffmpeg` and `ffprobe` on PATH:
 If `ffmpeg` was auto-provisioned by Canticle it ships **no** `ffprobe`; set
 `ffprobe_path` (or install `ffprobe` on PATH) or the detector silently falls back
 to a single window from the start and loses late-vocal protection. See
-[Configuration -> ffmpeg resolution](CONFIGURATION.md) for how `ffmpeg` is
-located.
+[Configuration -> ffmpeg resolution](CONFIGURATION.md#ffmpeg-resolution) for how
+`ffmpeg` is located.
 
 ### Upgrade ordering (important)
 

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -83,6 +83,7 @@ nav:
   - User Guide: USER_GUIDE.md
   - CLI Reference: CLI_REFERENCE.md
   - Configuration: CONFIGURATION.md
+  - Instrumental Detection: instrumental-detection.md
   - Developer Guide:
       - Overview: DEVELOPER.md
       - Multilingual Output Policy: multilingual-output-policy.md


### PR DESCRIPTION
## Summary

- Add `docs/instrumental-detection.md` - a single user-facing reference for the optional audio-based instrumental detector, consolidating content previously scattered across CONFIGURATION/USER_GUIDE/GETTING_STARTED/index/README and the calibration rationale that lived only in #384.
- Covers the five things users could not find: when it runs (provider-miss only, writes the `.txt` marker), the two-gate decision model (music = frame mean, vocals = max-over-frames + spread sampling, with the #384 calibration evidence), the YAMNet sidecar setup (`{mean,max}` contract, ffmpeg+ffprobe requirement, **upgrade Canticle before the sidecar**), the config/tuning reference, and ops/troubleshooting.
- Wire-up: link from `index.md`, a pointer from `CONFIGURATION.md` and `USER_GUIDE.md` (which keep only their own scope), and a top-level `properdocs.yml` nav entry.
- Fix the stale `vocal_classes` example comment (missing `Speech`) in `config.example.toml` and `CONFIGURATION.md` to match the code default (`internal/detector/detector.go` `defaultVocalClasses`).

## Linked issue

Closes #394.

## Test plan

- [x] `properdocs build --strict` passes (the `pages.yml` gate) - every internal link resolves, nav entry valid, no orphan pages.
- [x] Full pre-push gate green (`scripts/pre-push-gate.sh` via hook): build + race tests, patch coverage (no Go changes in scope), golangci-lint 0 issues, actionlint, govulncheck clean.
- [x] `internal/config` + `internal/detector` tests pass (the suites that parse `config.example.toml`).
- [x] Docs-only change: no Go source modified.