### PR TITLE
ci: enforce coverage floor in pre-push gate and a required CI job (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,10 +292,31 @@ jobs:
           fi
           echo "All Grype ignore entries are within their review-by window."
 
-  # Per-package coverage-floor CI enforcement is deferred: Codecov handles patch
-  # coverage for PR gates, and scripts/coverage-floor.sh remains available for
-  # local use. A CI job can be promoted here when the repo matures and a stable
-  # per-package floor baseline has been established.
+  coverage-floor:
+    name: Coverage Floor
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Enforce the per-package coverage floor (scripts/coverage-floor.json) against
+    # the profile the Test job produced: a whole-package regression fails here even
+    # when Codecov's line-level patch coverage passes. Pure file parsing (awk over
+    # the profile + JSON), so no Go toolchain or network is needed. Only runs when
+    # Test succeeded; a failed/skipped Test already gates the pipeline.
+    if: needs.test.result == 'success'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage
+
+      - name: Enforce per-package coverage floor
+        run: bash scripts/coverage-floor.sh --cover coverage.out
+
   coverage-upload:
     name: Upload Coverage
     runs-on: ubuntu-latest
@@ -330,12 +351,12 @@ jobs:
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
-    needs: [changes, lint, test]
+    needs: [changes, lint, test, coverage-floor]
     # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
     # named with the literal, unexpanded ${{ matrix.* }} template. Non-code PRs get
     # a single placeholder leg (skip='true', see the `changes` job) whose steps
     # no-op, so the check name still interpolates to a concrete goos/goarch.
-    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' }}
+    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' && needs.coverage-floor.result != 'failure' }}
     strategy:
       matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -112,6 +112,10 @@ echo "==> coverage floor (per-package ratchet)"
 # absent from the floor JSON, so the extra packages in the ./... profile are simply
 # not evaluated. Unlike patch coverage this has no external dependency, so it always
 # runs (the CI "Coverage Floor" job enforces the same check on every PR).
+# The test step above writes "$COVER_OUT" (and fails the gate otherwise), so this
+# guard only trips on an unexpected empty/missing profile -- and reports that
+# plainly instead of the misleading floor-breach message below.
+[ -s "$COVER_OUT" ] || fail "coverage floor: coverage profile missing or empty ($COVER_OUT)"
 bash scripts/coverage-floor.sh --cover "$COVER_OUT" \
   || fail "coverage floor (a package dropped below scripts/coverage-floor.json; add tests, or run 'bash scripts/coverage-floor.sh --bump <pkg>' if the higher coverage is intentional)"
 

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -105,6 +105,16 @@ else
   echo "    (install claude-kit for the local check)"
 fi
 
+echo "==> coverage floor (per-package ratchet)"
+# Reuse the profile from the test step; enforce the per-package floor recorded in
+# scripts/coverage-floor.json so a whole-package coverage regression is caught
+# locally, complementing the line-level patch-coverage gate above. internal/web is
+# absent from the floor JSON, so the extra packages in the ./... profile are simply
+# not evaluated. Unlike patch coverage this has no external dependency, so it always
+# runs (the CI "Coverage Floor" job enforces the same check on every PR).
+bash scripts/coverage-floor.sh --cover "$COVER_OUT" \
+  || fail "coverage floor (a package dropped below scripts/coverage-floor.json; add tests, or run 'bash scripts/coverage-floor.sh --bump <pkg>' if the higher coverage is intentional)"
+
 echo "==> codecov report validation (codecovcli dry-run)"
 # OPTIONAL local enhancement: validate that the coverage report parses and would
 # upload cleanly BEFORE burning PR/CI wall time. The dry-run runs the same CLI


### PR DESCRIPTION
## Summary

- **Item 3 (local):** `scripts/pre-push-gate.sh` now runs `scripts/coverage-floor.sh` against the coverage profile the test step already wrote (`--cover "$COVER_OUT"`, no second test run), so a whole-package coverage regression fails locally before push - complementing the line-level patch-coverage gate.
- **Item 4 (CI):** un-defer the `ci.yml` comment with a required **Coverage Floor** job that downloads the Test job's coverage artifact and enforces the floor (pure awk, no Go toolchain/network); the build matrix now `needs` it, so a floor failure gates the pipeline.
- Completes the issue's headline goal (ratchet + `--bump`/`--lower` from #397, now enforced both locally and on every PR).

## Linked issue

Closes #392. The optional item 5 (mirror per-package floors into `codecov.yml` as a redundant second gate) is intentionally left out - it adds a two-file-update burden on every `--bump` for no new coverage, per the issue's own "optional" note.

## Test plan

- [x] Full pre-push gate green (`make gate`): codegen + race tests, then the **new coverage-floor step** reports all 35 internal packages at or above floor (+0% deltas - baseline == current actuals), patch coverage, golangci-lint, **actionlint** (validates the new CI job + `needs`/`if` wiring), govulncheck.
- [x] Floor passes against a `go test -race ./...` profile (same shape CI's Test job produces), confirming the Coverage Floor CI job will pass.
- [x] `shellcheck scripts/pre-push-gate.sh` clean.
- No Go source modified.