### PR TITLE
feat(scanner): extract embedded synced lyrics (Vorbis SYNCEDLYRICS) to .lrc (#395)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -65,13 +65,15 @@ circuit_open_duration = 1800
 # Override with --outdir flag or MXLRC_OUTPUT_DIR env var (fetch mode only).
 dir = "lyrics"
 
-# Embedded (unsynced) lyrics handling (env: MXLRC_EMBEDDED_LYRICS; CLI:
-# --embedded-lyrics). One of:
+# Embedded lyrics handling (env: MXLRC_EMBEDDED_LYRICS; CLI: --embedded-lyrics).
+# One of:
 #   off     - ignore embedded lyrics (default)
 #   respect - skip fetching for files that already carry embedded lyrics
-#   extract - write embedded lyrics to a .txt sidecar (never overwriting an
-#             existing one), then skip fetching
-# Synced (SYLT) tags are intentionally not handled.
+#   extract - write embedded lyrics to a sidecar (never overwriting an existing
+#             one), then skip fetching. A Vorbis SYNCEDLYRICS comment with
+#             timestamped LRC text is written as a synced .lrc and preferred over
+#             unsynced lyrics, which are written as .txt.
+# ID3 SYLT and MP4 synced-lyric atoms are intentionally not handled.
 # embedded_lyrics = "off"
 
 # Bilingual interleaved output (env: MXLRC_BILINGUAL_OUTPUT). Default false.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -64,7 +64,7 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_TLS_REDIRECT_HTTP` | (none) | Plain-HTTP listen address (e.g. `:80`) that 301-redirects to HTTPS. Honored only when TLS is enabled. |
 | `MXLRC_TLS_SELF_SIGNED_HOSTS` | (none) | Comma-separated extra SAN hostnames/IPs for the self-signed certificate (on top of `localhost`, `canticle`, `127.0.0.1`, `::1`). Honored only when self-signed. |
 | `MXLRC_OUTPUT_DIR` | XDG / `/music` | Output directory for `fetch` mode. **Ignored in `serve` mode** (lyrics are written next to the audio file; the metadata-only webhook fallback uses the internal default). |
-| `MXLRC_EMBEDDED_LYRICS` | `off` | Embedded unsynced lyrics handling. `off` - ignore (default); `respect` - skip fetching when embedded lyrics exist; `extract` - write embedded lyrics to a `.txt` sidecar, then skip fetching. |
+| `MXLRC_EMBEDDED_LYRICS` | `off` | Embedded lyrics handling. `off` - ignore (default); `respect` - skip fetching when embedded lyrics exist; `extract` - write embedded lyrics to a sidecar, then skip fetching. A timestamped Vorbis `SYNCEDLYRICS` comment is written as a synced `.lrc` (preferred); unsynced lyrics become `.txt`. ID3 `SYLT` / MP4 atoms are not handled. |
 | `MXLRC_BILINGUAL_OUTPUT` | `false` | When `true` and a provider returns a translation track, interleave original and translated lines under shared timestamps in a single `.lrc`. |
 | `MXLRC_DB_PATH` | XDG / `/config/mxlrcgo.db` | SQLite database path. |
 | `MXLRC_DOCKER` | `false` | When `true`, storage defaults resolve under `/config`. Set automatically in the images. |
@@ -149,7 +149,7 @@ dir = "lyrics"
 
 Fallback output directory and per-file output controls (env: `MXLRC_OUTPUT_DIR`, `MXLRC_EMBEDDED_LYRICS`, `MXLRC_BILINGUAL_OUTPUT`; CLI: `--embedded-lyrics`).
 
-`embedded_lyrics` controls how unsynced lyrics already embedded in the audio file's tags are handled. `off` (default) ignores them and always fetches from providers. `respect` skips fetching for files that already carry embedded lyrics. `extract` writes the embedded lyrics to a `.txt` sidecar (never overwriting an existing one) and then skips fetching. Synced (SYLT) tags are intentionally not handled.
+`embedded_lyrics` controls how lyrics already embedded in the audio file's tags are handled. `off` (default) ignores them and always fetches from providers. `respect` skips fetching for files that already carry embedded lyrics. `extract` writes the embedded lyrics to a sidecar (never overwriting an existing one) and then skips fetching: a Vorbis `SYNCEDLYRICS` comment carrying timestamped LRC text is written as a synced `.lrc` and takes precedence over unsynced lyrics, which are written as `.txt`. ID3 `SYLT` and MP4 synced-lyric atoms are intentionally not handled.
 
 `bilingual_output` (default `false`): when `true` and a provider returns a non-empty translation track, the original and translation lines are interleaved under shared timestamps in a single `.lrc`. See `docs/multilingual-output-policy.md`.
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -85,11 +86,13 @@ type ScanOptions struct {
 	Upgrade  bool
 	MaxDepth int
 	BFS      bool
-	// EmbeddedLyrics controls handling of unsynced lyrics embedded in tags:
-	// "off" (default) ignores them; "respect" skips fetching a file that already
-	// carries embedded lyrics; "extract" writes them to a .txt sidecar (and then
-	// skips fetching). Synced (SYLT) tags are intentionally not handled. "off"
-	// (default) is a no-op.
+	// EmbeddedLyrics controls handling of lyrics embedded in tags: "off"
+	// (default) ignores them; "respect" skips fetching a file that already
+	// carries embedded lyrics; "extract" writes them to a sidecar (and then skips
+	// fetching). A Vorbis SYNCEDLYRICS comment carrying timestamped LRC text is
+	// extracted as a synced .lrc and takes precedence; unsynced lyrics (the ID3
+	// USLT frame) become a .txt. ID3 SYLT and MP4 synced atoms are intentionally
+	// not handled.
 	EmbeddedLyrics string
 	// EnrichRecording controls recording enrichment: reading ISRC, MusicBrainz
 	// recording ID, and duration from audio tags into the Track. When false, all
@@ -341,23 +344,41 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			continue
 		}
 
-		// Embedded (unsynced) lyrics handling. After sidecar checks and metadata
-		// load: in "respect" mode, a file that already carries embedded lyrics is
-		// skipped (the user has lyrics); in "extract" mode, those lyrics are
-		// written to a .txt sidecar and the file is then skipped. SYLT (synced)
-		// is intentionally not handled. "off" (default) is a no-op.
+		// Embedded lyrics handling. After sidecar checks and metadata load:
+		// "respect" skips a file that already carries embedded lyrics; "extract"
+		// writes them to a sidecar and then skips. Synced lyrics (Vorbis
+		// SYNCEDLYRICS, stored as LRC text) take precedence and write a .lrc;
+		// unsynced lyrics (m.Lyrics(), the ID3 USLT frame) write a .txt. ID3 SYLT
+		// and MP4 synced atoms are intentionally not handled. "off" is a no-op.
 		if opts.EmbeddedLyrics != "" && opts.EmbeddedLyrics != "off" {
-			if embedded := strings.TrimSpace(m.Lyrics()); embedded != "" {
+			synced := strings.TrimSpace(syncedLyrics(m))
+			unsynced := strings.TrimSpace(m.Lyrics())
+			hasSynced := synced != "" && looksLikeLRC(synced)
+			if synced != "" && !hasSynced {
+				// SYNCEDLYRICS present but not timestamped LRC: never write a bad
+				// .lrc -- warn (no silent failure) and fall through to the
+				// unsynced/fetch path.
+				slog.Warn("embedded SYNCEDLYRICS has no LRC timestamps; ignoring", "file", file.Name())
+			}
+			if hasSynced || unsynced != "" {
 				switch opts.EmbeddedLyrics {
 				case "extract":
-					if err := extractEmbeddedLyrics(dir, stem, m.Lyrics()); err != nil {
-						// Extraction failed: do NOT skip the track -- fall through
-						// and enqueue it so a normal fetch is still attempted
-						// (rather than silently dropping it from the pipeline).
+					// Prefer synced .lrc; else unsynced .txt. On a write failure do
+					// NOT skip the track -- fall through and enqueue so a normal
+					// fetch is still attempted (never silently dropped).
+					if hasSynced {
+						if err := extractEmbeddedSyncedLyrics(dir, stem, synced); err != nil {
+							slog.Warn("failed to extract embedded synced lyrics; enqueuing for fetch instead", "file", file.Name(), "error", err)
+						} else {
+							_ = f.Close()
+							slog.Debug("extracted embedded synced lyrics to .lrc sidecar; skipping fetch", "file", file.Name())
+							continue
+						}
+					} else if err := extractEmbeddedLyrics(dir, stem, unsynced); err != nil {
 						slog.Warn("failed to extract embedded lyrics; enqueuing for fetch instead", "file", file.Name(), "error", err)
 					} else {
 						_ = f.Close()
-						slog.Debug("extracted embedded lyrics to sidecar; skipping fetch", "file", file.Name())
+						slog.Debug("extracted embedded lyrics to .txt sidecar; skipping fetch", "file", file.Name())
 						continue
 					}
 				default: // "respect"
@@ -411,24 +432,44 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 	return nil
 }
 
-// extractEmbeddedLyrics writes embedded unsynced lyrics to a "<stem>.txt"
-// sidecar next to the audio file using exclusive-create semantics so an existing
-// sidecar is never overwritten. An already-present sidecar is treated as success.
-func extractEmbeddedLyrics(dir, stem, lyrics string) error {
-	path := filepath.Join(dir, stem+".txt")
-	// Write to a temp file in the same directory, then hard-link it into place.
-	// os.Link fails if the target already exists (atomic never-overwrite), and a
-	// partial or flush-failed write can never become the canonical sidecar
-	// because the temp file is always removed and only a fully written, closed
-	// file is linked. Close errors (where buffered-write failures surface) are
-	// returned rather than swallowed.
-	tmp, err := os.CreateTemp(dir, stem+".*.txt.tmp")
+// lrcTimestampRe matches a line beginning with an LRC timestamp, e.g.
+// "[00:12.34]". Used to vet that embedded SYNCEDLYRICS text is real synced LRC
+// before writing it as a .lrc sidecar -- writing prose as .lrc would win over a
+// real fetch forever via sidecar precedence.
+var lrcTimestampRe = regexp.MustCompile(`(?m)^\[\d{1,2}:\d{2}(?:[.:]\d{1,3})?\]`)
+
+// looksLikeLRC reports whether s carries at least one LRC-timestamped line.
+func looksLikeLRC(s string) bool { return lrcTimestampRe.MatchString(s) }
+
+// syncedLyrics returns the embedded Vorbis SYNCEDLYRICS comment (FLAC/OGG) if
+// present, else "". dhowden/tag lowercases comment keys, so the raw key is
+// "syncedlyrics"; other formats (MP3/MP4) do not surface this key.
+func syncedLyrics(m tag.Metadata) string {
+	if raw := m.Raw(); raw != nil {
+		if s, ok := raw["syncedlyrics"].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// linkSidecar writes content to a "<stem>.<ext>" sidecar next to the audio file
+// using exclusive-create semantics so an existing sidecar is never overwritten.
+// It writes to a temp file in the same directory, then hard-links it into place:
+// os.Link fails if the target already exists (atomic never-overwrite), and a
+// partial or flush-failed write can never become the canonical sidecar because
+// the temp file is always removed and only a fully written, closed file is
+// linked. Close errors (where buffered-write failures surface) are returned
+// rather than swallowed. An already-present sidecar is treated as success.
+func linkSidecar(dir, stem, ext, content string) error {
+	path := filepath.Join(dir, stem+"."+ext)
+	tmp, err := os.CreateTemp(dir, stem+".*."+ext+".tmp")
 	if err != nil {
 		return fmt.Errorf("scanner: create temp lyrics sidecar in %s: %w", dir, err)
 	}
 	tmpName := tmp.Name()
 	defer func() { _ = os.Remove(tmpName) }()
-	if _, err := tmp.WriteString(lyrics); err != nil {
+	if _, err := tmp.WriteString(content); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("scanner: write lyrics sidecar %s: %w", path, err)
 	}
@@ -442,6 +483,18 @@ func extractEmbeddedLyrics(dir, stem, lyrics string) error {
 		return fmt.Errorf("scanner: link lyrics sidecar %s: %w", path, err)
 	}
 	return nil
+}
+
+// extractEmbeddedLyrics writes embedded unsynced lyrics to a "<stem>.txt"
+// sidecar (never overwriting an existing one).
+func extractEmbeddedLyrics(dir, stem, lyrics string) error {
+	return linkSidecar(dir, stem, "txt", lyrics)
+}
+
+// extractEmbeddedSyncedLyrics writes embedded synced (LRC) lyrics to a
+// "<stem>.lrc" sidecar (never overwriting an existing one).
+func extractEmbeddedSyncedLyrics(dir, stem, lyrics string) error {
+	return linkSidecar(dir, stem, "lrc", lyrics)
 }
 
 // GetSongDir scans a directory for audio files and populates the queue with metadata.

--- a/internal/scanner/synced_lyrics_test.go
+++ b/internal/scanner/synced_lyrics_test.go
@@ -1,0 +1,238 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/testutil"
+)
+
+const syncedLRC = "[00:01.00]hello\n[00:02.00]world"
+
+// TestScanLibrary_SyncedLyricsExtract: a FLAC with a valid (timestamped)
+// SYNCEDLYRICS comment and no sidecar gets a .lrc sidecar (not .txt) and is not
+// enqueued.
+func TestScanLibrary_SyncedLyricsExtract(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan extract: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("synced extract: got %d results; want 0 (skipped after .lrc extraction)", len(res))
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "song.lrc"))
+	if err != nil {
+		t.Fatalf("expected song.lrc sidecar: %v", err)
+	}
+	if string(got) != syncedLRC {
+		t.Errorf("sidecar = %q; want %q", string(got), syncedLRC)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.txt")); !os.IsNotExist(err) {
+		t.Errorf(".txt sidecar should not be written for synced extraction")
+	}
+}
+
+// Malformed SYNCEDLYRICS (no timestamps) must not produce a .lrc; the track
+// falls through and is enqueued for a normal fetch.
+func TestScanLibrary_SyncedLyricsMalformed_FallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": "just prose, no timestamps at all"}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("malformed synced: got %d results; want 1 (enqueued for fetch)", len(res))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("no .lrc should be written for non-timestamped SYNCEDLYRICS")
+	}
+}
+
+// When both a valid SYNCEDLYRICS and unsynced lyrics are present, synced wins: a
+// .lrc is written and no .txt.
+func TestScanLibrary_SyncedPrecedenceOverUnsynced(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC, "LYRICS": "plain unsynced"}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("precedence: got %d results; want 0 (skipped)", len(res))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); err != nil {
+		t.Errorf(".lrc should be written when synced wins: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.txt")); !os.IsNotExist(err) {
+		t.Errorf(".txt must not be written when synced wins")
+	}
+}
+
+// A pre-existing sidecar is never overwritten (sidecar precedence is inherited
+// from the pre-embedded-block check).
+func TestScanLibrary_SyncedLyrics_ExistingSidecarWins(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "song.lrc"), []byte("EXISTING"), 0o644); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+	sc := NewScanner()
+
+	if _, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"}); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "song.lrc"))
+	if string(got) != "EXISTING" {
+		t.Errorf(".lrc = %q; want EXISTING (never overwrite)", string(got))
+	}
+}
+
+// respect mode treats a valid SYNCEDLYRICS as "already has lyrics": skip, write
+// nothing.
+func TestScanLibrary_SyncedLyricsRespect(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "respect"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("respect synced: got %d results; want 0 (skipped)", len(res))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("respect must not write any sidecar")
+	}
+}
+
+// Whitespace-only SYNCEDLYRICS is treated as absent; the unsynced .txt path
+// applies when m.Lyrics() is non-empty.
+func TestScanLibrary_EmptySyncedFallsToUnsynced(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": "   ", "LYRICS": "plain unsynced"}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty synced: got %d results; want 0 (extracted .txt)", len(res))
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "song.txt"))
+	if err != nil {
+		t.Fatalf("expected song.txt sidecar: %v", err)
+	}
+	if string(got) != "plain unsynced" {
+		t.Errorf(".txt = %q; want %q", string(got), "plain unsynced")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("no .lrc for whitespace-only SYNCEDLYRICS")
+	}
+}
+
+// A malformed SYNCEDLYRICS alongside non-empty unsynced lyrics: warn on the bad
+// synced, then fall through to write the unsynced .txt (the unsynced branch, not
+// just fall-through-to-fetch).
+func TestScanLibrary_MalformedSyncedFallsToUnsynced(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": "prose, no timestamps", "LYRICS": "plain unsynced"}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("malformed synced + unsynced: got %d results; want 0 (.txt extracted)", len(res))
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "song.txt"))
+	if err != nil {
+		t.Fatalf("expected song.txt sidecar: %v", err)
+	}
+	if string(got) != "plain unsynced" {
+		t.Errorf(".txt = %q; want %q", string(got), "plain unsynced")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("no .lrc for malformed SYNCEDLYRICS")
+	}
+}
+
+// Extract then rescan the same dir: the second scan skips the now-present .lrc
+// and leaves it unchanged (the real extract-then-rescan loop).
+func TestScanLibrary_SyncedLyricsExtract_RescanSkips(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+	opts := ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"}
+
+	if _, err := sc.ScanLibrary(context.Background(), dir, opts); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	res, err := sc.ScanLibrary(context.Background(), dir, opts)
+	if err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("rescan: got %d results; want 0 (skipped)", len(res))
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "song.lrc"))
+	if string(got) != syncedLRC {
+		t.Errorf(".lrc changed on rescan = %q; want unchanged", string(got))
+	}
+}
+
+// respect mode with only a malformed SYNCEDLYRICS (no valid lyrics): must NOT
+// skip -- the track is enqueued for a normal fetch.
+func TestScanLibrary_RespectMalformedSyncedOnly_Enqueues(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": "prose, no timestamps"}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "respect"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("respect malformed-only: got %d results; want 1 (enqueued)", len(res))
+	}
+}

--- a/internal/testutil/flac_vorbis_test.go
+++ b/internal/testutil/flac_vorbis_test.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dhowden/tag"
+)
+
+// TestGenerateFLACExtended_VorbisComment verifies that a header-only FLAC built
+// with a Vorbis SYNCEDLYRICS comment is parsed by dhowden/tag and surfaces the
+// value via Raw() under the lowercased key. This is the load-bearing assumption
+// for issue #395 (extract embedded synced lyrics): dhowden must read the Vorbis
+// Comment block even when the FLAC carries no audio frames.
+func TestGenerateFLACExtended_VorbisComment(t *testing.T) {
+	const synced = "[00:01.00]hello\n[00:02.00]world"
+	data := GenerateFLACExtended(44100, 441000, map[string]string{"SYNCEDLYRICS": synced})
+
+	if len(data) < 4 || string(data[:4]) != "fLaC" {
+		t.Fatalf("GenerateFLACExtended did not produce a FLAC stream (len=%d)", len(data))
+	}
+
+	m, err := tag.ReadFrom(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	got, _ := m.Raw()["syncedlyrics"].(string)
+	if got != synced {
+		t.Errorf("Raw()[syncedlyrics] = %q, want %q", got, synced)
+	}
+}
+
+// TestGenerateFLACExtended_NoComments: with no comments the extended generator
+// is byte-identical to GenerateFLAC (the early-return path).
+func TestGenerateFLACExtended_NoComments(t *testing.T) {
+	if !bytes.Equal(GenerateFLACExtended(44100, 441000, nil), GenerateFLAC(44100, 441000)) {
+		t.Error("GenerateFLACExtended(nil comments) != GenerateFLAC")
+	}
+}
+
+// TestWriteFLACFileWithComments writes a commented FLAC to disk and reads the
+// Vorbis comment back.
+func TestWriteFLACFileWithComments(t *testing.T) {
+	dir := t.TempDir()
+	const synced = "[00:01.00]x"
+	if err := WriteFLACFileWithComments(dir, "t.flac", 48000, 96000,
+		map[string]string{"SYNCEDLYRICS": synced}); err != nil {
+		t.Fatalf("WriteFLACFileWithComments: %v", err)
+	}
+	f, err := os.Open(filepath.Join(dir, "t.flac"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	m, err := tag.ReadFrom(f)
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if got, _ := m.Raw()["syncedlyrics"].(string); got != synced {
+		t.Errorf("syncedlyrics = %q, want %q", got, synced)
+	}
+}

--- a/internal/testutil/id3.go
+++ b/internal/testutil/id3.go
@@ -141,46 +141,76 @@ func WriteAudioFile(dir, filename, artist, title, album, lyrics string) error {
 //	bits 144-271: MD5 signature (128-bit, zeroed)
 func GenerateFLAC(sampleRate, totalSamples uint32) []byte {
 	var b bytes.Buffer
+	b.WriteString("fLaC") // stream marker
+	b.Write(flacStreaminfoBlock(sampleRate, totalSamples, true /* last block */))
+	return b.Bytes()
+}
 
-	// "fLaC" stream marker.
+// GenerateFLACExtended builds a header-only FLAC carrying the given Vorbis
+// comments (e.g. {"SYNCEDLYRICS": "[00:01.00]..."}) in a VORBIS_COMMENT block
+// after STREAMINFO. With no comments it is identical to GenerateFLAC. dhowden/tag
+// lowercases comment keys on read, so "SYNCEDLYRICS" surfaces via Raw() as
+// "syncedlyrics".
+func GenerateFLACExtended(sampleRate, totalSamples uint32, comments map[string]string) []byte {
+	if len(comments) == 0 {
+		return GenerateFLAC(sampleRate, totalSamples)
+	}
+	var b bytes.Buffer
 	b.WriteString("fLaC")
+	// STREAMINFO is no longer the final block; the VORBIS_COMMENT block is.
+	b.Write(flacStreaminfoBlock(sampleRate, totalSamples, false))
+	b.Write(flacVorbisCommentBlock(comments))
+	return b.Bytes()
+}
 
-	// STREAMINFO block header: last-metadata-block flag (0x80) | type 0.
-	b.WriteByte(0x80) // last metadata block, type = STREAMINFO (0)
-	// 24-bit block length = 34 bytes.
-	b.Write([]byte{0x00, 0x00, 0x22})
+// flacStreaminfoBlock builds a STREAMINFO metadata block (4-byte header + 34-byte
+// payload). last sets the final-metadata-block flag. channels=1, bps=16, frame
+// sizes unknown, MD5 zeroed -- enough for audioduration and tag parsing.
+func flacStreaminfoBlock(sampleRate, totalSamples uint32, last bool) []byte {
+	var b bytes.Buffer
+	hdr := byte(0x00) // block type 0 = STREAMINFO
+	if last {
+		hdr |= 0x80
+	}
+	b.WriteByte(hdr)
+	b.Write([]byte{0x00, 0x00, 0x22}) // 24-bit block length = 34 bytes
 
-	// 34-byte STREAMINFO payload -- build via bit-packing.
 	var si [34]byte
-
-	// min/max block size: 4096 (2 bytes each, big-endian).
-	si[0] = 0x10
-	si[1] = 0x00
-	si[2] = 0x10
-	si[3] = 0x00
-
-	// min/max frame size: 0 (3 bytes each, meaning unknown).
-	// si[4..9] already zero.
-
-	// Pack sample_rate (20 bits), channels-1 (3 bits), bps-1 (5 bits),
-	// total_samples (36 bits) into si[10..17].
-	// channels=1 (stored as 0), bps=16 (stored as 15=0x0F).
-	sr := uint64(sampleRate)
-	ts := uint64(totalSamples)
-
-	// Bits 80-99 = sample_rate (20 bits) at byte offset 10.
-	// Bits 100-102 = channels-1 (3 bits).
-	// Bits 103-107 = bps-1 (5 bits).
-	// Bits 108-143 = total_samples (36 bits).
-	//
-	// Pack into bytes 10-17 (8 bytes).
-	pack := (sr << 44) | (0 << 41) | (uint64(15) << 36) | (ts & 0xFFFFFFFFF)
-	var packed [8]byte
-	binary.BigEndian.PutUint64(packed[:], pack)
-	copy(si[10:18], packed[:])
-	// si[18..33] = MD5, zeroed.
-
+	si[0], si[2] = 0x10, 0x10 // min/max block size: 4096 (big-endian)
+	// Pack sample_rate (20 bits), channels-1 (3 bits, =0), bps-1 (5 bits, =15),
+	// total_samples (36 bits) into bytes 10-17.
+	pack := (uint64(sampleRate) << 44) | (uint64(15) << 36) | (uint64(totalSamples) & 0xFFFFFFFFF)
+	binary.BigEndian.PutUint64(si[10:18], pack)
 	b.Write(si[:])
+	return b.Bytes()
+}
+
+// flacVorbisCommentBlock builds a VORBIS_COMMENT metadata block (type 4) marked
+// as the last block. The FLAC block-length header is 24-bit big-endian, but the
+// payload's own length prefixes are 32-bit little-endian (the Vorbis spec).
+func flacVorbisCommentBlock(comments map[string]string) []byte {
+	var p bytes.Buffer
+	writeLE32 := func(n int) {
+		var u [4]byte
+		binary.LittleEndian.PutUint32(u[:], uint32(n)) //nolint:gosec // test-fixture comment sizes are small and non-negative; no overflow
+		p.Write(u[:])
+	}
+	vendor := []byte("canticle-testutil")
+	writeLE32(len(vendor))
+	p.Write(vendor)
+	writeLE32(len(comments))
+	for k, v := range comments {
+		kv := []byte(k + "=" + v)
+		writeLE32(len(kv))
+		p.Write(kv)
+	}
+	payload := p.Bytes()
+
+	var b bytes.Buffer
+	b.WriteByte(0x84) // last-block flag (0x80) | type 4 (VORBIS_COMMENT)
+	n := len(payload)
+	b.Write([]byte{byte(n >> 16), byte(n >> 8), byte(n)}) //nolint:gosec // 24-bit length of a tiny test fixture; no overflow
+	b.Write(payload)
 	return b.Bytes()
 }
 
@@ -189,6 +219,16 @@ func GenerateFLAC(sampleRate, totalSamples uint32) []byte {
 func WriteFLACFile(dir, filename string, sampleRate, totalSamples uint32) error {
 	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, GenerateFLAC(sampleRate, totalSamples), 0o644); err != nil { //nolint:gosec // test fixture file
+		return fmt.Errorf("testutil: write flac file %s: %w", path, err)
+	}
+	return nil
+}
+
+// WriteFLACFileWithComments writes a header-only FLAC fixture carrying the given
+// Vorbis comments (e.g. {"SYNCEDLYRICS": "[00:01.00]..."}) into dir.
+func WriteFLACFileWithComments(dir, filename string, sampleRate, totalSamples uint32, comments map[string]string) error {
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, GenerateFLACExtended(sampleRate, totalSamples, comments), 0o644); err != nil { //nolint:gosec // test fixture file
 		return fmt.Errorf("testutil: write flac file %s: %w", path, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Teach `output.embedded_lyrics = "extract"` / `"respect"` to also handle a Vorbis `SYNCEDLYRICS` comment (FLAC/OGG): timestamped LRC text is vetted and written as a synced `.lrc` sidecar (preferred over unsynced), so a track that already carries synced lyrics is no longer re-fetched and its lyrics no longer go unused.

- **Scanner:** reorder the embedded-lyrics block to prefer synced. `looksLikeLRC` (a compiled regex) vets the `SYNCEDLYRICS` value carries `[mm:ss.xx]` timestamps; if so it writes a `.lrc` and skips fetch, else it warns (no silent failure) and falls through to the unsynced `.txt` path / normal fetch. Factors the atomic temp + `os.Link` never-overwrite writer into a shared `linkSidecar` helper.
- **Out of scope (documented):** ID3 `SYLT` (binary frame) and MP4 synced atoms remain unhandled - this targets the cheap, format-honest subset (Vorbis comments surfaced by `dhowden/tag` with no new dependency).
- **Fixtures:** a Vorbis-comment FLAC generator in `internal/testutil` (`GenerateFLACExtended` / `WriteFLACFileWithComments`) so the synced paths are testable end-to-end.
- **Docs:** `config.example.toml` + `docs/CONFIGURATION.md` updated to describe the synced `.lrc` behavior and the SYLT/MP4 limitation.

## Linked issue

Closes #395.

## Test plan

- [x] Full pre-push gate green (`make gate`): race tests, **patch coverage 91.3%** (>70%), coverage floor OK, golangci-lint 0, actionlint, govulncheck.
- [x] TDD with mutation-proven test teeth: 9 scanner cases (valid synced -> `.lrc`; malformed -> warn + fall-through to fetch and to `.txt`; synced precedence over unsynced; existing-sidecar never overwritten; respect-skip; empty/whitespace absent; rescan-skip) + the fixture generator round-tripped through `dhowden/tag`.
- [x] Local review-toolkit (code-reviewer + silent-failure-hunter + test-analyzer) run pre-PR; findings fixed in-branch (the malformed-with-unsynced `.txt` gap + a trimming-consistency nit).