### PR TITLE
ci: remediate ffmpeg CVE-2026-8461 and harden GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -67,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -81,7 +81,7 @@ jobs:
         run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
           # Weekly (not daily) lint-cache key rotation: a daily interval cold-
@@ -103,7 +103,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -146,13 +146,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build image
         # buildx + GHA layer cache reuses the nightly's exported BuildKit layers
         # instead of cold-building. load:true keeps mxlrcgo-svc:scan in the local
         # daemon so the grype scan step below can still find it.
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
@@ -366,7 +366,7 @@ jobs:
           persist-credentials: false
 
       - if: ${{ matrix.skip != 'true' }}
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@09dec6cc8c147fd5737df267d90a7d19cd5ff9ea # v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: go
 
@@ -49,6 +49,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@09dec6cc8c147fd5737df267d90a7d19cd5ff9ea # v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: /language:go

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,13 +27,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
             type=raw,value=nightly-{{date 'YYYYMMDD'}}
 
       - name: Build and push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,19 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
           cosign-release: 'v3.0.6'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,11 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
       org.opencontainers.image.licenses="GPL-3.0" \
       net.unraid.docker.webui="http://[IP]:[PORT:50705]/"
 
-RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
+# ffmpeg floor pinned to remediate CVE-2026-8461 (HIGH, fixed in Alpine 8.1.2-r0).
+# The explicit version also cache-busts the GHA BuildKit layer so the image scan
+# stops reusing a stale 8.1.1-r0 layer. Keep in sync with Dockerfile.goreleaser;
+# raise/drop the floor when the base apk index ships a newer ffmpeg by default.
+RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -8,7 +8,11 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
       org.opencontainers.image.licenses="GPL-3.0" \
       net.unraid.docker.webui="http://[IP]:[PORT:50705]/"
 
-RUN apk add --no-cache bash ca-certificates ffmpeg su-exec tzdata && \
+# ffmpeg floor pinned to remediate CVE-2026-8461 (HIGH, fixed in Alpine 8.1.2-r0).
+# The explicit version also cache-busts the GHA BuildKit layer so the image scan
+# stops reusing a stale 8.1.1-r0 layer. Keep in sync with the top-level Dockerfile;
+# raise/drop the floor when the base apk index ships a newer ffmpeg by default.
+RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \


### PR DESCRIPTION
## Summary
- **Remediate CVE-2026-8461 (HIGH, ffmpeg).** Pin `ffmpeg>=8.1.2-r0` in both runtime Dockerfiles (`Dockerfile` + `build/docker/Dockerfile.goreleaser`). Alpine 3.24 ships the fix in `8.1.2-r0`; the image was pulling `8.1.1-r0`. The explicit floor doubles as a cache-bust for the GHA BuildKit layer, so the `Image Scan` job stops reusing the stale pre-fix layer.
- **Fix the codeql auto-approve root cause.** Re-pin `github/codeql-action/init`+`analyze` from `09dec6c # v4` (a floating-`v4`-tag tip, *not* a release commit) to the `v4.36.2` release SHA `8aad20d` (matching `upload-sarif`). Because the old pin tracked the moving `v4` tag, dependabot could not compute a semver delta and reported every bump as `semver-major`, which the auto-approve workflow deliberately skips — leaving codeql bumps stuck at `REVIEW_REQUIRED` (the now-closed #408/#409).
- **Normalize all action pins to full `vX.Y.Z` comments** so `dependabot/fetch-metadata` resolves patch/minor update-types and auto-approves cleanly (login, buildx, qemu, paths-filter, build-push, goreleaser, golangci, setup-go, claude-code-action).

## Verification
- `make gate` green locally (build, race tests, golangci-lint, **actionlint**, govulncheck).
- ffmpeg fix verified directly: rebuilt the runtime base with the floor pin, installed `ffmpeg-8.1.2-r0`, and `grype --fail-on high` reports **no vulnerabilities** / CVE-2026-8461 absent.

## Notes
- No application/Go code changed — CI workflows and Dockerfiles only.
- Mechanical CI/config change; `norabbit` may be appropriate.