### PR TITLE
feat(detector): instrumental-decision telemetry + scan reconcile (#404, #405)

### DIFF
--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -237,9 +237,68 @@ verdict, so you can see *why* a track was or was not marked.
   the conservative `0.03-0.05` borderline band (by design) or other separately
   tracked refinements (cross-version model drift). `Speech` activation on
   non-lyrical audio is now handled by the dedicated sustained-mean speech gate
-  (#403). Persisting per-decision telemetry (scores + model version) for
-  auditability is a separate follow-up.
+  (#403). Per-decision telemetry (the scores, the winning vocal class, and the
+  detector version) is persisted on the `work_queue` row - see *Decision
+  telemetry* below.
 - **Re-classifying / clearing stale markers.** After changing thresholds or
-  fixing the sidecar, force a re-check of affected tracks with `--update` (a full
-  re-fetch). Instrumental markers are otherwise sticky - `--upgrade` skips them
-  by design.
+  fixing the sidecar, re-validate existing markers with `scan reconcile` (see
+  below) rather than a blanket `--update`. Instrumental markers are otherwise
+  sticky - `--upgrade` skips them by design.
+
+### Decision telemetry on `work_queue`
+
+When the detector renders a verdict it stamps the decision inputs onto the
+`work_queue` row (migration 025), alongside the boolean `instrumental_result`, in
+a single atomic update:
+
+| column | meaning |
+| --- | --- |
+| `music_sum` | summed music-gate score (`Result.Confidence`) |
+| `vocal_peak` | peak sung-vocal score (`Result.VocalConfidence`) |
+| `speech_mean` | summed speech-gate score (`Result.SpeechConfidence`) |
+| `vocal_class` | the configured vocal class that produced `vocal_peak` (empty when none scored) |
+| `detector_version` | the Canticle app version (`internal/version`) at decision time |
+
+All five are **nullable**: `NULL` means detection did not run for that row
+(detection disabled, no source path, or a row written before migration 025). They
+make borderline review and drift detection a query rather than a 40-minute
+re-inference pass:
+
+```sql
+-- borderline sung-vocal tracks worth a human look
+SELECT id, source_path, vocal_peak FROM work_queue
+WHERE instrumental_result = 1 AND vocal_peak BETWEEN 0.03 AND 0.05;
+
+-- markers written by an older detector build (model/threshold drift)
+SELECT id, source_path, detector_version FROM work_queue
+WHERE instrumental_result = 1 AND detector_version <> '<current-version>';
+```
+
+> The version is the Canticle app version, which captures Go-side gate/threshold
+> drift. If sidecar/model identity is wanted later, derive it from the sidecar's
+> `YAMNET_HANDLE` config or image tag rather than a new `/health` field.
+
+### Reconciling stale markers (`scan reconcile`)
+
+`scan reconcile` re-runs the detector over instrumental-tagged tracks and, for any
+the current detector no longer classifies as instrumental, deletes the exact
+instrumental `.txt` marker and re-queues the row so the scheduler re-fetches it.
+
+- **Dry-run by default.** It prints what would change; pass `--yes` to apply.
+- **Cheap by default.** Using the telemetry above, it re-infers only the
+  *candidate* set - borderline `vocal_peak`/`speech_mean`, cross-version, or
+  un-scored (pre-telemetry) rows - instead of every tagged track. `--all` forces a
+  full re-inference of every `instrumental_result = 1` row.
+- **Safe deletes.** A `.txt` is removed only when its content is *exactly* the
+  instrumental marker, so genuine unsynced `.txt` lyrics are never touched. Every
+  cleared row is written to a JSONL backup first (`--backup <path>`, default
+  `<db-dir>/reconcile-backup-<timestamp>.jsonl`).
+- **No starvation.** Re-queued rows are deferred at `priority = -100`, so a bulk
+  reconcile is dequeued strictly behind foreground work.
+- `--library <name|id>` scopes the run; `--limit <n>` caps it.
+
+```sh
+mxlrcgo-svc scan reconcile                 # dry run, narrowed candidate set
+mxlrcgo-svc scan reconcile --yes           # apply
+mxlrcgo-svc scan reconcile --all --yes     # re-infer every tagged track
+```

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -2921,13 +2921,25 @@ func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd)
 			errCount++
 			continue
 		}
+		deleteFailed := false
 		for _, p := range markerPaths {
 			if err := os.Remove(p); err != nil {
-				slog.Warn("reconcile: failed to delete marker; continuing", "id", item.ID, "path", p, "error", err)
+				if os.IsNotExist(err) {
+					// Already gone (removed out-of-band since the check); not a failure.
+					continue
+				}
+				slog.Warn("reconcile: failed to delete marker; leaving row tagged", "id", item.ID, "path", p, "error", err)
 				errCount++
+				deleteFailed = true
 				continue
 			}
 			sidecarsDeleted++
+		}
+		if deleteFailed {
+			// A marker remains on disk: do NOT clear the verdict, or the row would say
+			// "not instrumental" while the on-disk marker still says it is. Leave the
+			// row tagged so a later reconcile retries it.
+			continue
 		}
 		if n, err := workQueue.ResetInstrumental(ctx, item.ID); err != nil {
 			slog.Warn("reconcile: failed to reset row (marker already deleted)", "id", item.ID, "error", err)

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -128,8 +129,21 @@ type ScanCmd struct {
 	NoDetectInstrumental bool     `arg:"--no-detect-instrumental" help:"force instrumental detection off for tracks enqueued by this scan, overriding per-library and global settings; mutually exclusive with --detect-instrumental"`
 	Libraries            []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
-	Results *ScanResultsCmd `arg:"subcommand:results" help:"list persisted scan_results rows"`
-	Clear   *ScanClearCmd   `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
+	Results   *ScanResultsCmd   `arg:"subcommand:results" help:"list persisted scan_results rows"`
+	Clear     *ScanClearCmd     `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
+	Reconcile *ScanReconcileCmd `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
+}
+
+// ScanReconcileCmd re-runs the audio detector over instrumental-tagged tracks and,
+// for tracks the current detector no longer classifies as instrumental, deletes the
+// exact-match instrumental .txt marker and re-queues the row. Dry-run unless --yes.
+type ScanReconcileCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id)" default:""`
+	All        bool   `arg:"--all" help:"re-infer every instrumental-tagged row; default re-infers only borderline / cross-version / un-scored rows via stored telemetry"`
+	Yes        bool   `arg:"--yes" help:"actually delete markers and re-queue rows (without it, prints what would change)"`
+	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
+	Backup     string `arg:"--backup" help:"path for the JSONL backup of cleared rows (default: <db-dir>/reconcile-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // ScanResultsCmd lists persisted scan results, optionally filtered.
@@ -1407,6 +1421,7 @@ func newAudioDetector(cfg config.Config, ffmpegPath string) (detector.Detector, 
 		FFmpegPath:            ffmpegPath,
 		FFprobePath:           cfg.InstrumentalDetector.FFprobePath,
 		CooldownSeconds:       cfg.InstrumentalDetector.CooldownSeconds,
+		Version:               version, // version is the package-level var in version.go mirroring appversion.Version
 	})
 }
 
@@ -1547,6 +1562,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runScanClear(ctx, out, sub)
+	case args.Reconcile != nil:
+		sub := *args.Reconcile
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runScanReconcile(ctx, out, sub)
 	default:
 		return runScan(ctx, out, args)
 	}
@@ -2734,4 +2755,272 @@ func runScanClear(ctx context.Context, out io.Writer, args ScanClearCmd) int {
 	}
 	_, _ = fmt.Fprintf(out, "deleted %d scan_results rows and canceled %d / updated %d work_queue rows for library %q (id=%d)\n", deleted, qDel, qUpd, lib.Name, lib.ID)
 	return 0
+}
+
+// runScanReconcile re-runs the audio detector over instrumental-tagged tracks and,
+// for any the current detector no longer classifies as instrumental, deletes the
+// exact-match instrumental .txt marker and re-queues the work_queue row so the
+// scheduler re-fetches it behind foreground work. Dry-run by default; --yes
+// applies. By default it re-infers only the telemetry-narrowed candidate set
+// (borderline / cross-version / un-scored rows); --all re-infers every tagged row.
+func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	var libraryID *int64
+	var libLabel string
+	if strings.TrimSpace(args.Library) != "" {
+		lib, err := resolveLibrary(ctx, library.New(sqlDB), args.Library)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
+				return 1
+			}
+			slog.Error("failed to resolve library", "error", err)
+			return 1
+		}
+		id := lib.ID
+		libraryID = &id
+		libLabel = fmt.Sprintf(" (library %q, id=%d)", lib.Name, lib.ID)
+	}
+
+	// Bail before resolving (or auto-downloading) ffmpeg when no classifier is
+	// configured: reconcile is inert without the detector.
+	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
+		_, _ = fmt.Fprintln(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot reconcile")
+		return 1
+	}
+
+	// Build the detector from the same config/ffmpeg/cooldown wiring serve uses, so
+	// reconcile inherits the cooldown and low-priority ffmpeg sampling. The detector
+	// is process-local: it does not coordinate cooldown with a concurrently running
+	// serve process against the same classifier (queue-level starvation is instead
+	// guaranteed by the deferred + priority=-100 reset).
+	ffmpegPath, err := resolveFFmpeg(ctx, cfg)
+	if err != nil {
+		slog.Error("failed to resolve ffmpeg", "error", err)
+		return 1
+	}
+	det, err := newAudioDetector(cfg, ffmpegPath)
+	if err != nil {
+		slog.Error("failed to construct audio detector", "error", err)
+		return 1
+	}
+	if det == nil {
+		_, _ = fmt.Fprintln(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot reconcile")
+		return 1
+	}
+
+	workQueue := queue.NewDBQueue(sqlDB)
+	workQueue.SetRandomized(cfg.Queue.Randomize)
+
+	total, err := workQueue.CountInstrumental(ctx)
+	if err != nil {
+		slog.Error("failed to count instrumental rows", "error", err)
+		return 1
+	}
+	candidates, err := workQueue.ListInstrumental(ctx, queue.ListInstrumentalOptions{
+		LibraryID:      libraryID,
+		Limit:          args.Limit,
+		All:            args.All,
+		CurrentVersion: version,
+	})
+	if err != nil {
+		slog.Error("failed to list instrumental rows", "error", err)
+		return 1
+	}
+	mode := "telemetry-narrowed"
+	if args.All {
+		mode = "full"
+	}
+	suffix := ""
+	if !args.Yes {
+		suffix = " [dry run; pass --yes to apply]"
+	}
+	_, _ = fmt.Fprintf(out, "reconcile%s: %d instrumental-tagged rows total; %d candidate(s) to re-infer (%s mode)%s\n",
+		libLabel, total, len(candidates), mode, suffix)
+
+	var (
+		checked, confirmed, disagreed    int
+		sidecarsDeleted, rowsReset       int
+		skippedNoSource, skippedNoMarker int
+		errCount                         int
+	)
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		backupPath = filepath.Join(filepath.Dir(cfg.DB.Path), fmt.Sprintf("reconcile-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	var backup *os.File
+	defer func() {
+		if backup != nil {
+			_ = backup.Close()
+		}
+	}()
+
+	for _, item := range candidates {
+		if err := ctx.Err(); err != nil {
+			_, _ = fmt.Fprintf(out, "interrupted: %v\n", err)
+			break
+		}
+		src := strings.TrimSpace(item.Inputs.SourcePath)
+		if src == "" {
+			skippedNoSource++
+			continue
+		}
+		res, derr := det.Detect(ctx, src)
+		if derr != nil {
+			slog.Warn("reconcile: detection failed; skipping row", "id", item.ID, "error", derr)
+			errCount++
+			continue
+		}
+		checked++
+		if res.Instrumental {
+			confirmed++
+			continue
+		}
+		disagreed++
+
+		markerPaths := exactInstrumentalSidecars(item)
+		if len(markerPaths) == 0 {
+			// Disagreement, but no on-disk file is exactly the instrumental marker
+			// (missing, edited, or genuine unsynced lyrics). Leave the row untouched
+			// so reconcile never clears a verdict whose marker it did not remove and
+			// never clobbers real lyrics.
+			skippedNoMarker++
+			slog.Info("reconcile: disagreement but no exact instrumental-marker sidecar; leaving row untouched", "id", item.ID, "source", src)
+			continue
+		}
+
+		if !args.Yes {
+			_, _ = fmt.Fprintf(out, "would clear: id=%d  %s  -> delete %d marker(s) + re-queue\n", item.ID, src, len(markerPaths))
+			continue
+		}
+
+		// Apply order: backup first (abort the row's mutation if it fails), then
+		// delete markers, then reset the row.
+		if backup == nil {
+			f, err := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+			if err != nil {
+				slog.Error("failed to open reconcile backup file", "path", backupPath, "error", err)
+				return 1
+			}
+			backup = f
+		}
+		if err := appendReconcileBackup(backup, item, markerPaths, res); err != nil {
+			slog.Error("reconcile: backup write failed; skipping row mutation", "id", item.ID, "error", err)
+			errCount++
+			continue
+		}
+		for _, p := range markerPaths {
+			if err := os.Remove(p); err != nil {
+				slog.Warn("reconcile: failed to delete marker; continuing", "id", item.ID, "path", p, "error", err)
+				errCount++
+				continue
+			}
+			sidecarsDeleted++
+		}
+		if n, err := workQueue.ResetInstrumental(ctx, item.ID); err != nil {
+			slog.Warn("reconcile: failed to reset row (marker already deleted)", "id", item.ID, "error", err)
+			errCount++
+		} else {
+			rowsReset += int(n)
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "reconcile done: checked=%d confirmed=%d disagreed=%d markers-deleted=%d rows-reset=%d skipped(no-source=%d,no-marker=%d) errors=%d\n",
+		checked, confirmed, disagreed, sidecarsDeleted, rowsReset, skippedNoSource, skippedNoMarker, errCount)
+	if args.Yes && rowsReset > 0 {
+		_, _ = fmt.Fprintf(out, "backup of cleared rows written to %s\n", backupPath)
+	}
+	if errCount > 0 {
+		return 1
+	}
+	return 0
+}
+
+// exactInstrumentalSidecars returns the .txt sidecar paths for item whose on-disk
+// content is exactly the instrumental marker. Paths derived via lyrics.SidecarName
+// (the same logic the writer uses) that are missing, unreadable, or do not match
+// the marker exactly are omitted, so genuine unsynced .txt lyrics are never
+// returned for deletion.
+func exactInstrumentalSidecars(item queue.WorkItem) []string {
+	paths := item.Inputs.OutputPaths
+	if len(paths) == 0 {
+		paths = []models.OutputPath{{Outdir: item.Inputs.Outdir, Filename: item.Inputs.Filename}}
+	}
+	var matched []string
+	for _, op := range paths {
+		name, err := lyrics.SidecarName(item.Inputs.Track.ArtistName, item.Inputs.Track.TrackName, op.Filename, false)
+		if err != nil {
+			continue
+		}
+		p := filepath.Join(op.Outdir, name)
+		if isExactInstrumentalMarker(p) {
+			matched = append(matched, p)
+		}
+	}
+	return matched
+}
+
+// isExactInstrumentalMarker reports whether the file at path exists and its content
+// trimmed of trailing whitespace equals lyrics.InstrumentalMarker exactly - a
+// stricter guard than a substring check so reconcile never deletes a .txt that
+// carries real unsynced lyrics.
+func isExactInstrumentalMarker(path string) bool {
+	b, err := os.ReadFile(path) //nolint:gosec // G304: path is derived from the queue row's stored output dir + the writer's own SidecarName; content is verified here before any deletion
+	if err != nil {
+		return false
+	}
+	return strings.TrimRight(string(b), " \t\r\n") == lyrics.InstrumentalMarker
+}
+
+// reconcileBackupRecord is one JSONL line capturing a cleared row so the operation
+// is restorable.
+type reconcileBackupRecord struct {
+	WorkItemID   int64                  `json:"work_item_id"`
+	Inputs       models.Inputs          `json:"inputs"`
+	DeletedPaths []string               `json:"deleted_paths"`
+	NewResult    reconcileVerdictRecord `json:"new_result"`
+}
+
+// reconcileVerdictRecord is the detector verdict that justified clearing a row.
+type reconcileVerdictRecord struct {
+	Instrumental      bool    `json:"instrumental"`
+	MusicSum          float64 `json:"music_sum"`
+	VocalPeak         float64 `json:"vocal_peak"`
+	SpeechMean        float64 `json:"speech_mean"`
+	WinningVocalClass string  `json:"winning_vocal_class"`
+}
+
+func appendReconcileBackup(f *os.File, item queue.WorkItem, deleted []string, res detector.Result) error {
+	rec := reconcileBackupRecord{
+		WorkItemID:   item.ID,
+		Inputs:       item.Inputs,
+		DeletedPaths: deleted,
+		NewResult: reconcileVerdictRecord{
+			Instrumental:      res.Instrumental,
+			MusicSum:          res.Confidence,
+			VocalPeak:         res.VocalConfidence,
+			SpeechMean:        res.SpeechConfidence,
+			WinningVocalClass: res.WinningVocalClass,
+		},
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal reconcile backup record: %w", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write reconcile backup record: %w", err)
+	}
+	return nil
 }

--- a/internal/commands/reconcile_test.go
+++ b/internal/commands/reconcile_test.go
@@ -105,6 +105,10 @@ func TestRunScanReconcile_ClearsStaleMarker(t *testing.T) {
 	if err := q.SetInstrumentalResult(ctx, item.ID, 1, queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: "old"}); err != nil {
 		t.Fatalf("SetInstrumentalResult: %v", err)
 	}
+	// Reconcile only touches completed instrumental rows.
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = 'done', completed_at = ? WHERE id = ?`, "2026-06-25T00:00:00Z", item.ID); err != nil {
+		t.Fatalf("mark done: %v", err)
+	}
 	_ = sqlDB.Close()
 
 	// Dry run: must not touch the marker.
@@ -176,6 +180,10 @@ func seedInstrumentalRow(t *testing.T, ctx context.Context, dbPath string, input
 	}
 	if err := q.SetInstrumentalResult(ctx, item.ID, 1, queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: detVer}); err != nil {
 		t.Fatalf("SetInstrumentalResult: %v", err)
+	}
+	// Reconcile only touches completed instrumental rows.
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = 'done', completed_at = ? WHERE id = ?`, "2026-06-25T00:00:00Z", item.ID); err != nil {
+		t.Fatalf("mark done: %v", err)
 	}
 	return item.ID
 }

--- a/internal/commands/reconcile_test.go
+++ b/internal/commands/reconcile_test.go
@@ -1,0 +1,386 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/mxlrcgo-svc/internal/db"
+	"github.com/sydlexius/mxlrcgo-svc/internal/lyrics"
+	"github.com/sydlexius/mxlrcgo-svc/internal/models"
+	"github.com/sydlexius/mxlrcgo-svc/internal/queue"
+)
+
+// writeReconcileCfg writes a minimal config pointing the detector at a stub
+// classifier and a fake ffmpeg so runScanReconcile constructs a working detector.
+func writeReconcileCfg(t *testing.T, path, dbPath, classifierURL, ffmpegPath string) {
+	t.Helper()
+	escape := func(s string) string { return strings.ReplaceAll(s, `\`, `\\`) }
+	// ffmpeg_path goes under [verification]: resolveFFmpeg prefers it, and a blank
+	// value is re-defaulted to "ffmpeg" (a real binary on PATH), which would shadow
+	// an [instrumental_detector] override.
+	content := "[db]\n" +
+		"path = \"" + escape(dbPath) + "\"\n\n" +
+		"[verification]\n" +
+		"ffmpeg_path = \"" + escape(ffmpegPath) + "\"\n\n" +
+		"[instrumental_detector]\n" +
+		"enabled = true\n" +
+		"classifier_url = \"" + escape(classifierURL) + "\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeReconcileCfg: %v", err)
+	}
+}
+
+// fakeFFmpegCmd writes a stub ffmpeg that writes a byte to its last argument (the
+// sample output path), so the detector's sampling step succeeds without real
+// ffmpeg. Mirrors the detector package's test fake.
+func fakeFFmpegCmd(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\nlast=''\nfor arg do\n  last=\"$arg\"\ndone\nprintf 'sampled audio' > \"$last\"\n"
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return path
+}
+
+// TestRunScanReconcile_ClearsStaleMarker is the end-to-end reconcile path: a row
+// flagged instrumental whose source the (stub) detector now classifies as NOT
+// instrumental must, under --yes, have its exact-marker .txt deleted and its
+// work_queue row re-queued (deferred, verdict NULL), with a JSONL backup written -
+// and the dry-run must change nothing.
+func TestRunScanReconcile_ClearsStaleMarker(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	srcPath := filepath.Join(outdir, "song.flac")
+	if err := os.WriteFile(srcPath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	markerPath := filepath.Join(outdir, "song.txt")
+	if err := os.WriteFile(markerPath, []byte(lyrics.InstrumentalMarker+"\n"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	// Classifier returns an empty max map -> the detector degrades to NOT
+	// instrumental, producing the disagreement reconcile acts on.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"mean":{"Speech":0.5},"max":{}}`))
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+
+	// Seed a completed, instrumental-tagged row carrying the marker. detector_version
+	// "old" differs from the current build, so the default narrowed prefilter selects it.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	q.SetRandomized(false)
+	inputs := models.Inputs{
+		Track:       models.Track{ArtistName: "A", TrackName: "Song"},
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}
+	if _, err := q.Enqueue(ctx, inputs, queue.PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, item.ID, 1, queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: "old"}); err != nil {
+		t.Fatalf("SetInstrumentalResult: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	// Dry run: must not touch the marker.
+	var dry bytes.Buffer
+	if code := runScanReconcile(ctx, &dry, ScanReconcileCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("dry-run exit=%d out=%s", code, dry.String())
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("dry-run must not delete the marker: %v", err)
+	}
+	if !strings.Contains(dry.String(), "would clear") {
+		t.Errorf("dry-run output missing 'would clear':\n%s", dry.String())
+	}
+
+	// Apply.
+	var app bytes.Buffer
+	if code := runScanReconcile(ctx, &app, ScanReconcileCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, app.String())
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("marker should be deleted after apply; stat err=%v", err)
+	}
+	if !strings.Contains(app.String(), "rows-reset=1") {
+		t.Errorf("apply output missing rows-reset=1:\n%s", app.String())
+	}
+
+	// Verify the row was re-queued and its verdict cleared.
+	sqlDB2, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer sqlDB2.Close() //nolint:errcheck // test cleanup
+	var status string
+	var instResult sql.NullInt64
+	if err := sqlDB2.QueryRowContext(ctx, `SELECT status, instrumental_result FROM work_queue WHERE id = ?`, item.ID).Scan(&status, &instResult); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred", status)
+	}
+	if instResult.Valid {
+		t.Errorf("instrumental_result not NULL after reconcile: %v", instResult)
+	}
+
+	// A JSONL backup must exist.
+	matches, _ := filepath.Glob(filepath.Join(dir, "reconcile-backup-*.jsonl"))
+	if len(matches) == 0 {
+		t.Errorf("no reconcile backup file written in %s", dir)
+	}
+}
+
+// seedInstrumentalRow enqueues + dequeues a row and stamps it instrumental with the
+// given telemetry version, returning its id. Opens and closes its own DB handle.
+func seedInstrumentalRow(t *testing.T, ctx context.Context, dbPath string, inputs models.Inputs, detVer string) int64 {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	q := queue.NewDBQueue(sqlDB)
+	q.SetRandomized(false)
+	if _, err := q.Enqueue(ctx, inputs, queue.PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, item.ID, 1, queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: detVer}); err != nil {
+		t.Fatalf("SetInstrumentalResult: %v", err)
+	}
+	return item.ID
+}
+
+// TestRunScanReconcile_DetectorNotConfigured: with no classifier_url, reconcile
+// reports the detector is not configured and exits 1 (before resolving ffmpeg).
+func TestRunScanReconcile_DetectorNotConfigured(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	content := "[db]\npath = \"" + strings.ReplaceAll(filepath.Join(dir, "test.db"), `\`, `\\`) + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	var buf bytes.Buffer
+	if code := runScanReconcile(ctx, &buf, ScanReconcileCmd{ConfigPath: cfgPath}); code != 1 {
+		t.Fatalf("exit=%d want 1; out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "not configured") {
+		t.Errorf("want 'not configured' message; got: %s", buf.String())
+	}
+}
+
+// TestRunScanReconcile_LibraryNotFound: an unknown --library exits 1.
+func TestRunScanReconcile_LibraryNotFound(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, filepath.Join(dir, "test.db"), "http://127.0.0.1:1", fakeFFmpegCmd(t))
+	// db.Open creates the schema so resolveLibrary can run.
+	sqlDB, err := db.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	_ = sqlDB.Close()
+	var buf bytes.Buffer
+	if code := runScanReconcile(ctx, &buf, ScanReconcileCmd{ConfigPath: cfgPath, Library: "no-such-library"}); code != 1 {
+		t.Fatalf("exit=%d want 1; out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "not found") {
+		t.Errorf("want 'not found' message; got: %s", buf.String())
+	}
+}
+
+// TestRunScanReconcile_ConfirmedAllMode: when the detector still classifies the
+// track as instrumental, --all re-infers it, the verdict is confirmed, and nothing
+// is deleted or re-queued.
+func TestRunScanReconcile_ConfirmedAllMode(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	srcPath := filepath.Join(outdir, "song.flac")
+	_ = os.WriteFile(srcPath, []byte("audio"), 0o600)
+	markerPath := filepath.Join(outdir, "song.txt")
+	_ = os.WriteFile(markerPath, []byte(lyrics.InstrumentalMarker+"\n"), 0o600)
+
+	// Classifier returns instrumental: high music, a present-but-low vocal peak.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"mean":{"Music":0.95},"max":{"Music":1.0,"Singing":0.01}}`))
+	}))
+	defer srv.Close()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+	seedInstrumentalRow(t, ctx, dbPath, models.Inputs{
+		Track:       models.Track{ArtistName: "A", TrackName: "Song"},
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}, "current")
+
+	var buf bytes.Buffer
+	if code := runScanReconcile(ctx, &buf, ScanReconcileCmd{ConfigPath: cfgPath, All: true, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("confirmed row's marker must NOT be deleted: %v", err)
+	}
+	if !strings.Contains(buf.String(), "confirmed=1") || !strings.Contains(buf.String(), "rows-reset=0") {
+		t.Errorf("want confirmed=1 rows-reset=0; got: %s", buf.String())
+	}
+}
+
+// TestRunScanReconcile_SkipsNoSourceAndNoMarker: a row with no source path is
+// skipped before detection; a disagreeing row with no on-disk marker is left
+// untouched (never reset on the basis of a missing marker).
+func TestRunScanReconcile_SkipsNoSourceAndNoMarker(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	srcPath := filepath.Join(outdir, "song.flac")
+	_ = os.WriteFile(srcPath, []byte("audio"), 0o600)
+	// Deliberately do NOT create song.txt -> disagreement but no marker.
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"mean":{"Speech":0.5},"max":{}}`)) // not instrumental
+	}))
+	defer srv.Close()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+
+	// Row 1: no source path -> skipped before detection.
+	seedInstrumentalRow(t, ctx, dbPath, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "NoSrc"}}, "old")
+	// Row 2: source present, disagreement, but no marker file on disk.
+	noMarkerID := seedInstrumentalRow(t, ctx, dbPath, models.Inputs{
+		Track:       models.Track{ArtistName: "B", TrackName: "NoMarker"},
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}, "old")
+
+	var buf bytes.Buffer
+	if code := runScanReconcile(ctx, &buf, ScanReconcileCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "no-source=1") || !strings.Contains(buf.String(), "no-marker=1") {
+		t.Errorf("want no-source=1 no-marker=1; got: %s", buf.String())
+	}
+	// The no-marker row must NOT have been reset.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	var instResult sql.NullInt64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT instrumental_result FROM work_queue WHERE id = ?`, noMarkerID).Scan(&instResult); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if !instResult.Valid || instResult.Int64 != 1 {
+		t.Errorf("no-marker row must remain instrumental_result=1; got %v", instResult)
+	}
+}
+
+// TestExactInstrumentalSidecars verifies the deletion-safety filter: only files
+// whose content is exactly the instrumental marker are returned; real unsynced
+// lyrics and missing files are excluded.
+func TestExactInstrumentalSidecars(t *testing.T) {
+	dir := t.TempDir()
+	markerDir := filepath.Join(dir, "marker")
+	lyricsDir := filepath.Join(dir, "lyrics")
+	missingDir := filepath.Join(dir, "missing")
+	for _, d := range []string{markerDir, lyricsDir, missingDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	// Exact marker (with trailing newline, as the writer emits it).
+	if err := os.WriteFile(filepath.Join(markerDir, "t.txt"), []byte(lyrics.InstrumentalMarker+"\n"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	// Genuine unsynced lyrics .txt - must NOT be returned.
+	if err := os.WriteFile(filepath.Join(lyricsDir, "t.txt"), []byte("These are real lyrics\nline two\n"), 0o600); err != nil {
+		t.Fatalf("write lyrics: %v", err)
+	}
+
+	item := queue.WorkItem{
+		ID: 1,
+		Inputs: models.Inputs{
+			Track: models.Track{ArtistName: "A", TrackName: "T"},
+			OutputPaths: []models.OutputPath{
+				{Outdir: markerDir, Filename: "t.flac"},
+				{Outdir: lyricsDir, Filename: "t.flac"},
+				{Outdir: missingDir, Filename: "t.flac"},
+			},
+		},
+	}
+	got := exactInstrumentalSidecars(item)
+	want := filepath.Join(markerDir, "t.txt")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("exactInstrumentalSidecars = %v; want exactly [%s]", got, want)
+	}
+}
+
+// TestIsExactInstrumentalMarker covers the strict marker match.
+func TestIsExactInstrumentalMarker(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"exact with newline", write("a.txt", lyrics.InstrumentalMarker+"\n"), true},
+		{"exact no newline", write("b.txt", lyrics.InstrumentalMarker), true},
+		{"exact trailing spaces", write("c.txt", lyrics.InstrumentalMarker+"  \n"), true},
+		{"real lyrics", write("d.txt", "real lyrics here"), false},
+		{"marker with prefix", write("e.txt", "x"+lyrics.InstrumentalMarker), false},
+		{"missing", filepath.Join(dir, "nope.txt"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExactInstrumentalMarker(tc.path); got != tc.want {
+				t.Errorf("isExactInstrumentalMarker(%s) = %v; want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/db/migrations/025_instrumental_telemetry.sql
+++ b/internal/db/migrations/025_instrumental_telemetry.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Five nullable telemetry columns added to work_queue so each instrumental
+-- detection decision is persisted alongside instrumental_result (issue #404).
+-- NULL semantics: NULL means detection did not run for this row (disabled,
+-- source_path absent, or a pre-telemetry row created before this migration).
+-- When detection ran, all five columns are stamped atomically with
+-- instrumental_result in a single UPDATE by SetInstrumentalResult.
+--
+-- music_sum    - summed instrumental-class MEAN probability (the music gate score).
+-- vocal_peak   - peak (max-over-frames) of the winning vocal class (sung-vocal gate score).
+-- speech_mean  - summed frame-MEAN of speech classes (speech gate score).
+-- vocal_class  - name of the vocal class that produced vocal_peak; empty when no
+--                vocal class scored or when the sidecar returned no max map.
+-- detector_version - app version string at detection time (internal/version.Version),
+--                    sourced from the running binary via Config.Version.
+ALTER TABLE work_queue ADD COLUMN music_sum REAL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue ADD COLUMN vocal_peak REAL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue ADD COLUMN speech_mean REAL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue ADD COLUMN vocal_class TEXT;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue ADD COLUMN detector_version TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN music_sum;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN vocal_peak;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN speech_mean;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN vocal_class;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN detector_version;
+-- +goose StatementEnd

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -91,6 +91,14 @@ type Result struct {
 	// (the speech score). A high value means speech is sustained across the
 	// sample (a spoken-word track), as opposed to a brief incidental transient.
 	SpeechConfidence float64
+	// WinningVocalClass is the name of the configured VocalClass that produced
+	// VocalConfidence (the vocal peak). Empty when no vocal class scored or when
+	// the sidecar returns no max map (legacy sidecar).
+	WinningVocalClass string
+	// Version is the detector version string populated from Config.Version at
+	// construction time, sourced from the app version (internal/version). Empty
+	// when the detector was constructed without a version (e.g. in tests).
+	Version string
 	// Classes is the per-class MEAN probability map from the classified sample,
 	// retained for debugging and observability.
 	Classes map[string]float64
@@ -131,6 +139,12 @@ type Config struct {
 	FFmpegPath          string
 	FFprobePath         string
 	CooldownSeconds     int
+	// Version is stamped onto every Result.Version returned by Detect. It is
+	// sourced from the app version (internal/version) at detector construction
+	// time in the commands layer, so each persisted telemetry row records which
+	// app build produced the decision. Empty is valid (leaves Result.Version
+	// empty); tests that do not need version tracking can omit it.
+	Version string
 }
 
 // clampSampleDuration clamps d to [minSampleDurationSeconds, maxSampleDurationSeconds].

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -1142,5 +1144,141 @@ func TestLegacyVocalSpeechDeDupBehavior(t *testing.T) {
 	}
 	if res.Instrumental {
 		t.Fatalf("sustained Speech mean %.3f >= 0.20 must block even with legacy config", res.SpeechConfidence)
+	}
+}
+
+// TestDetectWinningVocalClassCaptured verifies that Result.WinningVocalClass is
+// set to the vocal class that produced the highest peak and left empty when no
+// vocal class scored.
+func TestDetectWinningVocalClassCaptured(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("a"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"mean": map[string]float64{"Music": 0.93, "Musical instrument": 0.05, "Singing": 0.002, "Vocal music": 0.001},
+			// Vocal music peaks higher than Singing so it is the winner.
+			"max": map[string]float64{"Music": 1.0, "Singing": 0.01, "Vocal music": 0.03},
+		})
+	}))
+	defer srv.Close()
+	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, FFmpegPath: fakeFFmpeg(t),
+		InstrumentalClasses: []string{"Music", "Musical instrument"},
+		VocalClasses:        []string{"Singing", "Vocal music"}, VocalMaxConfidence: 0.05})
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	// vocal_peak = 0.03 (Vocal music wins over Singing 0.01); below 0.05 -> instrumental.
+	if res.WinningVocalClass != "Vocal music" {
+		t.Errorf("WinningVocalClass = %q; want Vocal music (highest peak)", res.WinningVocalClass)
+	}
+	if res.VocalConfidence != 0.03 {
+		t.Errorf("VocalConfidence = %v; want 0.03", res.VocalConfidence)
+	}
+}
+
+// TestDetectWinningVocalClassEmptyWhenNoMaxMap verifies that WinningVocalClass
+// is empty when the sidecar returns no max map (legacy sidecar path).
+func TestDetectWinningVocalClassEmptyWhenNoMaxMap(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("a"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Legacy flat-map sidecar: no "max" key, so Max will be nil.
+		_ = json.NewEncoder(w).Encode(map[string]float64{"Music": 0.95, "Singing": 0.4})
+	}))
+	defer srv.Close()
+	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, FFmpegPath: fakeFFmpeg(t),
+		InstrumentalClasses: []string{"Music"},
+		VocalClasses:        []string{"Singing"}, VocalMaxConfidence: 0.05})
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	// No max map -> vocal gate cannot run -> not instrumental, no winning class.
+	if res.WinningVocalClass != "" {
+		t.Errorf("WinningVocalClass = %q; want empty when no max map", res.WinningVocalClass)
+	}
+}
+
+// TestDetectVersionPropagatedToResult verifies that Config.Version is carried
+// through NewHTTPDetector onto every Result returned by Detect.
+func TestDetectVersionPropagatedToResult(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("a"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"mean": map[string]float64{"Music": 0.95, "Singing": 0.001},
+			"max":  map[string]float64{"Music": 1.0, "Singing": 0.005},
+		})
+	}))
+	defer srv.Close()
+	const wantVersion = "v1.2.3-test"
+	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, FFmpegPath: fakeFFmpeg(t),
+		InstrumentalClasses: []string{"Music"},
+		VocalClasses:        []string{"Singing"}, VocalMaxConfidence: 0.05,
+		Version: wantVersion})
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if res.Version != wantVersion {
+		t.Errorf("Result.Version = %q; want %q", res.Version, wantVersion)
+	}
+}
+
+// TestDetectLogLineIncludesVocalClassAndVersion verifies the slog.Info decision
+// line emitted by Detect includes vocal_class and detector_version attributes.
+func TestDetectLogLineIncludesVocalClassAndVersion(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("a"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"mean": map[string]float64{"Music": 0.95, "Singing": 0.001},
+			"max":  map[string]float64{"Music": 1.0, "Singing": 0.008},
+		})
+	}))
+	defer srv.Close()
+	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, FFmpegPath: fakeFFmpeg(t),
+		InstrumentalClasses: []string{"Music"},
+		VocalClasses:        []string{"Singing"}, VocalMaxConfidence: 0.05,
+		Version: "v9.9.9"})
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+
+	// Capture slog output via a text handler writing to a buffer, then assert the
+	// new structured attributes appear on the decision line.
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	if _, err := d.Detect(context.Background(), audioPath); err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "vocal_class=Singing") {
+		t.Errorf("log line missing vocal_class=Singing; got: %s", logged)
+	}
+	if !strings.Contains(logged, "detector_version=v9.9.9") {
+		t.Errorf("log line missing detector_version=v9.9.9; got: %s", logged)
 	}
 }

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -53,6 +53,10 @@ type HTTPDetector struct {
 	// per-decision gate enforces presence of THESE classes. Guarded by mu (written
 	// under the Detect lock).
 	vocalBaseline []string
+	// version is the app version string passed in via Config.Version at
+	// construction time. It is stamped onto every returned Result so each
+	// persisted telemetry row records which build produced the decision.
+	version string
 }
 
 // NewHTTPDetector creates a Detector that posts audio samples to the classifier
@@ -182,6 +186,7 @@ func NewHTTPDetector(cfg Config) (*HTTPDetector, error) {
 		nicePath:            nicePath,
 		httpClient:          &http.Client{Timeout: 3 * time.Minute},
 		cooldown:            time.Duration(cooldownSeconds) * time.Second,
+		version:             cfg.Version,
 	}, nil
 }
 
@@ -235,10 +240,14 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 	// Vocal gate: the loudest single vocal-class peak (max-over-frames) anywhere
 	// in the spread sample. A nil Max map (legacy sidecar) means the vocal gate
 	// cannot run, so the decision degrades safely to not-instrumental.
+	// winningVocalClass records the name of the class that produced vocalPeak so
+	// it can be persisted as telemetry alongside the score.
 	vocalPeak := 0.0
+	var winningVocalClass string
 	for _, name := range d.vocalClasses {
 		if v, ok := resp.Max[name]; ok && v > vocalPeak {
 			vocalPeak = v
+			winningVocalClass = name
 		}
 	}
 	// Speech gate: summed frame MEAN of the speech classes (sustained presence),
@@ -293,18 +302,23 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 
 	// Surface the decision inputs: the worker only reads res.Instrumental, so
 	// without this line a misclassification leaves no trace of the music_sum /
-	// vocal_peak / speech_mean that produced it.
+	// vocal_peak / speech_mean that produced it. vocal_class and detector_version
+	// are added here (issue #404); music_sum/vocal_peak/speech_mean were added
+	// earlier (#403) and must not be duplicated.
 	slog.Info("detector: instrumental decision",
 		"path", audioPath, "music_sum", music, "vocal_peak", vocalPeak, "speech_mean", speechMean,
+		"vocal_class", winningVocalClass, "detector_version", d.version,
 		"instrumental", instrumental, "min_confidence", d.minConfidence,
 		"vocal_max_confidence", d.vocalMaxConfidence, "speech_max_confidence", d.speechMaxConfidence)
 
 	return Result{
-		Instrumental:     instrumental,
-		Confidence:       music,
-		VocalConfidence:  vocalPeak,
-		SpeechConfidence: speechMean,
-		Classes:          resp.Mean,
+		Instrumental:      instrumental,
+		Confidence:        music,
+		VocalConfidence:   vocalPeak,
+		SpeechConfidence:  speechMean,
+		WinningVocalClass: winningVocalClass,
+		Version:           d.version,
+		Classes:           resp.Mean,
 	}, nil
 }
 

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -20,6 +20,41 @@ import (
 // before the marker line. The writer appends "\n" when writing the bare .txt form.
 const InstrumentalMarker = "♪ Instrumental ♪"
 
+// SidecarName derives the base file name WriteLRC writes for a track, applying the
+// same extension selection and base-name safety checks the writer uses. synced
+// selects the extension: ".lrc" for synced lyrics, ".txt" otherwise (unsynced
+// lyrics or the instrumental marker). When filename is non-empty it must be a
+// single path component (its extension is swapped to match the content type);
+// otherwise the name is derived from "artist - track" via Slugify. It returns an
+// error if the provided or derived name is not a safe base name (rejecting ".",
+// "..", any path separator, or an absolute path so a crafted name cannot traverse
+// out of the output dir). Reconcile (#405) uses this to locate the exact .txt
+// sidecar an instrumental marker would occupy, guaranteeing its path logic matches
+// the writer's rather than re-implementing it.
+func SidecarName(artist, track, filename string, synced bool) (string, error) {
+	ext := ".txt"
+	if synced {
+		ext = ".lrc"
+	}
+	var fn string
+	if filename != "" {
+		if filename == "." || filename == ".." || filename != filepath.Base(filename) ||
+			isUnsafeBaseName(filename) {
+			return "", fmt.Errorf("refusing to write: output filename %q is not a base name", filename)
+		}
+		fn = strings.TrimSuffix(filename, filepath.Ext(filename)) + ext
+	} else {
+		fn = Slugify(fmt.Sprintf("%s - %s", artist, track)) + ext
+	}
+	// Defense in depth: re-check the derived name after the extension swap or
+	// Slugify, keeping the base-name invariant local and failing closed if either
+	// branch ever regresses.
+	if isUnsafeBaseName(fn) {
+		return "", fmt.Errorf("refusing to write: derived output name %q is not a base name", fn)
+	}
+	return fn, nil
+}
+
 // Writer abstracts LRC file output.
 type Writer interface {
 	WriteLRC(song models.Song, filename string, outdir string) error
@@ -115,37 +150,11 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 		return fmt.Errorf("nothing to save for %s - %s", song.Track.ArtistName, song.Track.TrackName)
 	}
 
-	ext := ".txt"
-	if synced {
-		ext = ".lrc"
-	}
-
-	var fn string
-	if filename != "" {
-		// The provided filename must be a single path component. Reject ".",
-		// "..", any path separator, or an absolute path so a crafted filename
-		// cannot traverse out of outdir (or target outdir/its parent) via the
-		// filepath.Join below -- defense in depth alongside the confinement-root
-		// re-resolution that follows. Validate the raw input here, before the
-		// extension swap turns "."/".." into harmless-looking ".lrc"/"..lrc".
-		if filename == "." || filename == ".." || filename != filepath.Base(filename) ||
-			isUnsafeBaseName(filename) {
-			return fmt.Errorf("refusing to write: output filename %q is not a base name", filename)
-		}
-		// In dir mode the scanner sets an explicit .lrc filename. Swap the
-		// extension to match the content type (.lrc only for synced lyrics).
-		fn = strings.TrimSuffix(filename, filepath.Ext(filename)) + ext
-	} else {
-		fn = Slugify(fmt.Sprintf("%s - %s", song.Track.ArtistName, song.Track.TrackName)) + ext
-	}
-
-	// Defense in depth: re-check the derived name after the extension swap or
-	// Slugify. The raw-input guard above covers the provided-filename branch and
-	// Slugify strips separators (see TestSlugifyNeverReturnsSeparatorsOrAbs), so
-	// this is expected to be unreachable -- but it keeps the base-name invariant
-	// local to the write and fails closed if either branch ever regresses.
-	if isUnsafeBaseName(fn) {
-		return fmt.Errorf("refusing to write: derived output name %q is not a base name", fn)
+	// Derive the sidecar base name (extension selection + base-name safety) via
+	// the shared helper so reconcile (#405) locates the exact same .txt path.
+	fn, err := SidecarName(song.Track.ArtistName, song.Track.TrackName, filename, synced)
+	if err != nil {
+		return err
 	}
 
 	// When the output directory falls under a confinement root, re-resolve and

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1288,9 +1288,12 @@ type ListInstrumentalOptions struct {
 // cross-version / un-scored rows); set opts.All for the full flagged population.
 // Read-only.
 func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOptions) (items []WorkItem, retErr error) {
+	// status = 'done' restricts to COMPLETED instrumental rows: the worker stamps
+	// instrumental_result = 1 just before Complete, so a still-'processing' row could
+	// otherwise be picked up and cleared mid-write.
 	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
                        miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
-                       FROM work_queue WHERE instrumental_result = 1`
+                       FROM work_queue WHERE instrumental_result = 1 AND status = 'done'`
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	query := baseQuery
 	var args []any
@@ -1337,7 +1340,8 @@ func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOpt
 func (q *DBQueue) CountInstrumentalNarrowed(ctx context.Context, currentVersion string, libraryID *int64) (int64, error) {
 	clause, args := instrumentalNarrowedPredicate(currentVersion)
 	libClause, libArgs := recheckLibraryClause(libraryID)
-	query := `SELECT COUNT(*) FROM work_queue WHERE instrumental_result = 1` + clause + libClause
+	// status = 'done' matches ListInstrumental: count only completed instrumental rows.
+	query := `SELECT COUNT(*) FROM work_queue WHERE instrumental_result = 1 AND status = 'done'` + clause + libClause
 	allArgs := append(args, libArgs...)
 	var n int64
 	if err := q.db.QueryRowContext(ctx, query, allArgs...).Scan(&n); err != nil { //nolint:gosec // G202: fragments are package constants / fixed library clause, not user input
@@ -1352,8 +1356,9 @@ func (q *DBQueue) CountInstrumentalNarrowed(ctx context.Context, currentVersion 
 // priority=-100 (dequeue-eligible but strictly behind priority>=0 foreground work -
 // the queue-level starvation guard), with instrumental_result, outcome_type,
 // completed_at and all five telemetry columns cleared to NULL, last_error cleared,
-// and next_attempt_at = now. Guarded by instrumental_result = 1, so it is a no-op
-// on any other row. Linked scan_results rows are reset to 'pending'. Returns the
+// and next_attempt_at = now. Guarded by instrumental_result = 1 AND status = 'done'
+// (a still-'processing' row mid-write is left alone), so it is a no-op on any other
+// row. Linked scan_results rows are reset to 'pending'. Returns the
 // number of work_queue rows affected (0 or 1).
 func (q *DBQueue) ResetInstrumental(ctx context.Context, id int64) (int64, error) {
 	now := formatTime(q.now())
@@ -1377,7 +1382,7 @@ func (q *DBQueue) ResetInstrumental(ctx context.Context, id int64) (int64, error
              detector_version = NULL,
              last_error = '',
              next_attempt_at = ?
-         WHERE id = ? AND instrumental_result = 1`,
+         WHERE id = ? AND instrumental_result = 1 AND status = 'done'`,
 		now, id,
 	)
 	if err != nil {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1098,15 +1098,49 @@ func (q *DBQueue) SetProviderLane(ctx context.Context, id int64, lane string) er
 	return nil
 }
 
-// SetInstrumentalResult stamps the audio-detection outcome onto a work_queue row.
-// result=1 means the audio detector confirmed instrumental; result=0 means the
-// detector ran but the track is not instrumental. Call before Complete so the row
-// is still in 'processing' status (the UPDATE is a no-op on any other status,
-// which is benign).
-func (q *DBQueue) SetInstrumentalResult(ctx context.Context, id int64, result int) error {
+// InstrumentalTelemetry carries the five score fields from an audio detection
+// run. All fields are set when detection ran; the zero value (empty struct) is
+// used on the not-ran path, keeping the five DB columns NULL (pre-telemetry /
+// detection-disabled semantics are preserved by the caller passing no telemetry
+// struct in that case).
+type InstrumentalTelemetry struct {
+	// MusicSum is the summed instrumental-class MEAN probability (music gate score).
+	MusicSum float64
+	// VocalPeak is the peak (max-over-frames) of the winning vocal class (sung-vocal gate score).
+	VocalPeak float64
+	// SpeechMean is the summed frame-MEAN of speech classes (speech gate score).
+	SpeechMean float64
+	// VocalClass is the name of the vocal class that produced VocalPeak. Empty
+	// when no vocal class scored or when the sidecar returned no max map.
+	VocalClass string
+	// DetectorVersion is the app version string at detection time (internal/version.Version).
+	DetectorVersion string
+}
+
+// SetInstrumentalResult stamps the audio-detection outcome and telemetry onto a
+// work_queue row in a single UPDATE. result=1 means the audio detector confirmed
+// instrumental; result=0 means the detector ran but the track is not instrumental.
+// The five telemetry fields are written atomically with instrumental_result so
+// each persisted row records the scores that produced the decision. Call before
+// Complete while the row is still in 'processing' status (the UPDATE is a no-op
+// on any other status, which is benign).
+func (q *DBQueue) SetInstrumentalResult(ctx context.Context, id int64, result int, tel InstrumentalTelemetry) error {
 	_, err := q.db.ExecContext(ctx,
-		`UPDATE work_queue SET instrumental_result = ? WHERE id = ?`,
-		result, id,
+		`UPDATE work_queue
+         SET instrumental_result = ?,
+             music_sum = ?,
+             vocal_peak = ?,
+             speech_mean = ?,
+             vocal_class = ?,
+             detector_version = ?
+         WHERE id = ?`,
+		result,
+		tel.MusicSum,
+		tel.VocalPeak,
+		tel.SpeechMean,
+		tel.VocalClass,
+		tel.DetectorVersion,
+		id,
 	)
 	if err != nil {
 		return fmt.Errorf("queue: set instrumental result for id %d: %w", id, err)
@@ -1190,6 +1224,189 @@ func (q *DBQueue) CountInstrumental(ctx context.Context) (int64, error) {
 		`SELECT COUNT(*) FROM work_queue WHERE instrumental_result = 1`,
 	).Scan(&n); err != nil {
 		return 0, fmt.Errorf("queue: count instrumental: %w", err)
+	}
+	return n, nil
+}
+
+// Borderline bands for the reconcile telemetry prefilter. A row whose vocal_peak
+// sits just above the default vocal gate (detector defaultVocalMaxConfidence =
+// 0.03) or whose speech_mean sits just below the default speech gate
+// (defaultSpeechMaxConfidence = 0.20) is "borderline": small score drift could
+// flip the verdict, so it is worth re-inferring. Bounds are constants so they can
+// be tuned in one place; reconcile always re-infers the narrowed set to confirm a
+// disagreement before clearing anything.
+const (
+	reconcileVocalBorderlineLo  = 0.03
+	reconcileVocalBorderlineHi  = 0.05
+	reconcileSpeechBorderlineLo = 0.15
+	reconcileSpeechBorderlineHi = 0.20
+)
+
+// instrumentalNarrowedPredicate builds the telemetry-narrowed candidate filter
+// appended after "instrumental_result = 1". A flagged row is a reconcile candidate
+// when it is borderline (vocal_peak or speech_mean in band), cross-version
+// (detector_version differs from currentVersion), or un-scored (any telemetry
+// column NULL, e.g. a pre-#404 marker written before the telemetry columns
+// existed). currentVersion is the value #404 stamps into detector_version
+// (internal/version.Version). The returned clause uses only literal SQL and
+// placeholders, so it is safe to concatenate.
+func instrumentalNarrowedPredicate(currentVersion string) (clause string, args []any) {
+	clause = ` AND (
+            (vocal_peak BETWEEN ? AND ?)
+            OR (speech_mean BETWEEN ? AND ?)
+            OR detector_version IS NULL OR detector_version <> ?
+            OR music_sum IS NULL OR vocal_peak IS NULL OR speech_mean IS NULL OR vocal_class IS NULL
+        )`
+	args = []any{
+		reconcileVocalBorderlineLo, reconcileVocalBorderlineHi,
+		reconcileSpeechBorderlineLo, reconcileSpeechBorderlineHi,
+		currentVersion,
+	}
+	return clause, args
+}
+
+// ListInstrumentalOptions controls ListInstrumental and CountInstrumentalNarrowed.
+type ListInstrumentalOptions struct {
+	// LibraryID, when non-nil, scopes results to rows linked to that library via
+	// the work_queue_scan_results junction.
+	LibraryID *int64
+	// Limit caps the number of returned rows when > 0.
+	Limit int
+	// All returns the entire instrumental_result = 1 population, bypassing the
+	// telemetry-narrowed prefilter. CurrentVersion is then irrelevant.
+	All bool
+	// CurrentVersion is the detector version (internal/version.Version) the
+	// cross-version prefilter compares stored detector_version against. Required
+	// when All is false.
+	CurrentVersion string
+}
+
+// ListInstrumental returns work_queue rows flagged instrumental
+// (instrumental_result = 1), hydrated with full Inputs (SourcePath and
+// OutputPaths) so reconcile can locate audio sources and their sidecars. By
+// default only the telemetry-narrowed candidate set is returned (borderline /
+// cross-version / un-scored rows); set opts.All for the full flagged population.
+// Read-only.
+func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOptions) (items []WorkItem, retErr error) {
+	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       FROM work_queue WHERE instrumental_result = 1`
+	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
+	query := baseQuery
+	var args []any
+	if !opts.All {
+		clause, predArgs := instrumentalNarrowedPredicate(opts.CurrentVersion)
+		query += clause
+		args = append(args, predArgs...)
+	}
+	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
+	query += libClause
+	args = append(args, libArgs...)
+	query += orderClause
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: all concatenated fragments are package constants / recheckLibraryClause's fixed clause; never user-built SQL
+	if err != nil {
+		return nil, fmt.Errorf("queue: list instrumental: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close list instrumental rows: %w", err)
+		}
+	}()
+	for rows.Next() {
+		item, err := scanWorkItem(rows)
+		if err != nil {
+			return nil, fmt.Errorf("queue: list instrumental scan: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list instrumental rows: %w", err)
+	}
+	return items, nil
+}
+
+// CountInstrumentalNarrowed returns how many instrumental_result = 1 rows the
+// telemetry-narrowed prefilter would select (the same predicate ListInstrumental
+// applies when opts.All is false), so reconcile can report prefiltered-vs-total
+// scope without materializing rows.
+func (q *DBQueue) CountInstrumentalNarrowed(ctx context.Context, currentVersion string, libraryID *int64) (int64, error) {
+	clause, args := instrumentalNarrowedPredicate(currentVersion)
+	libClause, libArgs := recheckLibraryClause(libraryID)
+	query := `SELECT COUNT(*) FROM work_queue WHERE instrumental_result = 1` + clause + libClause
+	allArgs := append(args, libArgs...)
+	var n int64
+	if err := q.db.QueryRowContext(ctx, query, allArgs...).Scan(&n); err != nil { //nolint:gosec // G202: fragments are package constants / fixed library clause, not user input
+		return 0, fmt.Errorf("queue: count instrumental narrowed: %w", err)
+	}
+	return n, nil
+}
+
+// ResetInstrumental clears an instrumental verdict and its telemetry and re-queues
+// the row so the running scheduler re-fetches it behind foreground work. Modeled on
+// RecheckRetired: in one transaction the row is set to status='deferred',
+// priority=-100 (dequeue-eligible but strictly behind priority>=0 foreground work -
+// the queue-level starvation guard), with instrumental_result, outcome_type,
+// completed_at and all five telemetry columns cleared to NULL, last_error cleared,
+// and next_attempt_at = now. Guarded by instrumental_result = 1, so it is a no-op
+// on any other row. Linked scan_results rows are reset to 'pending'. Returns the
+// number of work_queue rows affected (0 or 1).
+func (q *DBQueue) ResetInstrumental(ctx context.Context, id int64) (int64, error) {
+	now := formatTime(q.now())
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("queue: begin reset instrumental tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE work_queue
+         SET status = 'deferred',
+             priority = -100,
+             instrumental_result = NULL,
+             outcome_type = NULL,
+             completed_at = NULL,
+             music_sum = NULL,
+             vocal_peak = NULL,
+             speech_mean = NULL,
+             vocal_class = NULL,
+             detector_version = NULL,
+             last_error = '',
+             next_attempt_at = ?
+         WHERE id = ? AND instrumental_result = 1`,
+		now, id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("queue: reset instrumental update: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("queue: reset instrumental rows affected: %w", err)
+	}
+	if n == 0 {
+		// No-op (row absent or not instrumental): nothing to write back.
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("queue: commit reset instrumental tx: %w", err)
+		}
+		return 0, nil
+	}
+	// Reset linked scan_results back to 'pending' so `scan results` reflects the
+	// re-queued state, mirroring Retry / RecheckRetired.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+             SET status = 'pending'
+             WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+               AND status = 'done'`,
+		id,
+	); err != nil {
+		return 0, fmt.Errorf("queue: reset instrumental scan_results writeback: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("queue: commit reset instrumental tx: %w", err)
 	}
 	return n, nil
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3400,6 +3400,10 @@ func TestDBQueue_ListInstrumentalNarrowedAndAll(t *testing.T) {
 				t.Fatalf("SetInstrumentalResult %s: %v", artist, err)
 			}
 		}
+		// ListInstrumental only returns completed rows; mark done after stamping.
+		if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET status = 'done', completed_at = ? WHERE id = ?`, "2026-06-25T00:00:00Z", it.ID); err != nil {
+			t.Fatalf("mark done %s: %v", artist, err)
+		}
 		return it.ID
 	}
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3082,10 +3082,10 @@ func TestDBQueue_SetInstrumentalResultAndCount(t *testing.T) {
 	}
 
 	// Stamp item1 as instrumental (result=1), item2 as not (result=0).
-	if err := q.SetInstrumentalResult(ctx, item1.ID, 1); err != nil {
+	if err := q.SetInstrumentalResult(ctx, item1.ID, 1, InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, SpeechMean: 0.005, VocalClass: "Singing", DetectorVersion: "v1.0.0"}); err != nil {
 		t.Fatalf("SetInstrumentalResult item1: %v", err)
 	}
-	if err := q.SetInstrumentalResult(ctx, item2.ID, 0); err != nil {
+	if err := q.SetInstrumentalResult(ctx, item2.ID, 0, InstrumentalTelemetry{MusicSum: 0.92, VocalPeak: 0.08, SpeechMean: 0.003, VocalClass: "Singing", DetectorVersion: "v1.0.0"}); err != nil {
 		t.Fatalf("SetInstrumentalResult item2: %v", err)
 	}
 	// item3: leave NULL (detection not run).
@@ -3097,6 +3097,124 @@ func TestDBQueue_SetInstrumentalResultAndCount(t *testing.T) {
 	}
 	if n != 1 {
 		t.Errorf("count = %d; want 1 (only item1 is instrumental)", n)
+	}
+}
+
+// TestDBQueue_SetInstrumentalResultPersistsTelemetry verifies that all five
+// telemetry columns (music_sum, vocal_peak, speech_mean, vocal_class,
+// detector_version) are written atomically with instrumental_result in a single
+// UPDATE and are readable back from the DB.
+func TestDBQueue_SetInstrumentalResultPersistsTelemetry(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Composer", TrackName: "Nocturne"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	tel := InstrumentalTelemetry{
+		MusicSum:        0.947,
+		VocalPeak:       0.012,
+		SpeechMean:      0.003,
+		VocalClass:      "Singing",
+		DetectorVersion: "v2.5.0",
+	}
+	if err := q.SetInstrumentalResult(ctx, item.ID, 1, tel); err != nil {
+		t.Fatalf("SetInstrumentalResult: %v", err)
+	}
+
+	// Read back all six stamped columns directly from the DB.
+	var (
+		instrumentalResult                          int
+		musicSum, vocalPeak, speechMean             float64
+		vocalClass, detectorVersion                 sql.NullString
+		musicSumNull, vocalPeakNull, speechMeanNull sql.NullFloat64
+	)
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
+         FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&instrumentalResult, &musicSumNull, &vocalPeakNull, &speechMeanNull, &vocalClass, &detectorVersion); err != nil {
+		t.Fatalf("read telemetry: %v", err)
+	}
+	musicSum = musicSumNull.Float64
+	vocalPeak = vocalPeakNull.Float64
+	speechMean = speechMeanNull.Float64
+
+	if instrumentalResult != 1 {
+		t.Errorf("instrumental_result = %d; want 1", instrumentalResult)
+	}
+	if musicSum != tel.MusicSum {
+		t.Errorf("music_sum = %v; want %v", musicSum, tel.MusicSum)
+	}
+	if vocalPeak != tel.VocalPeak {
+		t.Errorf("vocal_peak = %v; want %v", vocalPeak, tel.VocalPeak)
+	}
+	if speechMean != tel.SpeechMean {
+		t.Errorf("speech_mean = %v; want %v", speechMean, tel.SpeechMean)
+	}
+	if !vocalClass.Valid || vocalClass.String != tel.VocalClass {
+		t.Errorf("vocal_class = %v; want %q", vocalClass, tel.VocalClass)
+	}
+	if !detectorVersion.Valid || detectorVersion.String != tel.DetectorVersion {
+		t.Errorf("detector_version = %v; want %q", detectorVersion, tel.DetectorVersion)
+	}
+}
+
+// TestDBQueue_SetInstrumentalResultNullTelemetryWhenNotRun verifies that when
+// SetInstrumentalResult is NOT called (detection did not run), all five telemetry
+// columns stay NULL - the NULL semantics documented in the migration.
+func TestDBQueue_SetInstrumentalResultNullTelemetryWhenNotRun(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Composer", TrackName: "Opus"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	// Intentionally do NOT call SetInstrumentalResult; columns must remain NULL.
+	var (
+		musicSum        sql.NullFloat64
+		vocalPeak       sql.NullFloat64
+		speechMean      sql.NullFloat64
+		vocalClass      sql.NullString
+		detectorVersion sql.NullString
+		instrumentalRes sql.NullInt64
+	)
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
+         FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&instrumentalRes, &musicSum, &vocalPeak, &speechMean, &vocalClass, &detectorVersion); err != nil {
+		t.Fatalf("read telemetry: %v", err)
+	}
+	if instrumentalRes.Valid {
+		t.Errorf("instrumental_result = %d; want NULL when detection not run", instrumentalRes.Int64)
+	}
+	if musicSum.Valid {
+		t.Errorf("music_sum = %v; want NULL", musicSum.Float64)
+	}
+	if vocalPeak.Valid {
+		t.Errorf("vocal_peak = %v; want NULL", vocalPeak.Float64)
+	}
+	if speechMean.Valid {
+		t.Errorf("speech_mean = %v; want NULL", speechMean.Float64)
+	}
+	if vocalClass.Valid {
+		t.Errorf("vocal_class = %q; want NULL", vocalClass.String)
+	}
+	if detectorVersion.Valid {
+		t.Errorf("detector_version = %q; want NULL", detectorVersion.String)
 	}
 }
 
@@ -3231,7 +3349,7 @@ func TestDBQueue_ProviderMethodsClosedDB(t *testing.T) {
 	if err := q.SetProviderLane(ctx, 1, "musixmatch"); err == nil {
 		t.Fatal("SetProviderLane on closed db: want error, got nil")
 	}
-	if err := q.SetInstrumentalResult(ctx, 1, 1); err == nil {
+	if err := q.SetInstrumentalResult(ctx, 1, 1, InstrumentalTelemetry{}); err == nil {
 		t.Fatal("SetInstrumentalResult on closed db: want error, got nil")
 	}
 	if _, err := q.ProviderHits(ctx); err == nil {
@@ -3242,5 +3360,203 @@ func TestDBQueue_ProviderMethodsClosedDB(t *testing.T) {
 	}
 	if _, err := q.CountInstrumental(ctx); err == nil {
 		t.Fatal("CountInstrumental on closed db: want error, got nil")
+	}
+	if _, err := q.ListInstrumental(ctx, ListInstrumentalOptions{CurrentVersion: "v"}); err == nil {
+		t.Fatal("ListInstrumental on closed db: want error, got nil")
+	}
+	if _, err := q.CountInstrumentalNarrowed(ctx, "v", nil); err == nil {
+		t.Fatal("CountInstrumentalNarrowed on closed db: want error, got nil")
+	}
+	if _, err := q.ResetInstrumental(ctx, 1); err == nil {
+		t.Fatal("ResetInstrumental on closed db: want error, got nil")
+	}
+}
+
+// TestDBQueue_ListInstrumentalNarrowedAndAll covers the reconcile candidate query
+// (#405): the telemetry-narrowed default selects only borderline / cross-version /
+// un-scored rows, opts.All returns the whole flagged population, both hydrate full
+// Inputs, and CountInstrumentalNarrowed matches the narrowed set.
+func TestDBQueue_ListInstrumentalNarrowedAndAll(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC) }
+	const current = "v2.0.0"
+
+	mk := func(artist string, result int, tel InstrumentalTelemetry, stamp bool) int64 {
+		t.Helper()
+		if _, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: artist, TrackName: "T"},
+			SourcePath: "/music/" + artist + ".flac",
+		}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %s: %v", artist, err)
+		}
+		it, err := q.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("Dequeue %s: %v", artist, err)
+		}
+		if stamp {
+			if err := q.SetInstrumentalResult(ctx, it.ID, result, tel); err != nil {
+				t.Fatalf("SetInstrumentalResult %s: %v", artist, err)
+			}
+		}
+		return it.ID
+	}
+
+	// Confidently instrumental, in-version, non-NULL telemetry: NOT a candidate.
+	confident := mk("Confident", 1, InstrumentalTelemetry{MusicSum: 0.99, VocalPeak: 0.005, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: current}, true)
+	// Borderline vocal_peak (0.04 in 0.03-0.05): candidate.
+	borderVocal := mk("BorderVocal", 1, InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.04, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: current}, true)
+	// Borderline speech_mean (0.18 in 0.15-0.20): candidate.
+	borderSpeech := mk("BorderSpeech", 1, InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.005, SpeechMean: 0.18, VocalClass: "Singing", DetectorVersion: current}, true)
+	// Cross-version (stored != current) despite confident scores: candidate.
+	crossVer := mk("CrossVer", 1, InstrumentalTelemetry{MusicSum: 0.99, VocalPeak: 0.005, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: "v1.0.0"}, true)
+	// Un-scored pre-#404 row (NULL telemetry): candidate. Stamp result=1 directly.
+	preTel := mk("PreTel", 0, InstrumentalTelemetry{}, false)
+	if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET instrumental_result = 1 WHERE id = ?`, preTel); err != nil {
+		t.Fatalf("set pre-telemetry instrumental: %v", err)
+	}
+	// Not instrumental (result=0): never a candidate.
+	_ = mk("NotInst", 0, InstrumentalTelemetry{MusicSum: 0.9, VocalPeak: 0.6, SpeechMean: 0.01, VocalClass: "Singing", DetectorVersion: current}, true)
+
+	// All mode: every instrumental_result = 1 row, with hydrated SourcePath.
+	all, err := q.ListInstrumental(ctx, ListInstrumentalOptions{All: true})
+	if err != nil {
+		t.Fatalf("ListInstrumental all: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("All mode len = %d; want 5", len(all))
+	}
+	for _, it := range all {
+		if it.Inputs.SourcePath == "" {
+			t.Errorf("row %d missing hydrated SourcePath", it.ID)
+		}
+	}
+
+	// Narrowed mode: the four candidates, excluding the confident in-version row.
+	narrowed, err := q.ListInstrumental(ctx, ListInstrumentalOptions{CurrentVersion: current})
+	if err != nil {
+		t.Fatalf("ListInstrumental narrowed: %v", err)
+	}
+	got := map[int64]bool{}
+	for _, it := range narrowed {
+		got[it.ID] = true
+	}
+	for _, id := range []int64{borderVocal, borderSpeech, crossVer, preTel} {
+		if !got[id] {
+			t.Errorf("narrowed set missing candidate id %d", id)
+		}
+	}
+	if got[confident] {
+		t.Errorf("narrowed set must exclude the confident in-version row %d", confident)
+	}
+	if len(narrowed) != 4 {
+		t.Errorf("narrowed len = %d; want 4", len(narrowed))
+	}
+
+	cn, err := q.CountInstrumentalNarrowed(ctx, current, nil)
+	if err != nil {
+		t.Fatalf("CountInstrumentalNarrowed: %v", err)
+	}
+	if cn != 4 {
+		t.Errorf("CountInstrumentalNarrowed = %d; want 4", cn)
+	}
+	ct, err := q.CountInstrumental(ctx)
+	if err != nil {
+		t.Fatalf("CountInstrumental: %v", err)
+	}
+	if ct != 5 {
+		t.Errorf("CountInstrumental = %d; want 5", ct)
+	}
+}
+
+// TestDBQueue_ResetInstrumental covers the reconcile reset (#405): a flagged row is
+// re-queued as deferred/-100 with verdict + all five telemetry columns nulled and
+// last_error cleared; it is a no-op on a non-instrumental row.
+func TestDBQueue_ResetInstrumental(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC) }
+
+	// A confirmed-instrumental, completed row.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "Inst"}, SourcePath: "/m/a.flac"}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue inst: %v", err)
+	}
+	inst, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue inst: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, inst.ID, 1, InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.004, VocalClass: "Singing", DetectorVersion: "v1"}); err != nil {
+		t.Fatalf("SetInstrumentalResult inst: %v", err)
+	}
+	if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET status = 'done', completed_at = ? WHERE id = ?`, "2026-06-25T00:00:00Z", inst.ID); err != nil {
+		t.Fatalf("mark done: %v", err)
+	}
+
+	// A ran-but-not-instrumental row (result=0): reset must be a no-op.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "B", TrackName: "NotInst"}, SourcePath: "/m/b.flac"}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue noti: %v", err)
+	}
+	noti, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue noti: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, noti.ID, 0, InstrumentalTelemetry{MusicSum: 0.9, VocalPeak: 0.6, SpeechMean: 0.01, VocalClass: "Singing", DetectorVersion: "v1"}); err != nil {
+		t.Fatalf("SetInstrumentalResult noti: %v", err)
+	}
+
+	n, err := q.ResetInstrumental(ctx, inst.ID)
+	if err != nil {
+		t.Fatalf("ResetInstrumental: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rows affected = %d; want 1", n)
+	}
+
+	var (
+		status, lastErr           string
+		priority                  int
+		instResult                sql.NullInt64
+		outcome, vocalClass, dVer sql.NullString
+		completedAt               sql.NullString
+		musicSum, vocalPeak, sm   sql.NullFloat64
+	)
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, priority, instrumental_result, outcome_type, completed_at,
+                music_sum, vocal_peak, speech_mean, vocal_class, detector_version, last_error
+         FROM work_queue WHERE id = ?`, inst.ID,
+	).Scan(&status, &priority, &instResult, &outcome, &completedAt, &musicSum, &vocalPeak, &sm, &vocalClass, &dVer, &lastErr); err != nil {
+		t.Fatalf("read reset row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred", status)
+	}
+	if priority != -100 {
+		t.Errorf("priority = %d; want -100", priority)
+	}
+	if instResult.Valid {
+		t.Errorf("instrumental_result not NULL after reset: %v", instResult)
+	}
+	if outcome.Valid {
+		t.Errorf("outcome_type not NULL after reset")
+	}
+	if completedAt.Valid {
+		t.Errorf("completed_at not NULL after reset")
+	}
+	if musicSum.Valid || vocalPeak.Valid || sm.Valid || vocalClass.Valid || dVer.Valid {
+		t.Errorf("telemetry not all NULL after reset: ms=%v vp=%v sm=%v vc=%v dv=%v", musicSum, vocalPeak, sm, vocalClass, dVer)
+	}
+	if lastErr != "" {
+		t.Errorf("last_error = %q; want empty", lastErr)
+	}
+
+	// No-op on the result=0 row.
+	n0, err := q.ResetInstrumental(ctx, noti.ID)
+	if err != nil {
+		t.Fatalf("ResetInstrumental noti: %v", err)
+	}
+	if n0 != 0 {
+		t.Errorf("reset of result=0 row affected %d; want 0", n0)
 	}
 }

--- a/internal/worker/detect_instrumental_test.go
+++ b/internal/worker/detect_instrumental_test.go
@@ -96,12 +96,15 @@ func TestDetectInstrumental_WantedButNoClassifierLoudSkips(t *testing.T) {
 
 	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
 	// no EnableAudioDetector: classifier unconfigured
-	instrumental, err := w.detectInstrumental(context.Background(), detectItem(303, boolPtr(true)))
+	res, ran, err := w.detectInstrumental(context.Background(), detectItem(303, boolPtr(true)))
 	if err != nil {
 		t.Fatalf("detectInstrumental err = %v; want nil (non-fatal loud-skip)", err)
 	}
-	if instrumental {
+	if res.Instrumental {
 		t.Error("instrumental = true; want false when no classifier configured")
+	}
+	if ran {
+		t.Error("ran = true; want false when no classifier configured (loud-skip path)")
 	}
 	logged := buf.String()
 	if !strings.Contains(logged, "level=ERROR") || !strings.Contains(logged, "no classifier") {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -689,21 +689,6 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			}
 			if detResult.Instrumental {
 				slog.Info("worker audio detector: instrumental track confirmed; writing marker", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "kind", "instrumental")
-				// Stamp the audio-detection result (1 = instrumental) and telemetry on
-				// the queue row before Complete so the /metrics gauge reflects the
-				// outcome durably and the scores are queryable without re-running
-				// inference. Errors are non-fatal: a failed stamp is not worth aborting
-				// the write.
-				tel := queue.InstrumentalTelemetry{
-					MusicSum:        detResult.Confidence,
-					VocalPeak:       detResult.VocalConfidence,
-					SpeechMean:      detResult.SpeechConfidence,
-					VocalClass:      detResult.WinningVocalClass,
-					DetectorVersion: detResult.Version,
-				}
-				if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 1, tel); stampErr != nil {
-					slog.Warn("worker instrumental detection: stamp result failed; continuing", "id", item.ID, "error", stampErr)
-				}
 				instrumentalSong := models.Song{
 					Track: models.Track{
 						ArtistName:   resolvedTrack.ArtistName,
@@ -732,10 +717,24 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 					}
 				}
 				ctxNoCancel := context.WithoutCancel(ctx)
+				// Stamp instrumental_result=1 + telemetry only AFTER the marker write
+				// succeeded (a failed WriteLRC above requeues and returns before here),
+				// so a transient write error never leaves a row tagged instrumental with
+				// stale telemetry. Still before Complete, so /metrics reflects it durably.
+				// Non-fatal: a failed stamp is not worth aborting the completed write.
+				tel := queue.InstrumentalTelemetry{
+					MusicSum:        detResult.Confidence,
+					VocalPeak:       detResult.VocalConfidence,
+					SpeechMean:      detResult.SpeechConfidence,
+					VocalClass:      detResult.WinningVocalClass,
+					DetectorVersion: detResult.Version,
+				}
+				if stampErr := w.queue.SetInstrumentalResult(ctxNoCancel, item.ID, 1, tel); stampErr != nil {
+					slog.Warn("worker instrumental detection: stamp result failed; continuing", "id", item.ID, "error", stampErr)
+				}
 				// Record the written outcome before Complete so reports count this
 				// (and every other instrumental source) as instrumental, not just
-				// rows with instrumental_result=1 (#379). Non-fatal, like the
-				// instrumental_result stamp above.
+				// rows with instrumental_result=1 (#379). Non-fatal, like the stamp above.
 				if stampErr := w.queue.SetOutcomeType(ctxNoCancel, item.ID, "instrumental"); stampErr != nil {
 					slog.Warn("worker instrumental detection: stamp outcome type failed; continuing", "id", item.ID, "error", stampErr)
 				}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -36,10 +36,12 @@ type Queue interface {
 	// marking the track as terminal. The scan layer will show the track as done
 	// (not pending) so it is not mistaken for an in-flight item.
 	RetireMiss(ctx context.Context, id int64) (queue.WorkItem, error)
-	// SetInstrumentalResult stamps the audio-detection outcome onto a work_queue
-	// row. result=1 means instrumental confirmed; result=0 means not instrumental.
-	// Call before Complete while the row is still in processing status.
-	SetInstrumentalResult(ctx context.Context, id int64, result int) error
+	// SetInstrumentalResult stamps the audio-detection outcome and telemetry onto
+	// a work_queue row. result=1 means instrumental confirmed; result=0 means not
+	// instrumental. tel carries the five score fields written atomically with
+	// instrumental_result. Call before Complete while the row is still in
+	// processing status.
+	SetInstrumentalResult(ctx context.Context, id int64, result int, tel queue.InstrumentalTelemetry) error
 	// SetOutcomeType records what was actually written for a completed row
 	// ("synced" | "unsynced" | "instrumental"), so reports classify by the real
 	// outcome instead of the enqueue-time output_paths filename, which is always
@@ -681,16 +683,25 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// misses (no lyrics and not already flagged instrumental). Errors are
 			// non-fatal: starvation of the detector sidecar is acceptable; the miss
 			// path continues unchanged when the detector is absent or fails.
-			instrumental, detErr := w.detectInstrumental(ctx, item)
+			detResult, detRan, detErr := w.detectInstrumental(ctx, item)
 			if detErr != nil {
 				slog.Warn("worker instrumental detection failed; treating as miss", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "error", detErr)
 			}
-			if instrumental {
+			if detResult.Instrumental {
 				slog.Info("worker audio detector: instrumental track confirmed; writing marker", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "kind", "instrumental")
-				// Stamp the audio-detection result (1 = instrumental) on the queue row
-				// before Complete so the /metrics gauge reflects the outcome durably.
-				// Errors are non-fatal: a failed stamp is not worth aborting the write.
-				if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 1); stampErr != nil {
+				// Stamp the audio-detection result (1 = instrumental) and telemetry on
+				// the queue row before Complete so the /metrics gauge reflects the
+				// outcome durably and the scores are queryable without re-running
+				// inference. Errors are non-fatal: a failed stamp is not worth aborting
+				// the write.
+				tel := queue.InstrumentalTelemetry{
+					MusicSum:        detResult.Confidence,
+					VocalPeak:       detResult.VocalConfidence,
+					SpeechMean:      detResult.SpeechConfidence,
+					VocalClass:      detResult.WinningVocalClass,
+					DetectorVersion: detResult.Version,
+				}
+				if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 1, tel); stampErr != nil {
 					slog.Warn("worker instrumental detection: stamp result failed; continuing", "id", item.ID, "error", stampErr)
 				}
 				instrumentalSong := models.Song{
@@ -739,17 +750,21 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 				w.consecutiveFailures = 0
 				return nil
 			}
-			// Detection ran but the track is not instrumental: stamp result=0 so the
-			// row is distinguishable from "never detected" (NULL).
-			if detErr == nil {
-				detect := w.detectInstrumentalDefault
-				if item.DetectInstrumental != nil {
-					detect = *item.DetectInstrumental
+			// Detection ran but the track is not instrumental: stamp result=0 and
+			// the telemetry so the row is distinguishable from "never detected"
+			// (NULL) and the borderline scores are queryable. Only stamp when
+			// detection actually ran (detRan=true); a disabled/no-source/no-detector
+			// path leaves the columns NULL.
+			if detErr == nil && detRan {
+				tel := queue.InstrumentalTelemetry{
+					MusicSum:        detResult.Confidence,
+					VocalPeak:       detResult.VocalConfidence,
+					SpeechMean:      detResult.SpeechConfidence,
+					VocalClass:      detResult.WinningVocalClass,
+					DetectorVersion: detResult.Version,
 				}
-				if detect && w.audioDetector != nil && strings.TrimSpace(item.Inputs.SourcePath) != "" {
-					if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 0); stampErr != nil {
-						slog.Warn("worker instrumental detection: stamp non-instrumental result failed; continuing", "id", item.ID, "error", stampErr)
-					}
+				if stampErr := w.queue.SetInstrumentalResult(context.WithoutCancel(ctx), item.ID, 0, tel); stampErr != nil {
+					slog.Warn("worker instrumental detection: stamp non-instrumental result failed; continuing", "id", item.ID, "error", stampErr)
 				}
 			}
 			if derr := w.requeueDeferred(ctx, item, err); derr != nil {
@@ -865,32 +880,37 @@ func (w *Worker) verify(ctx context.Context, item queue.WorkItem, song models.So
 // detectInstrumental invokes the audio detector on the item's source path when
 // instrumental detection is enabled for this item. The decision is resolved from
 // the per-item stamp (item.DetectInstrumental) falling back to the global default
-// when nil (NULL rows). It returns (false, nil) when detection is off for the
-// item or the source path is absent. When an item requests detection but no
-// classifier is configured, it logs an error and proceeds without detection
-// (loud-skip, never a silent no-op). Any detector error is returned non-fatally:
-// the caller logs a warning and falls through to normal miss handling.
-func (w *Worker) detectInstrumental(ctx context.Context, item queue.WorkItem) (bool, error) {
+// when nil (NULL rows). It returns (Result{}, false, nil) when detection is off
+// for the item or the source path is absent - the false "ran" flag tells the
+// caller not to stamp telemetry (keeping the five telemetry columns NULL, which
+// preserves the pre-telemetry / detection-disabled semantics). When an item
+// requests detection but no classifier is configured, it logs an error and
+// proceeds without detection (loud-skip, never a silent no-op). Any detector
+// error is returned non-fatally: the caller logs a warning and falls through to
+// normal miss handling. The returned Result carries the full telemetry (scores +
+// winning class + version) on success; it is zero-valued when ran=false or on
+// error.
+func (w *Worker) detectInstrumental(ctx context.Context, item queue.WorkItem) (detector.Result, bool, error) {
 	detect := w.detectInstrumentalDefault
 	if item.DetectInstrumental != nil {
 		detect = *item.DetectInstrumental
 	}
 	if !detect {
-		return false, nil
+		return detector.Result{}, false, nil
 	}
 	if w.audioDetector == nil {
 		slog.Error("instrumental detection requested for item but no classifier is configured; skipping detection",
 			"id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName)
-		return false, nil
+		return detector.Result{}, false, nil
 	}
 	if strings.TrimSpace(item.Inputs.SourcePath) == "" {
-		return false, nil
+		return detector.Result{}, false, nil
 	}
 	res, err := w.audioDetector.Detect(ctx, item.Inputs.SourcePath)
 	if err != nil {
-		return false, err
+		return detector.Result{}, false, err
 	}
-	return res.Instrumental, nil
+	return res, true, nil
 }
 
 // song looks up or fetches lyrics for track. The caller is responsible for

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -174,7 +174,7 @@ func (q *fakeQueue) RetireMiss(_ context.Context, id int64) (queue.WorkItem, err
 	return queue.WorkItem{ID: id, Status: queue.StatusDone}, nil
 }
 
-func (q *fakeQueue) SetInstrumentalResult(_ context.Context, _ int64, _ int) error {
+func (q *fakeQueue) SetInstrumentalResult(_ context.Context, _ int64, _ int, _ queue.InstrumentalTelemetry) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Two batched, dependent features for instrumental detection (#404 lands the telemetry foundation; #405 consumes it).

- **#404 — decision telemetry on `work_queue`.** Migration 025 adds five nullable columns (`music_sum`, `vocal_peak`, `speech_mean`, `vocal_class`, `detector_version`), written atomically with `instrumental_result` via a new `InstrumentalTelemetry` struct. `detector.Result` gains `WinningVocalClass` + `Version` (the app version from `internal/version`). `NULL` means detection did not run. Turns borderline review and model-drift detection into a query instead of a ~40-minute re-inference pass.
- **#405 — `scan reconcile`.** Re-runs the detector over instrumental-tagged tracks and clears stale markers. Dry-run by default (`--yes` applies); by default it consumes #404's telemetry to re-infer only borderline / cross-version / un-scored candidates (`--all` forces the full set). Exact-marker-only `.txt` deletion guards real unsynced lyrics; every cleared row is JSONL-backed-up before mutation; re-queued rows are `deferred` at `priority = -100` so a bulk run stays behind foreground work. `--library` / `--limit` scope a run.

Adds queue primitives `ListInstrumental` / `CountInstrumentalNarrowed` / `ResetInstrumental` and extracts the shared `lyrics.SidecarName` helper so reconcile's sidecar paths match the writer exactly.

## Linked issues
Closes #404
Closes #405

## Verification
- [x] `make gate` green locally (race tests, per-package coverage floor, golangci-lint, actionlint, govulncheck)
- [x] Codecov patch coverage 73% (> 70% threshold)
- [x] New tests: detector (winning class / version / log line), queue (list narrowed+all / reset / counts), worker (telemetry writeback + NULL-when-not-run), lyrics (SidecarName via existing writer tests), and an end-to-end `scan reconcile` test (dry-run + `--yes` delete/reset/backup) plus error/skip-path tests
- [ ] Manual UAT on a live library (maintainer)

## Notes
- Backward-compatible: nullable columns, additive `Result`/`Config` fields, a new subcommand. No breaking changes.
- Version: feature/minor bump warranted (suggested `v1.11.0`); version is ldflags-injected at release, so nothing to bump in-repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `scan reconcile` command to review and repair stale instrumental markers, with dry-run, apply, and full-scan options.
  * Instrumental decisions now retain additional telemetry, including vocal class and detector version, for better review and auditing.
  * Sidecar filename generation is now more consistent and safer across synced and unsynced lyrics files.

* **Bug Fixes**
  * Improved cleanup so only exact instrumental marker files are removed during reconciliation.
  * Prevented outdated instrumental markers from lingering when detection results change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->