### PR TITLE
ci: bump codeql-action to v4.36.3 in lockstep + group in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
       - dependencies
       - ci
     open-pull-requests-limit: 5
+    groups:
+      # CodeQL sub-actions (init/analyze/autobuild) cross-check versions at
+      # runtime and must move in lockstep; group them so a bump never splits
+      # init and analyze across separate PRs (which fails with a config
+      # version-mismatch error).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: docker
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       # version-mismatch error).
       codeql-action:
         patterns:
-          - "github/codeql-action*"
+          - "github/codeql-action/*"
 
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: go
 
@@ -49,6 +49,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:go


### PR DESCRIPTION
## Summary

Fixes the CodeQL "Loaded a configuration file for version '4.36.2', but running version '4.36.3'" failure on dependabot PR #422.

**Root cause:** #422 bumped only `github/codeql-action/analyze` to v4.36.3 and left `github/codeql-action/init` at v4.36.2. CodeQL's sub-actions cross-check versions at runtime (init writes a config stamped with its version; analyze rejects a mismatch), so the split fails.

**Fix:**
- Bump both `init` and `analyze` to v4.36.3 (SHA `54f647b`) so they match.
- Add a dependabot `group` for `github/codeql-action*` so these sub-actions always bump together in one PR, preventing recurrence.

Supersedes dependabot PR #422 (dependabot auto-closes it once this lands).