### PR TITLE
ci: publish releases via a draft to survive immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      # GoReleaser creates the release as a draft (release.draft in .goreleaser.yml)
+      # and uploads every asset to it, but does not publish. Flip it to published
+      # here so GitHub's immutable-releases lock applies only after all assets are
+      # attached -- avoiding the "422 Cannot upload assets to an immutable release"
+      # that the publish-first flow hits. A failed GoReleaser run leaves an
+      # unpublished draft (this step is skipped), which is recoverable, unlike a
+      # half-published immutable release.
+      - name: Publish release (flip draft to published)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Mark only stable tags as latest. A SemVer prerelease is any tag with
+          # a '-' identifier after the version (v1.2.3-rc1, -beta, -pre.1, ...),
+          # so keying off the '-' mirrors goreleaser's prerelease:auto + make_latest
+          # exactly (they test ctx.Semver.Prerelease, i.e. any '-' segment -- not a
+          # fixed rc/beta/alpha list).
+          latest_flag="--latest"
+          case "$TAG" in
+            *-*) latest_flag="--latest=false" ;;
+          esac
+          gh release edit "$TAG" --draft=false "$latest_flag"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -246,7 +246,19 @@ release:
   github:
     owner: doxazo-net
     name: canticle
+  # Create the GitHub release as a DRAFT so every asset uploads to a mutable
+  # release, then flip it to published in a follow-up step (release.yml). The
+  # doxazo-net org has GitHub "immutable releases" enabled, which locks a
+  # PUBLISHED release immediately -- so the default publish-first flow 422s on
+  # asset upload ("Cannot upload assets to an immutable release"), leaving CI red
+  # even though the assets land. Uploading to a draft and publishing last applies
+  # immutability only after all assets are attached, so the run goes green.
+  draft: true
+  # Remove a leftover draft from a failed prior run so a re-run starts clean.
+  replace_existing_draft: true
   prerelease: auto
+  # make_latest is applied by the publish step in release.yml (GoReleaser does
+  # not publish when draft is true), but is kept here as the source of intent.
   make_latest: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
   header: |
     ## Canticle {{ .Tag }}


### PR DESCRIPTION
## Summary

- The `doxazo-net` org has GitHub **immutable releases** enabled, which locks a release the moment it is published. GoReleaser's default publish-first flow therefore 422s on every asset upload (`Cannot upload assets to an immutable release`): the assets still land, but the run exits 1 — so v1.12.0 shipped complete yet the Release workflow went red.
- Create the release as a **draft** (`release.draft` + `replace_existing_draft` in `.goreleaser.yml`) so all assets upload to a mutable release, then flip it to published in a follow-up `release.yml` step once every asset is attached. Immutability then applies with the release already complete, and the run goes green.
- Side benefit: a failed GoReleaser run now leaves a recoverable unpublished draft instead of a half-published immutable release (the previously-unrecoverable-by-re-run case).

## Linked issue

Refs #431 (release-pipeline follow-up noted there; not a close).

## Validation

- [x] `goreleaser check` — config valid with `draft: true` + `replace_existing_draft: true`
- [x] `actionlint` + `shellcheck` (embedded run block) — clean
- [x] `make gate` — green
- [x] Adversarial review — confirmed publish step correctness (`gh release edit --draft=false --latest`), prerelease flag survives the edit, brew cask not gated by draft, failed run leaves a recoverable draft. Fixed one finding: the "latest" gate now keys off any SemVer prerelease identifier (`-*`), matching goreleaser's `prerelease: auto`, instead of a fixed `-rc/-beta/-alpha` list.
- [ ] End-to-end draft→publish + immutable interaction — only verifiable on a live tag; first real exercise is v1.12.1. A failure now leaves a recoverable draft, so this is de-risked.

## Notes

CI/config-only (`.goreleaser.yml`, `.github/workflows/release.yml`); no code or test surface. Must land on `main` before the v1.12.1 tag is cut.
