### PR TITLE
fix: store Musixmatch transport errors as a clean, groupable reason

### DIFF
--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -66,50 +66,25 @@ var (
 	ErrTruncatedResponse = errors.New("musixmatch: truncated or empty response body")
 )
 
-// redactToken wraps err so its message has every occurrence of the usertoken
-// replaced with "REDACTED", while preserving the wrapped error for errors.Is/As
-// (context cancellation, the circuit breaker's sentinel checks, *url.Error
-// detection). It is applied to the request-build and transport error paths,
-// which are the ones that echo the request URL -- and thus the usertoken query
-// parameter -- into their message. Returns err unchanged when there is nothing
-// to redact (nil error or empty token).
-func (c *Client) redactToken(err error) error {
-	if err == nil || c.Token == "" {
-		return err
+// transportError converts a request-build or transport failure into a clean,
+// groupable error that carries neither the request URL nor the usertoken. Go
+// wraps http.Client.Do and http.NewRequestWithContext failures in a *url.Error
+// whose message embeds the full request URL -- which contains the usertoken and
+// the per-track query params (q_artist/q_track/q_album). Storing that raw
+// fragments the failure-analysis grouping (every URL is unique, so each failure
+// becomes its own single-count reason) and writes secrets plus library metadata
+// into work_queue.last_error. Unwrapping to the underlying cause yields a stable
+// "musixmatch: transport error: <cause>" (e.g. connection refused, timeout) that
+// aggregates across tracks, while %w preserves errors.Is/As so the worker still
+// classifies context cancellation and the like. Dropping the URL entirely also
+// removes any need to scrub the token from the message.
+func transportError(err error) error {
+	cause := err
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		cause = urlErr.Err
 	}
-	return &redactedTokenError{err: err, token: c.Token}
+	return fmt.Errorf("musixmatch: transport error: %w", cause)
 }
-
-// redactedTokenError overrides only the rendered message, delegating identity
-// (Unwrap) to the wrapped error so errors.Is/As are unaffected.
-//
-// Note: because Unwrap exposes the original error, errors.As(err, &urlErr) still
-// yields a *url.Error whose .URL field holds the raw token. That is safe only so
-// long as no caller logs urlErr.URL directly; every current consumer renders via
-// Error() (the redacted string). A future caller that reads the struct field must
-// redact it itself.
-type redactedTokenError struct {
-	err   error
-	token string
-}
-
-func (e *redactedTokenError) Error() string {
-	msg := strings.ReplaceAll(e.err.Error(), e.token, "REDACTED")
-	// url.Values.Encode percent-escapes the token in the URL; cover the escaped
-	// form too so a token containing reserved characters cannot slip through.
-	if esc := url.QueryEscape(e.token); esc != e.token {
-		msg = strings.ReplaceAll(msg, esc, "REDACTED")
-	}
-	return msg
-}
-
-func (e *redactedTokenError) Unwrap() error { return e.err }
-
-// GoString satisfies fmt.GoStringer so the %#v verb -- which otherwise prints the
-// struct's raw fields, including the token -- renders the redacted message instead.
-// Error() already covers %v/%s/%+v (they use the error interface); %#v is the one
-// verb that bypasses it.
-func (e *redactedTokenError) GoString() string { return e.Error() }
 
 // tokenRenewalError marks the upstream "renew" hint: the usertoken must be
 // regenerated. It satisfies errors.Is for BOTH itself and ErrUnauthorized, so
@@ -347,7 +322,7 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 
 	req, err := http.NewRequestWithContext(ctx, "GET", baseURL.String(), nil)
 	if err != nil {
-		return song, c.redactToken(err)
+		return song, transportError(err)
 	}
 
 	req.Header = http.Header{
@@ -358,10 +333,10 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		// A transport failure surfaces as a *url.Error whose message embeds the
-		// full request URL -- including the usertoken query parameter. Returning
-		// it raw would leak the secret into work_queue.last_error, the
-		// failure-analysis UI, and logs, so redact it at this boundary.
-		return song, c.redactToken(err)
+		// full request URL -- the usertoken and the per-track query params.
+		// transportError strips the URL down to the underlying cause so the
+		// stored reason is clean, groupable, and free of secrets/metadata.
+		return song, transportError(err)
 	}
 	defer func() { _ = res.Body.Close() }()
 

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -80,7 +80,8 @@ var (
 // removes any need to scrub the token from the message.
 func transportError(err error) error {
 	cause := err
-	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
 		cause = urlErr.Err
 	}
 	return fmt.Errorf("musixmatch: transport error: %w", cause)

--- a/internal/musixmatch/client_test.go
+++ b/internal/musixmatch/client_test.go
@@ -504,76 +504,64 @@ func TestFindLyricsReturnsTransportError(t *testing.T) {
 	}
 }
 
-// TestFindLyricsTransportErrorRedactsToken guards against the usertoken leaking
-// into error strings. net/http wraps a RoundTripper failure in a *url.Error
-// whose message embeds the full request URL, including the usertoken query
-// parameter. That error becomes work_queue.last_error and is rendered verbatim
-// on the failure-analysis screen (and logged), so the raw token must never
-// survive into the returned error's message.
-func TestFindLyricsTransportErrorRedactsToken(t *testing.T) {
+// TestFindLyricsTransportErrorIsCleanAndGroupable verifies that a transport
+// failure is stored as a clean, groupable reason. net/http wraps a RoundTripper
+// failure in a *url.Error whose message embeds the full request URL -- the
+// usertoken plus the per-track query params (q_artist/q_track/q_album). That
+// string becomes work_queue.last_error and is rendered on the failure-analysis
+// screen, so it must contain neither the token nor the URL/metadata, and two
+// different tracks failing the same way must produce the SAME message so the
+// report groups them instead of splintering into one row per track.
+func TestFindLyricsTransportErrorIsCleanAndGroupable(t *testing.T) {
 	const secret = "SUPER-SECRET-USERTOKEN-abc123"
-	wantErr := errors.New("network down")
+	netErr := errors.New("dial tcp: connect: connection refused")
 	client := NewClient(secret)
 	client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, wantErr
+		return nil, netErr
 	})}
 
-	_, err := client.FindLyrics(context.Background(), models.Track{TrackName: "title", ArtistName: "artist"})
-	if err == nil {
-		t.Fatal("FindLyrics returned nil error; want transport error")
+	_, err1 := client.FindLyrics(context.Background(), models.Track{ArtistName: "Artist One", TrackName: "Track One"})
+	_, err2 := client.FindLyrics(context.Background(), models.Track{ArtistName: "Artist Two", TrackName: "Track Two"})
+	if err1 == nil || err2 == nil {
+		t.Fatal("FindLyrics returned nil error; want transport errors")
 	}
-	if strings.Contains(err.Error(), secret) {
-		t.Errorf("error message leaks usertoken: %q", err.Error())
+
+	// Groupable: same failure on different tracks -> identical message.
+	if err1.Error() != err2.Error() {
+		t.Errorf("transport errors not groupable across tracks:\n  %q\n  %q", err1.Error(), err2.Error())
 	}
-	if !strings.Contains(err.Error(), "REDACTED") {
-		t.Errorf("error message should mark the redaction; got %q", err.Error())
-	}
-	// The underlying error chain must be preserved for errors.Is/As so callers
-	// (context cancellation, circuit breaker) still classify it correctly.
-	if !errors.Is(err, wantErr) {
-		t.Errorf("errors.Is broken by redaction: err = %v; want wrapped %v", err, wantErr)
-	}
-	// The %#v verb bypasses Error() and would otherwise print the struct's raw
-	// token field; GoString must keep it redacted too.
+
+	// No secret, no URL, no library metadata in any format verb.
+	banned := []string{secret, "usertoken", "http", "musixmatch.com", "Artist One", "Track One", "q_track", "q_artist"}
 	for _, verb := range []string{"%v", "%+v", "%s", "%#v"} {
-		if rendered := fmt.Sprintf(verb, err); strings.Contains(rendered, secret) {
-			t.Errorf("%s formatting leaks usertoken: %q", verb, rendered)
+		rendered := fmt.Sprintf(verb, err1)
+		for _, b := range banned {
+			if strings.Contains(rendered, b) {
+				t.Errorf("%s formatting leaks %q: %q", verb, b, rendered)
+			}
 		}
+	}
+
+	// The underlying cause is preserved for errors.Is/As so the worker still
+	// classifies the failure (retryable transport error, cancellation, etc.).
+	if !errors.Is(err1, netErr) {
+		t.Errorf("errors.Is(cause) broken by wrapping: %v", err1)
 	}
 }
 
-// TestRedactTokenEdgeCases covers the passthrough guards and the escaped-token
-// branch of the redaction helper directly, since a live transport error only
-// exercises the common (raw, non-empty token) path.
-func TestRedactTokenEdgeCases(t *testing.T) {
-	t.Run("nil error passes through", func(t *testing.T) {
-		c := NewClient("tok")
-		if got := c.redactToken(nil); got != nil {
-			t.Errorf("redactToken(nil) = %v; want nil", got)
-		}
-	})
+// TestFindLyricsTransportErrorPreservesCancellation ensures %w keeps the chain so
+// a context cancellation still satisfies errors.Is (the worker relies on this to
+// distinguish shutdown from a genuine failure).
+func TestFindLyricsTransportErrorPreservesCancellation(t *testing.T) {
+	client := NewClient("token")
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	})}
 
-	t.Run("empty token passes error through unchanged", func(t *testing.T) {
-		c := NewClient("")
-		orig := errors.New("boom")
-		if got := c.redactToken(orig); !errors.Is(got, orig) || got.Error() != "boom" {
-			t.Errorf("redactToken with empty token = %v; want unchanged %v", got, orig)
-		}
-	})
-
-	t.Run("escaped token form is redacted", func(t *testing.T) {
-		// A token with reserved characters is percent-escaped in the URL, so the
-		// error message contains the escaped form, not the raw token.
-		const secret = "a b/c&d"
-		c := NewClient(secret)
-		wrapped := c.redactToken(fmt.Errorf("Get %q: dial failed", "https://x/y?usertoken="+url.QueryEscape(secret)))
-		if strings.Contains(wrapped.Error(), url.QueryEscape(secret)) {
-			t.Errorf("escaped token leaked: %q", wrapped.Error())
-		}
-		if !strings.Contains(wrapped.Error(), "REDACTED") {
-			t.Errorf("missing redaction marker: %q", wrapped.Error())
-		}
-	})
+	_, err := client.FindLyrics(context.Background(), models.Track{TrackName: "title", ArtistName: "artist"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(context.Canceled) = false; err = %v", err)
+	}
 }
 
 func newTestClient(status int, body string) *Client {


### PR DESCRIPTION
## Summary

- A Musixmatch transport failure (`http.Client.Do` / `http.NewRequestWithContext`) surfaces as a `*url.Error` whose message embeds the full request URL. v1.12.1 (#432) redacted the usertoken from that string, but the URL still carried the per-track query params (`q_artist`/`q_track`/`q_album`), so every transport failure produced a unique `work_queue.last_error` -- the failure-analysis view splintered them into one single-count "reason" per track, and library metadata landed in the error text.
- Replace the `redactToken` wrapper with `transportError`, which unwraps the `*url.Error` to its underlying cause and stores `musixmatch: transport error: <cause>` (connection refused, timeout, ...). Dropping the URL entirely removes the token and the metadata, and the same cause now groups across tracks. `%w` preserves `errors.Is`/`As` (context cancellation, sentinel classification).
- Net `-37` LOC: the `redactedTokenError`/`GoString` machinery is no longer needed once the URL never enters the message.

## Linked issue

Closes #434

## Gates (run locally; CI enforces them)

- [x] `make gate` -- race tests, patch coverage (Codecov parity), golangci-lint, actionlint, govulncheck -- all green
- [x] Adversarial review -- verified no token leak across `%v/%+v/%s/%#v`, `errors.Is` preserved for cancellation/timeout, byte-identical grouping across tracks, and no stale references to the removed helpers
- [x] Verified on the live prod failure-analysis view (the 30 historical leaking rows that motivated this were also scrubbed out-of-band)

## Notes

Follow-up to #431/#432. The underlying cause on a DNS failure still names the fixed API host (not the token, not per-track metadata), and load-balanced IPs could split `dial tcp <IP>` messages -- both inherent to the cause and far better than the per-URL status quo.
