### PR TITLE
fix: add secrets and scan reconcile to shell completion

### DIFF
--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -20,7 +20,7 @@ type CompletionCmd struct {
 
 // completionSubcommands are the top-level subcommands offered at the first word.
 var completionSubcommands = []string{
-	"fetch", "serve", "scan", "library", "keys", "config", "queue", "provenance", "completion",
+	"fetch", "serve", "scan", "library", "keys", "secrets", "config", "queue", "provenance", "completion",
 }
 
 // completionCandidates maps a subcommand to the flags and/or nested subcommands
@@ -29,9 +29,10 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--work-interval"},
-	"scan":       {"results", "clear", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
+	"secrets":    {"import", "set", "list"},
 	"config":     {"get", "set", "list"},
 	"queue":      {"list", "failed", "deferred", "retry", "clear", "recheck"},
 	"provenance": {"backfill"},

--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,6 +12,104 @@ import (
 	"github.com/doxazo-net/canticle/internal/library"
 	"github.com/doxazo-net/canticle/internal/models"
 )
+
+// subcommandName returns the NAME from an `arg:"subcommand:NAME"` struct tag, or
+// "" if the tag declares no subcommand.
+func subcommandName(argTag string) string {
+	for _, part := range strings.Split(argTag, ",") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(part), "subcommand:"); ok {
+			return rest
+		}
+	}
+	return ""
+}
+
+// subcommandNames returns every `arg:"subcommand:..."` name declared on the
+// fields of struct type t -- the real command tree as go-arg sees it.
+func subcommandNames(t reflect.Type) []string {
+	var names []string
+	for i := 0; i < t.NumField(); i++ {
+		if n := subcommandName(t.Field(i).Tag.Get("arg")); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// TestCompletionSubcommandsMatchCommandTree guards against the drift that this
+// change fixes: every top-level subcommand declared on Args must appear in the
+// hand-maintained completionSubcommands table, so a newly added command cannot
+// silently go missing from shell completion.
+func TestCompletionSubcommandsMatchCommandTree(t *testing.T) {
+	known := make(map[string]bool, len(completionSubcommands))
+	for _, s := range completionSubcommands {
+		known[s] = true
+	}
+	for _, name := range subcommandNames(reflect.TypeOf(Args{})) {
+		if !known[name] {
+			t.Errorf("completionSubcommands missing top-level subcommand %q (declared in Args); add it in completion.go", name)
+		}
+	}
+}
+
+// TestCompletionCandidatesCoverNestedSubcommands extends the same guard one level
+// down: for each top-level command that has nested subcommands (scan, secrets,
+// queue, ...), every declared nested subcommand must appear in its
+// completionCandidates slice. Leaf commands (flags only) are skipped.
+func TestCompletionCandidatesCoverNestedSubcommands(t *testing.T) {
+	argsT := reflect.TypeOf(Args{})
+	for i := 0; i < argsT.NumField(); i++ {
+		f := argsT.Field(i)
+		parent := subcommandName(f.Tag.Get("arg"))
+		if parent == "" {
+			continue
+		}
+		ft := f.Type
+		if ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		nested := subcommandNames(ft)
+		if len(nested) == 0 {
+			continue // leaf command: flags only, nothing nested to mirror
+		}
+		have := make(map[string]bool, len(completionCandidates[parent]))
+		for _, c := range completionCandidates[parent] {
+			have[c] = true
+		}
+		for _, name := range nested {
+			if !have[name] {
+				t.Errorf("completionCandidates[%q] missing nested subcommand %q (declared in %s); add it in completion.go", parent, name, ft.Name())
+			}
+		}
+	}
+}
+
+// TestRunComplete_SecretsSubcommand verifies the newly added secrets command
+// surfaces at the first word and offers its nested candidates.
+func TestRunComplete_SecretsSubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	runComplete(context.Background(), &buf, []string{"sec"})
+	if !strings.Contains(buf.String(), "secrets") {
+		t.Fatalf("want 'secrets' for prefix 'sec'; got %q", buf.String())
+	}
+
+	buf.Reset()
+	runComplete(context.Background(), &buf, []string{"secrets", ""})
+	for _, want := range []string{"import", "set", "list"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("want %q in 'secrets' completions; got %q", want, buf.String())
+		}
+	}
+}
+
+// TestRunComplete_ScanReconcile verifies 'scan <TAB>' now offers reconcile.
+func TestRunComplete_ScanReconcile(t *testing.T) {
+	var buf bytes.Buffer
+	runComplete(context.Background(), &buf, []string{"scan", "rec"})
+	if !strings.Contains(buf.String(), "reconcile") {
+		t.Fatalf("want 'reconcile' for 'scan rec'; got %q", buf.String())
+	}
+}
 
 func TestRunComplete_TopLevelPrefix(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

- The hard-coded completion tables in `internal/commands/completion.go` had drifted from the command tree: the top-level `secrets` subcommand was absent, and `scan`'s nested list omitted `reconcile` (added in #405). Added `secrets` to `completionSubcommands` (with nested `import`/`set`/`list`) and appended `reconcile` to the `scan` slice -- data-only; `runComplete`/`firstSubcommand` derive everything from these tables.
- Added reflect-based drift guards: every top-level `arg:"subcommand:"` on `Args`, and every nested subcommand on the command structs that have them, must appear in the completion tables -- so a future command can't silently go missing from completion (this would have caught the `secrets` omission). Plus behavioral tests for the new completions.

## Linked issue

Closes #417

## Verification

- [x] `make gate` -- race tests, patch coverage, golangci-lint, actionlint, govulncheck -- all green
- [x] TDD: the four new tests fail on the old tables and pass after the fix
- [x] Exercised the real binary: `canticle __complete sec` -> `secrets`; `secrets ''` -> `import/list/set`; `scan rec` -> `reconcile`; `scan ''` lists `reconcile` alongside `clear`/`results`
- [x] Implemented against CodeRabbit's vetted Coding Plan (verified accurate vs current code before coding)

## Notes

Data + tests only; no runtime logic or shell-script template changes. Follows the ticket's suggestion to add a drift-prevention test.
