### PR TITLE
chore: bump Go toolchain to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS build
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/doxazo-net/canticle
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

- Bump the Go toolchain to 1.26.5 to keep the release on the patched standard library and preempt govulncheck stdlib findings (as recently hit on sydlexius/stillwater). canticle's govulncheck is clean on 1.26.4 today; this is preemptive so a new stdlib advisory does not flip future PRs and releases red with no code change.
- `go.mod` `go` directive 1.26.4 -> 1.26.5 (CI, release, and codeql read the version via `go-version-file: go.mod`, so they follow automatically).
- `Dockerfile` build image `golang:1.26.4-alpine` -> `golang:1.26.5-alpine`, re-pinned to the new multi-arch digest.

## Linked issue

None (maintenance / toolchain bump).

## Gates (run locally; CI enforces them)

- [x] gofmt / build
- [x] race tests (`go test -race ./...`)
- [x] patch coverage (no source lines changed; N/A)
- [x] golangci-lint
- [x] actionlint
- [x] govulncheck (0 vulnerabilities on 1.26.5)

## Test plan

- [x] `make gate` green on 1.26.5 (local toolchain go1.26.5).
- [ ] CI green on 1.26.5 across the build matrix + image scan.
