### PR TITLE
fix(queue): write scan_results back to failed on Fail (#454)

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -478,6 +478,21 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: fail: %w", err)
 	}
+
+	// Write the failure back to the linked scan_results rows, mirroring Complete's
+	// and RetireMiss's writeback, so a failed item does not strand the scan ledger
+	// in 'processing' (#454). Scoped to 'processing' so a retryable failure only
+	// clears the wedge and never downgrades a row already marked 'done'.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+         SET status = 'failed'
+         WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+           AND status = 'processing'`,
+		id,
+	); err != nil {
+		return WorkItem{}, fmt.Errorf("queue: fail scan_results writeback: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return WorkItem{}, fmt.Errorf("queue: commit fail tx: %w", err)
 	}
@@ -903,13 +918,14 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
 		return WorkItem{}, fmt.Errorf("queue: retry: %w", err)
 	}
 	// Reset every linked scan_results row so `scan results` reflects the
-	// retried state. Skip rows already in 'pending' or 'done' so we never
-	// overwrite a terminal outcome.
+	// retried state. Reset both 'processing' rows and the 'failed' rows that
+	// Fail now writes back (#454); skip 'pending'/'done' so we never overwrite a
+	// terminal outcome (both are non-retryable-here states).
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE scan_results
          SET status = 'pending'
          WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
-           AND status = 'processing'`,
+           AND status IN ('processing', 'failed')`,
 		id,
 	); err != nil {
 		return WorkItem{}, fmt.Errorf("queue: retry scan_results reset: %w", err)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -701,6 +701,46 @@ func TestDBQueue_CompleteAtomicallyWritesScanResultsDone(t *testing.T) {
 	}
 }
 
+// TestDBQueue_FailWritesScanResultsFailed: Fail must flip the linked scan_results
+// row out of 'processing' (to 'failed') so a failed work item does not leave the
+// scan ledger wedged in 'processing' indefinitely (#454).
+func TestDBQueue_FailWritesScanResultsFailed(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	scanID := insertScanResult(t, sqlDB, "/music/failwb.mp3") // seeded status='processing'
+	q := NewDBQueue(sqlDB)
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "FailWB"},
+		ScanResultID: scanID,
+	}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, item.ID, errors.New("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+
+	var queueStatus, scanStatus string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, item.ID).Scan(&queueStatus); err != nil {
+		t.Fatalf("read work_queue: %v", err)
+	}
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM scan_results WHERE id = ?`, scanID).Scan(&scanStatus); err != nil {
+		t.Fatalf("read scan_results: %v", err)
+	}
+	if queueStatus != "failed" {
+		t.Fatalf("work_queue status = %q; want failed", queueStatus)
+	}
+	if scanStatus != "failed" {
+		t.Fatalf("scan_results status = %q; want failed (Fail must not strand the row in processing, #454)", scanStatus)
+	}
+}
+
 func TestDBQueue_CompleteWithoutScanResultIDLeavesLedgerUntouched(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openQueueTestDB(t)
@@ -1382,6 +1422,50 @@ func TestDBQueue_RetryResetsLinkedScanResults(t *testing.T) {
 		if status != StatusPending {
 			t.Fatalf("scan_results %d status = %q; want %q (Retry must reset every linked processing row)", id, status, StatusPending)
 		}
+	}
+}
+
+// TestDBQueue_RetryResetsFailedScanResults: after Fail writes scan_results back
+// to 'failed' (#454), Retry must reset that 'failed' row to 'pending' so the two
+// ledgers stay consistent through the retry, with no manual re-seed in between.
+func TestDBQueue_RetryResetsFailedScanResults(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	scanID := insertScanResult(t, sqlDB, "/music/retry-failed.mp3")
+	q := NewDBQueue(sqlDB)
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: "RetryFailed"},
+		ScanResultID: scanID,
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Fail(ctx, item.ID, errors.New("boom")); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	// Natural post-Fail state: scan_results is 'failed', not 'processing'.
+	var afterFail string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM scan_results WHERE id = ?`, scanID).Scan(&afterFail); err != nil {
+		t.Fatalf("read scan_results: %v", err)
+	}
+	if afterFail != "failed" {
+		t.Fatalf("post-Fail scan_results = %q; want failed", afterFail)
+	}
+	if _, err := q.Retry(ctx, item.ID); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	var afterRetry string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM scan_results WHERE id = ?`, scanID).Scan(&afterRetry); err != nil {
+		t.Fatalf("read scan_results: %v", err)
+	}
+	if afterRetry != StatusPending {
+		t.Fatalf("post-Retry scan_results = %q; want %q (Retry must reset the failed row)", afterRetry, StatusPending)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `DBQueue.Fail` moved the `work_queue` row to `failed` but never wrote back to the linked `scan_results` row, leaving the scan ledger wedged in `processing` indefinitely for **any non-path failure** (transient provider errors, timeouts). This is the class #453's path-reconciliation prune can never reach, since the source file still exists on disk.
- `Fail` now flips the linked `scan_results` rows from `processing` to `failed` in the same transaction, mirroring `Complete`/`RetireMiss`'s writeback (scoped to `processing`, so a retryable failure never downgrades a `done` row).
- `Retry` now resets those `failed` scan_results back to `pending` alongside `processing` ones, so the two ledgers stay consistent across a retry.

## Linked issue

Closes #454

## Gates (run locally; CI enforces them)

- [x] `make gate` — build, race tests, patch coverage, coverage floor, codecov dry-run, golangci-lint, actionlint, govulncheck
- [x] TDD: added `TestDBQueue_FailWritesScanResultsFailed` (RED first) and `TestDBQueue_RetryResetsFailedScanResults`

## Test plan

- [x] `go test -race ./internal/queue/...` green
- [x] Full `make gate` green
