### PR TITLE
chore: enforce US English in the typos gate

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -12,6 +12,10 @@ extend-exclude = [
 ]
 
 [default]
+# Enforce US English across ALL files (misspell in golangci-lint only covers
+# .go sources; this extends US-spelling enforcement to markdown, comments, and
+# everything else typos scans -- e.g. modelling -> modeling, queueing -> queuing).
+locale = "en-us"
 # Ignore git commit hashes (7-40 hex chars) to avoid false positives on hash substrings.
 extend-ignore-re = ["\\b[0-9a-f]{7,40}\\b"]
 
@@ -20,3 +24,6 @@ extend-ignore-re = ["\\b[0-9a-f]{7,40}\\b"]
 TIT2 = "TIT2"
 TPE1 = "TPE1"
 TPE = "TPE"
+# typos' en-us locale does not flag -logue/-log variants, so enforce the US
+# spelling explicitly (the repo standard; the rest of the tree uses "catalog").
+catalogue = "catalog"

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/doxazo-net/canticle/internal/queue"
 )
 
-// PendingResultStore reads and updates scan results eligible for queueing.
+// PendingResultStore reads and updates scan results eligible for queuing.
 type PendingResultStore interface {
 	ListPendingByLibrary(ctx context.Context, libraryID int64) ([]models.ScanResult, error)
 	SetStatus(ctx context.Context, ids []int64, status string) error


### PR DESCRIPTION
## Summary
- Enforce US English in the `typos` spell gate. The check had no locale set, so British spellings passed unflagged -- the golangci-lint `misspell` (`locale: US`) enforcer only scans `.go` files, so nothing enforced US spelling in markdown, comments, or docs.
- Set `[default] locale = "en-us"` so typos flags British variants (e.g. `modelling` -> `modeling`, `queueing` -> `queuing`) across all scanned files.
- Add an explicit `catalogue = "catalog"` correction: typos' `en-us` locale does not cover `-logue`/`-log` variants, so "catalogue" slipped through even with the locale set. This closes that exact gap.
- Fix the one finding the hardened gate surfaces: a `scan/enqueuer.go` doc comment (`queueing` -> `queuing`).

## Linked issue
None -- follow-on hardening after the AGENTS.md retirement (#458) surfaced the gate gap.

## Notes for the reviewer
- **Stacked on #458** (base branch `worktree-retire-agents-md`). Merge #458 first; GitHub will retarget this to `main`. The stacking keeps the diff to just `.typos.toml` + `enqueuer.go` -- basing on `main` would also surface AGENTS.md's own British spellings, which #458 deletes.
- Verified: `typos` is 0 findings repo-wide with the new config, and the `catalogue` correction fires on a regression sample.

## Gates (run locally)
- [x] `make gate` -- conflict markers, gofmt, build, race tests + coverage, patch coverage, golangci-lint, actionlint, govulncheck -- all passed
- [x] `typos` clean repo-wide with the hardened config
- [x] `catalogue -> catalog` correction verified firing

## Test plan
- Config + one comment-word change; no behavior change. Ran the full gate and a typos regression check.
