### PR TITLE
chore: gitignore SESSION-STATE.md so the ignore travels to clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ docs/design/
 !.claude/release.toml
 
 # Orchestrate session checkpoint (machine-local, transient; never committed)
-SESSION-STATE.md
+/SESSION-STATE.md

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/design/
 # AI assistant config (local only — except shared release metadata)
 .claude/*
 !.claude/release.toml
+
+# Orchestrate session checkpoint (machine-local, transient; never committed)
+SESSION-STATE.md


### PR DESCRIPTION
## Summary

Commit the `SESSION-STATE.md` ignore to `.gitignore` so it travels to fresh clones.

The orchestrate session checkpoint was ignored only via the machine-local
`.git/info/exclude`, so a clone on another machine would not ignore it and could
accidentally commit the transient checkpoint. This matches the cc-orchestrator
convention (which commits the same ignore).

Docs/config-only; no code change.
