### PR TITLE
feat(lrc): scan reconcile-lrc CLI to expand stacked .lrc sidecars (#470)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -138,6 +138,18 @@ type ScanCmd struct {
 	Reconcile         *ScanReconcileCmd         `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
 	ReconcilePaths    *ScanReconcilePathsCmd    `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
 	ReconcileIdentity *ScanReconcileIdentityCmd `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
+	ReconcileLRC      *ScanReconcileLRCCmd      `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
+}
+
+// ScanReconcileLRCCmd walks the configured library roots and rewrites any .lrc
+// sidecar carrying compressed multi-timestamp lines (e.g. [t1][t2]text) into the
+// expanded one-cue-per-line form, backing up the pristine original to
+// <file>.lrc.orig. Dry-run unless --yes.
+type ScanReconcileLRCCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default reconciles every library"`
+	Yes        bool   `arg:"--yes" help:"actually rewrite files (without it, prints what would change)"`
+	Backup     string `arg:"--backup" help:"path for the JSONL record of rewritten files (default: <db-dir>/reconcile-lrc-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // ScanReconcileIdentityCmd re-reads each scan_results row's file tags and
@@ -1695,6 +1707,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runReconcileIdentity(ctx, out, sub)
+	case args.ReconcileLRC != nil:
+		sub := *args.ReconcileLRC
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runReconcileLRC(ctx, out, sub)
 	default:
 		return runScan(ctx, out, args)
 	}

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-paths", "reconcile-identity", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/reconcile_lrc.go
+++ b/internal/commands/reconcile_lrc.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/doxazo-net/canticle/internal/config"
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/library"
+	"github.com/doxazo-net/canticle/internal/lrcbackfill"
+)
+
+// runReconcileLRC walks the configured library roots and rewrites .lrc sidecars
+// that stack multiple timestamps on one line into the expanded one-cue-per-line
+// form, backing up each pristine original to <file>.lrc.orig. Dry-run by default;
+// --yes applies and writes a JSONL record of every rewritten file. Files that are
+// already clean are left untouched (needs-work gate), so the run is safely
+// re-runnable.
+func runReconcileLRC(ctx context.Context, out io.Writer, args ScanReconcileLRCCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	libRepo := library.New(sqlDB)
+	var roots []string
+	if strings.TrimSpace(args.Library) != "" {
+		lib, rerr := resolveLibrary(ctx, libRepo, args.Library)
+		if rerr != nil {
+			if errors.Is(rerr, sql.ErrNoRows) {
+				_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
+				return 1
+			}
+			slog.Error("failed to resolve library", "error", rerr)
+			return 1
+		}
+		roots = []string{lib.Path}
+	} else {
+		libs, lerr := libRepo.List(ctx)
+		if lerr != nil {
+			slog.Error("failed to list libraries", "error", lerr)
+			return 1
+		}
+		for _, l := range libs {
+			roots = append(roots, l.Path)
+		}
+	}
+	if len(roots) == 0 {
+		_, _ = fmt.Fprintln(out, "reconcile-lrc: no library roots configured")
+		return 0
+	}
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		// Sub-second precision so two runs in the same wall-clock second cannot
+		// share (and clobber) a default backup filename.
+		backupPath = filepath.Join(filepath.Dir(cfg.DB.Path), fmt.Sprintf("reconcile-lrc-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405.000000000")))
+	}
+	// Lazy backup: the file is created only on the first record written, so a
+	// zero-rewrite run never creates (and never has to delete) it -- a --yes run
+	// against an all-clean library, or against an operator-named --backup path,
+	// leaves the filesystem untouched. Appends rather than truncates.
+	var lb *lazyBackup
+	var backupW io.Writer
+	if args.Yes {
+		lb = &lazyBackup{path: backupPath}
+		backupW = lb
+		defer func() {
+			if cerr := lb.Close(); cerr != nil {
+				slog.Warn("failed to close reconcile-lrc backup file", "path", backupPath, "error", cerr)
+			}
+		}()
+	}
+
+	summary, err := lrcbackfill.Run(lrcbackfill.Options{Roots: roots, Apply: args.Yes, Backup: backupW})
+	if err != nil {
+		slog.Error("reconcile-lrc failed", "error", err)
+		return 1
+	}
+
+	verb := "would rewrite"
+	if args.Yes {
+		verb = "rewrote"
+	}
+	_, _ = fmt.Fprintf(out, "reconcile-lrc: %s %d stacked .lrc file(s) (%d scanned, %d already clean, %d skipped, %d errors)%s\n",
+		verb, summary.Normalized, summary.Scanned, summary.Clean, summary.Skipped, summary.Errors, suffixDryRun(args.Yes))
+	if lb != nil && lb.opened() {
+		_, _ = fmt.Fprintf(out, "backup records written to %s\n", backupPath)
+	}
+	return 0
+}
+
+// lazyBackup is an io.Writer that opens (create-or-append) its file on the first
+// Write, so a run that writes no records never creates the file.
+type lazyBackup struct {
+	path string
+	f    *os.File
+}
+
+func (l *lazyBackup) Write(p []byte) (int, error) {
+	if l.f == nil {
+		f, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: path is operator-supplied (--backup) or derived from the configured db dir
+		if err != nil {
+			return 0, fmt.Errorf("open reconcile-lrc backup %q: %w", l.path, err)
+		}
+		l.f = f
+	}
+	return l.f.Write(p)
+}
+
+func (l *lazyBackup) opened() bool { return l.f != nil }
+
+func (l *lazyBackup) Close() error {
+	if l.f != nil {
+		return l.f.Close()
+	}
+	return nil
+}

--- a/internal/commands/reconcile_lrc.go
+++ b/internal/commands/reconcile_lrc.go
@@ -102,6 +102,11 @@ func runReconcileLRC(ctx context.Context, out io.Writer, args ScanReconcileLRCCm
 	if lb != nil && lb.opened() {
 		_, _ = fmt.Fprintf(out, "backup records written to %s\n", backupPath)
 	}
+	if summary.Errors > 0 {
+		// A partial reconciliation is not success: some files failed and were
+		// left untouched, so callers/scripts must see a non-zero exit.
+		return 1
+	}
 	return 0
 }
 
@@ -124,6 +129,15 @@ func (l *lazyBackup) Write(p []byte) (int, error) {
 }
 
 func (l *lazyBackup) opened() bool { return l.f != nil }
+
+// Sync flushes the backup file so writeBackupRecord can make each record durable
+// before the .lrc it protects is rewritten.
+func (l *lazyBackup) Sync() error {
+	if l.f != nil {
+		return l.f.Sync()
+	}
+	return nil
+}
 
 func (l *lazyBackup) Close() error {
 	if l.f != nil {

--- a/internal/commands/reconcile_lrc_test.go
+++ b/internal/commands/reconcile_lrc_test.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/library"
+	"github.com/doxazo-net/canticle/internal/models"
+)
+
+func setupReconcileLRC(t *testing.T) (cfgPath, root string) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath = filepath.Join(dir, "config.toml")
+	root = filepath.Join(dir, "music")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	content := "[db]\npath = \"" + strings.ReplaceAll(dbPath, `\`, `\\`) + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := library.New(sqlDB).Add(ctx, root, "lib", models.LibrarySettings{}); err != nil {
+		t.Fatalf("library.Add: %v", err)
+	}
+	return cfgPath, root
+}
+
+func TestRunReconcileLRC_DryRunApplyIdempotent(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	stacked := filepath.Join(root, "a", "stacked.lrc")
+	clean := filepath.Join(root, "a", "clean.lrc")
+	a2 := filepath.Join(root, "a", "word.lrc")
+	if err := os.MkdirAll(filepath.Dir(stacked), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, stacked, "[00:39.26][00:47.06][01:03.06]Chorus\n[01:10.00]Line\n")
+	mustWrite(t, clean, "[00:10.00]a\n[00:20.00]b\n")
+	mustWrite(t, a2, "[00:12.00]<00:12.00>Word<00:13.00>sync\n")
+
+	// Dry run: reports one candidate, writes nothing.
+	var dry bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &dry, ScanReconcileLRCCmd{ConfigPath: cfgPath}); rc != 0 {
+		t.Fatalf("dry-run rc=%d out=%s", rc, dry.String())
+	}
+	if !strings.Contains(dry.String(), "would rewrite 1") {
+		t.Errorf("dry-run output: %q", dry.String())
+	}
+	if got := readFile(t, stacked); !strings.Contains(got, "][") {
+		t.Error("dry run mutated the stacked file")
+	}
+
+	// Apply: rewrites the stacked file, backs it up, leaves the A2 file untouched.
+	var apply bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &apply, ScanReconcileLRCCmd{ConfigPath: cfgPath, Yes: true}); rc != 0 {
+		t.Fatalf("apply rc=%d out=%s", rc, apply.String())
+	}
+	if !strings.Contains(apply.String(), "rewrote 1") {
+		t.Errorf("apply output: %q", apply.String())
+	}
+	if got := readFile(t, stacked); strings.Contains(got, "][") {
+		t.Errorf("stacked file not expanded: %q", got)
+	}
+	if _, err := os.Stat(stacked + ".orig"); err != nil {
+		t.Errorf(".orig backup missing: %v", err)
+	}
+	if _, err := os.Stat(a2 + ".orig"); !os.IsNotExist(err) {
+		t.Error("A2 word-sync file was wrongly backed up / touched")
+	}
+
+	// Re-run apply: idempotent, nothing left to do.
+	var again bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &again, ScanReconcileLRCCmd{ConfigPath: cfgPath, Yes: true}); rc != 0 {
+		t.Fatalf("re-run rc=%d", rc)
+	}
+	if !strings.Contains(again.String(), "rewrote 0") {
+		t.Errorf("re-run not idempotent: %q", again.String())
+	}
+}
+
+func TestRunReconcileLRC_LibraryFilterNotFoundAndBadConfig(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	mustWrite(t, filepath.Join(root, "s.lrc"), "[00:30.00][01:05.00]C\n")
+
+	// --library by name resolves and reports the candidate.
+	var byLib bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &byLib, ScanReconcileLRCCmd{ConfigPath: cfgPath, Library: "lib"}); rc != 0 {
+		t.Fatalf("--library rc=%d out=%s", rc, byLib.String())
+	}
+	if !strings.Contains(byLib.String(), "would rewrite 1") {
+		t.Errorf("--library output: %q", byLib.String())
+	}
+
+	// Unknown --library returns non-zero with a not-found message.
+	var missing bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &missing, ScanReconcileLRCCmd{ConfigPath: cfgPath, Library: "nope"}); rc == 0 {
+		t.Error("unknown library should return non-zero")
+	}
+	if !strings.Contains(missing.String(), "not found") {
+		t.Errorf("not-found output: %q", missing.String())
+	}
+
+	// A malformed config returns non-zero.
+	bad := filepath.Join(t.TempDir(), "bad.toml")
+	mustWrite(t, bad, "this is not = valid [toml\n")
+	if rc := runReconcileLRC(context.Background(), &bytes.Buffer{}, ScanReconcileLRCCmd{ConfigPath: bad}); rc == 0 {
+		t.Error("malformed config should return non-zero")
+	}
+}
+
+func TestRunScanCmd_DispatchesReconcileLRC(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	mustWrite(t, filepath.Join(root, "s.lrc"), "[00:30.00][01:05.00]C\n")
+
+	// Direct sub-config.
+	var buf bytes.Buffer
+	if rc := runScanCmd(context.Background(), &buf, ScanCmd{ReconcileLRC: &ScanReconcileLRCCmd{ConfigPath: cfgPath}}); rc != 0 {
+		t.Fatalf("dispatch rc=%d out=%s", rc, buf.String())
+	}
+	if !strings.Contains(buf.String(), "would rewrite 1") {
+		t.Errorf("dispatch output: %q", buf.String())
+	}
+
+	// Parent --config inherited when the subcommand omits it.
+	var buf2 bytes.Buffer
+	if rc := runScanCmd(context.Background(), &buf2, ScanCmd{ConfigPath: cfgPath, ReconcileLRC: &ScanReconcileLRCCmd{}}); rc != 0 {
+		t.Fatalf("inherited-config rc=%d out=%s", rc, buf2.String())
+	}
+}
+
+func TestRunReconcileLRC_DoesNotDeleteOperatorBackupOnZeroRewrite(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	mustWrite(t, filepath.Join(root, "clean.lrc"), "[00:10.00]a\n") // nothing to rewrite
+
+	// Operator points --backup at a pre-existing file holding their own data.
+	opBackup := filepath.Join(t.TempDir(), "operator.jsonl")
+	mustWrite(t, opBackup, "OPERATOR DATA\n")
+
+	var buf bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &buf, ScanReconcileLRCCmd{ConfigPath: cfgPath, Yes: true, Backup: opBackup}); rc != 0 {
+		t.Fatalf("rc=%d out=%s", rc, buf.String())
+	}
+	if !strings.Contains(buf.String(), "rewrote 0") {
+		t.Errorf("expected zero rewrites: %q", buf.String())
+	}
+	// C1: the operator's pre-existing file must be untouched (never deleted).
+	if got := readFile(t, opBackup); got != "OPERATOR DATA\n" {
+		t.Errorf("operator backup file was modified/deleted: %q", got)
+	}
+}
+
+func TestRunReconcileLRC_NoLibraryRoots(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	mustWrite(t, cfgPath, "[db]\npath = \""+strings.ReplaceAll(dbPath, `\`, `\\`)+"\"\n")
+	// Open the DB (creates schema) but add no library.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	if rc := runReconcileLRC(ctx, &out, ScanReconcileLRCCmd{ConfigPath: cfgPath}); rc != 0 {
+		t.Fatalf("rc=%d out=%s", rc, out.String())
+	}
+	if !strings.Contains(out.String(), "no library roots") {
+		t.Errorf("output: %q", out.String())
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/lrcbackfill/lrcbackfill.go
+++ b/internal/lrcbackfill/lrcbackfill.go
@@ -1,0 +1,255 @@
+// Package lrcbackfill rewrites existing .lrc sidecars that carry compressed
+// multi-timestamp lines into the expanded, one-cue-per-line form, backing up the
+// pristine original alongside each rewrite. It is the backfill half of issue
+// #470; the pure transform lives in internal/lrcnormalize.
+package lrcbackfill
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/doxazo-net/canticle/internal/lrcnormalize"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+)
+
+// Options configures a backfill run over one or more library roots.
+type Options struct {
+	Roots  []string  // directory trees to walk for *.lrc files
+	Apply  bool      // false = dry run (report only, write nothing)
+	Backup io.Writer // optional JSONL sink; one {path,backup} line per applied normalization
+}
+
+// Summary tallies a backfill run.
+type Summary struct {
+	Scanned    int // .lrc files examined
+	Normalized int // rewritten (apply) or would-be-rewritten (dry run)
+	Clean      int // already expanded; skipped
+	Skipped    int // symlinks and other intentional skips
+	Errors     int // per-file failures (the run continues past them)
+}
+
+// backupRecord is one line of the JSONL undo trail.
+type backupRecord struct {
+	Path   string `json:"path"`
+	Backup string `json:"backup"`
+}
+
+// Run walks each root for .lrc sidecars and normalizes stacked ones. In dry-run
+// mode (Apply=false) it only reports what would change; in apply mode it rewrites
+// each stacked file (backup-first) and emits a JSONL record to Backup. Per-file
+// errors are counted and logged but never abort the run.
+func Run(opts Options) (Summary, error) {
+	var s Summary
+	for _, root := range opts.Roots {
+		walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.EqualFold(filepath.Ext(d.Name()), ".lrc") {
+				return nil
+			}
+			s.Scanned++
+			var res Result
+			var ferr error
+			if opts.Apply {
+				res, ferr = NormalizeFile(path)
+			} else {
+				res, ferr = inspect(path)
+			}
+			if ferr != nil {
+				s.Errors++
+				slog.Warn("lrcbackfill: file failed; continuing", "path", path, "error", ferr)
+				return nil
+			}
+			switch res.Status {
+			case StatusNormalized:
+				s.Normalized++
+				if opts.Apply && opts.Backup != nil {
+					if err := writeBackupRecord(opts.Backup, path, res.Backup); err != nil {
+						return fmt.Errorf("write backup record: %w", err)
+					}
+				}
+			case StatusClean:
+				s.Clean++
+			case StatusSkipped:
+				s.Skipped++
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return s, fmt.Errorf("walk %s: %w", root, walkErr)
+		}
+	}
+	return s, nil
+}
+
+func writeBackupRecord(w io.Writer, path, backup string) error {
+	line, err := json.Marshal(backupRecord{Path: path, Backup: backup})
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(line, '\n'))
+	return err
+}
+
+// Status is the outcome of processing a single .lrc file.
+type Status int
+
+const (
+	// StatusClean means the file carried no stacked line; nothing was written.
+	StatusClean Status = iota
+	// StatusNormalized means the file was rewritten and a .lrc.orig backup exists.
+	StatusNormalized
+	// StatusSkipped means the file was intentionally not processed (e.g. symlink).
+	StatusSkipped
+)
+
+// Result reports what happened to a single file.
+type Result struct {
+	Status Status
+	Backup string // path of the .lrc.orig backup, set when StatusNormalized
+}
+
+// NormalizeFile expands stacked timestamps in the .lrc at path. It is the
+// needs-work-gated, backup-first primitive: a file with no stacked line is left
+// untouched (StatusClean); otherwise the pristine original is preserved to
+// "<path>.orig" (never overwritten) and fsynced before the expanded body is
+// atomically written over path.
+func NormalizeFile(path string) (Result, error) {
+	raw, origMode, skip, err := load(path)
+	if err != nil {
+		return Result{}, err
+	}
+	if skip {
+		return Result{Status: StatusSkipped}, nil
+	}
+	out, changed := lrcnormalize.NormalizeBody(string(raw))
+	if !changed {
+		return Result{Status: StatusClean}, nil // needs-work gate: nothing to do
+	}
+
+	// Refuse to overwrite a .lrc whose .orig backup already exists: we cannot
+	// verify that pre-existing backup is the true pristine original, and
+	// overwriting would leave the current bytes backed up nowhere. Skip instead
+	// (conservative-on-uncertainty). In normal single-tool operation this is
+	// unreachable -- after one expand the file is already clean and never
+	// rewritten -- so a .orig here means external interference.
+	backupPath := path + ".orig"
+	if _, statErr := os.Lstat(backupPath); statErr == nil {
+		slog.Warn("lrcbackfill: .orig backup already exists; skipping to avoid an unverified overwrite", "path", path, "backup", backupPath)
+		return Result{Status: StatusSkipped}, nil
+	} else if !os.IsNotExist(statErr) {
+		return Result{}, fmt.Errorf("stat backup %s: %w", backupPath, statErr)
+	}
+
+	// Backup-first: preserve the pristine original before touching the .lrc.
+	if err := writeBackup(backupPath, raw, origMode); err != nil {
+		return Result{}, err
+	}
+	// Atomic rewrite of the expanded body.
+	if err := atomicWrite(path, []byte(out), origMode); err != nil {
+		return Result{}, err
+	}
+	// One parent-dir fsync makes both new directory entries (.orig and the
+	// renamed .lrc) crash-durable.
+	lyrics.FsyncDir(filepath.Dir(path))
+	return Result{Status: StatusNormalized, Backup: backupPath}, nil
+}
+
+// inspect reports what NormalizeFile would do, without writing anything (dry run).
+func inspect(path string) (Result, error) {
+	raw, _, skip, err := load(path)
+	if err != nil {
+		return Result{}, err
+	}
+	if skip {
+		return Result{Status: StatusSkipped}, nil
+	}
+	if _, changed := lrcnormalize.NormalizeBody(string(raw)); !changed {
+		return Result{Status: StatusClean}, nil
+	}
+	return Result{Status: StatusNormalized, Backup: path + ".orig"}, nil
+}
+
+// load reads path, returning its body and permission bits. skip is true (with a
+// nil error) when the path is a symlink, which is never followed or rewritten.
+func load(path string) (body []byte, mode os.FileMode, skip bool, err error) {
+	fi, err := os.Lstat(path) // Lstat (not Stat) so a symlink is detected, not followed.
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("lstat %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		slog.Warn("lrcbackfill: skipping symlink", "path", path)
+		return nil, 0, true, nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // path is caller-controlled library enumeration
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return raw, fi.Mode().Perm(), false, nil
+}
+
+// writeBackup preserves content to backupPath with exclusive-create semantics,
+// fsyncing the data and chmod'ing to mode (umask-proof) before returning. The
+// caller has already confirmed backupPath does not exist, so an O_EXCL collision
+// here is a race with another process and is returned as an error rather than
+// silently overwriting the .lrc without a fresh backup.
+func writeBackup(backupPath string, content []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) //nolint:gosec // backupPath derived from a caller-controlled path
+	if err != nil {
+		return fmt.Errorf("create backup %s: %w", backupPath, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(content); err != nil {
+		return fmt.Errorf("write backup %s: %w", backupPath, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync backup %s: %w", backupPath, err)
+	}
+	if err := os.Chmod(backupPath, mode); err != nil { //nolint:gosec // mode copied from the original file
+		return fmt.Errorf("chmod backup %s: %w", backupPath, err)
+	}
+	return nil
+}
+
+// atomicWrite writes content over path via a same-directory temp file that is
+// synced, chmod'd to mode, and renamed into place, so a partial write can never
+// become the canonical file.
+func atomicWrite(path string, content []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		return fmt.Errorf("write temp %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temp %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp %s: %w", tmpPath, err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil { //nolint:gosec // mode copied from the original file
+		return fmt.Errorf("chmod temp %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/lrcbackfill/lrcbackfill.go
+++ b/internal/lrcbackfill/lrcbackfill.go
@@ -58,7 +58,15 @@ func Run(opts Options) (Summary, error) {
 			var res Result
 			var ferr error
 			if opts.Apply {
-				res, ferr = NormalizeFile(path)
+				// report writes the undo record before the rewrite; NormalizeFile
+				// aborts (and rolls back the backup) if it fails.
+				var report func(string) error
+				if opts.Backup != nil {
+					report = func(backupPath string) error {
+						return writeBackupRecord(opts.Backup, path, backupPath)
+					}
+				}
+				res, ferr = NormalizeFile(path, report)
 			} else {
 				res, ferr = inspect(path)
 			}
@@ -70,11 +78,6 @@ func Run(opts Options) (Summary, error) {
 			switch res.Status {
 			case StatusNormalized:
 				s.Normalized++
-				if opts.Apply && opts.Backup != nil {
-					if err := writeBackupRecord(opts.Backup, path, res.Backup); err != nil {
-						return fmt.Errorf("write backup record: %w", err)
-					}
-				}
 			case StatusClean:
 				s.Clean++
 			case StatusSkipped:
@@ -94,8 +97,15 @@ func writeBackupRecord(w io.Writer, path, backup string) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(append(line, '\n'))
-	return err
+	if _, err := w.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	// Flush the record to stable storage before the caller replaces the .lrc, so
+	// the undo trail is durable ahead of the mutation it protects.
+	if s, ok := w.(interface{ Sync() error }); ok {
+		return s.Sync()
+	}
+	return nil
 }
 
 // Status is the outcome of processing a single .lrc file.
@@ -121,7 +131,12 @@ type Result struct {
 // untouched (StatusClean); otherwise the pristine original is preserved to
 // "<path>.orig" (never overwritten) and fsynced before the expanded body is
 // atomically written over path.
-func NormalizeFile(path string) (Result, error) {
+//
+// report, if non-nil, is invoked once with the backup path after the .orig is
+// durably written but BEFORE the .lrc is replaced, so a failure to record the
+// undo trail aborts the rewrite (the file is left untouched and the just-created
+// backup rolled back) rather than leaving a rewritten file absent from the trail.
+func NormalizeFile(path string, report func(backupPath string) error) (Result, error) {
 	raw, origMode, skip, err := load(path)
 	if err != nil {
 		return Result{}, err
@@ -148,17 +163,30 @@ func NormalizeFile(path string) (Result, error) {
 		return Result{}, fmt.Errorf("stat backup %s: %w", backupPath, statErr)
 	}
 
-	// Backup-first: preserve the pristine original before touching the .lrc.
+	dir := filepath.Dir(path)
+	// Backup-first: preserve the pristine original before touching the .lrc, then
+	// fsync the directory so the .orig's entry is durable BEFORE the rename that
+	// replaces the .lrc (a crash must never leave the rewrite without its backup).
 	if err := writeBackup(backupPath, raw, origMode); err != nil {
 		return Result{}, err
 	}
-	// Atomic rewrite of the expanded body.
+	lyrics.FsyncDir(dir)
+
+	// Record the undo trail while the backup exists but before the rewrite. If
+	// recording fails, roll the backup back and abort so the .lrc is untouched
+	// and no rewritten file is ever missing from the trail.
+	if report != nil {
+		if rerr := report(backupPath); rerr != nil {
+			_ = os.Remove(backupPath)
+			return Result{}, fmt.Errorf("record backup for %s: %w", path, rerr)
+		}
+	}
+
+	// Atomic rewrite of the expanded body, then fsync the rename durable.
 	if err := atomicWrite(path, []byte(out), origMode); err != nil {
 		return Result{}, err
 	}
-	// One parent-dir fsync makes both new directory entries (.orig and the
-	// renamed .lrc) crash-durable.
-	lyrics.FsyncDir(filepath.Dir(path))
+	lyrics.FsyncDir(dir)
 	return Result{Status: StatusNormalized, Backup: backupPath}, nil
 }
 
@@ -205,7 +233,15 @@ func writeBackup(backupPath string, content []byte, mode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("create backup %s: %w", backupPath, err)
 	}
-	defer func() { _ = f.Close() }()
+	// Remove a partially-written backup on any failure, so a later run does not
+	// mistake a truncated/incomplete .orig for a valid one and skip the source.
+	committed := false
+	defer func() {
+		_ = f.Close()
+		if !committed {
+			_ = os.Remove(backupPath)
+		}
+	}()
 	if _, err := f.Write(content); err != nil {
 		return fmt.Errorf("write backup %s: %w", backupPath, err)
 	}
@@ -215,6 +251,7 @@ func writeBackup(backupPath string, content []byte, mode os.FileMode) error {
 	if err := os.Chmod(backupPath, mode); err != nil { //nolint:gosec // mode copied from the original file
 		return fmt.Errorf("chmod backup %s: %w", backupPath, err)
 	}
+	committed = true
 	return nil
 }
 

--- a/internal/lrcbackfill/lrcbackfill_test.go
+++ b/internal/lrcbackfill/lrcbackfill_test.go
@@ -1,0 +1,225 @@
+package lrcbackfill
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFile_SkipsWhenBackupExists(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "s.lrc")
+	stacked := "[00:30.00][01:05.00]C\n"
+	if err := os.WriteFile(p, []byte(stacked), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A .orig already exists but is NOT the original of the current .lrc. We must
+	// not overwrite the .lrc without a fresh, verifiable backup -> skip untouched.
+	if err := os.WriteFile(p+".orig", []byte("UNRELATED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := NormalizeFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusSkipped {
+		t.Errorf("status: want Skipped, got %v", res.Status)
+	}
+	if got, _ := os.ReadFile(p); string(got) != stacked {
+		t.Errorf(".lrc must be left untouched, got %q", string(got))
+	}
+	if got, _ := os.ReadFile(p + ".orig"); string(got) != "UNRELATED\n" {
+		t.Errorf("pre-existing .orig must be untouched, got %q", string(got))
+	}
+}
+
+func TestRun_TalliesSkippedAndErrors(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "t.lrc")
+	if err := os.WriteFile(target, []byte("[00:30.00][01:05.00]C\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.lrc")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	bad := filepath.Join(dir, "bad.lrc")
+	if err := os.WriteFile(bad, []byte("[00:30.00][01:05.00]C\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) }) // let TempDir cleanup remove it
+
+	s, err := Run(Options{Roots: []string{dir}, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Normalized < 1 {
+		t.Errorf("want >=1 normalized, got %d", s.Normalized)
+	}
+	if s.Skipped != 1 {
+		t.Errorf("want 1 skipped (symlink), got %d", s.Skipped)
+	}
+	if s.Errors != 1 {
+		t.Errorf("want 1 error (unreadable file), got %d", s.Errors)
+	}
+}
+
+func TestRun_DryRunThenApply(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.lrc", "[00:30.00][01:05.00]C\n")   // stacked
+	write("sub/b.lrc", "[00:10.00]x\n")         // clean
+	write("c.txt", "not an lrc file\n")         // ignored (not .lrc)
+	write("sub/d.lrc", "[00:05.00][00:09.00]Y") // stacked, no trailing newline
+
+	// Dry run: reports, writes nothing.
+	s, err := Run(Options{Roots: []string{dir}, Apply: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Scanned != 3 || s.Normalized != 2 || s.Clean != 1 {
+		t.Errorf("dry-run summary: %+v (want scanned=3 normalized=2 clean=1)", s)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dir, "a.lrc")); string(got) != "[00:30.00][01:05.00]C\n" {
+		t.Error("dry run mutated a file")
+	}
+
+	// Apply: rewrites the stacked files and logs a JSONL record per rewrite.
+	var buf bytes.Buffer
+	s2, err := Run(Options{Roots: []string{dir}, Apply: true, Backup: &buf})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s2.Normalized != 2 {
+		t.Errorf("apply normalized=%d, want 2", s2.Normalized)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dir, "a.lrc")); string(got) != "[00:30.00]C\n[01:05.00]C\n" {
+		t.Errorf("a.lrc not expanded: %q", string(got))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "a.lrc.orig")); err != nil {
+		t.Errorf("a.lrc.orig backup missing: %v", err)
+	}
+	if lines := strings.Count(strings.TrimSpace(buf.String()), "\n") + 1; lines != 2 {
+		t.Errorf("backup JSONL: want 2 records, got %d (%q)", lines, buf.String())
+	}
+}
+
+func TestNormalizeFile_CleanFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "clean.lrc")
+	body := "[ar:X]\n[00:10.00]a\n[00:20.00]b\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := NormalizeFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusClean {
+		t.Errorf("status: want Clean, got %v", res.Status)
+	}
+	if _, err := os.Stat(p + ".orig"); !os.IsNotExist(err) {
+		t.Error("clean file must not produce a .orig backup")
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != body {
+		t.Errorf("clean file mutated: %q", string(got))
+	}
+}
+
+func TestNormalizeFile_IdempotentAndNeverOverwritesBackup(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "song.lrc")
+	orig := "[00:30.00][01:05.00]C\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// First pass normalizes and backs up.
+	if res, err := NormalizeFile(p); err != nil || res.Status != StatusNormalized {
+		t.Fatalf("first pass: status=%v err=%v", res.Status, err)
+	}
+	afterFirst, _ := os.ReadFile(p)
+
+	// Second pass is a no-op (already expanded), and must NOT overwrite .orig.
+	res, err := NormalizeFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusClean {
+		t.Errorf("second pass: want Clean, got %v", res.Status)
+	}
+	if got, _ := os.ReadFile(p); string(got) != string(afterFirst) {
+		t.Error("second pass mutated an already-normalized file")
+	}
+	if backup, _ := os.ReadFile(p + ".orig"); string(backup) != orig {
+		t.Errorf("backup no longer pristine: %q", string(backup))
+	}
+}
+
+func TestNormalizeFile_SkipsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.lrc")
+	if err := os.WriteFile(target, []byte("[00:30.00][01:05.00]C\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.lrc")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	res, err := NormalizeFile(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != StatusSkipped {
+		t.Errorf("status: want Skipped, got %v", res.Status)
+	}
+	if _, err := os.Stat(link + ".orig"); !os.IsNotExist(err) {
+		t.Error("symlink must not produce a backup")
+	}
+}
+
+func TestNormalizeFile_ExpandsAndBacksUp(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "song.lrc")
+	orig := "[ar:X]\n[00:30.00][01:05.00]Chorus\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := NormalizeFile(p)
+	if err != nil {
+		t.Fatalf("NormalizeFile: %v", err)
+	}
+	if res.Status != StatusNormalized {
+		t.Fatalf("status: want Normalized, got %v", res.Status)
+	}
+
+	// The .lrc is now expanded, one cue per line.
+	got, _ := os.ReadFile(p)
+	want := "[ar:X]\n[00:30.00]Chorus\n[01:05.00]Chorus\n"
+	if string(got) != want {
+		t.Errorf("rewritten body:\n want %q\n got  %q", want, string(got))
+	}
+
+	// The pristine original is backed up verbatim.
+	backup, err := os.ReadFile(p + ".orig")
+	if err != nil {
+		t.Fatalf("reading backup: %v", err)
+	}
+	if string(backup) != orig {
+		t.Errorf("backup:\n want %q\n got  %q", orig, string(backup))
+	}
+	if res.Backup != p+".orig" {
+		t.Errorf("Backup path: want %q, got %q", p+".orig", res.Backup)
+	}
+}

--- a/internal/lrcbackfill/lrcbackfill_test.go
+++ b/internal/lrcbackfill/lrcbackfill_test.go
@@ -2,6 +2,7 @@ package lrcbackfill
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +21,7 @@ func TestNormalizeFile_SkipsWhenBackupExists(t *testing.T) {
 	if err := os.WriteFile(p+".orig", []byte("UNRELATED\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	res, err := NormalizeFile(p)
+	res, err := NormalizeFile(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,6 +51,12 @@ func TestRun_TalliesSkippedAndErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) }) // let TempDir cleanup remove it
+	// 0o000 does not guarantee an unreadable file on every runner (e.g. root, or
+	// some filesystems), so verify the premise deterministically before asserting
+	// the error tally.
+	if _, rerr := os.ReadFile(bad); rerr == nil { //nolint:gosec // test probe
+		t.Skip("runner can read a 0o000 file; cannot exercise the unreadable-file error path")
+	}
 
 	s, err := Run(Options{Roots: []string{dir}, Apply: true})
 	if err != nil {
@@ -63,6 +70,28 @@ func TestRun_TalliesSkippedAndErrors(t *testing.T) {
 	}
 	if s.Errors != 1 {
 		t.Errorf("want 1 error (unreadable file), got %d", s.Errors)
+	}
+}
+
+func TestNormalizeFile_ReportFailureRollsBackAndAborts(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "s.lrc")
+	orig := "[00:30.00][01:05.00]C\n"
+	if err := os.WriteFile(p, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	boom := errors.New("record failed")
+	_, err := NormalizeFile(p, func(string) error { return boom })
+	if !errors.Is(err, boom) {
+		t.Fatalf("want the report error, got %v", err)
+	}
+	// The .lrc must NOT have been rewritten (report ran before the rewrite).
+	if got, _ := os.ReadFile(p); string(got) != orig {
+		t.Errorf(".lrc mutated despite report failure: %q", string(got))
+	}
+	// The just-created backup must be rolled back so a re-run retries cleanly.
+	if _, serr := os.Stat(p + ".orig"); !os.IsNotExist(serr) {
+		t.Error(".orig backup not rolled back after report failure")
 	}
 }
 
@@ -121,7 +150,7 @@ func TestNormalizeFile_CleanFileUntouched(t *testing.T) {
 	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	res, err := NormalizeFile(p)
+	res, err := NormalizeFile(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,13 +174,13 @@ func TestNormalizeFile_IdempotentAndNeverOverwritesBackup(t *testing.T) {
 		t.Fatal(err)
 	}
 	// First pass normalizes and backs up.
-	if res, err := NormalizeFile(p); err != nil || res.Status != StatusNormalized {
+	if res, err := NormalizeFile(p, nil); err != nil || res.Status != StatusNormalized {
 		t.Fatalf("first pass: status=%v err=%v", res.Status, err)
 	}
 	afterFirst, _ := os.ReadFile(p)
 
 	// Second pass is a no-op (already expanded), and must NOT overwrite .orig.
-	res, err := NormalizeFile(p)
+	res, err := NormalizeFile(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +205,7 @@ func TestNormalizeFile_SkipsSymlink(t *testing.T) {
 	if err := os.Symlink(target, link); err != nil {
 		t.Skipf("symlink unsupported: %v", err)
 	}
-	res, err := NormalizeFile(link)
+	res, err := NormalizeFile(link, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +225,7 @@ func TestNormalizeFile_ExpandsAndBacksUp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := NormalizeFile(p)
+	res, err := NormalizeFile(p, nil)
 	if err != nil {
 		t.Fatalf("NormalizeFile: %v", err)
 	}

--- a/internal/lrcnormalize/lrcnormalize.go
+++ b/internal/lrcnormalize/lrcnormalize.go
@@ -6,6 +6,7 @@
 package lrcnormalize
 
 import (
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -134,6 +135,111 @@ func Expand(s models.Synced) models.Synced {
 	return models.Synced{Lines: out}
 }
 
+// NormalizeBody expands stacked multi-timestamp lines in a raw LRC body in
+// place, one cue per timestamp, and returns the rewritten body plus whether any
+// line changed. It is minimally invasive: every non-stacked line (header tags,
+// single-timestamp cues, blank lines, enhanced <..> word-sync markup, non-cue
+// text) is preserved verbatim, the original timestamp substrings and formatting
+// are kept (no re-render / precision loss), and line endings plus the trailing-
+// newline state are preserved. Idempotent: a body with no stacked line returns
+// unchanged.
+func NormalizeBody(body string) (string, bool) {
+	changed := false
+	var b strings.Builder
+	b.Grow(len(body))
+	for _, seg := range splitKeepEOL(body) {
+		expanded, did := splitStackedLine(seg.content)
+		if !did {
+			b.WriteString(seg.content)
+			b.WriteString(seg.term)
+			continue
+		}
+		changed = true
+		// Separate the new sub-lines with the source line's own terminator so
+		// each untouched line keeps its exact EOL (mixed LF/CRLF preserved). When
+		// the stacked line had no terminator (EOF), use "\n" between the new lines
+		// but leave the final one unterminated to preserve the no-trailing-newline
+		// state.
+		sep := seg.term
+		if sep == "" {
+			sep = "\n"
+		}
+		for i, e := range expanded {
+			b.WriteString(e)
+			if i < len(expanded)-1 {
+				b.WriteString(sep)
+			} else {
+				b.WriteString(seg.term)
+			}
+		}
+	}
+	if !changed {
+		return body, false
+	}
+	return b.String(), true
+}
+
+// eolSegment is one source line: its content (terminator stripped) and the exact
+// terminator that followed it ("\n", "\r\n", or "" at EOF).
+type eolSegment struct {
+	content string
+	term    string
+}
+
+// splitKeepEOL splits body into lines while preserving each line's exact
+// terminator, so a rewrite can reproduce mixed line endings byte-for-byte.
+func splitKeepEOL(body string) []eolSegment {
+	var segs []eolSegment
+	for i := 0; i < len(body); {
+		j := strings.IndexByte(body[i:], '\n')
+		if j < 0 {
+			segs = append(segs, eolSegment{content: body[i:], term: ""})
+			break
+		}
+		content := body[i : i+j]
+		term := "\n"
+		if strings.HasSuffix(content, "\r") {
+			content = content[:len(content)-1]
+			term = "\r\n"
+		}
+		segs = append(segs, eolSegment{content: content, term: term})
+		i += j + 1
+	}
+	return segs
+}
+
+// splitStackedLine expands a single line carrying two or more adjacent leading
+// timestamps into one line per timestamp, each preserving the exact original
+// timestamp substring and the shared trailing text verbatim, sorted ascending by
+// time (stable). Returns (nil, false) for a line with fewer than two leading
+// timestamps -- adjacency is required (tsRe is anchored, so any non-'[' between
+// stamps, including whitespace, ends the run and the line is left untouched).
+func splitStackedLine(line string) ([]string, bool) {
+	type stamp struct {
+		raw   string
+		total float64
+	}
+	var stamps []stamp
+	rest := line
+	for {
+		m := tsRe.FindStringSubmatch(rest)
+		if m == nil {
+			break
+		}
+		stamps = append(stamps, stamp{raw: m[0], total: stampSeconds(m[1], m[2], m[3])})
+		rest = rest[len(m[0]):]
+	}
+	if len(stamps) < 2 {
+		return nil, false
+	}
+	sort.SliceStable(stamps, func(i, j int) bool { return stamps[i].total < stamps[j].total })
+	expanded := make([]string, len(stamps))
+	for i, s := range stamps {
+		expanded[i] = s.raw + rest
+	}
+	return expanded, true
+}
+
 // splitLines splits a body on newlines, trimming a trailing carriage return.
 func splitLines(body string) []string {
 	lines := regexp.MustCompile("\r?\n").Split(body, -1)
@@ -154,6 +260,22 @@ func newCue(min, sec, frac, text string) models.Lines {
 			Hundredths: h,
 		},
 	}
+}
+
+// stampSeconds returns a timestamp's absolute seconds at the fractional string's
+// full precision, so the within-line ascending sort orders stamps that differ
+// only in the third fractional digit correctly (normalizeHundredths would
+// truncate them to a tie). Used only as a sort key; emitted substrings are the
+// exact originals.
+func stampSeconds(min, sec, frac string) float64 {
+	m, _ := strconv.Atoi(min)
+	s, _ := strconv.Atoi(sec)
+	total := float64(m*60 + s)
+	if frac != "" {
+		n, _ := strconv.Atoi(frac)
+		total += float64(n) / math.Pow10(len(frac))
+	}
+	return total
 }
 
 // normalizeHundredths converts a captured fractional-second string (0-3 digits)

--- a/internal/lrcnormalize/normalizebody_test.go
+++ b/internal/lrcnormalize/normalizebody_test.go
@@ -1,0 +1,118 @@
+package lrcnormalize
+
+import "testing"
+
+func FuzzNormalizeBody(f *testing.F) {
+	f.Add("")
+	f.Add("[00:30.00][01:05.00]Chorus\n")
+	f.Add("[ar:X]\n[00:10.00]a\n\n")
+	f.Add("[00:12.00]<00:12.00>Hi<00:13.00>there\n")
+	f.Add("[02:14.00][00:45.00]out\r\n[01:00.00]mid\r\n")
+	f.Add("[00:12.00] [00:45.00]spaced")
+
+	f.Fuzz(func(t *testing.T, body string) {
+		out1, changed1 := NormalizeBody(body)
+		// Idempotency: a second pass is a no-op (critical for a re-runnable backfill).
+		out2, changed2 := NormalizeBody(out1)
+		if out2 != out1 || changed2 {
+			t.Fatalf("not idempotent: out1=%q out2=%q changed2=%v", out1, out2, changed2)
+		}
+		// changed=false must mean the body is byte-identical (never a silent edit).
+		if !changed1 && out1 != body {
+			t.Fatalf("changed=false but body differs: in=%q out=%q", body, out1)
+		}
+		// No output line retains two adjacent leading timestamps.
+		for _, line := range splitLines(out1) {
+			if _, did := splitStackedLine(line); did {
+				t.Fatalf("output still carries a stacked line: %q", line)
+			}
+		}
+	})
+}
+
+func TestNormalizeBody_Guards(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "non-stacked body preserved verbatim, unchanged",
+			in:          "[ar:Artist]\n[ti:Title]\n[00:10.00]One\n\n[00:20.00]Two\n",
+			want:        "[ar:Artist]\n[ti:Title]\n[00:10.00]One\n\n[00:20.00]Two\n",
+			wantChanged: false,
+		},
+		{
+			name:        "exact timestamp substrings + text preserved (ms, 1-digit frac, no re-render)",
+			in:          "[00:39.267][01:03.5]  Line \n",
+			want:        "[00:39.267]  Line \n[01:03.5]  Line \n",
+			wantChanged: true,
+		},
+		{
+			name:        "CRLF line endings preserved",
+			in:          "[00:30.00][01:05.00]C\r\n",
+			want:        "[00:30.00]C\r\n[01:05.00]C\r\n",
+			wantChanged: true,
+		},
+		{
+			name:        "mixed line endings preserved per-line (untouched lines keep their EOL)",
+			in:          "[ar:X]\n[00:30.00][01:05.00]C\r\n[00:10.00]tail\n",
+			want:        "[ar:X]\n[00:30.00]C\r\n[01:05.00]C\r\n[00:10.00]tail\n",
+			wantChanged: true,
+		},
+		{
+			name:        "out-of-order stamps sorted ascending within the line",
+			in:          "[02:14.00][00:45.00]Chorus\n",
+			want:        "[00:45.00]Chorus\n[02:14.00]Chorus\n",
+			wantChanged: true,
+		},
+		{
+			name:        "whitespace between stamps is NOT stacked (left verbatim)",
+			in:          "[00:12.00] [00:45.00]word\n",
+			want:        "[00:12.00] [00:45.00]word\n",
+			wantChanged: false,
+		},
+		{
+			name:        "enhanced A2 word-sync left untouched",
+			in:          "[00:12.00]<00:12.00>Hi<00:13.00>there\n",
+			want:        "[00:12.00]<00:12.00>Hi<00:13.00>there\n",
+			wantChanged: false,
+		},
+		{
+			name:        "no trailing newline preserved",
+			in:          "[00:30.00][01:05.00]C",
+			want:        "[00:30.00]C\n[01:05.00]C",
+			wantChanged: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, changed := NormalizeBody(tt.in)
+			if changed != tt.wantChanged {
+				t.Errorf("changed: want %v, got %v", tt.wantChanged, changed)
+			}
+			if out != tt.want {
+				t.Errorf("body:\n want %q\n got  %q", tt.want, out)
+			}
+			// Idempotency: a second pass never changes an already-normalized body.
+			out2, changed2 := NormalizeBody(out)
+			if changed2 || out2 != out {
+				t.Errorf("not idempotent: changed2=%v, out2=%q", changed2, out2)
+			}
+		})
+	}
+}
+
+func TestNormalizeBody_SplitsStacked(t *testing.T) {
+	in := "[00:30.00][01:05.00][02:10.00]Chorus\n"
+	out, changed := NormalizeBody(in)
+
+	want := "[00:30.00]Chorus\n[01:05.00]Chorus\n[02:10.00]Chorus\n"
+	if !changed {
+		t.Error("want changed=true")
+	}
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}


### PR DESCRIPTION
## Summary

- Backfill half of #470: `scan reconcile-lrc` rewrites existing `.lrc` sidecars that stack multiple timestamps on one line (`[t1][t2]text`) into the expanded, universally-readable one-cue-per-line form that simple players render correctly.
- `internal/lrcnormalize.NormalizeBody` - minimally-invasive in-place splitter: touches only adjacent multi-timestamp lines; preserves exact original stamp substrings, text, header tags, blank lines, enhanced `<..>` word-sync, and each line's exact terminator (mixed LF/CRLF safe); sorts within the line at full fractional precision; idempotent.
- `internal/lrcbackfill` + the CLI: needs-work gate (already-clean files untouched, so runs are re-runnable with no compounding), backup-first `.lrc.orig` (exclusive-create + chmod + fsync; skips a file whose `.orig` already exists rather than overwrite unverified), atomic rewrite, per-file-error-continue, JSONL undo trail. Dry-run by default; `--yes` applies; `--library` filter; lazy backup so a zero-rewrite run never creates or deletes the backup file.
- **Size override rationale:** 437 LOC of production across 5 files (well within threshold); the larger total is ~515 LOC of tests. One cohesive feature - the pure foundation already shipped separately as #469, and the items below are deferred - so it can't split further without breaking atomicity.

## Linked issue

Part of #470 (backfill CLI only). Deferred follow-ups tracked on #470: marker-gated serve-mode startup pass (+ processing-row guard), `lrc-normalized` web outcome class, docs page + in-UI link. Parse-time expansion stays deferred to #472.

## Gates (run locally; CI enforces)

- [x] `make gate` - conflict-markers, gofmt, templ+tailwind generate, build, `go test -race`, patch coverage, coverage-floor, codecov dry-run, golangci-lint, actionlint, govulncheck
- [x] Patch coverage 71.89% (threshold 70%); `lrcnormalize` 98%, `lrcbackfill` ~85%
- [x] Adversarial pre-push review ran; 1 Critical + 3 Important data-safety findings fixed (backup never deletes an operator file; mixed-EOL preserved; stale-`.orig` skip; full-precision sort key; umask-proof backup perms), each regression-tested; C1 verified live via the CLI

## Test plan

- [x] Table + `FuzzNormalizeBody` (idempotency, unchanged=>byte-identical, no stacked line survives, mixed-EOL, A2 untouched)
- [x] `lrcbackfill` real-tempfile tests: expand+backup, clean-skip, idempotent, never-overwrite-`.orig`, symlink-skip, skipped/error tallies, dry-run vs apply, JSONL
- [x] `commands` tests: dry-run/apply/idempotent, `--library` filter + not-found, bad config, no-roots, dispatch, operator-backup-not-deleted
- [x] Functional (manual, via built binary): dry-run reports without mutating; `--yes` expands + `.lrc.orig` + JSONL; A2 word-sync left untouched; idempotent re-run; C1 operator-backup survives a zero-rewrite `--yes`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `scan reconcile-lrc` to detect and expand multiple timestamps stacked on one line in `.lrc` files.
  - Supports dry-run previews, applying changes, library-specific scanning, configuration overrides, and optional JSONL backup records.
  - Creates original-file backups before rewriting and safely skips symlinks and files that cannot be safely updated.
  - Preserves line endings and cue formatting while producing one timestamp per line.

- **Bug Fixes**
  - Reconciliation is idempotent and leaves already-clean or unrelated word-sync files unchanged.

- **Tests**
  - Added coverage for dry runs, backups, filtering, error handling, formatting preservation, and repeated execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->