### PR TITLE
feat(lrc): expand stacked LRC timestamps at parse time (#470)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Every package with a one-line purpose. `cmd/mxlrcgo-svc/main.go` is the entry po
 - `circuit` -- concurrency-safe per-lane circuit breaker modeling a provider's rate-limit/throttle response.
 - `backoff` -- shared retry-delay formula (1m, 2m, 4m, ..., capped at 1h) used by the worker, durable queue, and fetch loop.
 - `lyrics` -- LRC/TXT/instrumental writer (`Writer`, `LRCWriter`), `Slugify`, an `.lrc` parser, provenance-tag embedding, and fsync helpers.
-- `lrcnormalize` -- pure transform (`ParseBody`, `Expand`) that expands compressed multi-timestamp LRC lines (`[t1][t2]text`) into one cue per timestamp and classifies `[key:value]` ID-tag lines distinctly from cues; no I/O. Intended as the shared foundation for the LRC-text parse lanes, the write/backfill path (#470), and the upgrade scorer (#472); no consumer wired yet.
+- `lrcnormalize` -- pure transform (`ParseBody`, `Expand`) that expands compressed multi-timestamp LRC lines (`[t1][t2]text`) into one cue per timestamp and classifies `[key:value]` ID-tag lines distinctly from cues; no I/O. The shared foundation for the LRC-text parse lanes, the write/backfill path (#470), and the upgrade scorer (#472). Wired into the `petitlyrics` parse lane, so stacked timestamps expand at parse time and every downstream write is one-cue-per-line; `lrcbackfill` drives the `.lrc` rewrite path. Not yet consumed by #472.
 - `normalize` -- NFKC cache-key normalization, duration bucketing, fuzzy-match confidence, album-artist resolution.
 - `langguard` -- Unicode-script classification/filtering of lyric text against a configured language allowlist.
 - `scanner` -- parses CLI/text-file/directory input into the in-memory queue; skips files that consistently fail metadata read (via the injected `MetadataFailureStore`).

--- a/internal/lrcnormalize/lrcnormalize.go
+++ b/internal/lrcnormalize/lrcnormalize.go
@@ -2,7 +2,8 @@
 // cue per timestamp and classifies [key:value] ID-tag lines distinctly from
 // real cues. It is a pure transform (no I/O) intended as the shared foundation
 // for the LRC-text provider parse lanes, the write/backfill path, and the
-// upgrade match-scorer; no consumer is wired yet.
+// upgrade match-scorer. Wired into the petitlyrics parse lane (#470);
+// lrcbackfill drives the .lrc rewrite path.
 package lrcnormalize
 
 import (

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -22,11 +22,11 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/doxazo-net/canticle/internal/lrcnormalize"
 	"github.com/doxazo-net/canticle/internal/models"
 )
 
@@ -44,10 +44,6 @@ var lyricsLinkRe = regexp.MustCompile(`/lyrics/(\d+)`)
 // csrfTokenRe extracts the CSRF token from the static pl-lib.js file. The token
 // is assigned to a JS variable as a quoted string in observed responses.
 var csrfTokenRe = regexp.MustCompile(`csrfToken\s*[:=]\s*["']([^"']+)["']`)
-
-// lrcLineRe matches a single LRC timestamped line: [mm:ss.xx]text. Hundredths
-// may be two or three digits in the wild; we normalize to hundredths.
-var lrcLineRe = regexp.MustCompile(`^\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?\](.*)$`)
 
 // candidateBlockRe matches the inner content of a single <li> result block
 // (dot-all so the block can span multiple lines).
@@ -501,45 +497,14 @@ func applySecondaryTracks(song *models.Song, rest []ajaxEntry) {
 // parseLRC parses LRC-formatted text into synced lines. It returns ok=false
 // when no line carries a parseable [mm:ss.xx] timestamp, signaling the content
 // should be treated as plain lyrics instead.
+//
+// Expansion happens here rather than at write time (#470): a compressed line
+// carrying several leading stamps ([t1][t2]text) becomes one cue per stamp, so
+// everything downstream of this lane holds a one-cue-per-line model and every
+// future write is player-compatible. Simple player frontends read only the
+// first timestamp on a line, so a stranded [t2] would otherwise render as
+// literal lyric text and the repeat would never highlight.
 func parseLRC(text string) ([]models.Lines, bool) {
-	var lines []models.Lines
-	for _, raw := range strings.Split(text, "\n") {
-		raw = strings.TrimRight(raw, "\r")
-		m := lrcLineRe.FindStringSubmatch(raw)
-		if m == nil {
-			continue
-		}
-		minutes, _ := strconv.Atoi(m[1])
-		seconds, _ := strconv.Atoi(m[2])
-		hundredths := normalizeHundredths(m[3])
-		total := float64(minutes*60+seconds) + float64(hundredths)/100.0
-		lines = append(lines, models.Lines{
-			Text: strings.TrimSpace(m[4]),
-			Time: models.Time{
-				Total:      total,
-				Minutes:    minutes,
-				Seconds:    seconds,
-				Hundredths: hundredths,
-			},
-		})
-	}
-	return lines, len(lines) > 0
-}
-
-// normalizeHundredths converts a captured fractional-second string (1-3 digits)
-// to hundredths of a second. Empty means zero.
-func normalizeHundredths(frac string) int {
-	switch len(frac) {
-	case 0:
-		return 0
-	case 1:
-		n, _ := strconv.Atoi(frac)
-		return n * 10
-	case 2:
-		n, _ := strconv.Atoi(frac)
-		return n
-	default: // 3 digits: milliseconds -> hundredths
-		n, _ := strconv.Atoi(frac[:2])
-		return n
-	}
+	cues := lrcnormalize.ParseBody(text).Cues
+	return cues, len(cues) > 0
 }

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -403,3 +403,95 @@ func TestPacerEnforcesMinInterval(t *testing.T) {
 		}
 	}
 }
+
+// parseLRC expands a compressed multi-timestamp line into one cue per stamp
+// (#470). Simple player frontends read only the first timestamp on a line, so a
+// stranded trailing [t2] renders as literal lyric text and the repeat never
+// highlights. Each stamp must become its own cue carrying the shared text.
+func TestParseLRC_ExpandsStackedTimestamps(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		want   []models.Lines
+		wantOK bool
+	}{
+		{
+			name: "single timestamp is unchanged",
+			body: "[00:12.00]alpha\n",
+			want: []models.Lines{
+				{Text: "alpha", Time: models.Time{Total: 12, Minutes: 0, Seconds: 12, Hundredths: 0}},
+			},
+			wantOK: true,
+		},
+		{
+			name: "two stamps on one line become two cues sharing the text",
+			body: "[00:12.00][00:45.00]alpha\n",
+			want: []models.Lines{
+				{Text: "alpha", Time: models.Time{Total: 12, Minutes: 0, Seconds: 12, Hundredths: 0}},
+				{Text: "alpha", Time: models.Time{Total: 45, Minutes: 0, Seconds: 45, Hundredths: 0}},
+			},
+			wantOK: true,
+		},
+		{
+			name: "out-of-order stack sorts ascending",
+			body: "[02:14.00][00:45.00]alpha\n",
+			want: []models.Lines{
+				{Text: "alpha", Time: models.Time{Total: 45, Minutes: 0, Seconds: 45, Hundredths: 0}},
+				{Text: "alpha", Time: models.Time{Total: 134, Minutes: 2, Seconds: 14, Hundredths: 0}},
+			},
+			wantOK: true,
+		},
+		{
+			name:   "no timestamped line reports not-ok",
+			body:   "just text\n",
+			want:   nil,
+			wantOK: false,
+		},
+		{
+			// Behavior change vs the old regex parser, pinned deliberately: it
+			// returned cues in SOURCE order, so a non-ascending payload stayed
+			// non-ascending. Cues are now time-sorted regardless of source order.
+			name: "non-ascending source order is sorted, not preserved",
+			body: "[02:00.00]alpha\n[00:30.00]beta\n",
+			want: []models.Lines{
+				{Text: "beta", Time: models.Time{Total: 30, Minutes: 0, Seconds: 30, Hundredths: 0}},
+				{Text: "alpha", Time: models.Time{Total: 120, Minutes: 2, Seconds: 0, Hundredths: 0}},
+			},
+			wantOK: true,
+		},
+		{
+			// Millisecond precision narrows to hundredths, and CRLF payloads
+			// parse identically to LF (both were handled by the old parser).
+			name: "millisecond precision and CRLF line endings",
+			body: "[00:12.345]alpha\r\n[00:45.6]beta\r\n",
+			want: []models.Lines{
+				{Text: "alpha", Time: models.Time{Total: 12.34, Minutes: 0, Seconds: 12, Hundredths: 34}},
+				{Text: "beta", Time: models.Time{Total: 45.6, Minutes: 0, Seconds: 45, Hundredths: 60}},
+			},
+			wantOK: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseLRC(tc.body)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v; want %v", ok, tc.wantOK)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d cue(s); want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i].Text != tc.want[i].Text {
+					t.Errorf("cue %d text = %q; want %q", i, got[i].Text, tc.want[i].Text)
+				}
+				if got[i].Time.Total != tc.want[i].Time.Total {
+					t.Errorf("cue %d total = %v; want %v", i, got[i].Time.Total, tc.want[i].Time.Total)
+				}
+				if got[i].Time.Minutes != tc.want[i].Time.Minutes || got[i].Time.Seconds != tc.want[i].Time.Seconds {
+					t.Errorf("cue %d = %dm%ds; want %dm%ds", i,
+						got[i].Time.Minutes, got[i].Time.Seconds, tc.want[i].Time.Minutes, tc.want[i].Time.Seconds)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Wire `internal/lrcnormalize` into the petitlyrics parse lane so compressed multi-timestamp LRC lines (`[t1][t2]text`) expand to one cue per timestamp at parse time. Everything downstream of this lane now holds a one-cue-per-line model, so every future write is player-compatible.
- The old `lrcLineRe` anchored only the first stamp and swept the rest into the cue's text, so `[t2]` was re-emitted as literal lyric text and the repeat never highlighted in simple player frontends.
- `lrcnormalize` shipped in #469 with **no consumer wired**; this is that consumer. `lrcLineRe` and `normalizeHundredths` were reachable only from `parseLRC` and are removed.
- **Closes the live stacked-write vector** -- the stated precondition for re-enabling the petitlyrics lane (which would restore a fallback lane, currently absent).

**Behavior changes** (both pinned by test):
- Cues are now time-sorted rather than source-ordered.
- Timestamp tolerance is unchanged: the new `tsRe` is the *same regex literal* minus the trailing text capture (1-2 digit minutes, `.` or `:` separator, optional 1-3 digit fraction normalized to hundredths). Verified by a differential test of the old and new parsers across a wide input corpus -- zero divergence outside the intended stacked-line fix.

## Linked issue

Part of #470

Not `Closes`: AC 2 (marker-gated serve startup pass), the web `lrc-normalized` outcome class, and the docs page remain open on that issue.

## Gates (run locally; CI enforces them)

- [x] conflict markers
- [x] gofmt
- [x] generate web UI assets (templ + Tailwind)
- [x] go build
- [x] go test (race + coverage)
- [x] patch coverage (Codecov parity, conservative lower bound)
- [x] coverage floor (per-package ratchet)
- [x] codecov report validation (codecovcli dry-run)
- [x] golangci-lint (0 issues)
- [x] actionlint
- [x] govulncheck (0 vulnerabilities)

## Test plan

- [x] `TestParseLRC_ExpandsStackedTimestamps` -- table covering: single timestamp unchanged; two stamps -> two cues sharing the text; out-of-order stack sorts ascending; non-timestamped body reports not-ok; non-ascending source order sorted (not preserved); millisecond precision + CRLF payloads.
- [x] Test watched to FAIL against the old implementation before the fix (it returned `n=1, text="[00:45.00]alpha"`), so the assertions are not tautological.
- [x] Existing `TestFindLyrics_Synced` still exercises the end-to-end synced path.
- [x] Adversarial pass: no panic/hang across `[99:99.999]`, `[0:1]`, stamp-only lines, unicode, a 30KB line, and 2000 stacked stamps.
- [ ] Reviewer follow-ups

## Review notes

An adversarial pre-push review raised one **Important** finding, filed rather than fixed here: **#489** -- `writeSyncedLRC` pairs bilingual translations by slice **index**, so it misaligns whenever the original and translation tracks yield different cue counts. Expanding stacked lines is now one such trigger.

It is deliberately out of scope: the repair belongs to the writer (pair by timestamp, define the policy, test the interleaved format), not to the parse lane, and bundling them would force a reviewer to take both together. It is latent -- `bilingual_output` defaults to false. The fragility predates this PR; index correspondence was previously an *accident* of the lane emitting exactly one cue per source line.
