### PR TITLE
fix(worker): distinguish a blocked queue from an empty one

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -190,7 +190,46 @@ type Worker struct {
 	raceWait time.Duration
 }
 
-var errQueueEmpty = errors.New("worker queue empty")
+// errIdle marks a RunOnce outcome that unwinds the run loop without recording a
+// failure. Every idle sentinel below wraps it, so the loop can decide "stop and
+// idle" with a single errors.Is while still reporting *why* it idled: the causes
+// are not interchangeable. An empty queue means there is no work; the others mean
+// there is work we cannot currently do, which is close to the opposite.
+var errIdle = errors.New("worker idle")
+
+// errQueueEmpty means the queue holds no item ready to dequeue.
+var errQueueEmpty = fmt.Errorf("%w: queue empty", errIdle)
+
+// errLanesUnavailable means every available lane's breaker is open, so no lane
+// was consulted. Ready work may be waiting; we simply cannot ask anyone about it.
+var errLanesUnavailable = fmt.Errorf("%w: all lanes unavailable", errIdle)
+
+// errThrottled means a lane reported a throttle / auth / renewal signal and the
+// item was released back to the queue untouched.
+var errThrottled = fmt.Errorf("%w: provider throttled", errIdle)
+
+// logIdle reports why the run loop is unwinding. The blocked causes stay at DEBUG
+// deliberately: the loop polls every few seconds, so a per-tick WARN would flood a
+// log for hours, and the transition into the blocked state is already reported at
+// WARN by the lane ("lane circuit opened" / "provider throttling"). What was
+// missing was not severity but honesty -- a blocked queue previously reported
+// itself as an empty one, which is what makes a livelocked worker read as idle.
+func logIdle(err error) {
+	switch {
+	case errors.Is(err, errLanesUnavailable):
+		slog.Debug("worker poll: all lanes unavailable; work may be ready but no lane can be consulted")
+	case errors.Is(err, errThrottled):
+		slog.Debug("worker poll: provider throttled; item released back to the queue")
+	case errors.Is(err, errQueueEmpty):
+		slog.Debug("worker poll: queue empty")
+	default:
+		// A future idle sentinel with no case above. Report it verbatim rather than
+		// falling through to "queue empty": defaulting an unknown cause to the
+		// empty-queue message is precisely the lie this function exists to remove,
+		// and it would reintroduce it silently. Unhelpful beats false.
+		slog.Debug("worker poll: idle", "reason", err)
+	}
+}
 
 // New creates a queue consumer worker.
 func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Worker {
@@ -578,8 +617,8 @@ func (w *Worker) run(ctx context.Context, pause func(context.Context) error) err
 			}
 		}
 		if err := w.RunOnce(ctx); err != nil {
-			if errors.Is(err, errQueueEmpty) {
-				slog.Debug("worker poll: queue empty")
+			if errors.Is(err, errIdle) {
+				logIdle(err)
 				return nil
 			}
 			if ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
@@ -617,7 +656,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	// tick does not log a phantom probe. Recovery is only confirmed once a
 	// round-trip succeeds.
 	if w.allLanesUnavailable() {
-		return errQueueEmpty
+		return errLanesUnavailable
 	}
 	item, err := w.queue.Dequeue(ctx)
 	if err != nil {
@@ -649,7 +688,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
 				return fmt.Errorf("worker: release item %d after lanes unavailable: %w", item.ID, releaseErr)
 			}
-			return errQueueEmpty
+			return errLanesUnavailable
 		case orchestrator.OutcomeAuthRateLimit:
 			// A throttle / auth / renewal signal. The lane already tripped its
 			// breaker and emitted the honest classification log; the worker only
@@ -658,7 +697,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			if releaseErr := w.releaseAfterThrottle(ctx, item); releaseErr != nil {
 				return releaseErr
 			}
-			return errQueueEmpty
+			return errThrottled
 		case orchestrator.OutcomeSuccess, orchestrator.OutcomeBenignMiss, orchestrator.OutcomeTransport:
 			// Fall through to the miss / failure handling below.
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1091,8 +1091,8 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 
 			// First call dequeues, hits sentinel, opens circuit.
 			if err := w.RunOnce(context.Background()); err != nil {
-				if !errors.Is(err, errQueueEmpty) {
-					t.Fatalf("RunOnce: %v; want nil or errQueueEmpty", err)
+				if !errors.Is(err, errIdle) {
+					t.Fatalf("RunOnce: %v; want nil or an idle sentinel", err)
 				}
 			}
 			if len(q.failed) != 0 {
@@ -1115,8 +1115,8 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 			callsBefore := fetcher.calls
 			itemsBefore := len(q.items)
 			err := w.RunOnce(context.Background())
-			if !errors.Is(err, errQueueEmpty) {
-				t.Fatalf("RunOnce while open = %v; want errQueueEmpty", err)
+			if !errors.Is(err, errLanesUnavailable) {
+				t.Fatalf("RunOnce while open = %v; want errLanesUnavailable", err)
 			}
 			if fetcher.calls != callsBefore {
 				t.Fatalf("fetcher.calls = %d; want unchanged %d (no dequeue while open)", fetcher.calls, callsBefore)
@@ -1132,8 +1132,8 @@ func TestRunOnceOpensCircuitOnRateLimitedAndDoesNotMarkFailed(t *testing.T) {
 			// and resumes processing (and trips again on the same fetcher).
 			w.setClock(func() time.Time { return fixed.Add(31 * time.Minute) })
 			err = w.RunOnce(context.Background())
-			if err != nil && !errors.Is(err, errQueueEmpty) {
-				t.Fatalf("RunOnce after window = %v; want nil or errQueueEmpty", err)
+			if err != nil && !errors.Is(err, errIdle) {
+				t.Fatalf("RunOnce after window = %v; want nil or an idle sentinel", err)
 			}
 			if fetcher.calls == callsBefore {
 				t.Fatalf("fetcher.calls = %d; want >%d after circuit closed", fetcher.calls, callsBefore)
@@ -1377,8 +1377,8 @@ func TestRunOnceWithOpenCircuitDoesNotIncrementBackoff(t *testing.T) {
 	w.SetCircuitBackoff(10*time.Minute, 30*time.Minute)
 	w.circuit.Trip() // opens until fixed+10m
 
-	if err := w.RunOnce(context.Background()); !errors.Is(err, errQueueEmpty) {
-		t.Fatalf("RunOnce = %v; want errQueueEmpty", err)
+	if err := w.RunOnce(context.Background()); !errors.Is(err, errLanesUnavailable) {
+		t.Fatalf("RunOnce = %v; want errLanesUnavailable", err)
 	}
 	if w.consecutiveFailures != 0 {
 		t.Fatalf("consecutiveFailures = %d; want 0 (open-circuit must not trip backoff)", w.consecutiveFailures)
@@ -1401,8 +1401,8 @@ func TestRunOnceSurfacesReleaseFailureAfterCircuitTrip(t *testing.T) {
 	if err == nil {
 		t.Fatal("RunOnce returned nil; want release-failure error to be surfaced")
 	}
-	if errors.Is(err, errQueueEmpty) {
-		t.Fatalf("RunOnce returned errQueueEmpty; want a real error so the outer loop can react. got %v", err)
+	if errors.Is(err, errIdle) {
+		t.Fatalf("RunOnce returned an idle sentinel; want a real error so the outer loop can react. got %v", err)
 	}
 	if !errors.Is(err, q.releaseErr) {
 		t.Fatalf("RunOnce error %v; want errors.Is(_, releaseErr) so the cause is preserved", err)
@@ -1450,8 +1450,8 @@ func TestTruncatedResponseOpensCircuitAndReleases(t *testing.T) {
 	w.setClock(func() time.Time { return fixed })
 	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
 
-	if err := w.RunOnce(context.Background()); !errors.Is(err, errQueueEmpty) {
-		t.Fatalf("RunOnce = %v; want errQueueEmpty (circuit opened cleanly)", err)
+	if err := w.RunOnce(context.Background()); !errors.Is(err, errThrottled) {
+		t.Fatalf("RunOnce = %v; want errThrottled (circuit opened cleanly)", err)
 	}
 	if w.circuit.OpenUntil().IsZero() {
 		t.Fatal("circuitOpenUntil = zero; want circuit opened on a truncated response")
@@ -2388,5 +2388,119 @@ func TestRunOnceDetectorInstrumentalStampsOutcomeType(t *testing.T) {
 	}
 	if got := q.outcomeTypes[9]; got != "instrumental" {
 		t.Fatalf("outcome_type for id 9 = %q; want \"instrumental\"", got)
+	}
+}
+
+func TestOpenCircuitReturnsLanesUnavailableNotQueueEmpty(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 1, Inputs: models.Inputs{
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:   "out",
+			Filename: "a.lrc",
+		}},
+	}}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return fixed })
+	w.SetCircuitBackoff(10*time.Minute, 30*time.Minute)
+	w.circuit.Trip() // every lane open until fixed+10m
+
+	err := w.RunOnce(context.Background())
+
+	if !errors.Is(err, errLanesUnavailable) {
+		t.Fatalf("RunOnce with an open circuit = %v; want errLanesUnavailable", err)
+	}
+	if errors.Is(err, errQueueEmpty) {
+		t.Fatal("RunOnce reported errQueueEmpty while a ready item sits in the queue and every lane is open-circuited: the queue is not empty, it is blocked")
+	}
+	if !errors.Is(err, errIdle) {
+		t.Fatalf("RunOnce = %v; want it to still satisfy errIdle so the run loop unwinds without recording a failure", err)
+	}
+}
+
+func TestThrottleReleaseReturnsThrottledNotQueueEmpty(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 42, Inputs: models.Inputs{Track: track, Outdir: "out", Filename: "a.lrc"}},
+	}}
+	fetcher := &fakeFetcher{err: fmt.Errorf("upstream: %w", musixmatch.ErrRateLimited)}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return fixed })
+
+	err := w.RunOnce(context.Background())
+
+	if !errors.Is(err, errThrottled) {
+		t.Fatalf("RunOnce after a throttle = %v; want errThrottled", err)
+	}
+	if errors.Is(err, errQueueEmpty) {
+		t.Fatal("RunOnce reported errQueueEmpty after releasing a throttled item back to the queue: the item is still there")
+	}
+	if !errors.Is(err, errIdle) {
+		t.Fatalf("RunOnce = %v; want it to still satisfy errIdle", err)
+	}
+}
+
+func TestRunLoopDoesNotClaimQueueEmptyWhenLanesAreBlocked(t *testing.T) {
+	recs := captureLogs(t)
+	q := &fakeQueue{items: []queue.WorkItem{
+		{ID: 7, Inputs: models.Inputs{
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:   "out",
+			Filename: "a.lrc",
+		}},
+	}}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	fixed := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return fixed })
+	w.SetCircuitBackoff(10*time.Minute, 30*time.Minute)
+	w.circuit.Trip()
+
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run = %v; want nil (idle unwinds cleanly)", err)
+	}
+
+	if hasLog(*recs, slog.LevelDebug, "queue empty") {
+		t.Error("run loop logged \"queue empty\" while every lane was open-circuited and a ready item sat in the queue: this is the line that makes a livelocked worker look idle")
+	}
+	if !hasLog(*recs, slog.LevelDebug, "all lanes unavailable") {
+		t.Error("run loop did not report that all lanes were unavailable; the operator has no way to tell a blocked queue from an empty one")
+	}
+}
+
+// TestLogIdleNamesTheCauseNotJustEmptiness pins the whole point of issue #500:
+// each idle cause must report itself honestly, and an unrecognized one must NOT
+// claim the queue is empty. The default branch is the regression guard -- a future
+// sentinel wrapping errIdle with no case of its own would otherwise silently
+// re-arm exactly the lie this function exists to remove.
+func TestLogIdleNamesTheCauseNotJustEmptiness(t *testing.T) {
+	novelIdle := fmt.Errorf("%w: some future cause", errIdle)
+
+	for _, tc := range []struct {
+		name    string
+		err     error
+		wantSub string
+	}{
+		{"empty queue", errQueueEmpty, "queue empty"},
+		{"lanes unavailable", errLanesUnavailable, "all lanes unavailable"},
+		{"throttled", errThrottled, "provider throttled"},
+		{"unrecognized idle cause", novelIdle, "idle"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := captureLogs(t)
+			logIdle(tc.err)
+			if !hasLog(*recs, slog.LevelDebug, tc.wantSub) {
+				t.Fatalf("logIdle(%v) did not log %q; got %v", tc.err, tc.wantSub, *recs)
+			}
+		})
+	}
+
+	// The guard, stated separately: only the genuinely-empty cause may ever say so.
+	for _, err := range []error{errLanesUnavailable, errThrottled, novelIdle} {
+		recs := captureLogs(t)
+		logIdle(err)
+		if hasLog(*recs, slog.LevelDebug, "queue empty") {
+			t.Errorf("logIdle(%v) claimed \"queue empty\"; only errQueueEmpty may say that (#500)", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- `RunOnce` returned a single `errQueueEmpty` sentinel from four distinct causes, and the run loop logged `worker poll: queue empty` for every one. Only one is an empty queue; the others mean the queue holds ready work that no lane can be consulted about, which is close to the opposite.
- Found on a live deployment where 15,246 rows sat deferred (12,976 past `next_attempt_at`) while the log claimed the queue was empty. This line is why a livelocked worker read as idle for weeks.
- Split the sentinel by cause, all wrapping a shared `errIdle` so the loop still unwinds on one `errors.Is`.

| Sentinel | Meaning |
|---|---|
| `errQueueEmpty` | nothing ready to dequeue |
| `errLanesUnavailable` | every lane's breaker open (gate + post-dequeue) |
| `errThrottled` | throttle/auth signal, item released |

## Linked issue

Closes #500

## Notes for review

**Levels deliberately unchanged.** The blocked causes stay at DEBUG. The loop polls every few seconds, so a per-tick WARN would flood for hours, and the transition into the blocked state is already reported at WARN by the lane (`lane circuit opened`). The defect was never severity — the line was simply false. The issue floats a `; N items ready` count too; that needs a new `Queue` interface method and ripples through every implementation and mock, so it is out of scope here.

**Modified tests, and why they are not weakened.** Three existing tests asserted `errQueueEmpty` on throttle/circuit paths — they encoded the exact conflation being removed. Two became *stricter* (each now pins one cause where it previously accepted any of four). Two moved to `errIdle`, which is identical in breadth: before the split, `errQueueEmpty` *was* the whole idle set.

**The `default:` branch is a regression guard.** `logIdle` matches `errQueueEmpty` explicitly and reports an unknown `errIdle` verbatim. Falling through to "queue empty" would silently re-arm this very bug in the function written to remove it.

## Test plan

- [x] 3 new behavioral tests, each watched fail first for the right reason. The first reproduced the production symptom: `RunOnce with an open circuit = worker idle: queue empty; want errLanesUnavailable`.
- [x] A mid-loop RED caught a real regression I had just introduced: the sentinel split broke the clean unwind (`Run = worker idle: all lanes unavailable; want nil`), because the loop still only matched `errQueueEmpty`. Found by test, not inspection.
- [x] `logIdle` branch-selection test incl. the unknown-cause guard; mutation-verified (reverting the `default` makes it fail on both assertions).
- [x] `make gate` green: race tests, patch coverage **94.74%** (threshold 70%), coverage floor, codecov dry-run, golangci-lint 0 issues, actionlint, govulncheck 0 vulnerabilities.
- [x] Full suite: 2,238 tests across 42 packages.
- [x] Adversarial pre-push review (standard tier, multi-lens). No Critical/Important. Its M1 finding — the `default:` fallthrough — is fixed in this branch.
- [ ] Reviewer follow-ups.
