### PR TITLE
feat(commands): scan reconcile-instrumental to classify never-scored rows

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -3001,64 +3001,14 @@ func runScanClear(ctx context.Context, out io.Writer, args ScanClearCmd) int {
 // applies. By default it re-infers only the telemetry-narrowed candidate set
 // (borderline / cross-version / un-scored rows); --all re-infers every tagged row.
 func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd) int {
-	cfg, err := config.Load(args.ConfigPath)
-	if err != nil {
-		slog.Error("failed to load config", "error", err)
-		return 1
+	env, code := openDetectorEnv(ctx, out, args.ConfigPath, args.Library, "reconcile")
+	if env == nil {
+		return code
 	}
-	sqlDB, err := db.Open(ctx, cfg.DB.Path)
-	if err != nil {
-		slog.Error("failed to open database", "error", err)
-		return 1
-	}
-	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+	defer env.Close()
 
-	var libraryID *int64
-	var libLabel string
-	if strings.TrimSpace(args.Library) != "" {
-		lib, err := resolveLibrary(ctx, library.New(sqlDB), args.Library)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
-				return 1
-			}
-			slog.Error("failed to resolve library", "error", err)
-			return 1
-		}
-		id := lib.ID
-		libraryID = &id
-		libLabel = fmt.Sprintf(" (library %q, id=%d)", lib.Name, lib.ID)
-	}
-
-	// Bail before resolving (or auto-downloading) ffmpeg when no classifier is
-	// configured: reconcile is inert without the detector.
-	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
-		_, _ = fmt.Fprintln(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot reconcile")
-		return 1
-	}
-
-	// Build the detector from the same config/ffmpeg/cooldown wiring serve uses, so
-	// reconcile inherits the cooldown and low-priority ffmpeg sampling. The detector
-	// is process-local: it does not coordinate cooldown with a concurrently running
-	// serve process against the same classifier (queue-level starvation is instead
-	// guaranteed by the deferred + priority=-100 reset).
-	ffmpegPath, err := resolveFFmpeg(ctx, cfg)
-	if err != nil {
-		slog.Error("failed to resolve ffmpeg", "error", err)
-		return 1
-	}
-	det, err := newAudioDetector(cfg, ffmpegPath)
-	if err != nil {
-		slog.Error("failed to construct audio detector", "error", err)
-		return 1
-	}
-	if det == nil {
-		_, _ = fmt.Fprintln(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot reconcile")
-		return 1
-	}
-
-	workQueue := queue.NewDBQueue(sqlDB)
-	workQueue.SetRandomized(cfg.Queue.Randomize)
+	cfg, libraryID, libLabel := env.cfg, env.libraryID, env.libLabel
+	det, workQueue := env.detector, env.queue
 
 	total, err := workQueue.CountInstrumental(ctx)
 	if err != nil {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -133,12 +133,13 @@ type ScanCmd struct {
 	NoDetectInstrumental bool     `arg:"--no-detect-instrumental" help:"force instrumental detection off for tracks enqueued by this scan, overriding per-library and global settings; mutually exclusive with --detect-instrumental"`
 	Libraries            []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
-	Results           *ScanResultsCmd           `arg:"subcommand:results" help:"list persisted scan_results rows"`
-	Clear             *ScanClearCmd             `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
-	Reconcile         *ScanReconcileCmd         `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
-	ReconcilePaths    *ScanReconcilePathsCmd    `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
-	ReconcileIdentity *ScanReconcileIdentityCmd `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
-	ReconcileLRC      *ScanReconcileLRCCmd      `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
+	Results               *ScanResultsCmd               `arg:"subcommand:results" help:"list persisted scan_results rows"`
+	Clear                 *ScanClearCmd                 `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
+	Reconcile             *ScanReconcileCmd             `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
+	ReconcileInstrumental *ScanReconcileInstrumentalCmd `arg:"subcommand:reconcile-instrumental" help:"classify deferred rows the detector has never scored and write markers where it agrees; makes no provider requests (issue #499)"`
+	ReconcilePaths        *ScanReconcilePathsCmd        `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
+	ReconcileIdentity     *ScanReconcileIdentityCmd     `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
+	ReconcileLRC          *ScanReconcileLRCCmd          `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
 }
 
 // ScanReconcileLRCCmd walks the configured library roots and rewrites any .lrc
@@ -181,6 +182,23 @@ type ScanReconcileCmd struct {
 	Yes        bool   `arg:"--yes" help:"actually delete markers and re-queue rows (without it, prints what would change)"`
 	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
 	Backup     string `arg:"--backup" help:"path for the JSONL backup of cleared rows (default: <db-dir>/reconcile-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// ScanReconcileInstrumentalCmd classifies work_queue rows the detector has never
+// scored (instrumental_result IS NULL) that are parked on a benign provider miss,
+// writing an instrumental marker and completing the row where the detector agrees.
+// Dry-run unless --yes.
+//
+// The inverse of ScanReconcileCmd, which re-checks already-confirmed verdicts and
+// clears a marker on disagreement. Nothing previously reached the never-scored
+// population, so a queue drained before the detector shipped stayed permanently
+// unexamined (issue #499). Makes no provider requests.
+type ScanReconcileInstrumentalCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default covers every library"`
+	Yes        bool   `arg:"--yes" help:"actually write markers and settle rows (without it, prints what would change)"`
+	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
+	Backup     string `arg:"--backup" help:"path for the JSONL backup of classified rows (default: <db-dir>/reconcile-instrumental-backup-<ts>.jsonl)" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
@@ -1695,6 +1713,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runScanReconcile(ctx, out, sub)
+	case args.ReconcileInstrumental != nil:
+		sub := *args.ReconcileInstrumental
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runReconcileInstrumental(ctx, out, sub)
 	case args.ReconcilePaths != nil:
 		sub := *args.ReconcilePaths
 		if sub.ConfigPath == "" {

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/reconcile_env.go
+++ b/internal/commands/reconcile_env.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/doxazo-net/canticle/internal/config"
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/detector"
+	"github.com/doxazo-net/canticle/internal/library"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// detectorEnv carries the dependencies every detector-driven reconcile command
+// needs: resolved config, an open database, a constructed detector, the durable
+// queue, and the optional single-library narrowing. Callers must Close it.
+//
+// It exists because these commands agree on their setup and differ only in which
+// rows they select and what they do with the verdict. `scan reconcile` re-checks
+// rows the detector already confirmed and clears the marker on disagreement;
+// `scan reconcile-instrumental` (#499) checks rows it has never seen and writes a
+// marker on agreement. Opposite directions, identical wiring.
+type detectorEnv struct {
+	cfg      config.Config
+	db       *sql.DB
+	detector detector.Detector
+	queue    *queue.DBQueue
+
+	// libraryID narrows selection to one library when the operator passed
+	// --library; nil means every library. libLabel is the pre-rendered operator
+	// facing suffix (" (library %q, id=%d)") or empty.
+	libraryID *int64
+	libLabel  string
+}
+
+// Close releases the database handle. Safe on a nil env.
+func (e *detectorEnv) Close() {
+	if e == nil || e.db == nil {
+		return
+	}
+	_ = e.db.Close() //nolint:errcheck // reason: best-effort close on command exit
+}
+
+// openDetectorEnv performs the setup shared by the detector-driven reconcile
+// commands. verb names the caller in the not-configured message ("reconcile",
+// "backfill") so the operator is told which command went inert.
+//
+// On failure it returns a nil env and a process exit code, having already written
+// the operator-facing message to out or logged the internal error; the caller
+// returns that code verbatim. On success the caller owns the env and must Close it.
+func openDetectorEnv(ctx context.Context, out io.Writer, configPath, libraryArg, verb string) (*detectorEnv, int) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return nil, 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return nil, 1
+	}
+
+	env := &detectorEnv{cfg: cfg, db: sqlDB}
+
+	if strings.TrimSpace(libraryArg) != "" {
+		lib, rerr := resolveLibrary(ctx, library.New(sqlDB), libraryArg)
+		if rerr != nil {
+			env.Close()
+			if errors.Is(rerr, sql.ErrNoRows) {
+				_, _ = fmt.Fprintf(out, "library %q not found\n", libraryArg)
+				return nil, 1
+			}
+			slog.Error("failed to resolve library", "error", rerr)
+			return nil, 1
+		}
+		id := lib.ID
+		env.libraryID = &id
+		env.libLabel = fmt.Sprintf(" (library %q, id=%d)", lib.Name, lib.ID)
+	}
+
+	// Bail before resolving (or auto-downloading) ffmpeg when no classifier is
+	// configured: these commands are inert without the detector.
+	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
+		env.Close()
+		_, _ = fmt.Fprintf(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot %s\n", verb)
+		return nil, 1
+	}
+
+	// Build the detector from the same config/ffmpeg/cooldown wiring serve uses, so
+	// these commands inherit the cooldown and low-priority ffmpeg sampling. The
+	// detector is process-local: it does not coordinate cooldown with a concurrently
+	// running serve process against the same classifier.
+	ffmpegPath, err := resolveFFmpeg(ctx, cfg)
+	if err != nil {
+		env.Close()
+		slog.Error("failed to resolve ffmpeg", "error", err)
+		return nil, 1
+	}
+	det, err := newAudioDetector(cfg, ffmpegPath)
+	if err != nil {
+		env.Close()
+		slog.Error("failed to construct audio detector", "error", err)
+		return nil, 1
+	}
+	if det == nil {
+		env.Close()
+		_, _ = fmt.Fprintf(out, "instrumental detector is not configured (set instrumental_detector.classifier_url); cannot %s\n", verb)
+		return nil, 1
+	}
+	env.detector = det
+
+	workQueue := queue.NewDBQueue(sqlDB)
+	workQueue.SetRandomized(cfg.Queue.Randomize)
+	env.queue = workQueue
+
+	return env, 0
+}

--- a/internal/commands/reconcile_instrumental.go
+++ b/internal/commands/reconcile_instrumental.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/doxazo-net/canticle/internal/instrumentalbackfill"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+)
+
+// reconcileInstrumentalBackup is one JSONL record per row the backfill settles,
+// written and fsynced before the row is mutated so an applied change always has
+// its restorable record.
+type reconcileInstrumentalBackup struct {
+	QueueID     int64     `json:"queue_id"`
+	Artist      string    `json:"artist"`
+	Title       string    `json:"title"`
+	SourcePath  string    `json:"source_path"`
+	MarkerPaths []string  `json:"marker_paths"`
+	MusicSum    float64   `json:"music_sum"`
+	VocalPeak   float64   `json:"vocal_peak"`
+	SpeechMean  float64   `json:"speech_mean"`
+	VocalClass  string    `json:"vocal_class"`
+	Detector    string    `json:"detector_version"`
+	At          time.Time `json:"at"`
+}
+
+func appendReconcileInstrumentalBackup(f *os.File, ch instrumentalbackfill.Change) error {
+	rec := reconcileInstrumentalBackup{
+		QueueID:     ch.QueueID,
+		Artist:      ch.Artist,
+		Title:       ch.Title,
+		SourcePath:  ch.SourcePath,
+		MarkerPaths: ch.MarkerPaths,
+		MusicSum:    ch.Telemetry.MusicSum,
+		VocalPeak:   ch.Telemetry.VocalPeak,
+		SpeechMean:  ch.Telemetry.SpeechMean,
+		VocalClass:  ch.Telemetry.VocalClass,
+		Detector:    ch.Telemetry.DetectorVersion,
+		At:          time.Now().UTC(),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal backup record: %w", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write backup record: %w", err)
+	}
+	// fsync before the row is mutated (the identityrepair backup-first rule).
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync backup record: %w", err)
+	}
+	return nil
+}
+
+// runReconcileInstrumental is CLI wiring over internal/instrumentalbackfill: it
+// resolves config/detector/queue, owns the JSONL backup file and the operator
+// output, and lets the package own the classification logic. Dry-run unless --yes.
+func runReconcileInstrumental(ctx context.Context, out io.Writer, args ScanReconcileInstrumentalCmd) int {
+	env, code := openDetectorEnv(ctx, out, args.ConfigPath, args.Library, "backfill instrumental verdicts")
+	if env == nil {
+		return code
+	}
+	defer env.Close()
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		backupPath = filepath.Join(filepath.Dir(env.cfg.DB.Path), fmt.Sprintf("reconcile-instrumental-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	var backup *os.File
+	defer func() {
+		if backup != nil {
+			_ = backup.Close() //nolint:errcheck // reason: best-effort close on command exit
+		}
+	}()
+
+	if !args.Yes {
+		_, _ = fmt.Fprintf(out, "reconcile-instrumental%s: dry run; pass --yes to apply\n", env.libLabel)
+	}
+
+	bf := instrumentalbackfill.New(env.queue, env.detector, lyrics.NewLRCWriter())
+	res, err := bf.Run(ctx, instrumentalbackfill.Options{
+		LibraryID:           env.libraryID,
+		Limit:               args.Limit,
+		DryRun:              !args.Yes,
+		GlobalDetectDefault: env.cfg.InstrumentalDetector.Enabled,
+		Preview: func(ch instrumentalbackfill.Change) {
+			_, _ = fmt.Fprintf(out, "would mark: id=%d  %s  -> write instrumental marker + settle\n", ch.QueueID, ch.SourcePath)
+		},
+		Report: func(ch instrumentalbackfill.Change) error {
+			if backup == nil {
+				f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+				if ferr != nil {
+					return fmt.Errorf("open backup file %s: %w", backupPath, ferr)
+				}
+				backup = f
+			}
+			return appendReconcileInstrumentalBackup(backup, ch)
+		},
+	})
+	if err != nil {
+		slog.Error("reconcile-instrumental failed", "error", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental%s: %d never-classified deferred row(s) total; %d candidate(s) to classify\n",
+		env.libLabel, res.Total, res.Candidates)
+	// Never let a cap read as full coverage.
+	if args.Limit > 0 && res.Total > res.Candidates {
+		_, _ = fmt.Fprintf(out, "note: --limit=%d caps this run; %d row(s) left unexamined\n", args.Limit, res.Total-res.Candidates)
+	}
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental done: checked=%d instrumental=%d not-instrumental=%d markers-written=%d rows-settled=%d skipped(detect-off=%d,no-source=%d) errors=%d\n",
+		res.Checked, res.Instrumental, res.NotInstrumental, res.MarkersWritten, res.RowsSettled, res.SkippedDetectOff, res.SkippedNoSource, res.Errors)
+	if args.Yes && res.RowsSettled > 0 {
+		_, _ = fmt.Fprintf(out, "backup of classified rows written to %s\n", backupPath)
+	}
+	if res.Errors > 0 {
+		return 1
+	}
+	return 0
+}

--- a/internal/commands/reconcile_instrumental.go
+++ b/internal/commands/reconcile_instrumental.go
@@ -18,32 +18,38 @@ import (
 // written and fsynced before the row is mutated so an applied change always has
 // its restorable record.
 type reconcileInstrumentalBackup struct {
-	QueueID     int64     `json:"queue_id"`
-	Artist      string    `json:"artist"`
-	Title       string    `json:"title"`
-	SourcePath  string    `json:"source_path"`
-	MarkerPaths []string  `json:"marker_paths"`
-	MusicSum    float64   `json:"music_sum"`
-	VocalPeak   float64   `json:"vocal_peak"`
-	SpeechMean  float64   `json:"speech_mean"`
-	VocalClass  string    `json:"vocal_class"`
-	Detector    string    `json:"detector_version"`
-	At          time.Time `json:"at"`
+	QueueID    int64  `json:"queue_id"`
+	Artist     string `json:"artist"`
+	Title      string `json:"title"`
+	SourcePath string `json:"source_path"`
+	// Instrumental records WHICH mutation this row underwent: true settled it and
+	// wrote the markers below; false stamped instrumental_result=0 and left it
+	// deferred. Both are recorded -- a negative stamp also removes the row from
+	// every future backfill, so it needs a restorable record just as much.
+	Instrumental bool      `json:"instrumental"`
+	MarkerPaths  []string  `json:"marker_paths,omitempty"`
+	MusicSum     float64   `json:"music_sum"`
+	VocalPeak    float64   `json:"vocal_peak"`
+	SpeechMean   float64   `json:"speech_mean"`
+	VocalClass   string    `json:"vocal_class"`
+	Detector     string    `json:"detector_version"`
+	At           time.Time `json:"at"`
 }
 
 func appendReconcileInstrumentalBackup(f *os.File, ch instrumentalbackfill.Change) error {
 	rec := reconcileInstrumentalBackup{
-		QueueID:     ch.QueueID,
-		Artist:      ch.Artist,
-		Title:       ch.Title,
-		SourcePath:  ch.SourcePath,
-		MarkerPaths: ch.MarkerPaths,
-		MusicSum:    ch.Telemetry.MusicSum,
-		VocalPeak:   ch.Telemetry.VocalPeak,
-		SpeechMean:  ch.Telemetry.SpeechMean,
-		VocalClass:  ch.Telemetry.VocalClass,
-		Detector:    ch.Telemetry.DetectorVersion,
-		At:          time.Now().UTC(),
+		QueueID:      ch.QueueID,
+		Artist:       ch.Artist,
+		Title:        ch.Title,
+		SourcePath:   ch.SourcePath,
+		Instrumental: ch.Instrumental,
+		MarkerPaths:  ch.MarkerPaths,
+		MusicSum:     ch.Telemetry.MusicSum,
+		VocalPeak:    ch.Telemetry.VocalPeak,
+		SpeechMean:   ch.Telemetry.SpeechMean,
+		VocalClass:   ch.Telemetry.VocalClass,
+		Detector:     ch.Telemetry.DetectorVersion,
+		At:           time.Now().UTC(),
 	}
 	b, err := json.Marshal(rec)
 	if err != nil {
@@ -115,9 +121,14 @@ func runReconcileInstrumental(ctx context.Context, out io.Writer, args ScanRecon
 	if args.Limit > 0 && res.Total > res.Candidates {
 		_, _ = fmt.Fprintf(out, "note: --limit=%d caps this run; %d row(s) left unexamined\n", args.Limit, res.Total-res.Candidates)
 	}
-	_, _ = fmt.Fprintf(out, "reconcile-instrumental done: checked=%d instrumental=%d not-instrumental=%d markers-written=%d rows-settled=%d skipped(detect-off=%d,no-source=%d) errors=%d\n",
-		res.Checked, res.Instrumental, res.NotInstrumental, res.MarkersWritten, res.RowsSettled, res.SkippedDetectOff, res.SkippedNoSource, res.Errors)
-	if args.Yes && res.RowsSettled > 0 {
+	// Two axes, reported separately: what the detector heard, then what happened to
+	// the rows. Folding them into one line is how a claimed row silently looked like
+	// a changed verdict.
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental verdicts: checked=%d instrumental=%d not-instrumental=%d\n",
+		res.Checked, res.Instrumental, res.NotInstrumental)
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental done: markers-written=%d rows-settled=%d rows-stamped=%d skipped(detect-off=%d,no-source=%d,worker-claimed=%d,peer-settled=%d) errors=%d\n",
+		res.MarkersWritten, res.RowsSettled, res.RowsStamped, res.SkippedDetectOff, res.SkippedNoSource, res.SkippedClaimed, res.SkippedAlreadySettled, res.Errors)
+	if args.Yes && (res.RowsSettled > 0 || res.RowsStamped > 0) {
 		_, _ = fmt.Fprintf(out, "backup of classified rows written to %s\n", backupPath)
 	}
 	if res.Errors > 0 {

--- a/internal/commands/reconcile_instrumental_test.go
+++ b/internal/commands/reconcile_instrumental_test.go
@@ -1,0 +1,345 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// instrumentalClassifierResponse is a stub classifier body that passes all three
+// detector gates. Every configured class must be PRESENT: the detector fails
+// closed, so an absent vocal class means the vocal gate cannot run and the track
+// is treated as not-instrumental (it will not silently pass a gate it could not
+// evaluate). So the vocal classes appear with honest sub-threshold peaks rather
+// than being omitted.
+//
+//   - music gate:  summed mean of {Music, Musical instrument} = 0.95 >= 0.90
+//   - vocal gate:  every sung-vocal peak < 0.03
+//   - speech gate: summed mean of {Speech} = 0.01 < 0.20
+const instrumentalClassifierResponse = `{
+  "mean": {"Music": 0.85, "Musical instrument": 0.10, "Speech": 0.01},
+  "max":  {"Music": 0.99, "Musical instrument": 0.95, "Speech": 0.02,
+           "Singing": 0.005, "Vocal music": 0.004, "Choir": 0.001,
+           "A capella": 0.001, "Chant": 0.002, "Rapping": 0.001,
+           "Child singing": 0.001, "Synthetic singing": 0.001,
+           "Yodeling": 0.001, "Humming": 0.002}
+}`
+
+// seedUnclassifiedDeferred parks one row in the state issue #499 targets: deferred
+// on a benign provider miss, never scored by the detector (instrumental_result
+// NULL). Returns the row id.
+func seedUnclassifiedDeferred(t *testing.T, ctx context.Context, dbPath, outdir string) int64 {
+	t.Helper()
+	srcPath := filepath.Join(outdir, "song.flac")
+	if err := os.WriteFile(srcPath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:       models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:      outdir,
+		Filename:    "song.lrc",
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	return item.ID
+}
+
+// TestRunReconcileInstrumental_WritesMarkerForNeverScoredRow is the end-to-end
+// #499 path: a deferred row the detector has never seen, which the (stub)
+// classifier now calls instrumental, must under --yes get its marker written and
+// the row completed -- with zero provider requests. The dry run must change
+// nothing.
+func TestRunReconcileInstrumental_WritesMarkerForNeverScoredRow(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(instrumentalClassifierResponse))
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+	id := seedUnclassifiedDeferred(t, ctx, dbPath, outdir)
+	markerPath := filepath.Join(outdir, "song.txt")
+
+	// Dry run: must change nothing on disk or in the row.
+	var dry bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &dry, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("dry-run exit=%d out=%s", code, dry.String())
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not write a marker; stat err=%v", err)
+	}
+	if !strings.Contains(dry.String(), "would mark") {
+		t.Errorf("dry-run output missing 'would mark':\n%s", dry.String())
+	}
+
+	// Apply.
+	var app bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &app, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, app.String())
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("apply must write the instrumental marker: %v", err)
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var status string
+	var result *int
+	var outcome *string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT status, instrumental_result, outcome_type FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result, &outcome); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done (the row is settled, not left deferred)", status)
+	}
+	if result == nil || *result != 1 {
+		t.Errorf("instrumental_result = %v; want 1 (stamped so it is never re-checked blindly)", result)
+	}
+	if outcome == nil || *outcome != "instrumental" {
+		t.Errorf("outcome_type = %v; want instrumental (so reports classify it)", outcome)
+	}
+}
+
+// TestRunReconcileInstrumental_HonorsPerItemOptOut: a row whose enqueue-time
+// decision explicitly disabled detection must stay untouched. This command is a
+// backfill for rows nobody ever looked at, not a license to override a decision
+// the operator already made.
+func TestRunReconcileInstrumental_HonorsPerItemOptOut(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(instrumentalClassifierResponse))
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+
+	srcPath := filepath.Join(outdir, "song.flac")
+	if err := os.WriteFile(srcPath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	optOut := false
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:              models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:             outdir,
+		Filename:           "song.lrc",
+		SourcePath:         srcPath,
+		OutputPaths:        []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+		DetectInstrumental: &optOut, // explicitly opted out at enqueue
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &buf, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(outdir, "song.txt")); !os.IsNotExist(err) {
+		t.Errorf("opted-out row must not get a marker; stat err=%v", err)
+	}
+	if !strings.Contains(buf.String(), "detect-off=1") {
+		t.Errorf("output should report the opt-out skip:\n%s", buf.String())
+	}
+}
+
+// notInstrumentalClassifierResponse fails the vocal gate: a strong sung-vocal
+// peak. All configured classes are present so every gate can actually run.
+const notInstrumentalClassifierResponse = `{
+  "mean": {"Music": 0.85, "Musical instrument": 0.10, "Speech": 0.01},
+  "max":  {"Music": 0.99, "Musical instrument": 0.95, "Speech": 0.02,
+           "Singing": 0.80, "Vocal music": 0.60, "Choir": 0.001,
+           "A capella": 0.001, "Chant": 0.002, "Rapping": 0.001,
+           "Child singing": 0.001, "Synthetic singing": 0.001,
+           "Yodeling": 0.001, "Humming": 0.002}
+}`
+
+// TestRunReconcileInstrumental_NotInstrumentalStampsAndLeavesDeferred: when the
+// detector disagrees, no marker is written and the row stays deferred (the
+// provider may still find lyrics for it) -- but the negative verdict is stamped
+// so a later run does not re-pay the inference and the row is distinguishable
+// from "never detected".
+func TestRunReconcileInstrumental_NotInstrumentalStampsAndLeavesDeferred(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(notInstrumentalClassifierResponse))
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+	id := seedUnclassifiedDeferred(t, ctx, dbPath, outdir)
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &buf, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(outdir, "song.txt")); !os.IsNotExist(err) {
+		t.Errorf("a vocal track must never get an instrumental marker; stat err=%v", err)
+	}
+	if !strings.Contains(buf.String(), "not-instrumental=1") {
+		t.Errorf("output should report the disagreement:\n%s", buf.String())
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var status string
+	var result *int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT status, instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred (a provider may still find lyrics)", status)
+	}
+	if result == nil || *result != 0 {
+		t.Errorf("instrumental_result = %v; want 0 stamped (distinguishable from never-detected)", result)
+	}
+}
+
+// TestRunReconcileInstrumental_LimitReportsWhatItLeftBehind: a capped run must
+// say what it did not examine. A silent truncation reads as "covered
+// everything" when it did not.
+func TestRunReconcileInstrumental_LimitReportsWhatItLeftBehind(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(instrumentalClassifierResponse))
+	}))
+	defer srv.Close()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+
+	// Two never-classified deferred rows; --limit=1 must examine one and say so.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	for _, title := range []string{"one", "two"} {
+		src := filepath.Join(outdir, title+".flac")
+		if err := os.WriteFile(src, []byte("audio"), 0o600); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:       models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:      outdir,
+			Filename:    title + ".lrc",
+			SourcePath:  src,
+			OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: title + ".flac"}},
+		}, queue.PriorityScan)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %s: %v", title, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+			t.Fatalf("defer %s: %v", title, err)
+		}
+	}
+	_ = sqlDB.Close()
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &buf, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath, Limit: 1}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 never-classified deferred row(s) total; 1 candidate") {
+		t.Errorf("output should report the full backlog alongside the capped candidate set:\n%s", out)
+	}
+	if !strings.Contains(out, "left unexamined") {
+		t.Errorf("a capped run must say what it left behind; got:\n%s", out)
+	}
+}
+
+// TestRunReconcileInstrumental_DetectorNotConfigured: with no classifier_url the
+// command is inert and must say so rather than silently reporting zero work.
+func TestRunReconcileInstrumental_DetectorNotConfigured(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, "", fakeFFmpegCmd(t))
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &buf, ScanReconcileInstrumentalCmd{ConfigPath: cfgPath}); code != 1 {
+		t.Fatalf("exit=%d; want 1 when no classifier is configured. out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "instrumental detector is not configured") {
+		t.Errorf("must name the missing classifier; got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "backfill instrumental verdicts") {
+		t.Errorf("message should name this command, not the sibling reconcile; got:\n%s", buf.String())
+	}
+}

--- a/internal/commands/reconcile_instrumental_test.go
+++ b/internal/commands/reconcile_instrumental_test.go
@@ -139,8 +139,14 @@ func TestRunReconcileInstrumental_WritesMarkerForNeverScoredRow(t *testing.T) {
 
 // TestRunReconcileInstrumental_HonorsPerItemOptOut: a row whose enqueue-time
 // decision explicitly disabled detection must stay untouched. This command is a
-// backfill for rows nobody ever looked at, not a license to override a decision
-// the operator already made.
+// backfill for rows nobody ever looked at, not an override of a decision the
+// operator already made.
+//
+// The opt-out is applied in SQL, so such a row is not merely skipped after
+// selection -- it is never a candidate. That matters beyond tidiness: --limit is
+// applied by the database, so a row filtered afterwards in Go would already have
+// consumed a slot, and the deterministic ordering would let opted-out rows fill
+// every capped run forever (#508 review).
 func TestRunReconcileInstrumental_HonorsPerItemOptOut(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -193,8 +199,13 @@ func TestRunReconcileInstrumental_HonorsPerItemOptOut(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(outdir, "song.txt")); !os.IsNotExist(err) {
 		t.Errorf("opted-out row must not get a marker; stat err=%v", err)
 	}
-	if !strings.Contains(buf.String(), "detect-off=1") {
-		t.Errorf("output should report the opt-out skip:\n%s", buf.String())
+	// Excluded from the backlog entirely, not counted and then skipped: a total
+	// that included rows the run can never classify would overstate the work.
+	if !strings.Contains(buf.String(), "0 never-classified deferred row(s) total") {
+		t.Errorf("an opted-out row must not count toward the backlog total:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "checked=0") {
+		t.Errorf("an opted-out row must never reach the detector:\n%s", buf.String())
 	}
 }
 

--- a/internal/instrumentalbackfill/instrumentalbackfill.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill.go
@@ -1,0 +1,319 @@
+// Package instrumentalbackfill classifies work_queue rows the audio detector has
+// never scored, writing an instrumental marker where it agrees.
+//
+// It exists because detection is otherwise reachable only as a side effect of a
+// provider miss inside the worker: a row deferred before the detector shipped is
+// never re-examined, and `scan reconcile` cannot help because its selector is
+// `instrumental_result = 1 AND status = 'done'` -- it only re-checks verdicts the
+// detector already confirmed, to clear false positives. The inverse direction,
+// classifying a row nobody ever looked at, had no path at all (issue #499).
+//
+// The rows this targets are already deferred on a benign provider miss, so the
+// catalog has been asked and had no answer. Only the local detector is consulted
+// and NO provider request is made, which is also why a tripped provider breaker
+// does not block a backfill.
+package instrumentalbackfill
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/doxazo-net/canticle/internal/detector"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// Store is the durable-queue surface a backfill needs. Satisfied by
+// *queue.DBQueue; narrowed to a seam so every failure path is testable.
+//
+// Both writes are single guarded transactions reporting whether they applied,
+// because the backfill does not own its rows: it leaves them 'deferred' while the
+// detector runs, and a serve-mode worker can claim one mid-classification. A
+// false return means a worker took the row and nothing was written.
+type Store interface {
+	CountUnclassified(ctx context.Context, libraryID *int64) (int, error)
+	ListUnclassified(ctx context.Context, opts queue.ListUnclassifiedOptions) ([]queue.WorkItem, error)
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
+	StampUnclassifiedMiss(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
+}
+
+// Detector classifies a track from its audio. Satisfied by detector.Detector.
+type Detector interface {
+	Detect(ctx context.Context, path string) (detector.Result, error)
+}
+
+// Writer writes the instrumental marker sidecar. Satisfied by lyrics.Writer.
+//
+// Note the sidecar's real name is NOT the filename passed in: the writer derives
+// it via lyrics.SidecarName, which swaps the extension (an instrumental marker is
+// unsynced, so an enqueued "song.lrc" lands as "song.txt"). Use MarkerPaths, never
+// the raw Inputs.Filename, to name what is actually on disk. A fake Writer in a
+// test MUST reproduce that derivation or it will agree with a buggy caller and
+// validate nothing.
+type Writer interface {
+	WriteLRC(song models.Song, filename, outdir string) error
+}
+
+// Change is one row the backfill settled as instrumental. It is the unit handed
+// to Options.Report (the durable backup record) and Options.Preview (the dry-run
+// line), so both describe exactly the same thing.
+type Change struct {
+	QueueID     int64
+	Artist      string
+	Title       string
+	SourcePath  string
+	MarkerPaths []string
+	Telemetry   queue.InstrumentalTelemetry
+}
+
+// Result counts one Run.
+type Result struct {
+	Total            int // rows in the backlog, before Limit
+	Candidates       int // rows this run considered (Total capped by Limit)
+	Checked          int // rows the detector actually classified
+	Instrumental     int // detector agreed
+	NotInstrumental  int // detector disagreed
+	MarkersWritten   int // marker sidecars written
+	RowsSettled      int // rows moved to done
+	SkippedDetectOff int // rows whose detect decision was off
+	SkippedNoSource  int // rows with no readable source path
+	SkippedClaimed   int // rows a serve-mode worker claimed mid-classification
+	Errors           int // non-fatal per-row failures
+}
+
+// Options controls a Run.
+type Options struct {
+	// LibraryID, when non-nil, limits the backfill to one library's rows.
+	LibraryID *int64
+	// Limit caps the candidate set when > 0. Result.Total still reports the full
+	// backlog so a capped run can say what it left behind.
+	Limit int
+	// DryRun classifies and previews without mutating anything.
+	DryRun bool
+	// GlobalDetectDefault resolves rows whose per-item detect decision is NULL,
+	// mirroring how the worker resolves it.
+	GlobalDetectDefault bool
+	// Report is invoked once per instrumental change BEFORE the row is mutated, so
+	// an applied change always has its restorable record first. A Report error
+	// aborts that row's mutation and counts an error; it never aborts the Run.
+	// Nil disables it.
+	Report func(Change) error
+	// Preview is invoked once per instrumental change in a dry run instead of
+	// mutating. Nil disables it.
+	Preview func(Change)
+}
+
+// Backfiller classifies never-scored rows.
+type Backfiller struct {
+	store Store
+	det   Detector
+	w     Writer
+}
+
+// New builds a Backfiller over store, classifying with det and writing with w.
+func New(store Store, det Detector, w Writer) *Backfiller {
+	return &Backfiller{store: store, det: det, w: w}
+}
+
+// Run classifies the never-scored backlog. Per-row failures are counted in
+// Result.Errors and do not abort the run; only a failure to enumerate the
+// backlog returns an error.
+func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
+	var res Result
+
+	total, err := b.store.CountUnclassified(ctx, opts.LibraryID)
+	if err != nil {
+		return res, fmt.Errorf("instrumentalbackfill: count unclassified: %w", err)
+	}
+	res.Total = total
+
+	candidates, err := b.store.ListUnclassified(ctx, queue.ListUnclassifiedOptions{
+		LibraryID: opts.LibraryID,
+		Limit:     opts.Limit,
+	})
+	if err != nil {
+		return res, fmt.Errorf("instrumentalbackfill: list unclassified: %w", err)
+	}
+	res.Candidates = len(candidates)
+
+	for _, item := range candidates {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+
+		// Honor the per-item decision stamped at enqueue, falling back to the global
+		// default, exactly as the worker resolves it. A row explicitly opted out
+		// stays opted out: this is a backfill for rows nobody looked at, not an
+		// override of a decision already made.
+		detect := opts.GlobalDetectDefault
+		if item.DetectInstrumental != nil {
+			detect = *item.DetectInstrumental
+		}
+		if !detect {
+			res.SkippedDetectOff++
+			continue
+		}
+
+		src := strings.TrimSpace(item.Inputs.SourcePath)
+		if src == "" {
+			res.SkippedNoSource++
+			continue
+		}
+
+		verdict, err := b.det.Detect(ctx, src)
+		if err != nil {
+			res.Errors++
+			continue
+		}
+		res.Checked++
+
+		tel := queue.InstrumentalTelemetry{
+			MusicSum:        verdict.Confidence,
+			VocalPeak:       verdict.VocalConfidence,
+			SpeechMean:      verdict.SpeechConfidence,
+			VocalClass:      verdict.WinningVocalClass,
+			DetectorVersion: verdict.Version,
+		}
+
+		if !verdict.Instrumental {
+			res.NotInstrumental++
+			if opts.DryRun {
+				continue
+			}
+			// Stamp the negative verdict so the row is distinguishable from "never
+			// detected" and a later run does not re-pay the inference. The row stays
+			// deferred: a provider may still find lyrics for it.
+			stamped, err := b.store.StampUnclassifiedMiss(ctx, item.ID, tel)
+			if err != nil {
+				res.Errors++
+				continue
+			}
+			if !stamped {
+				res.SkippedClaimed++
+			}
+			continue
+		}
+
+		res.Instrumental++
+		change := Change{
+			QueueID:     item.ID,
+			Artist:      item.Inputs.Track.ArtistName,
+			Title:       item.Inputs.Track.TrackName,
+			SourcePath:  src,
+			MarkerPaths: MarkerPaths(item.Inputs),
+			Telemetry:   tel,
+		}
+
+		if opts.DryRun {
+			if opts.Preview != nil {
+				opts.Preview(change)
+			}
+			continue
+		}
+
+		// Backup first: an applied change must always have its restorable record on
+		// disk before the change exists.
+		if opts.Report != nil {
+			if err := opts.Report(change); err != nil {
+				res.Errors++
+				continue
+			}
+		}
+
+		if err := b.writeMarkers(item, &res); err != nil {
+			res.Errors++
+			// Never stamp a verdict whose marker did not land, or the row would claim
+			// instrumental with nothing on disk. Same ordering rule the worker uses.
+			continue
+		}
+
+		// One guarded transaction: verdict, telemetry, outcome, and completion all
+		// land together or not at all.
+		settled, err := b.store.SettleInstrumental(ctx, item.ID, tel)
+		if err != nil {
+			res.Errors++
+			continue
+		}
+		if !settled {
+			// A worker claimed the row while the detector was running, so nothing was
+			// written to the DB. Take the marker back rather than leave a sidecar the
+			// database has no record of -- and leave the row entirely to its new owner.
+			if rerr := removeMarkers(change.MarkerPaths); rerr != nil {
+				res.Errors++
+				continue
+			}
+			res.MarkersWritten -= len(change.MarkerPaths)
+			res.Instrumental--
+			res.SkippedClaimed++
+			continue
+		}
+		res.RowsSettled++
+	}
+
+	return res, nil
+}
+
+// writeMarkers writes the instrumental marker to every output path for item.
+func (b *Backfiller) writeMarkers(item queue.WorkItem, res *Result) error {
+	song := models.Song{Track: models.Track{
+		ArtistName:   item.Inputs.Track.ArtistName,
+		TrackName:    item.Inputs.Track.TrackName,
+		AlbumName:    item.Inputs.Track.AlbumName,
+		Instrumental: 1,
+	}}
+	for _, p := range outputPaths(item.Inputs) {
+		if err := b.w.WriteLRC(song, p.Filename, p.Outdir); err != nil {
+			return fmt.Errorf("instrumentalbackfill: write marker for %d: %w", item.ID, err)
+		}
+		res.MarkersWritten++
+	}
+	return nil
+}
+
+// outputPaths mirrors the worker's resolution: the enqueued OutputPaths when
+// present, else the single Outdir/Filename pair, so the CLI and the worker agree
+// on where a marker lands.
+func outputPaths(inputs models.Inputs) []models.OutputPath {
+	if len(inputs.OutputPaths) > 0 {
+		return inputs.OutputPaths
+	}
+	return []models.OutputPath{{Outdir: inputs.Outdir, Filename: inputs.Filename}}
+}
+
+// MarkerPaths returns the sidecar paths a marker write actually lands on, derived
+// with lyrics.SidecarName -- the same function the writer uses -- rather than the
+// raw enqueued filename.
+//
+// This distinction is load-bearing, not pedantry: an instrumental marker is
+// unsynced, so SidecarName rewrites an enqueued "song.lrc" to "song.txt". Naming
+// the raw filename in the backup record produced a restorable record pointing at a
+// path that never existed, which silently voided the backup contract. The sibling
+// `scan reconcile` derives its marker paths the same way for the same reason.
+func MarkerPaths(inputs models.Inputs) []string {
+	paths := outputPaths(inputs)
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		name, err := lyrics.SidecarName(inputs.Track.ArtistName, inputs.Track.TrackName, p.Filename, false)
+		if err != nil {
+			continue
+		}
+		out = append(out, filepath.Join(p.Outdir, name))
+	}
+	return out
+}
+
+// removeMarkers deletes markers this run wrote, used when the settle is refused
+// because a worker claimed the row: the DB write did not happen, so the sidecar
+// must not survive either. An already-absent file is not an error.
+func removeMarkers(paths []string) error {
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("instrumentalbackfill: remove orphaned marker %s: %w", p, err)
+		}
+	}
+	return nil
+}

--- a/internal/instrumentalbackfill/instrumentalbackfill.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill.go
@@ -17,6 +17,7 @@ package instrumentalbackfill
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,9 +36,9 @@ import (
 // detector runs, and a serve-mode worker can claim one mid-classification. A
 // false return means a worker took the row and nothing was written.
 type Store interface {
-	CountUnclassified(ctx context.Context, libraryID *int64) (int, error)
+	CountUnclassified(ctx context.Context, libraryID *int64, globalDetectDefault bool) (int, error)
 	ListUnclassified(ctx context.Context, opts queue.ListUnclassifiedOptions) ([]queue.WorkItem, error)
-	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error)
 	StampUnclassifiedMiss(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
 }
 
@@ -62,27 +63,42 @@ type Writer interface {
 // to Options.Report (the durable backup record) and Options.Preview (the dry-run
 // line), so both describe exactly the same thing.
 type Change struct {
-	QueueID     int64
-	Artist      string
-	Title       string
-	SourcePath  string
+	QueueID    int64
+	Artist     string
+	Title      string
+	SourcePath string
+	// Instrumental is the detector's verdict, and therefore which mutation this
+	// change records: true settles the row and writes a marker, false stamps
+	// instrumental_result=0 and leaves it deferred. Both are backed up, because
+	// both remove the row from future backfills.
+	Instrumental bool
+	// MarkerPaths are the sidecars a positive change writes, empty for a negative
+	// one. Derived via lyrics.SidecarName, never the raw enqueued filename.
 	MarkerPaths []string
 	Telemetry   queue.InstrumentalTelemetry
 }
 
 // Result counts one Run.
+//
+// The verdict counts and the mutation counts are deliberately separate axes.
+// Instrumental + NotInstrumental == Checked ALWAYS: they record what the detector
+// heard, and no mutation outcome revises that. What happened to the row afterwards
+// is RowsSettled / RowsStamped / SkippedClaimed / SkippedAlreadySettled / Errors.
 type Result struct {
-	Total            int // rows in the backlog, before Limit
-	Candidates       int // rows this run considered (Total capped by Limit)
-	Checked          int // rows the detector actually classified
-	Instrumental     int // detector agreed
-	NotInstrumental  int // detector disagreed
-	MarkersWritten   int // marker sidecars written
-	RowsSettled      int // rows moved to done
-	SkippedDetectOff int // rows whose detect decision was off
-	SkippedNoSource  int // rows with no readable source path
-	SkippedClaimed   int // rows a serve-mode worker claimed mid-classification
-	Errors           int // non-fatal per-row failures
+	Total           int // eligible rows in the backlog, before Limit
+	Candidates      int // rows this run considered (Total capped by Limit)
+	Checked         int // rows the detector actually classified
+	Instrumental    int // detector agreed  (verdict axis)
+	NotInstrumental int // detector disagreed (verdict axis)
+
+	MarkersWritten        int // marker sidecars written and still on disk
+	RowsSettled           int // rows settled instrumental and completed
+	RowsStamped           int // rows stamped not-instrumental, left deferred
+	SkippedDetectOff      int // rows whose detect decision was off
+	SkippedNoSource       int // rows with no readable source path
+	SkippedClaimed        int // rows a serve-mode worker claimed mid-classification
+	SkippedAlreadySettled int // rows a PEER BACKFILL settled first (marker preserved)
+	Errors                int // non-fatal per-row failures
 }
 
 // Options controls a Run.
@@ -125,15 +141,18 @@ func New(store Store, det Detector, w Writer) *Backfiller {
 func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 	var res Result
 
-	total, err := b.store.CountUnclassified(ctx, opts.LibraryID)
+	total, err := b.store.CountUnclassified(ctx, opts.LibraryID, opts.GlobalDetectDefault)
 	if err != nil {
 		return res, fmt.Errorf("instrumentalbackfill: count unclassified: %w", err)
 	}
 	res.Total = total
 
+	// Eligibility is resolved in SQL so ineligible rows never consume Limit; the
+	// per-item check below is the belt-and-braces half of the same rule.
 	candidates, err := b.store.ListUnclassified(ctx, queue.ListUnclassifiedOptions{
-		LibraryID: opts.LibraryID,
-		Limit:     opts.Limit,
+		LibraryID:           opts.LibraryID,
+		Limit:               opts.Limit,
+		GlobalDetectDefault: opts.GlobalDetectDefault,
 	})
 	if err != nil {
 		return res, fmt.Errorf("instrumentalbackfill: list unclassified: %w", err)
@@ -179,14 +198,38 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			DetectorVersion: verdict.Version,
 		}
 
+		// Instrumental / NotInstrumental are DETECTOR-VERDICT counts and are never
+		// walked back by a mutation outcome: a worker claim does not change what the
+		// detector heard. They must always sum to Checked. The mutation outcome is
+		// described by RowsSettled / SkippedClaimed / Errors instead.
+		change := Change{
+			QueueID:      item.ID,
+			Artist:       item.Inputs.Track.ArtistName,
+			Title:        item.Inputs.Track.TrackName,
+			SourcePath:   src,
+			Instrumental: verdict.Instrumental,
+			Telemetry:    tel,
+		}
+		if verdict.Instrumental {
+			change.MarkerPaths = MarkerPaths(item.Inputs)
+		}
+
 		if !verdict.Instrumental {
 			res.NotInstrumental++
 			if opts.DryRun {
 				continue
 			}
-			// Stamp the negative verdict so the row is distinguishable from "never
-			// detected" and a later run does not re-pay the inference. The row stays
-			// deferred: a provider may still find lyrics for it.
+			// A negative verdict is a MUTATION too: it stamps instrumental_result=0,
+			// which removes the row from every future backfill's candidate set. So it
+			// gets the same backup-first treatment as a positive one -- otherwise --yes
+			// could quietly retire rows with no recoverable record of having done so.
+			if opts.Report != nil {
+				if err := opts.Report(change); err != nil {
+					res.Errors++
+					continue
+				}
+			}
+			// The row stays deferred: a provider may still find lyrics for it.
 			stamped, err := b.store.StampUnclassifiedMiss(ctx, item.ID, tel)
 			if err != nil {
 				res.Errors++
@@ -194,19 +237,13 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			}
 			if !stamped {
 				res.SkippedClaimed++
+				continue
 			}
+			res.RowsStamped++
 			continue
 		}
 
 		res.Instrumental++
-		change := Change{
-			QueueID:     item.ID,
-			Artist:      item.Inputs.Track.ArtistName,
-			Title:       item.Inputs.Track.TrackName,
-			SourcePath:  src,
-			MarkerPaths: MarkerPaths(item.Inputs),
-			Telemetry:   tel,
-		}
 
 		if opts.DryRun {
 			if opts.Preview != nil {
@@ -224,41 +261,62 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			}
 		}
 
-		if err := b.writeMarkers(item, &res); err != nil {
+		// written records exactly the markers that landed, so a rollback removes what
+		// this run created and nothing else -- a partial write (some paths succeeded,
+		// one failed) must not leave its successful siblings behind.
+		written, err := b.writeMarkers(item)
+		res.MarkersWritten += len(written)
+		if err != nil {
 			res.Errors++
-			// Never stamp a verdict whose marker did not land, or the row would claim
-			// instrumental with nothing on disk. Same ordering rule the worker uses.
+			// Never stamp a verdict whose marker did not fully land, or the row would
+			// claim instrumental against an incomplete set of sidecars. The DB was not
+			// touched, so removing what did land is unambiguously correct.
+			res.MarkersWritten -= b.rollback(written, &res)
 			continue
 		}
 
 		// One guarded transaction: verdict, telemetry, outcome, and completion all
 		// land together or not at all.
-		settled, err := b.store.SettleInstrumental(ctx, item.ID, tel)
+		outcome, err := b.store.SettleInstrumental(ctx, item.ID, tel)
 		if err != nil {
+			// AMBIGUOUS: the error may have come from Commit itself, so the settle may
+			// or may not have landed. Deleting the marker could destroy a committed
+			// result, so keep it and report the error -- an orphan marker is recoverable
+			// by a later run, a deleted valid marker is not. Errs toward the reversible
+			// failure.
 			res.Errors++
+			slog.Warn("instrumentalbackfill: settle failed after the marker was written; leaving the marker in place because the commit outcome is unknown",
+				"id", item.ID, "markers", written, "error", err)
 			continue
 		}
-		if !settled {
-			// A worker claimed the row while the detector was running, so nothing was
-			// written to the DB. Take the marker back rather than leave a sidecar the
-			// database has no record of -- and leave the row entirely to its new owner.
-			if rerr := removeMarkers(change.MarkerPaths); rerr != nil {
-				res.Errors++
-				continue
-			}
-			res.MarkersWritten -= len(change.MarkerPaths)
-			res.Instrumental--
+
+		switch outcome {
+		case queue.Settled:
+			res.RowsSettled++
+		case queue.SettleAlreadyInstrumental:
+			// A PEER BACKFILL settled this row first with the same verdict. The marker
+			// on disk is correct -- it is the peer's, and ours is byte-identical. Do
+			// NOT remove it: that would delete a valid result over a race we lost
+			// harmlessly.
+			res.SkippedAlreadySettled++
+		case queue.SettleClaimed, queue.SettleRowGone:
+			// A worker owns the row, or it is gone. Nothing was written to the DB, so
+			// our marker is an orphan the database has no record of: take it back.
+			res.MarkersWritten -= b.rollback(written, &res)
 			res.SkippedClaimed++
-			continue
+		case queue.SettleFailed:
+			// Unreachable: a failure returns a non-nil error, handled above.
+			res.Errors++
 		}
-		res.RowsSettled++
 	}
 
 	return res, nil
 }
 
-// writeMarkers writes the instrumental marker to every output path for item.
-func (b *Backfiller) writeMarkers(item queue.WorkItem, res *Result) error {
+// writeMarkers writes the instrumental marker to every output path for item,
+// returning the paths that ACTUALLY landed -- including on the error path, so a
+// partial write can be rolled back precisely rather than guessed at.
+func (b *Backfiller) writeMarkers(item queue.WorkItem) (written []string, err error) {
 	song := models.Song{Track: models.Track{
 		ArtistName:   item.Inputs.Track.ArtistName,
 		TrackName:    item.Inputs.Track.TrackName,
@@ -266,12 +324,30 @@ func (b *Backfiller) writeMarkers(item queue.WorkItem, res *Result) error {
 		Instrumental: 1,
 	}}
 	for _, p := range outputPaths(item.Inputs) {
-		if err := b.w.WriteLRC(song, p.Filename, p.Outdir); err != nil {
-			return fmt.Errorf("instrumentalbackfill: write marker for %d: %w", item.ID, err)
+		if werr := b.w.WriteLRC(song, p.Filename, p.Outdir); werr != nil {
+			return written, fmt.Errorf("instrumentalbackfill: write marker for %d: %w", item.ID, werr)
 		}
-		res.MarkersWritten++
+		name, nerr := lyrics.SidecarName(item.Inputs.Track.ArtistName, item.Inputs.Track.TrackName, p.Filename, false)
+		if nerr != nil {
+			return written, fmt.Errorf("instrumentalbackfill: resolve marker name for %d: %w", item.ID, nerr)
+		}
+		written = append(written, filepath.Join(p.Outdir, name))
 	}
-	return nil
+	return written, nil
+}
+
+// rollback removes markers this run wrote and reports how many came off, so the
+// caller can keep MarkersWritten honest. A rollback failure is counted as an
+// error rather than swallowed: it means a sidecar the database has no record of
+// survived on disk, which an operator needs to know about.
+func (b *Backfiller) rollback(written []string, res *Result) int {
+	if err := removeMarkers(written); err != nil {
+		res.Errors++
+		slog.Warn("instrumentalbackfill: could not remove an orphaned marker; a sidecar the database has no record of remains on disk",
+			"markers", written, "error", err)
+		return 0
+	}
+	return len(written)
 }
 
 // outputPaths mirrors the worker's resolution: the enqueued OutputPaths when

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -1,0 +1,476 @@
+package instrumentalbackfill
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/detector"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeStore struct {
+	items []queue.WorkItem
+	total int
+
+	countErr error
+	listErr  error
+	stampErr error
+
+	settleErr error
+	// settleClaimed makes SettleInstrumental report settled=false, simulating a
+	// serve-mode worker claiming the row while the detector ran.
+	settleClaimed bool
+	// stampClaimed makes StampUnclassifiedMiss report stamped=false.
+	stampClaimed bool
+
+	lastOpts    queue.ListUnclassifiedOptions
+	stamped     map[int64]int
+	settled     []int64
+	stampCalls  int
+	settleCalls int
+}
+
+func newFakeStore(items ...queue.WorkItem) *fakeStore {
+	return &fakeStore{
+		items:   items,
+		total:   len(items),
+		stamped: map[int64]int{},
+	}
+}
+
+func (s *fakeStore) CountUnclassified(_ context.Context, _ *int64) (int, error) {
+	return s.total, s.countErr
+}
+
+func (s *fakeStore) ListUnclassified(_ context.Context, opts queue.ListUnclassifiedOptions) ([]queue.WorkItem, error) {
+	s.lastOpts = opts
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	items := s.items
+	if opts.Limit > 0 && len(items) > opts.Limit {
+		items = items[:opts.Limit]
+	}
+	return items, nil
+}
+
+func (s *fakeStore) SettleInstrumental(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (bool, error) {
+	s.settleCalls++
+	if s.settleErr != nil {
+		return false, s.settleErr
+	}
+	if s.settleClaimed {
+		return false, nil
+	}
+	s.stamped[id] = 1
+	s.settled = append(s.settled, id)
+	return true, nil
+}
+
+func (s *fakeStore) StampUnclassifiedMiss(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (bool, error) {
+	s.stampCalls++
+	if s.stampErr != nil {
+		return false, s.stampErr
+	}
+	if s.stampClaimed {
+		return false, nil
+	}
+	s.stamped[id] = 0
+	return true, nil
+}
+
+type fakeDetector struct {
+	res detector.Result
+	err error
+}
+
+func (d fakeDetector) Detect(_ context.Context, _ string) (detector.Result, error) {
+	return d.res, d.err
+}
+
+// fakeWriter records what a real lyrics.Writer would ACTUALLY put on disk. It
+// derives the sidecar name with lyrics.SidecarName -- the same call the real
+// writer makes -- instead of echoing the filename it was handed.
+//
+// An earlier version appended outdir+"/"+filename, which is exactly the bug the
+// production code had: it ignored that an instrumental marker is unsynced and
+// lands as .txt, not the enqueued .lrc. Because the fake shared the bug, every
+// test agreed with the broken code and none could see it. A fake that does not
+// faithfully model its seam validates nothing.
+type fakeWriter struct {
+	err     error
+	written []string
+}
+
+func (w *fakeWriter) WriteLRC(song models.Song, filename, outdir string) error {
+	if w.err != nil {
+		return w.err
+	}
+	name, err := lyrics.SidecarName(song.Track.ArtistName, song.Track.TrackName, filename, false)
+	if err != nil {
+		return err
+	}
+	w.written = append(w.written, filepath.Join(outdir, name))
+	return nil
+}
+
+func item(id int64, src string) queue.WorkItem {
+	return queue.WorkItem{ID: id, Inputs: models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "song.lrc",
+		SourcePath: src,
+	}}
+}
+
+func instrumentalVerdict() detector.Result {
+	return detector.Result{Instrumental: true, Confidence: 0.95, Version: "v1"}
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	w := &fakeWriter{}
+	var order []string
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		Report: func(Change) error {
+			order = append(order, "backup")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Instrumental != 1 || res.MarkersWritten != 1 || res.RowsSettled != 1 {
+		t.Fatalf("res = %+v; want instrumental/markers/settled all 1", res)
+	}
+	if store.stamped[1] != 1 {
+		t.Errorf("stamped = %v; want 1", store.stamped[1])
+	}
+	if len(order) != 1 || order[0] != "backup" {
+		t.Errorf("backup did not run: %v", order)
+	}
+}
+
+// A Report failure must abort that row's mutation entirely: the whole point of
+// backup-first is that a change never exists without its restorable record.
+func TestRun_ReportFailureAbortsRowMutation(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	w := &fakeWriter{}
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		Report:              func(Change) error { return errors.New("disk full") },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.RowsSettled != 0 {
+		t.Fatalf("res = %+v; want errors=1 settled=0", res)
+	}
+	if len(w.written) != 0 {
+		t.Errorf("wrote a marker despite a failed backup: %v", w.written)
+	}
+	if store.stampCalls != 0 {
+		t.Errorf("stamped a verdict despite a failed backup (%d calls)", store.stampCalls)
+	}
+}
+
+// A failed marker write must leave the row unstamped: a row claiming
+// instrumental with nothing on disk is worse than an unexamined row.
+func TestRun_MarkerWriteFailureLeavesRowUnstamped(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	w := &fakeWriter{err: errors.New("read-only filesystem")}
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.RowsSettled != 0 || res.MarkersWritten != 0 {
+		t.Fatalf("res = %+v; want errors=1 settled=0 markers=0", res)
+	}
+	if store.stampCalls != 0 {
+		t.Errorf("stamped instrumental despite no marker on disk (%d calls)", store.stampCalls)
+	}
+	if store.settleCalls != 0 {
+		t.Errorf("settled the row despite no marker on disk (%d calls)", store.settleCalls)
+	}
+}
+
+func TestRun_NotInstrumentalStampsZeroAndDoesNotWrite(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	w := &fakeWriter{}
+
+	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, w).Run(
+		context.Background(), Options{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.NotInstrumental != 1 || res.RowsSettled != 0 {
+		t.Fatalf("res = %+v; want not-instrumental=1 settled=0", res)
+	}
+	if len(w.written) != 0 {
+		t.Errorf("a vocal track must never get a marker: %v", w.written)
+	}
+	if got, ok := store.stamped[1]; !ok || got != 0 {
+		t.Errorf("stamped = %v (present=%v); want 0 so it is distinguishable from never-detected", got, ok)
+	}
+}
+
+func TestRun_DryRunPreviewsAndMutatesNothing(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	w := &fakeWriter{}
+	var previewed []int64
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		DryRun:              true,
+		Preview:             func(ch Change) { previewed = append(previewed, ch.QueueID) },
+		Report:              func(Change) error { t.Fatal("dry run must not write a backup record"); return nil },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Instrumental != 1 {
+		t.Errorf("res.Instrumental = %d; want 1 (a dry run still classifies)", res.Instrumental)
+	}
+	if res.RowsSettled != 0 || len(w.written) != 0 || store.stampCalls != 0 {
+		t.Errorf("dry run mutated something: settled=%d written=%v stamps=%d", res.RowsSettled, w.written, store.stampCalls)
+	}
+	if len(previewed) != 1 || previewed[0] != 1 {
+		t.Errorf("previewed = %v; want [1]", previewed)
+	}
+}
+
+func TestRun_HonorsPerItemOptOutOverGlobalDefault(t *testing.T) {
+	optOut := false
+	it := item(1, "/music/a.flac")
+	it.DetectInstrumental = &optOut
+	store := newFakeStore(it)
+	w := &fakeWriter{}
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true, // global says yes; the row says no and must win
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.SkippedDetectOff != 1 || res.Checked != 0 {
+		t.Fatalf("res = %+v; want detect-off=1 checked=0", res)
+	}
+	if len(w.written) != 0 {
+		t.Errorf("opted-out row got a marker: %v", w.written)
+	}
+}
+
+// A per-item opt-IN must survive a global default of off, so a library that
+// enabled detection is still backfilled when the global switch is off.
+func TestRun_PerItemOptInOverridesGlobalOff(t *testing.T) {
+	optIn := true
+	it := item(1, "/music/a.flac")
+	it.DetectInstrumental = &optIn
+	store := newFakeStore(it)
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(context.Background(), Options{
+		GlobalDetectDefault: false,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Checked != 1 || res.Instrumental != 1 {
+		t.Fatalf("res = %+v; want the row classified despite the global default being off", res)
+	}
+}
+
+func TestRun_DetectorFailureIsNonFatalAndLeavesRowAlone(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"), item(2, "/music/b.flac"))
+	w := &fakeWriter{}
+
+	res, err := New(store, fakeDetector{err: errors.New("sidecar down")}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+	})
+	if err != nil {
+		t.Fatalf("Run should not abort on a per-row detector failure: %v", err)
+	}
+	if res.Errors != 2 || res.Checked != 0 || res.RowsSettled != 0 {
+		t.Fatalf("res = %+v; want errors=2 checked=0 settled=0", res)
+	}
+	if store.stampCalls != 0 {
+		t.Errorf("stamped a verdict the detector never produced (%d calls)", store.stampCalls)
+	}
+}
+
+func TestRun_SkipsRowWithNoSourcePath(t *testing.T) {
+	store := newFakeStore(item(1, "   "))
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.SkippedNoSource != 1 || res.Checked != 0 {
+		t.Fatalf("res = %+v; want no-source=1 checked=0", res)
+	}
+}
+
+// Result.Total must report the FULL backlog even when Limit caps the candidate
+// set, so a capped run can say what it left behind rather than reading as full
+// coverage.
+func TestRun_LimitCapsCandidatesButTotalReportsBacklog(t *testing.T) {
+	store := newFakeStore(item(1, "/a.flac"), item(2, "/b.flac"), item(3, "/c.flac"))
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true, Limit: 1})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Total != 3 {
+		t.Errorf("Total = %d; want 3 (the whole backlog)", res.Total)
+	}
+	if res.Candidates != 1 || res.Checked != 1 {
+		t.Errorf("res = %+v; want candidates=1 checked=1", res)
+	}
+	if store.lastOpts.Limit != 1 {
+		t.Errorf("Limit was not passed to the store: %+v", store.lastOpts)
+	}
+}
+
+// The miss path's stamp failure must be counted, not swallowed.
+func TestRun_MissStampFailureIsCounted(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.stampErr = errors.New("db locked")
+
+	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.NotInstrumental != 1 {
+		t.Fatalf("res = %+v; want errors=1 not-instrumental=1", res)
+	}
+}
+
+func TestRun_SettleFailureCountsErrorAndDoesNotClaimSuccess(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.settleErr = errors.New("row owned by a worker")
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.RowsSettled != 0 {
+		t.Fatalf("res = %+v; want errors=1 settled=0", res)
+	}
+}
+
+func TestRun_CountFailureAborts(t *testing.T) {
+	store := newFakeStore()
+	store.countErr = errors.New("db gone")
+	if _, err := New(store, fakeDetector{}, &fakeWriter{}).Run(context.Background(), Options{}); err == nil {
+		t.Fatal("Run must abort when the backlog cannot be enumerated")
+	}
+}
+
+func TestRun_ListFailureAborts(t *testing.T) {
+	store := newFakeStore()
+	store.listErr = errors.New("db gone")
+	if _, err := New(store, fakeDetector{}, &fakeWriter{}).Run(context.Background(), Options{}); err == nil {
+		t.Fatal("Run must abort when candidates cannot be listed")
+	}
+}
+
+func TestRun_CancelledContextStopsWithoutMutating(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(ctx, Options{
+		GlobalDetectDefault: true,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v; want context.Canceled", err)
+	}
+	if res.RowsSettled != 0 || store.stampCalls != 0 {
+		t.Errorf("mutated after cancellation: settled=%d stamps=%d", res.RowsSettled, store.stampCalls)
+	}
+}
+
+// TestMarkerPaths_NamesTheFileTheWriterActuallyWrites is the regression guard for
+// the backup contract. An instrumental marker is UNSYNCED, so lyrics.SidecarName
+// rewrites an enqueued "song.lrc" to "song.txt". Naming the raw enqueued filename
+// produced a backup record pointing at a path that never existed -- a restorable
+// record that cannot restore. This asserts MarkerPaths agrees with what a real
+// write puts on disk, which is the only claim the backup makes.
+func TestMarkerPaths_NamesTheFileTheWriterActuallyWrites(t *testing.T) {
+	it := item(1, "/music/a.flac")
+
+	claimed := MarkerPaths(it.Inputs)
+
+	w := &fakeWriter{}
+	if err := (&Backfiller{w: w}).writeMarkers(it, &Result{}); err != nil {
+		t.Fatalf("writeMarkers: %v", err)
+	}
+
+	if len(claimed) != len(w.written) {
+		t.Fatalf("MarkerPaths = %v but the writer wrote %v", claimed, w.written)
+	}
+	for i := range claimed {
+		if claimed[i] != w.written[i] {
+			t.Errorf("backup record claims %q but the writer wrote %q; a backup naming a nonexistent path cannot restore anything",
+				claimed[i], w.written[i])
+		}
+	}
+	if filepath.Ext(claimed[0]) != ".txt" {
+		t.Errorf("MarkerPaths = %q; an instrumental marker is unsynced and must land as .txt, not the enqueued .lrc", claimed[0])
+	}
+}
+
+// TestRun_WorkerClaimedRowLeavesNoOrphanMarker: the backfill does not own its
+// rows, so a serve-mode worker can claim one while the detector runs. When the
+// guarded settle then reports it wrote nothing, the marker this run put on disk
+// must be taken back -- a sidecar the database has no record of is exactly the
+// inconsistency the guard exists to prevent.
+func TestRun_WorkerClaimedRowLeavesNoOrphanMarker(t *testing.T) {
+	dir := t.TempDir()
+	it := queue.WorkItem{ID: 1, Inputs: models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     dir,
+		Filename:   "song.lrc",
+		SourcePath: "/music/a.flac",
+	}}
+	store := newFakeStore(it)
+	store.settleClaimed = true // a worker took the row mid-classification
+
+	// A real writer, so a real file lands on disk and must really be removed.
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
+		context.Background(), Options{GlobalDetectDefault: true, Report: func(Change) error { return nil }})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.SkippedClaimed != 1 {
+		t.Errorf("res = %+v; want SkippedClaimed=1", res)
+	}
+	if res.RowsSettled != 0 {
+		t.Errorf("RowsSettled = %d; want 0 (the settle wrote nothing)", res.RowsSettled)
+	}
+	for _, p := range MarkerPaths(it.Inputs) {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("orphan marker survived at %s: the DB has no record of it (stat err=%v)", p, err)
+		}
+	}
+	if res.MarkersWritten != 0 {
+		t.Errorf("MarkersWritten = %d; want 0 after the marker was taken back", res.MarkersWritten)
+	}
+}

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -24,11 +24,15 @@ type fakeStore struct {
 	stampErr error
 
 	settleErr error
-	// settleClaimed makes SettleInstrumental report settled=false, simulating a
-	// serve-mode worker claiming the row while the detector ran.
-	settleClaimed bool
+	// settleOutcome is what SettleInstrumental reports. Defaults to queue.Settled;
+	// set it to SettleClaimed / SettleAlreadyInstrumental / SettleRowGone to stage
+	// the races those outcomes represent.
+	settleOutcome queue.SettleOutcome
 	// stampClaimed makes StampUnclassifiedMiss report stamped=false.
 	stampClaimed bool
+	// order, when set, records the mutation sequence so a test can assert ORDERING
+	// rather than mere callback execution.
+	order *[]string
 
 	lastOpts    queue.ListUnclassifiedOptions
 	stamped     map[int64]int
@@ -39,13 +43,14 @@ type fakeStore struct {
 
 func newFakeStore(items ...queue.WorkItem) *fakeStore {
 	return &fakeStore{
-		items:   items,
-		total:   len(items),
-		stamped: map[int64]int{},
+		items:         items,
+		total:         len(items),
+		stamped:       map[int64]int{},
+		settleOutcome: queue.Settled,
 	}
 }
 
-func (s *fakeStore) CountUnclassified(_ context.Context, _ *int64) (int, error) {
+func (s *fakeStore) CountUnclassified(_ context.Context, _ *int64, _ bool) (int, error) {
 	return s.total, s.countErr
 }
 
@@ -61,17 +66,20 @@ func (s *fakeStore) ListUnclassified(_ context.Context, opts queue.ListUnclassif
 	return items, nil
 }
 
-func (s *fakeStore) SettleInstrumental(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (bool, error) {
+func (s *fakeStore) SettleInstrumental(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (queue.SettleOutcome, error) {
 	s.settleCalls++
-	if s.settleErr != nil {
-		return false, s.settleErr
+	if s.order != nil {
+		*s.order = append(*s.order, "settle")
 	}
-	if s.settleClaimed {
-		return false, nil
+	if s.settleErr != nil {
+		return queue.SettleFailed, s.settleErr
+	}
+	if s.settleOutcome != queue.Settled {
+		return s.settleOutcome, nil
 	}
 	s.stamped[id] = 1
 	s.settled = append(s.settled, id)
-	return true, nil
+	return queue.Settled, nil
 }
 
 func (s *fakeStore) StampUnclassifiedMiss(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (bool, error) {
@@ -107,6 +115,8 @@ func (d fakeDetector) Detect(_ context.Context, _ string) (detector.Result, erro
 type fakeWriter struct {
 	err     error
 	written []string
+	// order, when set, records "marker" so a test can assert the real sequence.
+	order *[]string
 }
 
 func (w *fakeWriter) WriteLRC(song models.Song, filename, outdir string) error {
@@ -118,6 +128,9 @@ func (w *fakeWriter) WriteLRC(song models.Song, filename, outdir string) error {
 		return err
 	}
 	w.written = append(w.written, filepath.Join(outdir, name))
+	if w.order != nil {
+		*w.order = append(*w.order, "marker")
+	}
 	return nil
 }
 
@@ -137,9 +150,10 @@ func instrumentalVerdict() detector.Result {
 // --- tests ---------------------------------------------------------------
 
 func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
-	w := &fakeWriter{}
 	var order []string
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.order = &order
+	w := &fakeWriter{order: &order}
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
 		GlobalDetectDefault: true,
@@ -157,8 +171,18 @@ func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
 	if store.stamped[1] != 1 {
 		t.Errorf("stamped = %v; want 1", store.stamped[1])
 	}
-	if len(order) != 1 || order[0] != "backup" {
-		t.Errorf("backup did not run: %v", order)
+
+	// Assert the ACTUAL sequence, not merely that the backup ran. An earlier
+	// version only recorded "backup", so it passed even if the report fired last --
+	// which is precisely the ordering the backup-first contract exists to forbid.
+	want := []string{"backup", "marker", "settle"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v; want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v; want %v (the restorable record must exist before the change it describes)", order, want)
+		}
 	}
 }
 
@@ -418,7 +442,7 @@ func TestMarkerPaths_NamesTheFileTheWriterActuallyWrites(t *testing.T) {
 	claimed := MarkerPaths(it.Inputs)
 
 	w := &fakeWriter{}
-	if err := (&Backfiller{w: w}).writeMarkers(it, &Result{}); err != nil {
+	if _, err := (&Backfiller{w: w}).writeMarkers(it); err != nil {
 		t.Fatalf("writeMarkers: %v", err)
 	}
 
@@ -450,7 +474,7 @@ func TestRun_WorkerClaimedRowLeavesNoOrphanMarker(t *testing.T) {
 		SourcePath: "/music/a.flac",
 	}}
 	store := newFakeStore(it)
-	store.settleClaimed = true // a worker took the row mid-classification
+	store.settleOutcome = queue.SettleClaimed // a worker took the row mid-classification
 
 	// A real writer, so a real file lands on disk and must really be removed.
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
@@ -472,5 +496,149 @@ func TestRun_WorkerClaimedRowLeavesNoOrphanMarker(t *testing.T) {
 	}
 	if res.MarkersWritten != 0 {
 		t.Errorf("MarkersWritten = %d; want 0 after the marker was taken back", res.MarkersWritten)
+	}
+}
+
+// TestRun_PeerSettledRowKeepsItsMarker is the data-loss guard. Zero affected rows
+// only proves the row is no longer deferred -- it does NOT prove a worker took it.
+// A PEER BACKFILL may have settled it first with the identical verdict, in which
+// case the marker on disk is correct and deleting it would destroy a valid result
+// over a race we lost harmlessly.
+func TestRun_PeerSettledRowKeepsItsMarker(t *testing.T) {
+	dir := t.TempDir()
+	it := queue.WorkItem{ID: 1, Inputs: models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     dir,
+		Filename:   "song.lrc",
+		SourcePath: "/music/a.flac",
+	}}
+	store := newFakeStore(it)
+	store.settleOutcome = queue.SettleAlreadyInstrumental // a peer got there first
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
+		context.Background(), Options{GlobalDetectDefault: true, Report: func(Change) error { return nil }})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.SkippedAlreadySettled != 1 {
+		t.Errorf("res = %+v; want SkippedAlreadySettled=1", res)
+	}
+	for _, p := range MarkerPaths(it.Inputs) {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("peer-settled marker was DELETED at %s: the peer's result is valid and this run must not destroy it (%v)", p, err)
+		}
+	}
+	if res.MarkersWritten != 1 {
+		t.Errorf("MarkersWritten = %d; want 1 (the marker stands, it is simply the peer's)", res.MarkersWritten)
+	}
+}
+
+// A settle ERROR is ambiguous -- the failure may have come from Commit itself, so
+// the row may or may not be settled. Deleting the marker could destroy a committed
+// result, so it must survive; an orphan is recoverable, a deleted valid marker is
+// not.
+func TestRun_AmbiguousSettleErrorKeepsMarker(t *testing.T) {
+	dir := t.TempDir()
+	it := queue.WorkItem{ID: 1, Inputs: models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     dir,
+		Filename:   "song.lrc",
+		SourcePath: "/music/a.flac",
+	}}
+	store := newFakeStore(it)
+	store.settleErr = errors.New("commit failed: outcome unknown")
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
+		context.Background(), Options{GlobalDetectDefault: true, Report: func(Change) error { return nil }})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.RowsSettled != 0 {
+		t.Errorf("res = %+v; want errors=1 settled=0", res)
+	}
+	for _, p := range MarkerPaths(it.Inputs) {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("marker deleted on an AMBIGUOUS settle error at %s; the commit may have landed (%v)", p, err)
+		}
+	}
+}
+
+// Verdict counts are a separate axis from mutation outcomes: a worker claim does
+// not change what the detector heard. Instrumental + NotInstrumental must always
+// equal Checked, or the summary underreports.
+func TestRun_VerdictCountsSurviveAWorkerClaim(t *testing.T) {
+	dir := t.TempDir()
+	it := queue.WorkItem{ID: 1, Inputs: models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     dir,
+		Filename:   "song.lrc",
+		SourcePath: "/music/a.flac",
+	}}
+	store := newFakeStore(it)
+	store.settleOutcome = queue.SettleClaimed
+
+	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
+		context.Background(), Options{GlobalDetectDefault: true, Report: func(Change) error { return nil }})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Checked != res.Instrumental+res.NotInstrumental {
+		t.Errorf("res = %+v; Checked must always equal Instrumental+NotInstrumental -- the detector's verdict stands regardless of what happened to the row", res)
+	}
+	if res.Instrumental != 1 {
+		t.Errorf("Instrumental = %d; want 1 (the detector said instrumental; the claim did not change that)", res.Instrumental)
+	}
+	if res.SkippedClaimed != 1 || res.RowsSettled != 0 {
+		t.Errorf("res = %+v; want claimed=1 settled=0", res)
+	}
+}
+
+// A negative verdict is a mutation too -- it stamps instrumental_result=0, which
+// retires the row from every future backfill. It must be backed up first.
+func TestRun_NegativeVerdictIsBackedUpBeforeStamping(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	var order []string
+	store.order = &order
+
+	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(
+		context.Background(), Options{
+			GlobalDetectDefault: true,
+			Report: func(ch Change) error {
+				if ch.Instrumental {
+					t.Error("Change.Instrumental = true for a negative verdict")
+				}
+				order = append(order, "backup")
+				return nil
+			},
+		})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.RowsStamped != 1 {
+		t.Errorf("res = %+v; want RowsStamped=1", res)
+	}
+	if len(order) == 0 || order[0] != "backup" {
+		t.Fatalf("order = %v; a negative stamp retires the row from future backfills and must be recorded BEFORE it lands", order)
+	}
+}
+
+// A Report failure on the negative path must abort the stamp: no record, no change.
+func TestRun_NegativeVerdictReportFailureAbortsStamp(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+
+	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(
+		context.Background(), Options{
+			GlobalDetectDefault: true,
+			Report:              func(Change) error { return errors.New("disk full") },
+		})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Errors != 1 || res.RowsStamped != 0 {
+		t.Fatalf("res = %+v; want errors=1 stamped=0", res)
+	}
+	if store.stampCalls != 0 {
+		t.Errorf("stamped despite a failed backup (%d calls)", store.stampCalls)
 	}
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1297,6 +1297,86 @@ type ListInstrumentalOptions struct {
 	CurrentVersion string
 }
 
+// ListUnclassifiedOptions narrows ListUnclassified.
+type ListUnclassifiedOptions struct {
+	// LibraryID, when non-nil, scopes results to rows linked to that library via
+	// the work_queue_scan_results junction.
+	LibraryID *int64
+	// Limit caps the number of returned rows when > 0.
+	Limit int
+}
+
+// ListUnclassified returns work_queue rows the detector has never scored
+// (instrumental_result IS NULL) that are parked on a benign provider miss
+// (status = 'deferred') and carry a source path to read.
+//
+// This is the population ListInstrumental structurally cannot reach: it selects
+// instrumental_result = 1 AND status = 'done', so it only re-checks verdicts the
+// detector already confirmed, in order to clear false positives. Nothing selects
+// the inverse -- rows never classified at all -- which is why a queue drained
+// before the detector shipped stays permanently unexamined (#499).
+//
+// 'deferred' is the operative status: those rows already lost their provider
+// round-trip, so classifying them costs no provider request. 'processing' rows are
+// excluded (in-flight), as are rows with no source_path (nothing to feed the
+// detector). Read-only.
+func (q *DBQueue) ListUnclassified(ctx context.Context, opts ListUnclassifiedOptions) (items []WorkItem, retErr error) {
+	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       FROM work_queue
+                       WHERE instrumental_result IS NULL
+                         AND status = 'deferred'
+                         AND TRIM(COALESCE(source_path, '')) <> ''`
+	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
+	query := baseQuery
+	var args []any
+	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
+	query += libClause
+	args = append(args, libArgs...)
+	query += orderClause
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: all concatenated fragments are package constants / recheckLibraryClause's fixed clause; never user-built SQL
+	if err != nil {
+		return nil, fmt.Errorf("queue: list unclassified: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close list unclassified rows: %w", err)
+		}
+	}()
+	for rows.Next() {
+		item, err := scanWorkItem(rows)
+		if err != nil {
+			return nil, fmt.Errorf("queue: list unclassified scan: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list unclassified rows: %w", err)
+	}
+	return items, nil
+}
+
+// CountUnclassified returns the total number of rows ListUnclassified would
+// consider, ignoring Limit, so a run can report coverage against the backlog.
+func (q *DBQueue) CountUnclassified(ctx context.Context, libraryID *int64) (int, error) {
+	query := `SELECT COUNT(*) FROM work_queue
+              WHERE instrumental_result IS NULL
+                AND status = 'deferred'
+                AND TRIM(COALESCE(source_path, '')) <> ''`
+	libClause, libArgs := recheckLibraryClause(libraryID)
+	query += libClause
+	var n int
+	if err := q.db.QueryRowContext(ctx, query, libArgs...).Scan(&n); err != nil { //nolint:gosec // G202: fragments are package constants / recheckLibraryClause's fixed clause; never user-built SQL
+		return 0, fmt.Errorf("queue: count unclassified: %w", err)
+	}
+	return n, nil
+}
+
 // ListInstrumental returns work_queue rows flagged instrumental
 // (instrumental_result = 1), hydrated with full Inputs (SourcePath and
 // OutputPaths) so reconcile can locate audio sources and their sidecars. By

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -392,6 +392,102 @@ func (q *DBQueue) Complete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// SettleInstrumental records an instrumental verdict on a DEFERRED row and
+// completes it, in ONE transaction: telemetry, instrumental_result=1,
+// outcome_type='instrumental', status='done', and the scan_results writeback all
+// commit together or not at all.
+//
+// It is a single guarded statement rather than the worker's
+// stamp-then-stamp-then-complete sequence because the backfill does NOT own its
+// rows. The worker holds its row in 'processing' for the whole write, so nothing
+// can race it. The backfill leaves rows 'deferred' while the (slow) detector runs,
+// and Dequeue selects status IN ('pending','failed','deferred') -- so a serve-mode
+// worker can and will claim one mid-classification. Guarding only the final step
+// would let the earlier stamps land on a row the worker already owns, leaving it
+// stamped instrumental while the worker goes on to complete it with real lyrics.
+//
+// Reports settled=false when the row is no longer deferred (a worker took it).
+// Nothing was written in that case, and the caller must undo any marker it wrote.
+func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry) (settled bool, retErr error) {
+	now := formatTime(q.now())
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("queue: begin settle instrumental tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE work_queue
+         SET instrumental_result = 1,
+             music_sum = ?,
+             vocal_peak = ?,
+             speech_mean = ?,
+             vocal_class = ?,
+             detector_version = ?,
+             outcome_type = 'instrumental',
+             status = 'done',
+             completed_at = ?,
+             last_error = ''
+         WHERE id = ?
+           AND status = 'deferred'`,
+		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion,
+		now, id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("queue: settle instrumental: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("queue: settle instrumental rows affected: %w", err)
+	}
+	if n == 0 {
+		return false, nil // no longer deferred: a worker owns it
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+         SET status = 'done'
+         WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+           AND status != 'done'`,
+		id,
+	); err != nil {
+		return false, fmt.Errorf("queue: settle instrumental scan_results writeback: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("queue: commit settle instrumental tx: %w", err)
+	}
+	return true, nil
+}
+
+// StampUnclassifiedMiss records a NOT-instrumental verdict on a DEFERRED row,
+// leaving it deferred: a provider may still find lyrics for it. Guarded on
+// 'deferred' for the same reason as SettleInstrumental -- it must not stamp a row
+// a worker has since claimed and is writing its own verdict onto.
+//
+// Reports stamped=false when the row is no longer deferred.
+func (q *DBQueue) StampUnclassifiedMiss(ctx context.Context, id int64, tel InstrumentalTelemetry) (bool, error) {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET instrumental_result = 0,
+             music_sum = ?,
+             vocal_peak = ?,
+             speech_mean = ?,
+             vocal_class = ?,
+             detector_version = ?
+         WHERE id = ?
+           AND status = 'deferred'`,
+		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion, id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("queue: stamp unclassified miss: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("queue: stamp unclassified miss rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
 // Release returns a processing item to the pending pool without recording a
 // failure. Used when the worker dequeued the item but cannot process it for a
 // reason that should not count against the row's retry budget (e.g. the

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -392,6 +392,30 @@ func (q *DBQueue) Complete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// SettleOutcome explains what a guarded settle actually did. It is an enum rather
+// than a bool because "the UPDATE matched no rows" is ambiguous, and the ambiguity
+// is dangerous: the caller has already written a marker to disk, and whether that
+// marker must be removed or preserved depends on WHY the row was not settled.
+type SettleOutcome int
+
+const (
+	// SettleFailed means the operation errored; the outcome is unknown.
+	SettleFailed SettleOutcome = iota
+	// Settled means this call wrote the verdict and completed the row.
+	Settled
+	// SettleClaimed means a serve-mode worker owns the row now (it is no longer
+	// deferred and carries no instrumental verdict). Nothing was written, so the
+	// caller's marker is orphaned and must be removed.
+	SettleClaimed
+	// SettleAlreadyInstrumental means a PEER BACKFILL settled the row first with the
+	// same verdict. The marker on disk is correct and MUST NOT be removed --
+	// deleting it would destroy a valid result the peer just established.
+	SettleAlreadyInstrumental
+	// SettleRowGone means the row no longer exists (e.g. pruned mid-run). Nothing
+	// was written and no marker is warranted.
+	SettleRowGone
+)
+
 // SettleInstrumental records an instrumental verdict on a DEFERRED row and
 // completes it, in ONE transaction: telemetry, instrumental_result=1,
 // outcome_type='instrumental', status='done', and the scan_results writeback all
@@ -406,13 +430,18 @@ func (q *DBQueue) Complete(ctx context.Context, id int64) error {
 // would let the earlier stamps land on a row the worker already owns, leaving it
 // stamped instrumental while the worker goes on to complete it with real lyrics.
 //
-// Reports settled=false when the row is no longer deferred (a worker took it).
-// Nothing was written in that case, and the caller must undo any marker it wrote.
-func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry) (settled bool, retErr error) {
+// The outcome is stateful, not a bool, because zero affected rows only proves the
+// row is no longer deferred -- it does NOT prove a worker claimed it. A PEER
+// BACKFILL may have settled it first, and the two demand opposite actions: a
+// worker claim means this run's marker is orphaned and must be removed, while a
+// peer settle means the marker on disk is CORRECT and deleting it would destroy a
+// valid result. So on a no-op the row is re-read inside the same transaction and
+// classified.
+func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry) (outcome SettleOutcome, retErr error) {
 	now := formatTime(q.now())
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
-		return false, fmt.Errorf("queue: begin settle instrumental tx: %w", err)
+		return SettleFailed, fmt.Errorf("queue: begin settle instrumental tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -434,14 +463,14 @@ func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel Instrume
 		now, id,
 	)
 	if err != nil {
-		return false, fmt.Errorf("queue: settle instrumental: %w", err)
+		return SettleFailed, fmt.Errorf("queue: settle instrumental: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("queue: settle instrumental rows affected: %w", err)
+		return SettleFailed, fmt.Errorf("queue: settle instrumental rows affected: %w", err)
 	}
 	if n == 0 {
-		return false, nil // no longer deferred: a worker owns it
+		return q.classifyNoSettle(ctx, tx, id)
 	}
 
 	if _, err := tx.ExecContext(ctx,
@@ -451,12 +480,35 @@ func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel Instrume
            AND status != 'done'`,
 		id,
 	); err != nil {
-		return false, fmt.Errorf("queue: settle instrumental scan_results writeback: %w", err)
+		return SettleFailed, fmt.Errorf("queue: settle instrumental scan_results writeback: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("queue: commit settle instrumental tx: %w", err)
+		return SettleFailed, fmt.Errorf("queue: commit settle instrumental tx: %w", err)
 	}
-	return true, nil
+	return Settled, nil
+}
+
+// classifyNoSettle explains why the guarded settle UPDATE matched nothing. It
+// reads inside the caller's transaction, so the answer is consistent with the
+// UPDATE that just ran rather than a later, separately-racing read.
+func (q *DBQueue) classifyNoSettle(ctx context.Context, tx *sql.Tx, id int64) (SettleOutcome, error) {
+	var status string
+	var result *int
+	err := tx.QueryRowContext(ctx,
+		`SELECT status, instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SettleRowGone, nil
+	}
+	if err != nil {
+		return SettleFailed, fmt.Errorf("queue: classify no-settle for %d: %w", id, err)
+	}
+	// A peer backfill got there first: the row already carries the same verdict this
+	// run was about to write, and the marker on disk is ITS marker and is correct.
+	if status == "done" && result != nil && *result == 1 {
+		return SettleAlreadyInstrumental, nil
+	}
+	return SettleClaimed, nil
 }
 
 // StampUnclassifiedMiss records a NOT-instrumental verdict on a DEFERRED row,
@@ -1400,6 +1452,23 @@ type ListUnclassifiedOptions struct {
 	LibraryID *int64
 	// Limit caps the number of returned rows when > 0.
 	Limit int
+	// GlobalDetectDefault resolves rows whose per-item detect_instrumental is NULL,
+	// mirroring how the worker resolves it. It MUST be applied here, in SQL, rather
+	// than by the caller after the fact: Limit is applied by the database, so an
+	// ineligible row filtered in Go has already consumed a slot. Because the
+	// ordering is deterministic, the same ineligible rows would fill every capped
+	// run and the eligible rows behind them would never be reached -- a permanent
+	// starvation rather than a slow drain.
+	GlobalDetectDefault bool
+}
+
+// detectEligibleClause selects rows whose effective detection decision is ON:
+// the per-item stamp when present, else the global default. Mirrors the worker's
+// resolution (item.DetectInstrumental ?? global).
+func detectEligibleClause(globalDefault bool) (clause string, args []any) {
+	// A NULL stamp defers to the global default; when that default is off, no NULL
+	// row is eligible at all.
+	return " AND (detect_instrumental = 1 OR (detect_instrumental IS NULL AND ?))", []any{globalDefault}
 }
 
 // ListUnclassified returns work_queue rows the detector has never scored
@@ -1426,6 +1495,12 @@ func (q *DBQueue) ListUnclassified(ctx context.Context, opts ListUnclassifiedOpt
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	query := baseQuery
 	var args []any
+	// Eligibility BEFORE the limit: an ineligible row filtered in Go has already
+	// consumed a slot, and the deterministic ordering would hand the same
+	// ineligible rows to every capped run forever.
+	detClause, detArgs := detectEligibleClause(opts.GlobalDetectDefault)
+	query += detClause
+	args = append(args, detArgs...)
 	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
 	query += libClause
 	args = append(args, libArgs...)
@@ -1435,7 +1510,7 @@ func (q *DBQueue) ListUnclassified(ctx context.Context, opts ListUnclassifiedOpt
 		args = append(args, opts.Limit)
 	}
 
-	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: all concatenated fragments are package constants / recheckLibraryClause's fixed clause; never user-built SQL
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: all concatenated fragments are package constants / recheckLibraryClause's + detectEligibleClause's fixed clauses; never user-built SQL
 	if err != nil {
 		return nil, fmt.Errorf("queue: list unclassified: %w", err)
 	}
@@ -1459,15 +1534,23 @@ func (q *DBQueue) ListUnclassified(ctx context.Context, opts ListUnclassifiedOpt
 
 // CountUnclassified returns the total number of rows ListUnclassified would
 // consider, ignoring Limit, so a run can report coverage against the backlog.
-func (q *DBQueue) CountUnclassified(ctx context.Context, libraryID *int64) (int, error) {
+// It applies the SAME eligibility rule as ListUnclassified: a total that counted
+// rows the run can never classify would overstate the backlog and make a capped
+// run's "N left unexamined" a lie.
+func (q *DBQueue) CountUnclassified(ctx context.Context, libraryID *int64, globalDetectDefault bool) (int, error) {
 	query := `SELECT COUNT(*) FROM work_queue
               WHERE instrumental_result IS NULL
                 AND status = 'deferred'
                 AND TRIM(COALESCE(source_path, '')) <> ''`
+	var args []any
+	detClause, detArgs := detectEligibleClause(globalDetectDefault)
+	query += detClause
+	args = append(args, detArgs...)
 	libClause, libArgs := recheckLibraryClause(libraryID)
 	query += libClause
+	args = append(args, libArgs...)
 	var n int
-	if err := q.db.QueryRowContext(ctx, query, libArgs...).Scan(&n); err != nil { //nolint:gosec // G202: fragments are package constants / recheckLibraryClause's fixed clause; never user-built SQL
+	if err := q.db.QueryRowContext(ctx, query, args...).Scan(&n); err != nil { //nolint:gosec // G202: fragments are package constants / recheckLibraryClause's + detectEligibleClause's fixed clauses; never user-built SQL
 		return 0, fmt.Errorf("queue: count unclassified: %w", err)
 	}
 	return n, nil

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3723,3 +3723,200 @@ func TestDBQueue_ListUnclassifiedFindsNeverScoredDeferredRows(t *testing.T) {
 		t.Fatalf("SourcePath = %q; want the hydrated source so the detector has a file to read", got[0].Inputs.SourcePath)
 	}
 }
+
+// TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker pins the concurrency
+// contract (#499). The backfill does not own its rows: it leaves them 'deferred'
+// while the detector runs, and Dequeue selects deferred rows, so a serve-mode
+// worker can claim one mid-classification. Both writes must then apply NOTHING --
+// not merely skip the final step. A partial write would leave the row stamped
+// instrumental while the worker goes on to complete it with real lyrics.
+func TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	tel := InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, VocalClass: "Singing", DetectorVersion: "v1"}
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	// A worker claims it: status becomes 'processing'.
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	settled, err := q.SettleInstrumental(ctx, item.ID, tel)
+	if err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+	if settled {
+		t.Error("SettleInstrumental settled a row owned by a worker; the deferred guard must refuse it")
+	}
+	stamped, err := q.StampUnclassifiedMiss(ctx, item.ID, tel)
+	if err != nil {
+		t.Fatalf("StampUnclassifiedMiss: %v", err)
+	}
+	if stamped {
+		t.Error("StampUnclassifiedMiss stamped a row owned by a worker")
+	}
+
+	// Nothing may have landed: not the status, and not the verdict.
+	var status string
+	var result *int
+	var outcome *string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, instrumental_result, outcome_type FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &result, &outcome); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "processing" {
+		t.Errorf("status = %q; want processing (the row must be left to its owner)", status)
+	}
+	if result != nil {
+		t.Errorf("instrumental_result = %v; want NULL -- a refused write must write nothing at all", *result)
+	}
+	if outcome != nil {
+		t.Errorf("outcome_type = %v; want NULL -- a refused write must write nothing at all", *outcome)
+	}
+
+	// Complete still works for the worker that owns it.
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete on a processing row: %v; want success", err)
+	}
+}
+
+// TestDBQueue_SettleInstrumentalCompletesDeferredRowAtomically: the happy path --
+// verdict, telemetry, outcome, and completion all land in one transaction.
+func TestDBQueue_SettleInstrumentalCompletesDeferredRowAtomically(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	tel := InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.01, VocalClass: "Singing", DetectorVersion: "v1"}
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+
+	settled, err := q.SettleInstrumental(ctx, item.ID, tel)
+	if err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+	if !settled {
+		t.Fatal("SettleInstrumental reported not-settled for a deferred row")
+	}
+
+	var status string
+	var result int
+	var outcome string
+	var vocalClass string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, instrumental_result, outcome_type, vocal_class FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &result, &outcome, &vocalClass); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "done" || result != 1 || outcome != "instrumental" {
+		t.Errorf("row = (status %q, result %d, outcome %q); want (done, 1, instrumental)", status, result, outcome)
+	}
+	if vocalClass != "Singing" {
+		t.Errorf("vocal_class = %q; want the telemetry written in the same transaction", vocalClass)
+	}
+}
+
+// TestDBQueue_ListUnclassifiedScopesToLibrary: the --library narrowing must
+// actually filter, or a single-library backfill would silently classify the
+// whole install.
+func TestDBQueue_ListUnclassifiedScopesToLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA, srA := insertLibraryAndScanResult(t, sqlDB, "/libA", "/libA/a.mp3")
+	_, srB := insertLibraryAndScanResult(t, sqlDB, "/libB", "/libB/b.mp3")
+
+	mk := func(title, src string, scanResultID int64) int64 {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:        models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:       "out",
+			Filename:     title + ".lrc",
+			SourcePath:   src,
+			ScanResultID: scanResultID,
+		}, PriorityScan)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %s: %v", title, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+			t.Fatalf("defer %s: %v", title, err)
+		}
+		return item.ID
+	}
+	inA := mk("in-lib-a", "/libA/a.mp3", srA)
+	_ = mk("in-lib-b", "/libB/b.mp3", srB)
+
+	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{LibraryID: &libA})
+	if err != nil {
+		t.Fatalf("ListUnclassified: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != inA {
+		var ids []int64
+		for _, it := range got {
+			ids = append(ids, it.ID)
+		}
+		t.Fatalf("scoped list = %v; want only the libA row %d", ids, inA)
+	}
+
+	n, err := q.CountUnclassified(ctx, &libA)
+	if err != nil {
+		t.Fatalf("CountUnclassified: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("scoped count = %d; want 1", n)
+	}
+
+	// Unscoped sees both, so the filter above is doing real work.
+	all, err := q.CountUnclassified(ctx, nil)
+	if err != nil {
+		t.Fatalf("CountUnclassified unscoped: %v", err)
+	}
+	if all != 2 {
+		t.Fatalf("unscoped count = %d; want 2", all)
+	}
+}
+
+// A database failure must surface, not be reported as an empty backlog: "0 rows
+// to classify" and "the database is gone" must never look the same.
+func TestDBQueue_UnclassifiedQueriesPropagateDBFailure(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{}); err == nil {
+		t.Error("ListUnclassified returned nil error on a closed database; an empty backlog and a dead database must not look alike")
+	}
+	if _, err := q.CountUnclassified(ctx, nil); err == nil {
+		t.Error("CountUnclassified returned nil error on a closed database")
+	}
+	if _, err := q.SettleInstrumental(ctx, 1, InstrumentalTelemetry{}); err == nil {
+		t.Error("SettleInstrumental returned nil error on a closed database")
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3648,3 +3648,78 @@ func TestDBQueue_ResetInstrumental(t *testing.T) {
 		t.Errorf("reset of result=0 row affected %d; want 0", n0)
 	}
 }
+
+// TestDBQueue_ListUnclassifiedFindsNeverScoredDeferredRows covers the population
+// ListInstrumental structurally cannot reach: rows the detector has never seen.
+// ListInstrumental selects `instrumental_result = 1 AND status = 'done'`, so it
+// only ever re-checks verdicts already confirmed. A row deferred on a provider
+// miss before the detector existed has instrumental_result IS NULL and is
+// invisible to it (issue #499).
+func TestDBQueue_ListUnclassifiedFindsNeverScoredDeferredRows(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC) }
+
+	mk := func(title, src string) int64 {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:     "out",
+			Filename:   title + ".lrc",
+			SourcePath: src,
+		}, 1)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		return item.ID
+	}
+
+	// The target: deferred on a benign miss, never scored.
+	wanted := mk("never-scored", "/music/never-scored.flac")
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, wanted, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+
+	// Already scored not-instrumental: the detector has seen it, so it is not a
+	// candidate.
+	scored := mk("already-scored", "/music/already-scored.flac")
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue scored: %v", err)
+	}
+	if _, err := q.Defer(ctx, scored, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer scored: %v", err)
+	}
+	if err := q.SetInstrumentalResult(ctx, scored, 0, InstrumentalTelemetry{DetectorVersion: "v1"}); err != nil {
+		t.Fatalf("stamp scored: %v", err)
+	}
+
+	// No source path: nothing to feed the detector.
+	noSrc := mk("no-source", "")
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue no-source: %v", err)
+	}
+	if _, err := q.Defer(ctx, noSrc, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer no-source: %v", err)
+	}
+
+	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{})
+	if err != nil {
+		t.Fatalf("ListUnclassified: %v", err)
+	}
+
+	if len(got) != 1 {
+		var ids []int64
+		for _, it := range got {
+			ids = append(ids, it.ID)
+		}
+		t.Fatalf("ListUnclassified returned ids %v; want exactly [%d] (the never-scored deferred row)", ids, wanted)
+	}
+	if got[0].ID != wanted {
+		t.Fatalf("ListUnclassified id = %d; want %d", got[0].ID, wanted)
+	}
+	if got[0].Inputs.SourcePath != "/music/never-scored.flac" {
+		t.Fatalf("SourcePath = %q; want the hydrated source so the detector has a file to read", got[0].Inputs.SourcePath)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3704,7 +3704,7 @@ func TestDBQueue_ListUnclassifiedFindsNeverScoredDeferredRows(t *testing.T) {
 		t.Fatalf("defer no-source: %v", err)
 	}
 
-	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{})
+	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{GlobalDetectDefault: true})
 	if err != nil {
 		t.Fatalf("ListUnclassified: %v", err)
 	}
@@ -3749,12 +3749,12 @@ func TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker(t *testing.T) {
 		t.Fatalf("dequeue: %v", err)
 	}
 
-	settled, err := q.SettleInstrumental(ctx, item.ID, tel)
+	outcome, err := q.SettleInstrumental(ctx, item.ID, tel)
 	if err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
-	if settled {
-		t.Error("SettleInstrumental settled a row owned by a worker; the deferred guard must refuse it")
+	if outcome != SettleClaimed {
+		t.Errorf("outcome = %v; want SettleClaimed (a worker owns the row)", outcome)
 	}
 	stamped, err := q.StampUnclassifiedMiss(ctx, item.ID, tel)
 	if err != nil {
@@ -3767,10 +3767,10 @@ func TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker(t *testing.T) {
 	// Nothing may have landed: not the status, and not the verdict.
 	var status string
 	var result *int
-	var outcome *string
+	var outcomeType *string
 	if err := q.db.QueryRowContext(ctx,
 		`SELECT status, instrumental_result, outcome_type FROM work_queue WHERE id = ?`, item.ID,
-	).Scan(&status, &result, &outcome); err != nil {
+	).Scan(&status, &result, &outcomeType); err != nil {
 		t.Fatalf("read row: %v", err)
 	}
 	if status != "processing" {
@@ -3779,8 +3779,8 @@ func TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker(t *testing.T) {
 	if result != nil {
 		t.Errorf("instrumental_result = %v; want NULL -- a refused write must write nothing at all", *result)
 	}
-	if outcome != nil {
-		t.Errorf("outcome_type = %v; want NULL -- a refused write must write nothing at all", *outcome)
+	if outcomeType != nil {
+		t.Errorf("outcome_type = %v; want NULL -- a refused write must write nothing at all", *outcomeType)
 	}
 
 	// Complete still works for the worker that owns it.
@@ -3812,25 +3812,25 @@ func TestDBQueue_SettleInstrumentalCompletesDeferredRowAtomically(t *testing.T) 
 		t.Fatalf("defer: %v", err)
 	}
 
-	settled, err := q.SettleInstrumental(ctx, item.ID, tel)
+	outcome, err := q.SettleInstrumental(ctx, item.ID, tel)
 	if err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
-	if !settled {
-		t.Fatal("SettleInstrumental reported not-settled for a deferred row")
+	if outcome != Settled {
+		t.Fatalf("outcome = %v; want Settled for a deferred row", outcome)
 	}
 
 	var status string
 	var result int
-	var outcome string
+	var outcomeType string
 	var vocalClass string
 	if err := q.db.QueryRowContext(ctx,
 		`SELECT status, instrumental_result, outcome_type, vocal_class FROM work_queue WHERE id = ?`, item.ID,
-	).Scan(&status, &result, &outcome, &vocalClass); err != nil {
+	).Scan(&status, &result, &outcomeType, &vocalClass); err != nil {
 		t.Fatalf("read row: %v", err)
 	}
-	if status != "done" || result != 1 || outcome != "instrumental" {
-		t.Errorf("row = (status %q, result %d, outcome %q); want (done, 1, instrumental)", status, result, outcome)
+	if status != "done" || result != 1 || outcomeType != "instrumental" {
+		t.Errorf("row = (status %q, result %d, outcome %q); want (done, 1, instrumental)", status, result, outcomeType)
 	}
 	if vocalClass != "Singing" {
 		t.Errorf("vocal_class = %q; want the telemetry written in the same transaction", vocalClass)
@@ -3870,7 +3870,7 @@ func TestDBQueue_ListUnclassifiedScopesToLibrary(t *testing.T) {
 	inA := mk("in-lib-a", "/libA/a.mp3", srA)
 	_ = mk("in-lib-b", "/libB/b.mp3", srB)
 
-	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{LibraryID: &libA})
+	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{LibraryID: &libA, GlobalDetectDefault: true})
 	if err != nil {
 		t.Fatalf("ListUnclassified: %v", err)
 	}
@@ -3882,7 +3882,7 @@ func TestDBQueue_ListUnclassifiedScopesToLibrary(t *testing.T) {
 		t.Fatalf("scoped list = %v; want only the libA row %d", ids, inA)
 	}
 
-	n, err := q.CountUnclassified(ctx, &libA)
+	n, err := q.CountUnclassified(ctx, &libA, true)
 	if err != nil {
 		t.Fatalf("CountUnclassified: %v", err)
 	}
@@ -3891,7 +3891,7 @@ func TestDBQueue_ListUnclassifiedScopesToLibrary(t *testing.T) {
 	}
 
 	// Unscoped sees both, so the filter above is doing real work.
-	all, err := q.CountUnclassified(ctx, nil)
+	all, err := q.CountUnclassified(ctx, nil, true)
 	if err != nil {
 		t.Fatalf("CountUnclassified unscoped: %v", err)
 	}
@@ -3910,13 +3910,191 @@ func TestDBQueue_UnclassifiedQueriesPropagateDBFailure(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	if _, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{}); err == nil {
+	if _, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{GlobalDetectDefault: true}); err == nil {
 		t.Error("ListUnclassified returned nil error on a closed database; an empty backlog and a dead database must not look alike")
 	}
-	if _, err := q.CountUnclassified(ctx, nil); err == nil {
+	if _, err := q.CountUnclassified(ctx, nil, true); err == nil {
 		t.Error("CountUnclassified returned nil error on a closed database")
 	}
 	if _, err := q.SettleInstrumental(ctx, 1, InstrumentalTelemetry{}); err == nil {
 		t.Error("SettleInstrumental returned nil error on a closed database")
+	}
+}
+
+// TestDBQueue_SettleInstrumentalDistinguishesPeerFromWorker is the data-loss
+// guard at the DB layer. Zero affected rows only proves the row is not deferred.
+// A worker claim and a peer backfill's settle both produce zero rows, but demand
+// OPPOSITE actions: the caller must remove its orphaned marker in the first case
+// and preserve the valid one in the second. A bool cannot carry that.
+func TestDBQueue_SettleInstrumentalDistinguishesPeerFromWorker(t *testing.T) {
+	ctx := context.Background()
+	tel := InstrumentalTelemetry{MusicSum: 0.95, DetectorVersion: "v1"}
+
+	mkDeferred := func(t *testing.T, q *DBQueue, title string) int64 {
+		t.Helper()
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:     "out",
+			Filename:   title + ".lrc",
+			SourcePath: "/music/" + title + ".flac",
+		}, 1)
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue: %v", err)
+		}
+		// Zero cooldown: next_attempt_at = now, so the row is immediately
+		// dequeue-eligible and a worker can genuinely race it -- which is the whole
+		// point of the guard under test.
+		if _, err := q.Defer(ctx, item.ID, 0, errors.New("no results found")); err != nil {
+			t.Fatalf("defer: %v", err)
+		}
+		return item.ID
+	}
+
+	t.Run("peer backfill settled it first", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		id := mkDeferred(t, q, "peer")
+		// The peer wins the race.
+		if out, err := q.SettleInstrumental(ctx, id, tel); err != nil || out != Settled {
+			t.Fatalf("peer settle = (%v, %v); want (Settled, nil)", out, err)
+		}
+		// We lose it, and must be told WHY -- our marker is identical and valid.
+		out, err := q.SettleInstrumental(ctx, id, tel)
+		if err != nil {
+			t.Fatalf("second settle: %v", err)
+		}
+		if out != SettleAlreadyInstrumental {
+			t.Fatalf("outcome = %v; want SettleAlreadyInstrumental. Reporting a worker claim here makes the caller DELETE the marker the peer just validly established", out)
+		}
+	})
+
+	t.Run("worker claimed it", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		id := mkDeferred(t, q, "worker")
+		if _, err := q.Dequeue(ctx); err != nil { // a worker takes it back
+			t.Fatalf("dequeue: %v", err)
+		}
+		out, err := q.SettleInstrumental(ctx, id, tel)
+		if err != nil {
+			t.Fatalf("settle: %v", err)
+		}
+		if out != SettleClaimed {
+			t.Fatalf("outcome = %v; want SettleClaimed", out)
+		}
+	})
+
+	t.Run("row gone", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		id := mkDeferred(t, q, "gone")
+		if _, err := q.db.ExecContext(ctx, `DELETE FROM work_queue WHERE id = ?`, id); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+		out, err := q.SettleInstrumental(ctx, id, tel)
+		if err != nil {
+			t.Fatalf("settle: %v", err)
+		}
+		if out != SettleRowGone {
+			t.Fatalf("outcome = %v; want SettleRowGone", out)
+		}
+	})
+}
+
+// TestDBQueue_ListUnclassifiedAppliesEligibilityBeforeLimit is the starvation
+// guard. Limit is applied by the database, so filtering ineligible rows in Go
+// after the fact means they have already consumed the slots. The ordering is
+// deterministic, so the SAME ineligible rows would fill every capped run and the
+// eligible rows behind them would never be classified -- ever.
+func TestDBQueue_ListUnclassifiedAppliesEligibilityBeforeLimit(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	mk := func(title string, detect *bool) int64 {
+		inputs := models.Inputs{
+			Track:              models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:             "out",
+			Filename:           title + ".lrc",
+			SourcePath:         "/music/" + title + ".flac",
+			DetectInstrumental: detect,
+		}
+		item, err := q.Enqueue(ctx, inputs, 1)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %s: %v", title, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+			t.Fatalf("defer %s: %v", title, err)
+		}
+		return item.ID
+	}
+
+	off, on := false, true
+	// Two opted-out rows are created FIRST, so the deterministic ordering
+	// (created_at ASC) puts them ahead of the eligible one.
+	mk("optout-a", &off)
+	mk("optout-b", &off)
+	eligible := mk("eligible", &on)
+
+	got, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{Limit: 2, GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("ListUnclassified: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != eligible {
+		var ids []int64
+		for _, it := range got {
+			ids = append(ids, it.ID)
+		}
+		t.Fatalf("--limit=2 returned %v; want only the eligible row [%d]. Opted-out rows consuming the limit would starve it forever, since the ordering never changes", ids, eligible)
+	}
+
+	// The total must use the same rule, or "N left unexamined" is a lie.
+	n, err := q.CountUnclassified(ctx, nil, true)
+	if err != nil {
+		t.Fatalf("CountUnclassified: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("CountUnclassified = %d; want 1 (only eligible rows are really in the backlog)", n)
+	}
+}
+
+// A NULL per-item stamp defers to the global default -- including when that
+// default is OFF, in which case nothing is eligible.
+func TestDBQueue_ListUnclassifiedRespectsGlobalDefaultForNullStamps(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "null-stamp"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1) // DetectInstrumental nil -> NULL
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+
+	on, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("ListUnclassified(on): %v", err)
+	}
+	if len(on) != 1 {
+		t.Errorf("global default on: got %d rows; want 1 (a NULL stamp defers to the default)", len(on))
+	}
+
+	off, err := q.ListUnclassified(ctx, ListUnclassifiedOptions{GlobalDetectDefault: false})
+	if err != nil {
+		t.Fatalf("ListUnclassified(off): %v", err)
+	}
+	if len(off) != 0 {
+		t.Errorf("global default off: got %d rows; want 0 (a NULL stamp is ineligible when the default is off)", len(off))
 	}
 }


### PR DESCRIPTION
## Summary

Adds `scan reconcile-instrumental`: classifies deferred `work_queue` rows the audio detector has **never scored** and writes an instrumental marker where it agrees. Makes **zero provider requests**.

Three commits, smallest-first:

1. **`refactor(commands)`** — extract `openDetectorEnv` from `runScanReconcile`. Pure refactor; the 5 existing reconcile tests pass untouched.
2. **`feat(queue)`** — `ListUnclassified` / `CountUnclassified` / `SettleInstrumental` / `StampUnclassifiedMiss`.
3. **`feat(commands)`** — the `internal/instrumentalbackfill` package + thin CLI wiring.

## Linked issue

Closes #499

## Why this exists

Detection was reachable only as a side effect of a provider miss inside the worker. `scan reconcile` drives the detector standalone, but its selector is `instrumental_result = 1 AND status = 'done'` — it only **re-checks verdicts already confirmed**, to clear false positives. Classifying a row nobody ever looked at had no path at all.

The gap is an asymmetry: canticle could **un-tag a false positive** but not **tag a never-checked row**. On one deployment that is 7,762 deferred rows, ~2,600 of them in libraries that classify ~60% instrumental. The original issue body claimed no standalone detector path existed; that was wrong and is corrected in the issue.

**Not blocked by #496.** These rows already lost their provider round-trip, so no provider request is made and a tripped breaker is irrelevant.

## Design notes for review

**Sibling subcommand, not a flag.** `reconcile` clears a marker on detector *disagreement*; this writes one on *agreement*. Opposite directions — hiding that behind a flag would be a trap. They share `openDetectorEnv`.

**The backfill does not own its rows.** It leaves them `deferred` while the (slow) detector runs, and `Dequeue` selects `status IN ('pending','failed','deferred')` — so a serve-mode worker *can* claim one mid-classification. Hence `SettleInstrumental` is one guarded transaction (verdict + telemetry + outcome + completion + scan_results writeback) rather than the worker's stamp-then-stamp-then-complete: the worker holds `processing` for its whole write and cannot be raced; this cannot. A refused settle writes **nothing**, and the run takes its marker back off disk rather than leaving a sidecar the DB has no record of.

**Marker paths come from `lyrics.SidecarName`**, never the raw enqueued filename. An instrumental marker is unsynced, so an enqueued `song.lrc` lands as `song.txt`; naming the raw filename produced a backup record pointing at a path that never existed.

**Ordering** follows the worker and `identityrepair`: backup-first (fsynced before any mutation) → marker write → guarded settle. A failed marker write leaves the row unstamped. A per-item opt-out is honored — this is a backfill, not an override.

## Test plan

- [x] `make gate` green: race tests, patch coverage **74.44%** (threshold 70%), coverage floor, codecov dry-run, golangci-lint 0 issues, actionlint, govulncheck 0 vulnerabilities.
- [x] 20 tests in `internal/instrumentalbackfill` over injected `Store`/`Detector`/`Writer` seams, so every error path is exercised on purpose.
- [x] 5 end-to-end CLI tests against a stub classifier + fake ffmpeg.
- [x] Adversarial pre-push review found **2 Criticals**; both fixed, both now covered by mutation-verified regression tests:
  - backup record named `song.lrc` while `song.txt` was written — the restorable record could not restore. Mutant reverting it fails the test with `claims "out/song.lrc" but the writer wrote "out/song.txt"`.
  - `SetInstrumentalResult`/`SetOutcomeType` were unguarded (`WHERE id = ?`), so a worker claiming the row mid-detect left it stamped instrumental with an orphan marker. Mutant reverting it fails with `orphan marker survived ... the DB has no record of it`.
- [x] The reviewer also proved the suite was self-blind: the `fakeWriter` had baked in the *same* wrong path assumption as the code, so the tests agreed with the bug. The fake now derives the name via `lyrics.SidecarName`, and a test pins `MarkerPaths` against what a real write puts on disk.
- [ ] Reviewer follow-ups.

## Notes

Rebased onto merged main (`ed6b2dd`). No CodeRabbit pass triggered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scan reconcile-instrumental` to classify previously unprocessed items.
  * Supports library filtering, result limits, dry-run previews, and explicit apply mode.
  * Writes instrumental markers and safely completes eligible items.
  * Creates backups before applying changes and reports processing summaries.
  * Respects per-item detection settings and avoids modifying items claimed by another process.
* **Tests**
  * Added comprehensive coverage for previews, failures, limits, backups, concurrency, and detector configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->