### PR TITLE
fix(lrcbackfill): distinguish blocked from already-expanded .orig skips

### DIFF
--- a/internal/commands/reconcile_lrc.go
+++ b/internal/commands/reconcile_lrc.go
@@ -97,14 +97,29 @@ func runReconcileLRC(ctx context.Context, out io.Writer, args ScanReconcileLRCCm
 	if args.Yes {
 		verb = "rewrote"
 	}
-	_, _ = fmt.Fprintf(out, "reconcile-lrc: %s %d stacked .lrc file(s) (%d scanned, %d already clean, %d skipped, %d errors)%s\n",
-		verb, summary.Normalized, summary.Scanned, summary.Clean, summary.Skipped, summary.Errors, suffixDryRun(args.Yes))
+	_, _ = fmt.Fprintf(out, "reconcile-lrc: %s %d stacked .lrc file(s) (%d scanned, %d already clean, %d skipped, %d blocked, %d errors)%s\n",
+		verb, summary.Normalized, summary.Scanned, summary.Clean, summary.Skipped, summary.Blocked, summary.Errors, suffixDryRun(args.Yes))
+	if summary.Blocked > 0 {
+		// Blocked files are the only tally that demands follow-up, and the count
+		// alone is useless without the paths -- which are in the WARN lines.
+		_, _ = fmt.Fprintf(out, "%d file(s) still stacked but blocked by a pre-existing .orig; see the BLOCKED warnings above for paths\n", summary.Blocked)
+	}
 	if lb != nil && lb.opened() {
 		_, _ = fmt.Fprintf(out, "backup records written to %s\n", backupPath)
 	}
-	if summary.Errors > 0 {
-		// A partial reconciliation is not success: some files failed and were
-		// left untouched, so callers/scripts must see a non-zero exit.
+	if summary.Errors > 0 || summary.Blocked > 0 {
+		// A partial reconciliation is not success: some files failed or were left
+		// untouched, so callers/scripts must see a non-zero exit.
+		//
+		// Blocked counts here deliberately (#487). A blocked file is still stacked,
+		// was left untouched, and its WARN says "operator action required" -- that is
+		// the same partial reconciliation the errors rule already covers. Exiting 0
+		// would tell a script "all clear" while telling a human "you must act", which
+		// is precisely the benign/actionable conflation this issue removes, just at
+		// the exit-code level. Before #487 blocked files were tallied as Skipped and
+		// exited 0; promoting them to their own actionable tally without moving the
+		// machine-readable signal would leave scripts blind to the one state that
+		// demands attention.
 		return 1
 	}
 	return 0

--- a/internal/commands/reconcile_lrc_test.go
+++ b/internal/commands/reconcile_lrc_test.go
@@ -198,3 +198,61 @@ func readFile(t *testing.T, path string) string {
 	}
 	return string(b)
 }
+
+// TestRunReconcileLRC_ReportsBlockedWithPointerToPaths pins the operator-facing
+// half of #487. A blocked file is the ONLY tally that demands follow-up, and the
+// count alone is useless -- the paths live in the WARN lines. So the summary must
+// carry a distinct blocked count (not folded into skipped, or a zero blocked
+// count would not be a real all-clear) and, when non-zero, point at where the
+// paths are.
+func TestRunReconcileLRC_ReportsBlockedWithPointerToPaths(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	blocked := filepath.Join(root, "blocked.lrc")
+
+	// Still stacked, with a pre-existing .orig barring a verifiable rewrite.
+	mustWrite(t, blocked, "[00:39.26][00:47.06]Chorus\n")
+	mustWrite(t, blocked+".orig", "operator's own backup\n")
+
+	var buf bytes.Buffer
+	// rc=1 deliberately (#487): a blocked file is still stacked and was left
+	// untouched, so a script must not read the run as an all-clear while the WARN
+	// tells a human that action is required.
+	if rc := runReconcileLRC(context.Background(), &buf, ScanReconcileLRCCmd{ConfigPath: cfgPath, Yes: true}); rc != 1 {
+		t.Fatalf("rc=%d; want 1 when a file is blocked. out=%s", rc, buf.String())
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "1 blocked") {
+		t.Errorf("summary must carry a distinct blocked count; got:\n%s", out)
+	}
+	if !strings.Contains(out, "see the BLOCKED warnings above for paths") {
+		t.Errorf("a non-zero blocked count must point at the paths; got:\n%s", out)
+	}
+	// The operator's backup is theirs: a blocked file must never be rewritten and
+	// the .orig must survive untouched.
+	if got := readFile(t, blocked+".orig"); !strings.Contains(got, "operator's own backup") {
+		t.Errorf(".orig was clobbered; it is the operator's file: %q", got)
+	}
+	if got := readFile(t, blocked); !strings.Contains(got, "][") {
+		t.Error("blocked file was rewritten despite the .orig barring it")
+	}
+}
+
+// A clean run must not emit the follow-up line: it fires only when there is
+// something to follow up on.
+func TestRunReconcileLRC_NoBlockedPointerWhenNoneBlocked(t *testing.T) {
+	cfgPath, root := setupReconcileLRC(t)
+	mustWrite(t, filepath.Join(root, "stacked.lrc"), "[00:39.26][00:47.06]Chorus\n")
+
+	var buf bytes.Buffer
+	if rc := runReconcileLRC(context.Background(), &buf, ScanReconcileLRCCmd{ConfigPath: cfgPath, Yes: true}); rc != 0 {
+		t.Fatalf("rc=%d out=%s", rc, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "0 blocked") {
+		t.Errorf("summary should report a zero blocked count as a real all-clear; got:\n%s", out)
+	}
+	if strings.Contains(out, "see the BLOCKED warnings above") {
+		t.Errorf("the follow-up pointer must not fire when nothing is blocked; got:\n%s", out)
+	}
+}

--- a/internal/lrcbackfill/lrcbackfill.go
+++ b/internal/lrcbackfill/lrcbackfill.go
@@ -29,8 +29,9 @@ type Options struct {
 type Summary struct {
 	Scanned    int // .lrc files examined
 	Normalized int // rewritten (apply) or would-be-rewritten (dry run)
-	Clean      int // already expanded; skipped
-	Skipped    int // symlinks and other intentional skips
+	Clean      int // already expanded; nothing to do
+	Skipped    int // symlinks and other benign, non-actionable skips
+	Blocked    int // still stacked but a pre-existing .orig bars a safe rewrite
 	Errors     int // per-file failures (the run continues past them)
 }
 
@@ -82,6 +83,8 @@ func Run(opts Options) (Summary, error) {
 				s.Clean++
 			case StatusSkipped:
 				s.Skipped++
+			case StatusBlocked:
+				s.Blocked++
 			}
 			return nil
 		})
@@ -118,6 +121,11 @@ const (
 	StatusNormalized
 	// StatusSkipped means the file was intentionally not processed (e.g. symlink).
 	StatusSkipped
+	// StatusBlocked means the file still needs work but a pre-existing .orig
+	// prevents a verifiable rewrite. Unlike StatusSkipped this always warrants
+	// operator attention, and is counted separately so a zero tally is a real
+	// all-clear (issue #487).
+	StatusBlocked
 )
 
 // Result reports what happened to a single file.
@@ -151,14 +159,14 @@ func NormalizeFile(path string, report func(backupPath string) error) (Result, e
 
 	// Refuse to overwrite a .lrc whose .orig backup already exists: we cannot
 	// verify that pre-existing backup is the true pristine original, and
-	// overwriting would leave the current bytes backed up nowhere. Skip instead
-	// (conservative-on-uncertainty). In normal single-tool operation this is
-	// unreachable -- after one expand the file is already clean and never
-	// rewritten -- so a .orig here means external interference.
+	// overwriting would leave the current bytes backed up nowhere. Decline
+	// instead (conservative-on-uncertainty). In normal single-tool operation this
+	// is unreachable -- after one expand the file is already clean and never
+	// rewritten -- so a .orig here means a concurrent run or external
+	// interference. classifyBackupExists re-reads to tell those apart.
 	backupPath := path + ".orig"
 	if _, statErr := os.Lstat(backupPath); statErr == nil {
-		slog.Warn("lrcbackfill: .orig backup already exists; skipping to avoid an unverified overwrite", "path", path, "backup", backupPath)
-		return Result{Status: StatusSkipped}, nil
+		return classify(path, backupPath)
 	} else if !os.IsNotExist(statErr) {
 		return Result{}, fmt.Errorf("stat backup %s: %w", backupPath, statErr)
 	}
@@ -190,7 +198,59 @@ func NormalizeFile(path string, report func(backupPath string) error) (Result, e
 	return Result{Status: StatusNormalized, Backup: backupPath}, nil
 }
 
+// classifyBackupExists decides what a pre-existing .orig means for path, and is
+// the fix for issue #487. The caller's needs-work verdict was computed from bytes
+// read BEFORE the backup was observed, so a concurrent run may have expanded the
+// file in between; those stale bytes cannot distinguish the two states. Re-read
+// the current file and re-apply the gate:
+//
+//   - no longer stacked -> a peer run finished the rewrite and the .orig is its
+//     legitimate backup. Benign, no work remains, and emphatically not a warning:
+//     an operator who "cleared the blockage" here would delete a real backup.
+//   - still stacked -> the .orig genuinely bars the rewrite. Warn; needs an operator.
+//
+// classify is classifyBackupExists, indirected so a test can pin that the
+// .orig-exists paths actually ROUTE here rather than deciding from bytes they
+// already hold.
+//
+// That routing is the entire fix for #487 and it cannot be reached from a
+// fixture: NormalizeFile only consults the .orig gate when the file was stacked
+// at load time, so the benign case (a peer expanded it in between) requires the
+// file to change between load() and the Lstat. Without this seam a regression
+// that classified from the stale bytes -- the exact pre-fix bug -- passes the
+// whole suite, because testing classifyBackupExists directly can never
+// distinguish a re-read from a stale read: on disk they are the same bytes.
+var classify = classifyBackupExists
+
+func classifyBackupExists(path, backupPath string) (Result, error) {
+	cur, _, skip, err := load(path)
+	if err != nil {
+		// The re-read failed where the first read succeeded (the file vanished or
+		// became unreadable mid-run). The row is counted as an error, NOT as
+		// Blocked -- which is why a zero blocked tally is only an all-clear
+		// alongside zero errors.
+		return Result{}, err
+	}
+	if skip {
+		// Defensive, not live: both callers already returned on skip before
+		// consulting the .orig gate, so this only fires if the path became a symlink
+		// between their load and this re-read. Kept rather than deleted because it is
+		// the correct answer if a future caller reaches here without pre-checking.
+		return Result{Status: StatusSkipped}, nil
+	}
+	if _, stacked := lrcnormalize.NormalizeBody(string(cur)); !stacked {
+		slog.Debug("lrcbackfill: .orig backup exists and the .lrc is already expanded; nothing to do",
+			"path", path, "backup", backupPath)
+		return Result{Status: StatusClean}, nil
+	}
+	slog.Warn("lrcbackfill: BLOCKED -- .lrc is still stacked but a pre-existing .orig bars a verifiable rewrite; operator action required (compare the two, then remove or rename the .orig and re-run)",
+		"path", path, "backup", backupPath)
+	return Result{Status: StatusBlocked}, nil
+}
+
 // inspect reports what NormalizeFile would do, without writing anything (dry run).
+// It mirrors NormalizeFile's .orig gate so a dry run never promises a rewrite that
+// apply would decline -- the count is the only output some callers have (#470 AC2).
 func inspect(path string) (Result, error) {
 	raw, _, skip, err := load(path)
 	if err != nil {
@@ -202,7 +262,13 @@ func inspect(path string) (Result, error) {
 	if _, changed := lrcnormalize.NormalizeBody(string(raw)); !changed {
 		return Result{Status: StatusClean}, nil
 	}
-	return Result{Status: StatusNormalized, Backup: path + ".orig"}, nil
+	backupPath := path + ".orig"
+	if _, statErr := os.Lstat(backupPath); statErr == nil {
+		return classify(path, backupPath)
+	} else if !os.IsNotExist(statErr) {
+		return Result{}, fmt.Errorf("stat backup %s: %w", backupPath, statErr)
+	}
+	return Result{Status: StatusNormalized, Backup: backupPath}, nil
 }
 
 // load reads path, returning its body and permission bits. skip is true (with a

--- a/internal/lrcbackfill/lrcbackfill_test.go
+++ b/internal/lrcbackfill/lrcbackfill_test.go
@@ -438,13 +438,31 @@ func TestClassifyBackupExists_ReReadFailureIsAnErrorNotAVerdict(t *testing.T) {
 	}
 }
 
-// The dry-run path must surface the same failure the same way, or dry-run and
-// apply would disagree about what a run found.
+// The dry-run path must PROPAGATE a classifier re-read failure, not swallow it,
+// or dry-run and apply would disagree about what a run found. This must exercise
+// the re-read path, not a missing-file initial load: inspect only reaches classify
+// once the file is stacked AND a .orig exists, so a stacked file plus a .orig with
+// an injected classify error is the only setup that proves inspect surfaces the
+// re-read failure rather than counting the file clean.
 func TestInspect_ReReadFailureIsAnError(t *testing.T) {
 	dir := t.TempDir()
-	gone := filepath.Join(dir, "vanished.lrc")
+	path := filepath.Join(dir, "song.lrc")
+	if err := os.WriteFile(path, []byte("[00:39.26][00:47.06]Chorus\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".orig", []byte("a pre-existing backup\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	if _, err := inspect(gone); err == nil {
-		t.Fatal("inspect on a missing file returned nil error; a dry run must report the failure, not silently count the file as clean")
+	prev := classify
+	t.Cleanup(func() { classify = prev })
+
+	wantErr := errors.New("re-read failed")
+	classify = func(string, string) (Result, error) {
+		return Result{}, wantErr
+	}
+
+	if _, err := inspect(path); !errors.Is(err, wantErr) {
+		t.Fatalf("inspect error = %v; want the classifier's re-read failure propagated -- a dry run must surface it, not swallow it and count the file clean", err)
 	}
 }

--- a/internal/lrcbackfill/lrcbackfill_test.go
+++ b/internal/lrcbackfill/lrcbackfill_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestNormalizeFile_SkipsWhenBackupExists(t *testing.T) {
+func TestNormalizeFile_BlockedWhenBackupExistsAndFileStillStacked(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "s.lrc")
 	stacked := "[00:30.00][01:05.00]C\n"
@@ -17,7 +17,8 @@ func TestNormalizeFile_SkipsWhenBackupExists(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A .orig already exists but is NOT the original of the current .lrc. We must
-	// not overwrite the .lrc without a fresh, verifiable backup -> skip untouched.
+	// not overwrite the .lrc without a fresh, verifiable backup -> decline. The
+	// .lrc is still stacked, so this is the genuinely-blocked case (issue #487).
 	if err := os.WriteFile(p+".orig", []byte("UNRELATED\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -25,14 +26,105 @@ func TestNormalizeFile_SkipsWhenBackupExists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != StatusSkipped {
-		t.Errorf("status: want Skipped, got %v", res.Status)
+	if res.Status != StatusBlocked {
+		t.Errorf("status: want Blocked, got %v", res.Status)
 	}
 	if got, _ := os.ReadFile(p); string(got) != stacked {
 		t.Errorf(".lrc must be left untouched, got %q", string(got))
 	}
 	if got, _ := os.ReadFile(p + ".orig"); string(got) != "UNRELATED\n" {
 		t.Errorf("pre-existing .orig must be untouched, got %q", string(got))
+	}
+}
+
+// classifyBackupExists is the seam that separates the two states issue #487
+// conflated. NormalizeFile's own `raw` predates the .orig check, so under a
+// concurrent run it can be stale; classification must re-read the file.
+func TestClassifyBackupExists(t *testing.T) {
+	tests := []struct {
+		name    string
+		onDisk  string
+		want    Status
+		wantWhy string
+	}{
+		{
+			// The benign case: a peer run expanded the .lrc and wrote the .orig
+			// after we read stale stacked bytes. Nothing remains to do.
+			name:    "already expanded by a peer run is clean, not blocked",
+			onDisk:  "[00:30.00]C\n[01:05.00]C\n",
+			want:    StatusClean,
+			wantWhy: "the .orig is a legitimate backup of a finished rewrite",
+		},
+		{
+			// The actionable case: the file really is still stacked and the
+			// pre-existing .orig is what prevents its expansion.
+			name:    "still stacked is blocked and needs an operator",
+			onDisk:  "[00:30.00][01:05.00]C\n",
+			want:    StatusBlocked,
+			wantWhy: "the .orig blocks a file that still needs work",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "s.lrc")
+			if err := os.WriteFile(p, []byte(tc.onDisk), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p+".orig", []byte("PRIOR\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			res, err := classifyBackupExists(p, p+".orig")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Status != tc.want {
+				t.Errorf("status: want %v, got %v (%s)", tc.want, res.Status, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// The #470 AC2 blocker: a dry run must not promise a rewrite that --yes then
+// declines to perform, because that count is the startup check's entire output.
+func TestRun_DryRunCountMatchesApplyWhenBlocked(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked.lrc")
+	if err := os.WriteFile(blocked, []byte("[00:30.00][01:05.00]C\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocked+".orig", []byte("PRIOR\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	free := filepath.Join(dir, "free.lrc")
+	if err := os.WriteFile(free, []byte("[00:05.00][00:09.00]Y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dry, err := Run(Options{Roots: []string{dir}, Apply: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dry.Normalized != 1 || dry.Blocked != 1 {
+		t.Errorf("dry run: %+v (want normalized=1 blocked=1; the blocked file must not be promised)", dry)
+	}
+
+	apply, err := Run(Options{Roots: []string{dir}, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if apply.Normalized != dry.Normalized {
+		t.Errorf("dry run promised normalized=%d but apply delivered %d", dry.Normalized, apply.Normalized)
+	}
+	if apply.Blocked != dry.Blocked {
+		t.Errorf("dry run blocked=%d but apply blocked=%d", dry.Blocked, apply.Blocked)
+	}
+	// The blocked file and its pre-existing .orig must both survive untouched.
+	if got, _ := os.ReadFile(blocked); string(got) != "[00:30.00][01:05.00]C\n" {
+		t.Errorf("blocked .lrc mutated: %q", string(got))
+	}
+	if got, _ := os.ReadFile(blocked + ".orig"); string(got) != "PRIOR\n" {
+		t.Errorf("pre-existing .orig mutated: %q", string(got))
 	}
 }
 
@@ -250,5 +342,109 @@ func TestNormalizeFile_ExpandsAndBacksUp(t *testing.T) {
 	}
 	if res.Backup != p+".orig" {
 		t.Errorf("Backup path: want %q, got %q", p+".orig", res.Backup)
+	}
+}
+
+// TestNormalizeFile_RoutesOrigGateThroughClassify pins the root-cause fix for
+// #487: NormalizeFile must DELEGATE the .orig-exists decision to a fresh re-read,
+// not decide from the bytes it loaded earlier.
+//
+// This needs a seam because the interesting case cannot be staged from outside.
+// NormalizeFile only consults the .orig gate when the file was stacked at load
+// time, so the benign state (a peer expanded it in between) requires the file to
+// change between load() and the Lstat. Without this, a regression that classified
+// from the stale bytes -- the exact pre-fix bug -- passed the entire suite:
+// testing classifyBackupExists directly cannot tell a re-read from a stale read,
+// because on disk they are the same bytes.
+func TestNormalizeFile_RoutesOrigGateThroughClassify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.lrc")
+	if err := os.WriteFile(path, []byte("[00:39.26][00:47.06]Chorus\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".orig", []byte("a pre-existing backup\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := classify
+	t.Cleanup(func() { classify = prev })
+
+	var gotPath, gotBackup string
+	classify = func(p, b string) (Result, error) {
+		gotPath, gotBackup = p, b
+		return Result{Status: StatusClean}, nil
+	}
+
+	res, err := NormalizeFile(path, nil)
+	if err != nil {
+		t.Fatalf("NormalizeFile: %v", err)
+	}
+	if gotPath != path || gotBackup != path+".orig" {
+		t.Fatalf("classify called with (%q, %q); want (%q, %q) -- NormalizeFile must delegate the .orig verdict, not decide from its stale bytes",
+			gotPath, gotBackup, path, path+".orig")
+	}
+	if res.Status != StatusClean {
+		t.Errorf("Status = %v; want the delegate's verdict to be returned verbatim", res.Status)
+	}
+}
+
+// The same routing must hold for the dry-run path, or dry-run and apply would
+// disagree on a .orig -- the #470 AC2 count agreement this fix exists to keep.
+func TestInspect_RoutesOrigGateThroughClassify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.lrc")
+	if err := os.WriteFile(path, []byte("[00:39.26][00:47.06]Chorus\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".orig", []byte("a pre-existing backup\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := classify
+	t.Cleanup(func() { classify = prev })
+
+	called := false
+	classify = func(string, string) (Result, error) {
+		called = true
+		return Result{Status: StatusBlocked}, nil
+	}
+
+	res, err := inspect(path)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if !called {
+		t.Fatal("inspect did not route the .orig verdict through classify; a dry run would then promise a rewrite apply declines")
+	}
+	if res.Status != StatusBlocked {
+		t.Errorf("Status = %v; want StatusBlocked from the delegate", res.Status)
+	}
+}
+
+// TestClassifyBackupExists_ReReadFailureIsAnErrorNotAVerdict backs the "a zero
+// blocked count alongside zero errors is a real all-clear" claim. If the .lrc
+// becomes unreadable between the first read and the re-read, the classifier must
+// surface an error rather than guess a verdict: reporting Clean would silently
+// drop a file that may still need work, and reporting Blocked would invent an
+// operator action for a file nobody can read. Either way the run must count it as
+// an error, which is what keeps Blocked=0 meaningful.
+func TestClassifyBackupExists_ReReadFailureIsAnErrorNotAVerdict(t *testing.T) {
+	dir := t.TempDir()
+	gone := filepath.Join(dir, "vanished.lrc")
+
+	res, err := classifyBackupExists(gone, gone+".orig")
+	if err == nil {
+		t.Fatalf("classifyBackupExists on an unreadable file returned (%v, nil); want an error -- a verdict guessed from a file it could not read is exactly the conflation #487 removes", res.Status)
+	}
+}
+
+// The dry-run path must surface the same failure the same way, or dry-run and
+// apply would disagree about what a run found.
+func TestInspect_ReReadFailureIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	gone := filepath.Join(dir, "vanished.lrc")
+
+	if _, err := inspect(gone); err == nil {
+		t.Fatal("inspect on a missing file returned nil error; a dry run must report the failure, not silently count the file as clean")
 	}
 }


### PR DESCRIPTION
## Summary

`lrcbackfill` emitted one identical WARN when it declined to rewrite a file because a sibling `.orig` already existed. That single message covered two states meaning opposite things: a **benign** backup of a rewrite a concurrent run had already finished, and a **genuinely blocked** file still needing expansion. An operator "clearing the blockage" for all of them would have deleted legitimate backups.

## Linked issue

Closes #487

## What changed

**Root cause.** `NormalizeFile` computed its needs-work verdict from bytes read *before* the `.orig` was observed, so under a concurrent run those bytes were stale and could not tell the two states apart. `classifyBackupExists` now re-reads at skip time and re-applies the gate: no longer stacked is Clean and silent; still stacked is a Blocked WARN naming the operator action.

**Dry-run/apply agreement.** `inspect` ignored `.orig` entirely, so a dry run could promise a rewrite `--yes` then declined. It now mirrors the same gate — required by #470 AC2, whose whole output is that count.

**Blocked is its own tally**, separate from Skipped (symlinks), and a zero blocked count *alongside zero errors* is a real all-clear: a file that becomes unreadable at re-read time is counted as an error, not silently dropped.

## Two decisions worth reviewer attention

**A blocked run now exits non-zero.** Deliberate, and the same conflation this issue removes one level down: a blocked file is still stacked and was left untouched, so exiting 0 tells a script "all clear" while the WARN tells a human "operator action required". The existing errors rule (*"a partial reconciliation is not success"*) already covers exactly this case. **This is a behavior change** — before this, blocked files were tallied as Skipped and exited 0. Easy to revert if you'd rather not move the machine-readable signal.

**A `classify` seam.** The `.orig` gate routes through an indirection so both callers can be pinned to *delegate* the verdict rather than decide from bytes they already hold. This exists because the fix was otherwise untestable: an adversarial review proved that a regression classifying from the stale bytes — the exact pre-fix bug — passed the entire 293-test suite. Testing `classifyBackupExists` directly cannot distinguish a re-read from a stale read (on disk they are the same bytes), and the interleave that reaches it benignly cannot be staged from a fixture.

## Test plan

- [x] `make gate` green: race tests, patch coverage **81.48%** (threshold 70%), coverage floor, codecov dry-run, golangci-lint 0 issues, actionlint, govulncheck 0 vulnerabilities.
- [x] Adversarial pre-push review: no Criticals. Its one Important was the coverage gap above (the root-cause claim was asserted, not tested) — closed by the seam, and mutation-verified: restoring the stale-bytes behavior now fails with *"NormalizeFile must delegate the .orig verdict, not decide from its stale bytes"*.
- [x] Mutation-verified CLI tests: folding blocked back into skipped, or dropping the pointer to the WARN paths, each fail.
- [x] Re-read failure paths covered, backing the "zero blocked *and* zero errors is a real all-clear" claim.
- [ ] Reviewer follow-ups.

Rebased onto `b77c728` (v1.17.0). No CodeRabbit pass triggered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciliation reports blocked stacked `.lrc` files separately from errors.
  * Blocked files now include guidance to review their associated warnings.
  * Dry-run and apply modes consistently identify files blocked by existing backups.

* **Bug Fixes**
  * Existing backups no longer automatically hide `.lrc` files that remain stacked.
  * Reconciliation returns a failure status when blocked files require follow-up.
  * Files that cannot be re-read are reported as errors instead of being misclassified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->