### PR TITLE
feat(detector): vocal-gate calibration tooling (sweep + validation) (#510)

### DIFF
--- a/cmd/vocalcalib/main.go
+++ b/cmd/vocalcalib/main.go
@@ -1,0 +1,346 @@
+// Command vocalcalib calibrates the sung-vocal-peak threshold used by the
+// instrumental detector's three-gate decision (internal/detector.Instrumental).
+// It has three modes:
+//
+//   - sample:   draw a randomized set of known-labeled tracks from a (seeded
+//     copy of a) work_queue database, run the live detector sidecar against
+//     each, and emit internal/vocalcalib.LabeledScore JSONL.
+//   - sweep:    read a LabeledScore JSONL file and sweep the vocal-peak
+//     threshold to find the highest value that keeps the positive-error-rate
+//     at or below a target ceiling (internal/vocalcalib.SelectThreshold).
+//   - validate: read a LabeledScore JSONL file and check a fixed threshold
+//     against a positive-error-rate ceiling (internal/vocalcalib.Validate).
+//
+// It is a developer-only operational tool (used to recalibrate the vocal-peak
+// gate, see #384/#510) and is intentionally excluded from releases
+// (GoReleaser builds only ./cmd/mxlrcgo-svc).
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/doxazo-net/canticle/internal/config"
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/detector"
+	"github.com/doxazo-net/canticle/internal/ffmpeg"
+	"github.com/doxazo-net/canticle/internal/vocalcalib"
+)
+
+func main() {
+	mode := flag.String("mode", "", "operation mode: sample|sweep|validate")
+
+	// sample mode flags.
+	dbPath := flag.String("db", "", "sample: path to a (seeded copy of a) work_queue SQLite database")
+	configPath := flag.String("config", "", "sample: path to config.toml (defaults to XDG resolution)")
+	label := flag.String("label", "", "sample: label to draw, \"vocal\" or \"instrumental\"")
+	n := flag.Int("n", 100, "sample: number of tracks to draw")
+	seed := flag.Int64("seed", 1, "sample: PRNG seed for reproducible draws")
+	out := flag.String("out", "", "sample: output JSONL path (defaults to stdout)")
+
+	// sweep mode flags.
+	in := flag.String("in", "", "sweep|validate: input LabeledScore JSONL path")
+	minConfidence := flag.Float64("min-confidence", 0, "sweep|validate: music-gate MinConfidence")
+	speechMax := flag.Float64("speech-max", 0, "sweep|validate: speech-gate SpeechMax")
+	maxErr := flag.Float64("max-err", 0.01, "sweep|validate: maximum acceptable positive-error-rate")
+	bottomK := flag.Int("bottom-k", 10, "sweep: number of lowest-vocal-peak positives to print for outlier inspection")
+
+	// validate mode flags.
+	threshold := flag.Float64("threshold", 0, "validate: fixed vocal-peak threshold to check")
+
+	flag.Parse()
+
+	var err error
+	switch *mode {
+	case "sample":
+		err = runSample(sampleArgs{
+			dbPath:     *dbPath,
+			configPath: *configPath,
+			label:      *label,
+			n:          *n,
+			seed:       *seed,
+			out:        *out,
+		})
+	case "sweep":
+		err = runSweep(sweepArgs{
+			in:            *in,
+			minConfidence: *minConfidence,
+			speechMax:     *speechMax,
+			maxErr:        *maxErr,
+			bottomK:       *bottomK,
+		})
+	case "validate":
+		err = runValidate(validateArgs{
+			in:            *in,
+			minConfidence: *minConfidence,
+			speechMax:     *speechMax,
+			threshold:     *threshold,
+			maxErr:        *maxErr,
+		})
+	default:
+		fmt.Fprintln(os.Stderr, "vocalcalib: -mode must be one of sample, sweep, validate")
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vocalcalib: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// sampleArgs holds the parsed flags for -mode sample.
+type sampleArgs struct {
+	dbPath     string
+	configPath string
+	label      string
+	n          int
+	seed       int64
+	out        string
+}
+
+// runSample draws a randomized set of labeled rows from the work_queue table,
+// runs the live detector sidecar against each reachable audio file, and emits
+// one vocalcalib.LabeledScore JSONL line per successfully classified track.
+func runSample(a sampleArgs) error {
+	if strings.TrimSpace(a.dbPath) == "" {
+		return fmt.Errorf("sample: -db is required")
+	}
+	if a.label != "vocal" && a.label != "instrumental" {
+		return fmt.Errorf("sample: -label must be \"vocal\" or \"instrumental\"")
+	}
+	if a.n <= 0 {
+		return fmt.Errorf("sample: -n must be > 0")
+	}
+
+	ctx := context.Background()
+
+	cfg, err := config.Load(a.configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if strings.TrimSpace(cfg.InstrumentalDetector.ClassifierURL) == "" {
+		return fmt.Errorf("sample: instrumental detector is not configured (set instrumental_detector.classifier_url)")
+	}
+	ffmpegPath, err := resolveFFmpeg(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("resolve ffmpeg: %w", err)
+	}
+	det, err := newAudioDetector(cfg, ffmpegPath)
+	if err != nil {
+		return fmt.Errorf("construct audio detector: %w", err)
+	}
+
+	sqlDB, err := db.OpenReadOnly(ctx, a.dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() { _ = sqlDB.Close() }() //nolint:errcheck // reason: best-effort close on exit
+
+	paths, err := candidatePaths(ctx, sqlDB, a.label)
+	if err != nil {
+		return fmt.Errorf("query candidates: %w", err)
+	}
+
+	rng := rand.New(rand.NewSource(a.seed)) //nolint:gosec // reason: reproducible sample draw, not a security-sensitive PRNG use
+	rng.Shuffle(len(paths), func(i, j int) { paths[i], paths[j] = paths[j], paths[i] })
+
+	w := os.Stdout
+	if strings.TrimSpace(a.out) != "" {
+		f, ferr := os.Create(a.out) //nolint:gosec // reason: operator-supplied output path for a dev-only tool
+		if ferr != nil {
+			return fmt.Errorf("create output: %w", ferr)
+		}
+		defer func() { _ = f.Close() }() //nolint:errcheck // reason: best-effort close on exit
+		w = f
+	}
+
+	written := 0
+	for _, p := range paths {
+		if written >= a.n {
+			break
+		}
+		if _, statErr := os.Stat(p); statErr != nil {
+			continue
+		}
+		res, detErr := det.Detect(ctx, p)
+		if detErr != nil {
+			fmt.Fprintf(os.Stderr, "vocalcalib: sample: detect %s: %v\n", p, detErr)
+			continue
+		}
+		score := vocalcalib.LabeledScore{
+			MusicSum:        res.Confidence,
+			VocalPeak:       res.VocalConfidence,
+			SpeechMean:      res.SpeechConfidence,
+			VocalClass:      res.WinningVocalClass,
+			DetectorVersion: res.Version,
+			Label:           a.label,
+		}
+		if writeErr := vocalcalib.WriteJSONL(w, score); writeErr != nil {
+			return fmt.Errorf("write score: %w", writeErr)
+		}
+		written++
+	}
+	fmt.Fprintf(os.Stderr, "vocalcalib: sample: wrote %d/%d requested scores (label=%s, candidates=%d)\n", written, a.n, a.label, len(paths))
+	return nil
+}
+
+// candidatePaths returns the source_path of every row matching label, in
+// whatever order SQLite returns them; the caller shuffles in Go with an
+// explicit seed for reproducible draws.
+func candidatePaths(ctx context.Context, sqlDB *sql.DB, label string) ([]string, error) {
+	var query string
+	switch label {
+	case "vocal":
+		query = `SELECT source_path FROM work_queue WHERE outcome_type IN ('synced','unsynced') AND TRIM(COALESCE(source_path,'')) <> ''`
+	case "instrumental":
+		query = `SELECT source_path FROM work_queue WHERE outcome_type='instrumental' AND instrumental_result IS NULL AND TRIM(COALESCE(source_path,'')) <> ''`
+	default:
+		return nil, fmt.Errorf("candidatePaths: unknown label %q", label)
+	}
+	rows, err := sqlDB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }() //nolint:errcheck // reason: best-effort close on exit
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if scanErr := rows.Scan(&p); scanErr != nil {
+			return nil, scanErr
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
+}
+
+// resolveFFmpeg mirrors internal/commands.resolveFFmpeg: the verification
+// override takes precedence, then the detector's, resolved to an absolute
+// executable path with the auto-provisioning cache beside the database.
+func resolveFFmpeg(ctx context.Context, cfg config.Config) (string, error) {
+	override := strings.TrimSpace(cfg.Verification.FFmpegPath)
+	if override == "" {
+		override = strings.TrimSpace(cfg.InstrumentalDetector.FFmpegPath)
+	}
+	cacheDir := filepath.Join(filepath.Dir(cfg.DB.Path), "ffmpeg")
+	return ffmpeg.Resolve(ctx, override, ffmpeg.Options{CacheDir: cacheDir})
+}
+
+// newAudioDetector mirrors internal/commands.newAudioDetector's config
+// mapping (commands.go:1506-1525) so this tool exercises the exact same
+// detector construction serve mode uses.
+func newAudioDetector(cfg config.Config, ffmpegPath string) (detector.Detector, error) {
+	return detector.NewHTTPDetector(detector.Config{
+		ClassifierURL:         cfg.InstrumentalDetector.ClassifierURL,
+		SampleDurationSeconds: cfg.InstrumentalDetector.SampleDurationSeconds,
+		MinConfidence:         cfg.InstrumentalDetector.MinConfidence,
+		InstrumentalClasses:   cfg.InstrumentalDetector.InstrumentalClasses,
+		VocalClasses:          cfg.InstrumentalDetector.VocalClasses,
+		VocalMaxConfidence:    cfg.InstrumentalDetector.VocalMaxConfidence,
+		SpeechClasses:         cfg.InstrumentalDetector.SpeechClasses,
+		SpeechMaxConfidence:   cfg.InstrumentalDetector.SpeechMaxConfidence,
+		SpreadSamples:         cfg.InstrumentalDetector.SpreadSamples,
+		FFmpegPath:            ffmpegPath,
+		FFprobePath:           cfg.InstrumentalDetector.FFprobePath,
+		CooldownSeconds:       cfg.InstrumentalDetector.CooldownSeconds,
+	})
+}
+
+// sweepArgs holds the parsed flags for -mode sweep.
+type sweepArgs struct {
+	in            string
+	minConfidence float64
+	speechMax     float64
+	maxErr        float64
+	bottomK       int
+}
+
+// runSweep reads a LabeledScore JSONL file, sweeps the vocal-peak threshold,
+// and prints the chosen operating point plus the bottom-K lowest-vocal-peak
+// positives for outlier inspection.
+func runSweep(a sweepArgs) error {
+	if strings.TrimSpace(a.in) == "" {
+		return fmt.Errorf("sweep: -in is required")
+	}
+	scores, err := readScores(a.in)
+	if err != nil {
+		return err
+	}
+
+	sel, err := vocalcalib.SelectThreshold(scores, vocalcalib.Gates{MinConfidence: a.minConfidence, SpeechMax: a.speechMax}, a.maxErr)
+	if err != nil {
+		return fmt.Errorf("select threshold: %w", err)
+	}
+
+	fmt.Printf("threshold=%.6f pos_err_rate=%.4f neg_recovery=%.4f pos_n=%d neg_n=%d curve_points=%d\n",
+		sel.Threshold, sel.PosErrRate, sel.NegRecovery, sel.PosN, sel.NegN, len(sel.Curve))
+
+	var pos []vocalcalib.LabeledScore
+	for _, s := range scores {
+		if s.Label == "vocal" {
+			pos = append(pos, s)
+		}
+	}
+	sort.Slice(pos, func(i, j int) bool { return pos[i].VocalPeak < pos[j].VocalPeak })
+	k := a.bottomK
+	if k > len(pos) {
+		k = len(pos)
+	}
+	fmt.Printf("bottom-%d positives by vocal_peak:\n", k)
+	for i := 0; i < k; i++ {
+		s := pos[i]
+		fmt.Printf("  vocal_peak=%.6f music_sum=%.6f speech_mean=%.6f vocal_class=%s\n", s.VocalPeak, s.MusicSum, s.SpeechMean, s.VocalClass)
+	}
+	return nil
+}
+
+// validateArgs holds the parsed flags for -mode validate.
+type validateArgs struct {
+	in            string
+	minConfidence float64
+	speechMax     float64
+	threshold     float64
+	maxErr        float64
+}
+
+// runValidate reads a LabeledScore JSONL file, checks the fixed threshold
+// against the positive-error-rate ceiling, and prints the report. It returns
+// an error (non-zero exit) when the report does not pass.
+func runValidate(a validateArgs) error {
+	if strings.TrimSpace(a.in) == "" {
+		return fmt.Errorf("validate: -in is required")
+	}
+	scores, err := readScores(a.in)
+	if err != nil {
+		return err
+	}
+
+	r := vocalcalib.Validate(scores, vocalcalib.Gates{MinConfidence: a.minConfidence, SpeechMax: a.speechMax}, a.threshold, a.maxErr)
+	fmt.Printf("threshold=%.6f pos_n=%d pos_err_n=%d pos_err_rate=%.4f neg_n=%d neg_recovered_n=%d neg_recovery=%.4f pass=%t\n",
+		r.Threshold, r.PosN, r.PosErrN, r.PosErrRate, r.NegN, r.NegRecoveredN, r.NegRecovery, r.Pass)
+	if !r.Pass {
+		return fmt.Errorf("validate: FAIL (pos_err_rate=%.4f, ceiling=%.4f)", r.PosErrRate, a.maxErr)
+	}
+	return nil
+}
+
+// readScores opens path and reads it as LabeledScore JSONL.
+func readScores(path string) ([]vocalcalib.LabeledScore, error) {
+	f, err := os.Open(path) //nolint:gosec // reason: operator-supplied input path for a dev-only tool
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck // reason: best-effort close on exit
+
+	scores, err := vocalcalib.ReadJSONL(f)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return scores, nil
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,11 @@ ignore:
   # internal/testutil.GenerateLibrary; main.go is just flag wiring and is not
   # shipped (excluded from GoReleaser's build allowlist).
   - "cmd/genlib/main.go"
+  # Dev-only vocal-gate calibration tool (#510). Its sweep/validate/sample logic
+  # lives in (and is tested via) internal/vocalcalib; main.go is flag wiring plus
+  # DB/detector plumbing, and is not shipped (excluded from GoReleaser's build
+  # allowlist).
+  - "cmd/vocalcalib/main.go"
   # Generated templ output (make ui / `templ generate`). Authored from the
   # *.templ sources and CI-verified current via `make ui-check`; the rendered
   # behavior is covered by internal/web tests, not by counting generated lines.

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -70,6 +70,16 @@ var defaultVocalClasses = []string{"Singing", "Vocal music", "Choir", "A capella
 // sung-vocal peak gate.
 var defaultSpeechClasses = []string{"Speech"}
 
+// Instrumental is the pure three-gate score predicate: a track is instrumental
+// when the summed music mean clears minConfidence, the sung-vocal peak stays
+// below vocalMax, and the speech mean stays below speechMax. Kept free of the
+// sidecar-completeness guards (maxAvailable/baselineComplete) so the same
+// decision can be re-applied to STORED telemetry by the calibration sweep and
+// the recalibration reopen path, which have no live sidecar response.
+func Instrumental(musicSum, vocalPeak, speechMean, minConfidence, vocalMax, speechMax float64) bool {
+	return musicSum >= minConfidence && vocalPeak < vocalMax && speechMean < speechMax
+}
+
 // Result describes an instrumental detection decision.
 type Result struct {
 	// Instrumental is true only when all three gates pass: the summed mean

--- a/internal/detector/gate_test.go
+++ b/internal/detector/gate_test.go
@@ -1,0 +1,25 @@
+package detector
+
+import "testing"
+
+func TestInstrumental(t *testing.T) {
+	cases := []struct {
+		name                         string
+		music, vocalPeak, speechMean float64
+		minConf, vocalMax, speechMax float64
+		want                         bool
+	}{
+		{"all gates pass", 0.95, 0.02, 0.001, 0.90, 0.03, 0.20, true},
+		{"music too low", 0.80, 0.02, 0.001, 0.90, 0.03, 0.20, false},
+		{"vocal peak at threshold is not instrumental", 0.95, 0.03, 0.001, 0.90, 0.03, 0.20, false},
+		{"vocal peak below threshold passes", 0.95, 0.029, 0.001, 0.90, 0.03, 0.20, true},
+		{"speech too high", 0.95, 0.02, 0.25, 0.90, 0.03, 0.20, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Instrumental(c.music, c.vocalPeak, c.speechMean, c.minConf, c.vocalMax, c.speechMax); got != c.want {
+				t.Fatalf("Instrumental=%v want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -297,8 +297,8 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 			}
 		}
 	}
-	instrumental := music >= d.minConfidence && maxAvailable && baselineComplete &&
-		vocalPeak < d.vocalMaxConfidence && speechMean < d.speechMaxConfidence
+	instrumental := maxAvailable && baselineComplete &&
+		Instrumental(music, vocalPeak, speechMean, d.minConfidence, d.vocalMaxConfidence, d.speechMaxConfidence)
 
 	// Surface the decision inputs: the worker only reads res.Instrumental, so
 	// without this line a misclassification leaves no trace of the music_sum /

--- a/internal/vocalcalib/scores.go
+++ b/internal/vocalcalib/scores.go
@@ -1,0 +1,54 @@
+// Package vocalcalib re-thresholds stored per-track detector scores to
+// calibrate the sung-vocal gate. All logic here is pure (no audio, no DB); the
+// cmd/vocalcalib tool feeds it labeled scores gathered on a test environment.
+package vocalcalib
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// LabeledScore is one track's raw detector scores plus its ground-truth label.
+// Label is "vocal" (provider returned lyrics) or "instrumental" (provider
+// self-labeled instrumental, detector-independent).
+type LabeledScore struct {
+	MusicSum        float64 `json:"music_sum"`
+	VocalPeak       float64 `json:"vocal_peak"`
+	SpeechMean      float64 `json:"speech_mean"`
+	VocalClass      string  `json:"vocal_class"`
+	DetectorVersion string  `json:"detector_version"`
+	Label           string  `json:"label"`
+}
+
+// WriteJSONL appends one score as a JSON line.
+func WriteJSONL(w io.Writer, s LabeledScore) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal score: %w", err)
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write score: %w", err)
+	}
+	return nil
+}
+
+// ReadJSONL reads all scores from a JSONL stream.
+func ReadJSONL(r io.Reader) ([]LabeledScore, error) {
+	var out []LabeledScore
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var s LabeledScore
+		if err := json.Unmarshal(line, &s); err != nil {
+			return nil, fmt.Errorf("unmarshal score: %w", err)
+		}
+		out = append(out, s)
+	}
+	return out, sc.Err()
+}

--- a/internal/vocalcalib/scores_test.go
+++ b/internal/vocalcalib/scores_test.go
@@ -1,0 +1,26 @@
+package vocalcalib
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestJSONLRoundTrip(t *testing.T) {
+	in := []LabeledScore{
+		{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "", DetectorVersion: "1.17.0", Label: "instrumental"},
+		{MusicSum: 0.98, VocalPeak: 0.61, SpeechMean: 0.002, VocalClass: "Singing", DetectorVersion: "1.17.0", Label: "vocal"},
+	}
+	var buf bytes.Buffer
+	for _, s := range in {
+		if err := WriteJSONL(&buf, s); err != nil {
+			t.Fatalf("WriteJSONL: %v", err)
+		}
+	}
+	got, err := ReadJSONL(&buf)
+	if err != nil {
+		t.Fatalf("ReadJSONL: %v", err)
+	}
+	if len(got) != 2 || got[1].VocalClass != "Singing" || got[0].Label != "instrumental" {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+}

--- a/internal/vocalcalib/sweep.go
+++ b/internal/vocalcalib/sweep.go
@@ -1,0 +1,99 @@
+package vocalcalib
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/doxazo-net/canticle/internal/detector"
+)
+
+// Gates holds the music and speech thresholds kept fixed while the vocal-peak
+// threshold is swept.
+type Gates struct {
+	MinConfidence float64
+	SpeechMax     float64
+}
+
+// CurvePoint is one swept vocal-peak threshold and its measured rates.
+type CurvePoint struct {
+	Threshold   float64
+	PosErrRate  float64 // fraction of positives wrongly marked instrumental
+	NegRecovery float64 // fraction of negatives correctly marked instrumental
+}
+
+// Selection is the chosen operating point plus the full swept curve.
+type Selection struct {
+	Threshold   float64
+	PosErrRate  float64
+	NegRecovery float64
+	PosN        int
+	NegN        int
+	Curve       []CurvePoint
+}
+
+// SelectThreshold sweeps the vocal-peak threshold over every distinct positive
+// vocal_peak value and returns the HIGHEST threshold whose positive-error-rate
+// stays <= maxPosErrRate. Music and speech gates are held at gates; a track is
+// "marked instrumental" per detector.Instrumental. Positives set the ceiling;
+// negatives measure recovery only.
+func SelectThreshold(scores []LabeledScore, gates Gates, maxPosErrRate float64) (Selection, error) {
+	var pos, neg []LabeledScore
+	for _, s := range scores {
+		switch s.Label {
+		case "vocal":
+			pos = append(pos, s)
+		case "instrumental":
+			neg = append(neg, s)
+		}
+	}
+	if len(pos) == 0 {
+		return Selection{}, fmt.Errorf("no positive (vocal) samples")
+	}
+
+	// Candidate thresholds: each distinct positive vocal_peak, plus a hair above
+	// the max so the top of the range is reachable. Sorted ascending.
+	cand := map[float64]struct{}{}
+	for _, p := range pos {
+		cand[p.VocalPeak] = struct{}{}
+	}
+	thresholds := make([]float64, 0, len(cand)+1)
+	for t := range cand {
+		thresholds = append(thresholds, t)
+	}
+	sort.Float64s(thresholds)
+	if n := len(thresholds); n > 0 {
+		thresholds = append(thresholds, thresholds[n-1]*1.0001+1e-9)
+	}
+
+	markInstrumental := func(s LabeledScore, vocalMax float64) bool {
+		return detector.Instrumental(s.MusicSum, s.VocalPeak, s.SpeechMean, gates.MinConfidence, vocalMax, gates.SpeechMax)
+	}
+
+	sel := Selection{PosN: len(pos), NegN: len(neg), Threshold: 0}
+	for _, th := range thresholds {
+		posErr := 0
+		for _, p := range pos {
+			if markInstrumental(p, th) {
+				posErr++
+			}
+		}
+		negRec := 0
+		for _, n := range neg {
+			if markInstrumental(n, th) {
+				negRec++
+			}
+		}
+		pr := float64(posErr) / float64(len(pos))
+		nr := 0.0
+		if len(neg) > 0 {
+			nr = float64(negRec) / float64(len(neg))
+		}
+		sel.Curve = append(sel.Curve, CurvePoint{Threshold: th, PosErrRate: pr, NegRecovery: nr})
+		if pr <= maxPosErrRate && th > sel.Threshold {
+			sel.Threshold = th
+			sel.PosErrRate = pr
+			sel.NegRecovery = nr
+		}
+	}
+	return sel, nil
+}

--- a/internal/vocalcalib/sweep_test.go
+++ b/internal/vocalcalib/sweep_test.go
@@ -1,0 +1,57 @@
+package vocalcalib
+
+import (
+	"math"
+	"testing"
+)
+
+// Positives (vocal) peak high; negatives (instrumental) peak low, with one
+// positive outlier at 0.04 that the 1% budget must tolerate rather than let it
+// drag the threshold down to ~0.04.
+func sample() []LabeledScore {
+	var s []LabeledScore
+	for i := 0; i < 199; i++ { // 199 clean positives at 0.50
+		s = append(s, LabeledScore{MusicSum: 0.98, VocalPeak: 0.50, SpeechMean: 0.001, Label: "vocal"})
+	}
+	s = append(s, LabeledScore{MusicSum: 0.98, VocalPeak: 0.04, SpeechMean: 0.001, Label: "vocal"}) // 1 outlier
+	for i := 0; i < 100; i++ {                                                                      // negatives at 0.02
+		s = append(s, LabeledScore{MusicSum: 0.98, VocalPeak: 0.02, SpeechMean: 0.001, Label: "instrumental"})
+	}
+	return s
+}
+
+func TestSelectThreshold_ToleratesSingleOutlierUnder1Percent(t *testing.T) {
+	gates := Gates{MinConfidence: 0.90, SpeechMax: 0.20}
+	sel, err := SelectThreshold(sample(), gates, 0.01)
+	if err != nil {
+		t.Fatalf("SelectThreshold: %v", err)
+	}
+	// With 1/200 positives = 0.5% < 1%, the threshold may rise above the 0.04
+	// outlier (up to just below the clean cluster at 0.50), recovering all
+	// negatives (all 100 have vocalPeak 0.02 < threshold).
+	if sel.Threshold <= 0.04 {
+		t.Fatalf("threshold=%.4f should clear the single sub-1%% outlier", sel.Threshold)
+	}
+	if sel.PosErrRate >= 0.01 {
+		t.Fatalf("PosErrRate=%.4f must stay < 1%%", sel.PosErrRate)
+	}
+	if math.Abs(sel.NegRecovery-1.0) > 1e-9 {
+		t.Fatalf("NegRecovery=%.4f want 1.0", sel.NegRecovery)
+	}
+}
+
+func TestSelectThreshold_ZeroBudgetPinsBelowLowestPositive(t *testing.T) {
+	gates := Gates{MinConfidence: 0.90, SpeechMax: 0.20}
+	sel, err := SelectThreshold(sample(), gates, 0.0)
+	if err != nil {
+		t.Fatalf("SelectThreshold: %v", err)
+	}
+	// Zero budget: threshold must sit at/below the outlier 0.04 so NO positive
+	// is misclassified.
+	if sel.Threshold > 0.04 {
+		t.Fatalf("threshold=%.4f must not exceed the lowest positive under a 0 budget", sel.Threshold)
+	}
+	if sel.PosErrRate != 0 {
+		t.Fatalf("PosErrRate=%.4f want 0", sel.PosErrRate)
+	}
+}

--- a/internal/vocalcalib/validate.go
+++ b/internal/vocalcalib/validate.go
@@ -1,0 +1,45 @@
+package vocalcalib
+
+import "github.com/doxazo-net/canticle/internal/detector"
+
+// Report is the outcome of validating a fixed threshold against a labeled set.
+type Report struct {
+	Threshold     float64
+	PosN          int
+	PosErrN       int
+	PosErrRate    float64
+	NegN          int
+	NegRecoveredN int
+	NegRecovery   float64
+	Pass          bool
+}
+
+// Validate measures a fixed threshold against a labeled set and reports whether
+// the positive-error-rate stays below maxPosErrRate (the #384 close-out check).
+func Validate(scores []LabeledScore, gates Gates, threshold, maxPosErrRate float64) Report {
+	var r Report
+	r.Threshold = threshold
+	for _, s := range scores {
+		inst := detector.Instrumental(s.MusicSum, s.VocalPeak, s.SpeechMean, gates.MinConfidence, threshold, gates.SpeechMax)
+		switch s.Label {
+		case "vocal":
+			r.PosN++
+			if inst {
+				r.PosErrN++
+			}
+		case "instrumental":
+			r.NegN++
+			if inst {
+				r.NegRecoveredN++
+			}
+		}
+	}
+	if r.PosN > 0 {
+		r.PosErrRate = float64(r.PosErrN) / float64(r.PosN)
+	}
+	if r.NegN > 0 {
+		r.NegRecovery = float64(r.NegRecoveredN) / float64(r.NegN)
+	}
+	r.Pass = r.PosN > 0 && r.PosErrRate < maxPosErrRate
+	return r
+}

--- a/internal/vocalcalib/validate_test.go
+++ b/internal/vocalcalib/validate_test.go
@@ -1,0 +1,20 @@
+package vocalcalib
+
+import "testing"
+
+func TestValidate_PassFail(t *testing.T) {
+	gates := Gates{MinConfidence: 0.90, SpeechMax: 0.20}
+	scores := sample() // from sweep_test.go: 200 positives (1 at 0.04), 100 negatives at 0.02
+
+	// Threshold 0.30: only the single 0.04 positive is misclassified => 0.5% < 1% => pass.
+	r := Validate(scores, gates, 0.30, 0.01)
+	if !r.Pass || r.PosErrN != 1 || r.NegRecoveredN != 100 {
+		t.Fatalf("expected pass with 1 pos err and full recovery, got %+v", r)
+	}
+
+	// Threshold 0.60: clean cluster at 0.50 now misclassified => >1% => fail.
+	r2 := Validate(scores, gates, 0.60, 0.01)
+	if r2.Pass {
+		t.Fatalf("expected fail at 0.60, got %+v", r2)
+	}
+}


### PR DESCRIPTION
## Summary

First of two stacked PRs for vocal-gate calibration (#510): the calibration **tooling** half. It extracts the detector's three-gate decision into a shared pure predicate and builds the offline sweep/validation tooling on top of it. No behavior change to the live detector, and the placeholder threshold is unchanged (it awaits the empirical sweep).

- **refactor(detector):** extract `detector.Instrumental(...)`, the pure three-gate score predicate, and route the live detector through it (behavior-preserving; the sidecar-completeness guards stay at the call site).
- **feat(vocalcalib):** new pure package: labeled-score type + JSONL I/O, a threshold sweep that selects the highest vocal-peak threshold under a <1% false-instrumental bar (positives set the ceiling, negatives measure recovery), and a re-runnable validation gate (the #384 close-out).
- **feat(vocalcalib):** non-shipped `cmd/vocalcalib` tool (sample / sweep / validate); excluded from releases and from coverage like the other dev-tool entry points.

The reopen engine that consumes a calibrated threshold ships as the **stacked follow-up PR** (queue lister + `instrumentalrecalib` + `scan reconcile-instrumental-recalibrate`).

## Linked issue

Part of #510.

## Test plan

- [x] `make gate` green: race tests, patch coverage (86% on scope), golangci-lint, actionlint, govulncheck
- [x] New TDD tests: gate-predicate boundaries; vocalcalib JSONL round-trip, sweep selection (single-outlier tolerance + zero-budget pinning), validation pass/fail
- [x] `cmd/vocalcalib` builds; sweep/validate modes smoke-tested on synthetic JSONL (sample mode needs a live classifier, exercised in the held operational calibration run)
