### PR TITLE
fix(orchestrator): reclassify empty-body response out of the throttle bucket to unstick the queue (#496)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ docs/design/
 
 # Orchestrate session checkpoint (machine-local, transient; never committed)
 /SESSION-STATE.md
+/FIX496-REPORT.md

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -60,9 +60,11 @@ var (
 	ErrNoLyrics = errors.New("musixmatch: no lyrics available")
 	// ErrTruncatedResponse indicates a structurally valid response (HTTP 200,
 	// track present) whose inner data is missing -- e.g. has_subtitles=1 but the
-	// subtitle_body is empty. This is typically observed during egress-IP
-	// throttling, where the upstream returns a well-formed but hollow body.
-	// Treat as a circuit-breaker signal rather than a parse error.
+	// subtitle_body is empty. This was originally observed during egress-IP
+	// throttling, but detection here only proves the body was hollow for THIS
+	// request; the callers (orchestrator, worker) classify it as a benign miss
+	// rather than a throttle signal, since an empty body is deterministic per
+	// request and not evidence of a transient rate limit (#496).
 	ErrTruncatedResponse = errors.New("musixmatch: truncated or empty response body")
 )
 

--- a/internal/orchestrator/errors.go
+++ b/internal/orchestrator/errors.go
@@ -25,15 +25,19 @@ const (
 	// no error precedence.
 	OutcomeSuccess OutcomeClass = iota
 	// OutcomeBenignMiss means the lane reached the provider and the track was
-	// absent or had no usable lyrics (ErrNotFound, ErrNoLyrics). The only signal
-	// that the track is genuinely absent.
+	// absent or had no usable lyrics (ErrNotFound, ErrNoLyrics), or the
+	// provider returned a structurally valid but hollow body
+	// (ErrTruncatedResponse). ErrTruncatedResponse is deterministic per
+	// request rather than a genuine catalog answer, but it is bucketed here
+	// (not with the throttle signals below) because it must take the same
+	// bounded-retry path as a clean miss -- see #496.
 	OutcomeBenignMiss
 	// OutcomeTransport means a retriable failure that is not a clean miss
 	// (timeout, connection failure, an unexpected error).
 	OutcomeTransport
 	// OutcomeAuthRateLimit means an auth or rate-limit / throttle signal
-	// (ErrUnauthorized, ErrTokenRenewalRequired, ErrRateLimited,
-	// ErrTruncatedResponse). The catalog answer is unknown.
+	// (ErrUnauthorized, ErrTokenRenewalRequired, ErrRateLimited). The catalog
+	// answer is unknown.
 	OutcomeAuthRateLimit
 	// OutcomeUnavailable means the lane's breaker was open and the provider was
 	// not called (ErrLaneUnavailable).
@@ -44,7 +48,11 @@ const (
 // success. The auth/rate-limit check folds in the Musixmatch throttle sentinels
 // the worker historically tripped the circuit on; classification is per-provider
 // today (only Musixmatch lanes exist) and lives here so the breaker stays
-// provider-agnostic.
+// provider-agnostic. ErrTruncatedResponse is deliberately NOT in the
+// auth/rate-limit bucket: it is a deterministic per-request condition (an
+// empty body), not a transient throttle, so it must classify as a benign miss
+// and take the bounded-retry path rather than the no-cost throttle release
+// (#496).
 func ClassifyOutcome(err error) OutcomeClass {
 	switch {
 	case err == nil:
@@ -53,10 +61,9 @@ func ClassifyOutcome(err error) OutcomeClass {
 		return OutcomeUnavailable
 	case errors.Is(err, musixmatch.ErrTokenRenewalRequired),
 		errors.Is(err, musixmatch.ErrUnauthorized),
-		errors.Is(err, musixmatch.ErrRateLimited),
-		errors.Is(err, musixmatch.ErrTruncatedResponse):
+		errors.Is(err, musixmatch.ErrRateLimited):
 		return OutcomeAuthRateLimit
-	case musixmatch.IsBenignMiss(err):
+	case musixmatch.IsBenignMiss(err), errors.Is(err, musixmatch.ErrTruncatedResponse):
 		return OutcomeBenignMiss
 	default:
 		return OutcomeTransport

--- a/internal/orchestrator/errors_test.go
+++ b/internal/orchestrator/errors_test.go
@@ -19,9 +19,9 @@ func TestClassifyOutcome(t *testing.T) {
 		{"token renewal is auth", fmt.Errorf("x: %w", musixmatch.ErrTokenRenewalRequired), OutcomeAuthRateLimit},
 		{"unauthorized is auth", fmt.Errorf("x: %w", musixmatch.ErrUnauthorized), OutcomeAuthRateLimit},
 		{"rate limited is auth", fmt.Errorf("x: %w", musixmatch.ErrRateLimited), OutcomeAuthRateLimit},
-		{"truncated is auth", fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse), OutcomeAuthRateLimit},
 		{"not found is benign miss", fmt.Errorf("x: %w", musixmatch.ErrNotFound), OutcomeBenignMiss},
 		{"no lyrics is benign miss", fmt.Errorf("x: %w", musixmatch.ErrNoLyrics), OutcomeBenignMiss},
+		{"truncated is benign miss", fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse), OutcomeBenignMiss},
 		{"generic error is transport", errors.New("connection refused"), OutcomeTransport},
 	}
 	for _, tt := range tests {

--- a/internal/orchestrator/lane.go
+++ b/internal/orchestrator/lane.go
@@ -49,8 +49,9 @@ func (l *Lane) Breaker() *circuit.Breaker { return l.breaker }
 //
 //   - If the breaker is open, it returns ErrLaneUnavailable WITHOUT calling the
 //     provider, so an open lane spends no calls.
-//   - On a benign miss it resets the breaker ramp (a clean miss is a successful
-//     round-trip, not a throttle) and returns the classified miss error.
+//   - On a benign miss (including a truncated/empty-body response, #496) it
+//     resets the breaker ramp (a clean round-trip is not a throttle) and
+//     returns the classified miss error.
 //   - On a rate-limit / auth / renewal signal it trips the breaker (or holds the
 //     full renewal window) and returns the classified error after emitting the
 //     honest four-way throttle log.
@@ -115,13 +116,9 @@ func (l *Lane) classify(err error) error {
 	}
 
 	if errors.Is(err, musixmatch.ErrRateLimited) ||
-		errors.Is(err, musixmatch.ErrUnauthorized) ||
-		errors.Is(err, musixmatch.ErrTruncatedResponse) {
+		errors.Is(err, musixmatch.ErrUnauthorized) {
 		res := l.breaker.Trip()
 		switch {
-		case errors.Is(err, musixmatch.ErrTruncatedResponse):
-			slog.Warn("lane circuit opened: provider returned truncated response; likely throttling",
-				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
 		case l.breaker.EverSucceeded() && res.Trips >= escalationThreshold:
 			slog.Warn("lane circuit opened: token validated earlier this session but has failed repeatedly; it may have expired",
 				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
@@ -133,21 +130,24 @@ func (l *Lane) classify(err error) error {
 				"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
 		}
 		// Ratchet the adaptive pacer only on genuine throttle signals: a rate-limit
-		// or truncated response is ALWAYS throttling; a 401 is throttling only AFTER
-		// the token has succeeded this session (before that it's a bad token, not a
-		// throttle). Never ratchet on a never-succeeded 401.
+		// is ALWAYS throttling; a 401 is throttling only AFTER the token has
+		// succeeded this session (before that it's a bad token, not a throttle).
+		// Never ratchet on a never-succeeded 401.
 		if errors.Is(err, musixmatch.ErrRateLimited) ||
-			errors.Is(err, musixmatch.ErrTruncatedResponse) ||
 			(errors.Is(err, musixmatch.ErrUnauthorized) && l.breaker.EverSucceeded()) {
 			l.notifyThrottle()
 		}
 		return err
 	}
 
-	if musixmatch.IsBenignMiss(err) {
+	if musixmatch.IsBenignMiss(err) || errors.Is(err, musixmatch.ErrTruncatedResponse) {
 		// A clean miss proves the provider round-trip succeeded, so we are not
 		// being throttled: reset the ramp. EverSucceeded is deliberately NOT set
-		// (a miss is a successful round-trip but not a genuine lyric match).
+		// (a miss is a successful round-trip but not a genuine lyric match). A
+		// truncated/empty body is bucketed here too (#496): it is a deterministic
+		// per-request condition, not a transient throttle, so it must not trip the
+		// breaker or ratchet the pacer -- the worker's benign-miss cadence bounds
+		// its cost instead.
 		if l.breaker.RecordBenignMiss() {
 			slog.Info("lane circuit closed; provider recovered", "provider", l.Name())
 		}

--- a/internal/orchestrator/lane_test.go
+++ b/internal/orchestrator/lane_test.go
@@ -183,14 +183,27 @@ func TestLaneHonest401EscalatesAfterThreshold(t *testing.T) {
 	}
 }
 
-func TestLaneHonest401Truncated(t *testing.T) {
+func TestLaneTruncatedResponseRecordsBenignMissNoTrip(t *testing.T) {
+	// An empty/truncated body is a deterministic per-request condition, not a
+	// throttle signal: it must be treated like a benign miss (reset the ramp,
+	// no trip) rather than opening the circuit.
 	p := &stubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse)}
-	l, _ := newTestLane(p)
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+
+	_, err := l.FindLyrics(context.Background(), models.Track{})
+	if !errors.Is(err, musixmatch.ErrTruncatedResponse) {
+		t.Fatalf("err = %v; want ErrTruncatedResponse", err)
+	}
+	if cb.Trips() != 0 {
+		t.Fatalf("trips = %d; want 0 (a truncated response must not trip the breaker)", cb.Trips())
+	}
 	logs := captureLogs(t, func() {
 		_, _ = l.FindLyrics(context.Background(), models.Track{})
 	})
-	if !strings.Contains(logs, "truncated response") {
-		t.Fatalf("logs = %q; want truncated-response message", logs)
+	if strings.Contains(logs, "throttling") || strings.Contains(logs, "rate limit") {
+		t.Fatalf("logs = %q; want no throttle/rate-limit wording for a truncated response", logs)
 	}
 }
 
@@ -299,9 +312,9 @@ func TestLaneCallsOnThrottleOnRateLimitAfterSuccess(t *testing.T) {
 	}
 }
 
-func TestLaneCallsOnThrottleOnTruncated(t *testing.T) {
-	// A truncated response is always a throttle signal, even with no prior
-	// success this session: the pacer must ratchet.
+func TestLaneNoOnThrottleOnTruncated(t *testing.T) {
+	// A truncated/empty body is a deterministic per-request condition, not a
+	// throttle signal: the pacer must not ratchet on it.
 	p := &adaptiveStubProvider{name: "musixmatch", err: fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse)}
 	cb := circuit.New(60*time.Second, 30*time.Minute)
 	l := NewLane(p, cb)
@@ -310,8 +323,8 @@ func TestLaneCallsOnThrottleOnTruncated(t *testing.T) {
 	if !errors.Is(err, musixmatch.ErrTruncatedResponse) {
 		t.Fatalf("err = %v; want ErrTruncatedResponse", err)
 	}
-	if p.throttles != 1 {
-		t.Fatalf("OnThrottle calls = %d; want 1 (truncated response is always a throttle)", p.throttles)
+	if p.throttles != 0 {
+		t.Fatalf("OnThrottle calls = %d; want 0 (a truncated response is a benign miss, not a throttle)", p.throttles)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -708,7 +708,13 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// so reset the consecutive-failure counter: an earlier transient failure
 		// must not pin the worker in a permanent geometric backoff while it is
 		// otherwise healthily reaching the provider and getting clean misses.
-		if musixmatch.IsBenignMiss(err) {
+		//
+		// Gated on orchestrator.ClassifyOutcome rather than musixmatch.IsBenignMiss
+		// directly so this stays in lockstep with the outer switch above: a
+		// truncated/empty-body response now classifies as OutcomeBenignMiss (#496)
+		// and must take this same bounded-retry path, not the no-cost throttle
+		// release the outer switch reserves for genuine auth/rate-limit signals.
+		if orchestrator.ClassifyOutcome(err) == orchestrator.OutcomeBenignMiss {
 			slog.Debug("worker no lyrics match; requeuing deferred", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", err)
 			// Every active lane was tried and none returned lyrics: record a miss for
 			// each. Errors are non-fatal; recording happens before the Defer/Complete

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1438,7 +1438,15 @@ func TestThrottleResetsStaleFailureState(t *testing.T) {
 	}
 }
 
-func TestTruncatedResponseOpensCircuitAndReleases(t *testing.T) {
+// TestTruncatedResponseRequeuesDeferredWithoutTrippingCircuit covers #496: a
+// truncated/empty-body response (HasSubtitles=1, empty subtitle_body) is a
+// deterministic per-request condition, not a transient rate limit, so it must
+// NOT route through the no-cost throttle Release (which left attempts/
+// miss_count/next_attempt_at untouched and returned the row to pending at
+// priority=0, spinning forever ahead of the miss-cadence-parked rows). It must
+// take the same state-advancing benign-miss Defer path as ErrNotFound /
+// ErrNoLyrics, and must never trip the circuit breaker or log as throttling.
+func TestTruncatedResponseRequeuesDeferredWithoutTrippingCircuit(t *testing.T) {
 	recs := captureLogs(t)
 	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
 	q := &fakeQueue{items: []queue.WorkItem{
@@ -1450,35 +1458,26 @@ func TestTruncatedResponseOpensCircuitAndReleases(t *testing.T) {
 	w.setClock(func() time.Time { return fixed })
 	w.SetCircuitBackoff(60*time.Second, 30*time.Minute)
 
-	if err := w.RunOnce(context.Background()); !errors.Is(err, errThrottled) {
-		t.Fatalf("RunOnce = %v; want errThrottled (circuit opened cleanly)", err)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce = %v; want nil (a truncated response defers, it does not throttle-release)", err)
 	}
-	if w.circuit.OpenUntil().IsZero() {
-		t.Fatal("circuitOpenUntil = zero; want circuit opened on a truncated response")
+	if !w.circuit.OpenUntil().IsZero() {
+		t.Fatal("circuitOpenUntil != zero; a truncated response must NOT open the circuit")
 	}
-	if got := q.released; len(got) != 1 || got[0] != 77 {
-		t.Fatalf("released = %v; want [77] (Release, not Fail)", got)
+	if len(q.deferred) != 1 || q.deferred[0] != 77 {
+		t.Fatalf("deferred = %v; want [77] (Defer, not Release)", q.deferred)
+	}
+	if len(q.released) != 0 {
+		t.Fatalf("released = %v; want none (no-cost Release is the bug this guards against)", q.released)
 	}
 	if len(q.failed) != 0 {
 		t.Fatalf("failed = %v; want none (a truncated response is not the song's failure)", q.failed)
 	}
-	// Release leaves Attempts untouched (it does not increment the attempt count);
-	// the item is back in the pending pool unchanged.
-	if len(q.processing) != 0 {
-		t.Fatalf("processing = %v; want empty after release", q.processing)
+	if w.consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures = %d; want 0 (a truncated response must not trip backoff)", w.consecutiveFailures)
 	}
-	if !hasLog(*recs, slog.LevelWarn, "truncated response") {
-		t.Fatalf("logs = %+v; want a Warn naming the truncated response", *recs)
-	}
-	rec := findLog(*recs, slog.LevelWarn, "truncated response")
-	if rec == nil {
-		t.Fatal("no captured truncated-response Warn")
-	}
-	if got := attrDuration(rec, "backoff"); got != 60*time.Second {
-		t.Fatalf("backoff attr = %v; want 60s", got)
-	}
-	if got := attrTime(rec, "next_retry"); !got.Equal(fixed.Add(60 * time.Second)) {
-		t.Fatalf("next_retry attr = %v; want %v", got, fixed.Add(60*time.Second))
+	if hasLog(*recs, slog.LevelWarn, "throttling") || hasLog(*recs, slog.LevelWarn, "rate limit") {
+		t.Fatalf("logs = %+v; want no throttle/rate-limit wording for a truncated response", *recs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the work_queue livelock (#496). Musixmatch 200s with `has_subtitles=1` but an empty `subtitle_body` (wrapped as `ErrTruncatedResponse`) were misclassified as a rate-limit/throttle and routed to a no-cost `queue.Release`: the row returned to `pending` at priority 0 with its state untouched and spun forever, starving the ~15k benign-miss rows parked at priority -100.

Reclassify `ErrTruncatedResponse` as a benign miss end-to-end so it takes the bounded-retry Defer/miss-cadence path (miss_count+1, priority -100, RetireMiss ceiling) instead of the throttle Release:

- **orchestrator/errors.go:** `ClassifyOutcome` moves `ErrTruncatedResponse` from `OutcomeAuthRateLimit` to `OutcomeBenignMiss`.
- **orchestrator/lane.go:** no longer trips the circuit breaker or ratchets the adaptive pacer on a truncated response; resets the ramp via the benign-miss path. Drops the misleading "likely throttling" log.
- **worker/worker.go:** the inner benign gate switches from `musixmatch.IsBenignMiss` to `orchestrator.ClassifyOutcome(err) == OutcomeBenignMiss` so the truncated case takes the miss cadence (not `w.fail`). Verified the two predicates are equivalent for every error except the intentionally-moved `ErrTruncatedResponse`.

Drain is automatic on deploy: the corrected classification lets the already-spinning rows advance and stop starving the backlog, no data reset needed. (`queue recheck --deferred` optionally re-arms the not-yet-due tail once the spinners clear.)

## Linked issue

Closes #496.

## Test plan

- [x] `make gate` green: race tests, patch coverage, golangci-lint, actionlint, govulncheck
- [x] TDD RED to GREEN: truncated classifies as benign miss; lane does not trip/ratchet on it; `RunOnce` returns nil and the row goes through Defer not Release, circuit stays closed, no throttle wording. The old tests that asserted the buggy throttle-release were replaced, not deleted.
- [x] Blast-radius check: `ClassifyOutcome==OutcomeBenignMiss` is equivalent to `IsBenignMiss` for every error except `ErrTruncatedResponse` (opus-reviewed).
