### PR TITLE
feat(instrumentalrecalib): reopen vocal-gate-buried rows from stored telemetry (#510)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -133,13 +133,14 @@ type ScanCmd struct {
 	NoDetectInstrumental bool     `arg:"--no-detect-instrumental" help:"force instrumental detection off for tracks enqueued by this scan, overriding per-library and global settings; mutually exclusive with --detect-instrumental"`
 	Libraries            []string `arg:"--only,separate" help:"limit scan to named or numeric libraries; repeat to select more than one. Distinct from subcommand --library flags (which target a single library row)"`
 
-	Results               *ScanResultsCmd               `arg:"subcommand:results" help:"list persisted scan_results rows"`
-	Clear                 *ScanClearCmd                 `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
-	Reconcile             *ScanReconcileCmd             `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
-	ReconcileInstrumental *ScanReconcileInstrumentalCmd `arg:"subcommand:reconcile-instrumental" help:"classify deferred rows the detector has never scored and write markers where it agrees; makes no provider requests (issue #499)"`
-	ReconcilePaths        *ScanReconcilePathsCmd        `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
-	ReconcileIdentity     *ScanReconcileIdentityCmd     `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
-	ReconcileLRC          *ScanReconcileLRCCmd          `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
+	Results                          *ScanResultsCmd                          `arg:"subcommand:results" help:"list persisted scan_results rows"`
+	Clear                            *ScanClearCmd                            `arg:"subcommand:clear" help:"delete persisted scan_results rows for a library"`
+	Reconcile                        *ScanReconcileCmd                        `arg:"subcommand:reconcile" help:"re-validate instrumental markers against the current detector and clear stale ones"`
+	ReconcileInstrumental            *ScanReconcileInstrumentalCmd            `arg:"subcommand:reconcile-instrumental" help:"classify deferred rows the detector has never scored and write markers where it agrees; makes no provider requests (issue #499)"`
+	ReconcileInstrumentalRecalibrate *ScanReconcileInstrumentalRecalibrateCmd `arg:"subcommand:reconcile-instrumental-recalibrate" help:"re-decide stamped not-instrumental rows against the current detector thresholds using stored telemetry; makes no provider or detector-sidecar requests (issue #510)"`
+	ReconcilePaths                   *ScanReconcilePathsCmd                   `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
+	ReconcileIdentity                *ScanReconcileIdentityCmd                `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
+	ReconcileLRC                     *ScanReconcileLRCCmd                     `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
 }
 
 // ScanReconcileLRCCmd walks the configured library roots and rewrites any .lrc
@@ -199,6 +200,26 @@ type ScanReconcileInstrumentalCmd struct {
 	Yes        bool   `arg:"--yes" help:"actually write markers and settle rows (without it, prints what would change)"`
 	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
 	Backup     string `arg:"--backup" help:"path for the JSONL backup of classified rows (default: <db-dir>/reconcile-instrumental-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// ScanReconcileInstrumentalRecalibrateCmd re-decides work_queue rows already
+// stamped not-instrumental (instrumental_result = 0, a "vocal-gate rejection")
+// against the CURRENT detector thresholds, using each row's stored telemetry
+// (music_sum/vocal_peak/speech_mean) rather than re-scanning audio. A row a
+// tightened-then-loosened threshold buried is settled and marked; a row
+// scored by a different detector version is reset to never-classified for a
+// real re-scan instead of being trusted on stale telemetry. Makes no
+// provider or detector-sidecar requests. Dry-run unless --yes.
+//
+// The counterpart of ScanReconcileInstrumentalCmd, which classifies rows the
+// detector has never scored at all; this one re-opens rows it already
+// scored negative (issue #510).
+type ScanReconcileInstrumentalRecalibrateCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default covers every library"`
+	Yes        bool   `arg:"--yes" help:"actually write markers and settle/reset rows (without it, prints what would change)"`
+	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
+	Backup     string `arg:"--backup" help:"path for the JSONL backup of changed rows (default: <db-dir>/reconcile-instrumental-recalibrate-backup-<ts>.jsonl)" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
@@ -1719,6 +1740,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runReconcileInstrumental(ctx, out, sub)
+	case args.ReconcileInstrumentalRecalibrate != nil:
+		sub := *args.ReconcileInstrumentalRecalibrate
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runReconcileInstrumentalRecalibrate(ctx, out, sub)
 	case args.ReconcilePaths != nil:
 		sub := *args.ReconcilePaths
 		if sub.ConfigPath == "" {

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/reconcile_env.go
+++ b/internal/commands/reconcile_env.go
@@ -84,10 +84,10 @@ func resolveEnvLibrary(ctx context.Context, out io.Writer, sqlDB *sql.DB, librar
 	if rerr != nil {
 		if errors.Is(rerr, sql.ErrNoRows) {
 			_, _ = fmt.Fprintf(out, "library %q not found\n", libraryArg)
-			return nil, "", 1, rerr
+			return nil, "", 1, fmt.Errorf("resolve library %q: %w", libraryArg, rerr)
 		}
 		slog.Error("failed to resolve library", "error", rerr)
-		return nil, "", 1, rerr
+		return nil, "", 1, fmt.Errorf("resolve library %q: %w", libraryArg, rerr)
 	}
 	got := lib.ID
 	return &got, fmt.Sprintf(" (library %q, id=%d)", lib.Name, lib.ID), 0, nil

--- a/internal/commands/reconcile_env.go
+++ b/internal/commands/reconcile_env.go
@@ -46,6 +46,94 @@ func (e *detectorEnv) Close() {
 	_ = e.db.Close() //nolint:errcheck // reason: best-effort close on command exit
 }
 
+// queueEnv carries the dependencies a pure-stored-telemetry reconcile command
+// needs: resolved config, an open database, the durable queue, and the
+// optional single-library narrowing. Callers must Close it.
+//
+// Unlike detectorEnv, it never constructs an audio detector and never requires
+// one configured: instrumentalrecalib re-decides vocal-gate rejections from
+// telemetry already stamped on each row (music_sum/vocal_peak/speech_mean),
+// making no provider or sidecar calls, so gating it on a reachable classifier
+// would wrongly block a command that needs none.
+type queueEnv struct {
+	cfg   config.Config
+	db    *sql.DB
+	queue *queue.DBQueue
+
+	// libraryID narrows selection to one library when the operator passed
+	// --library; nil means every library. libLabel is the pre-rendered
+	// operator-facing suffix (" (library %q, id=%d)") or empty.
+	libraryID *int64
+	libLabel  string
+}
+
+// Close releases the database handle. Safe on a nil env.
+func (e *queueEnv) Close() {
+	if e == nil || e.db == nil {
+		return
+	}
+	_ = e.db.Close() //nolint:errcheck // reason: best-effort close on command exit
+}
+
+// resolveEnvLibrary resolves the operator-supplied --library argument (name or
+// numeric id) against lib, returning the narrowed id and its pre-rendered
+// operator-facing label. Shared by openDetectorEnv and openQueueEnv so the two
+// setups agree on --library semantics.
+func resolveEnvLibrary(ctx context.Context, out io.Writer, sqlDB *sql.DB, libraryArg string) (id *int64, label string, code int, err error) {
+	lib, rerr := resolveLibrary(ctx, library.New(sqlDB), libraryArg)
+	if rerr != nil {
+		if errors.Is(rerr, sql.ErrNoRows) {
+			_, _ = fmt.Fprintf(out, "library %q not found\n", libraryArg)
+			return nil, "", 1, rerr
+		}
+		slog.Error("failed to resolve library", "error", rerr)
+		return nil, "", 1, rerr
+	}
+	got := lib.ID
+	return &got, fmt.Sprintf(" (library %q, id=%d)", lib.Name, lib.ID), 0, nil
+}
+
+// openQueueEnv performs the setup shared by reconcile commands that re-decide
+// from stored telemetry alone: config, database, optional --library
+// narrowing, and the durable queue. It does not resolve ffmpeg or construct a
+// detector, so it works whether or not a classifier is configured or
+// reachable.
+//
+// On failure it returns a nil env and a process exit code, having already
+// written the operator-facing message to out or logged the internal error;
+// the caller returns that code verbatim. On success the caller owns the env
+// and must Close it.
+func openQueueEnv(ctx context.Context, out io.Writer, configPath, libraryArg string) (*queueEnv, int) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return nil, 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return nil, 1
+	}
+
+	env := &queueEnv{cfg: cfg, db: sqlDB}
+
+	if strings.TrimSpace(libraryArg) != "" {
+		id, label, code, rerr := resolveEnvLibrary(ctx, out, sqlDB, libraryArg)
+		if rerr != nil {
+			env.Close()
+			return nil, code
+		}
+		env.libraryID = id
+		env.libLabel = label
+	}
+
+	workQueue := queue.NewDBQueue(sqlDB)
+	workQueue.SetRandomized(cfg.Queue.Randomize)
+	env.queue = workQueue
+
+	return env, 0
+}
+
 // openDetectorEnv performs the setup shared by the detector-driven reconcile
 // commands. verb names the caller in the not-configured message ("reconcile",
 // "backfill") so the operator is told which command went inert.

--- a/internal/commands/reconcile_instrumental_recalibrate.go
+++ b/internal/commands/reconcile_instrumental_recalibrate.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/doxazo-net/canticle/internal/instrumentalrecalib"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+)
+
+// reconcileInstrumentalRecalibrateBackup is one JSONL record per row this run
+// acted on, written and fsynced before the row is mutated so an applied
+// change always has its restorable record.
+type reconcileInstrumentalRecalibrateBackup struct {
+	QueueID     int64     `json:"queue_id"`
+	Artist      string    `json:"artist"`
+	Title       string    `json:"title"`
+	SourcePath  string    `json:"source_path"`
+	VocalPeak   float64   `json:"vocal_peak"`
+	Action      string    `json:"action"`
+	MarkerPaths []string  `json:"marker_paths,omitempty"`
+	At          time.Time `json:"at"`
+}
+
+func appendReconcileInstrumentalRecalibrateBackup(f *os.File, ch instrumentalrecalib.Change) error {
+	rec := reconcileInstrumentalRecalibrateBackup{
+		QueueID:     ch.QueueID,
+		Artist:      ch.Artist,
+		Title:       ch.Title,
+		SourcePath:  ch.SourcePath,
+		VocalPeak:   ch.VocalPeak,
+		Action:      ch.Action,
+		MarkerPaths: ch.MarkerPaths,
+		At:          time.Now().UTC(),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal backup record: %w", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write backup record: %w", err)
+	}
+	// fsync before the row is mutated (the identityrepair backup-first rule).
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync backup record: %w", err)
+	}
+	return nil
+}
+
+// runReconcileInstrumentalRecalibrate is CLI wiring over
+// internal/instrumentalrecalib: it resolves config/queue (no detector -- the
+// engine re-decides from telemetry already stamped on each row), owns the
+// JSONL backup file and the operator output, and lets the package own the
+// re-decision logic. Dry-run unless --yes.
+func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, args ScanReconcileInstrumentalRecalibrateCmd) int {
+	env, code := openQueueEnv(ctx, out, args.ConfigPath, args.Library)
+	if env == nil {
+		return code
+	}
+	defer env.Close()
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		backupPath = filepath.Join(filepath.Dir(env.cfg.DB.Path), fmt.Sprintf("reconcile-instrumental-recalibrate-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	var backup *os.File
+	defer func() {
+		if backup != nil {
+			_ = backup.Close() //nolint:errcheck // reason: best-effort close on command exit
+		}
+	}()
+
+	if !args.Yes {
+		_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate%s: dry run; pass --yes to apply\n", env.libLabel)
+	}
+
+	rc := instrumentalrecalib.New(env.queue, lyrics.NewLRCWriter())
+	res, err := rc.Run(ctx, instrumentalrecalib.Options{
+		LibraryID:      env.libraryID,
+		Limit:          args.Limit,
+		DryRun:         !args.Yes,
+		MinConfidence:  env.cfg.InstrumentalDetector.MinConfidence,
+		VocalMax:       env.cfg.InstrumentalDetector.VocalMaxConfidence,
+		SpeechMax:      env.cfg.InstrumentalDetector.SpeechMaxConfidence,
+		CurrentVersion: version,
+		Preview: func(ch instrumentalrecalib.Change) {
+			switch ch.Action {
+			case "settle":
+				_, _ = fmt.Fprintf(out, "would settle: id=%d  %s  -> write instrumental marker + settle\n", ch.QueueID, ch.SourcePath)
+			default:
+				_, _ = fmt.Fprintf(out, "would reset: id=%d  %s  -> stale telemetry version, reset for re-scan\n", ch.QueueID, ch.SourcePath)
+			}
+		},
+		Report: func(ch instrumentalrecalib.Change) error {
+			if backup == nil {
+				f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+				if ferr != nil {
+					return fmt.Errorf("open backup file %s: %w", backupPath, ferr)
+				}
+				backup = f
+			}
+			return appendReconcileInstrumentalRecalibrateBackup(backup, ch)
+		},
+	})
+	if err != nil {
+		slog.Error("reconcile-instrumental-recalibrate failed", "error", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate%s: %d vocal-gate-rejected row(s) considered\n",
+		env.libLabel, res.Total)
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate done: settled=%d markers-written=%d reset-stale=%d skipped(worker-claimed=%d) errors=%d\n",
+		res.Settled, res.MarkersWritten, res.ResetStale, res.SkippedClaimed, res.Errors)
+	if args.Yes && (res.Settled > 0 || res.ResetStale > 0) {
+		_, _ = fmt.Fprintf(out, "backup of changed rows written to %s\n", backupPath)
+	}
+	if res.Errors > 0 {
+		return 1
+	}
+	return 0
+}

--- a/internal/commands/reconcile_instrumental_recalibrate_test.go
+++ b/internal/commands/reconcile_instrumental_recalibrate_test.go
@@ -219,3 +219,133 @@ func TestRunReconcileInstrumentalRecalibrate_VersionMismatchResets(t *testing.T)
 		t.Errorf("instrumental_result = %v; want NULL (reset to never-classified)", *result)
 	}
 }
+
+// TestRunReconcileInstrumentalRecalibrate_ConfigLoadFailure covers
+// openQueueEnv's config.Load error branch: a config file that exists but
+// fails to decode.
+func TestRunReconcileInstrumentalRecalibrate_ConfigLoadFailure(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("not valid toml [[["), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath})
+	if code != 1 {
+		t.Fatalf("exit=%d; want 1 for an undecodable config", code)
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_LibraryNotFound covers
+// openQueueEnv/resolveEnvLibrary's not-found error branch.
+func TestRunReconcileInstrumentalRecalibrate_LibraryNotFound(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	// db.Open creates the schema so resolveLibrary can run.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath, Library: "no-such-library"})
+	if code != 1 {
+		t.Fatalf("exit=%d; want 1 for an unknown --library; out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "not found") {
+		t.Errorf("want 'not found' message; got: %s", buf.String())
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_ScopedToLibrary covers
+// resolveEnvLibrary's success branch (id + label resolved) and confirms the
+// scoping actually narrows the candidate set: a row in a different library is
+// left untouched.
+func TestRunReconcileInstrumentalRecalibrate_ScopedToLibrary(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	var libID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES (?, ?) RETURNING id`, outdir, "music-lib",
+	).Scan(&libID); err != nil {
+		t.Fatalf("insert library: %v", err)
+	}
+	_ = sqlDB.Close()
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath, Library: "music-lib"})
+	if code != 0 {
+		t.Fatalf("exit=%d; want 0; out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "library \"music-lib\"") {
+		t.Errorf("want the operator-facing library label in output; got: %s", buf.String())
+	}
+	// The row has no linked scan_results row for this library, so scoping to
+	// it must exclude the row: nothing considered.
+	if !strings.Contains(buf.String(), "0 vocal-gate-rejected row(s) considered") {
+		t.Errorf("expected the library scoping to exclude the unlinked row; got: %s", buf.String())
+	}
+
+	sqlDB2, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB2.Close() }()
+	var status string
+	if err := sqlDB2.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred (row outside the scoped library must be untouched)", status)
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_BackupOpenFailure covers Report's
+// backup-file-open error branch: an unwritable --backup path must count as a
+// per-row error (and thus a non-zero exit) rather than silently dropping the
+// backup record.
+func TestRunReconcileInstrumentalRecalibrate_BackupOpenFailure(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+
+	// A backup path inside a non-existent directory: os.OpenFile fails.
+	badBackup := filepath.Join(dir, "no-such-dir", "backup.jsonl")
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{
+		ConfigPath: cfgPath, Yes: true, Backup: badBackup,
+	})
+	if code != 1 {
+		t.Fatalf("exit=%d; want 1 when the backup file cannot be opened; out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "errors=1") {
+		t.Errorf("want the backup-open failure counted as an error; got: %s", buf.String())
+	}
+}

--- a/internal/commands/reconcile_instrumental_recalibrate_test.go
+++ b/internal/commands/reconcile_instrumental_recalibrate_test.go
@@ -1,0 +1,221 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// writeRecalibrateCfg writes a minimal config with NO classifier configured,
+// proving runReconcileInstrumentalRecalibrate needs no detector sidecar: it
+// re-decides purely from telemetry already stamped on each row.
+func writeRecalibrateCfg(t *testing.T, path, dbPath string) {
+	t.Helper()
+	content := "[db]\npath = \"" + strings.ReplaceAll(dbPath, `\`, `\\`) + "\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeRecalibrateCfg: %v", err)
+	}
+}
+
+// seedVocalGateRejection parks a deferred row already stamped
+// instrumental_result=0 with re-decidable telemetry that PASSES the default
+// thresholds (min_confidence=0.90, vocal_max=0.03, speech_max=0.20) -- the
+// "old tight threshold buried it" case this command exists to reopen.
+func seedVocalGateRejection(t *testing.T, ctx context.Context, dbPath, outdir, detectorVersion string) int64 {
+	t.Helper()
+	srcPath := filepath.Join(outdir, "song.flac")
+	if err := os.WriteFile(srcPath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:       models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:      outdir,
+		Filename:    "song.lrc",
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	tel := queue.InstrumentalTelemetry{
+		MusicSum:        0.95,
+		VocalPeak:       0.01,
+		SpeechMean:      0.01,
+		VocalClass:      "Singing",
+		DetectorVersion: detectorVersion,
+	}
+	if err := q.SetInstrumentalResult(ctx, item.ID, 0, tel); err != nil {
+		t.Fatalf("SetInstrumentalResult: %v", err)
+	}
+	return item.ID
+}
+
+// TestRunReconcileInstrumentalRecalibrate_NoClassifierRequired is the core
+// requirement of #510: the command must work with NO classifier_url
+// configured at all, because it re-decides from stored telemetry alone.
+func TestRunReconcileInstrumentalRecalibrate_NoClassifierRequired(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath})
+	if code != 0 {
+		t.Fatalf("exit=%d out=%s (must not require a detector)", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "0 vocal-gate-rejected row(s) considered") {
+		t.Errorf("unexpected output:\n%s", buf.String())
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_DryRunSettlesNothing: a
+// version-matched row that now passes the (default) thresholds must be
+// previewed as "would settle" in a dry run, and the row/marker must stay
+// untouched until --yes.
+func TestRunReconcileInstrumentalRecalibrate_DryRunSettlesNothing(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+	markerPath := filepath.Join(outdir, "song.txt")
+
+	var dry bytes.Buffer
+	if code := runReconcileInstrumentalRecalibrate(ctx, &dry, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("dry-run exit=%d out=%s", code, dry.String())
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not write a marker; stat err=%v", err)
+	}
+	if !strings.Contains(dry.String(), "would settle") {
+		t.Errorf("dry-run output missing 'would settle':\n%s", dry.String())
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var status string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred (dry-run must not settle the row)", status)
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_ApplySettlesVersionMatchedRow:
+// under --yes, a version-matched passing row gets its marker written and is
+// settled/completed.
+func TestRunReconcileInstrumentalRecalibrate_ApplySettlesVersionMatchedRow(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+	markerPath := filepath.Join(outdir, "song.txt")
+
+	var app bytes.Buffer
+	if code := runReconcileInstrumentalRecalibrate(ctx, &app, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, app.String())
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("apply must write the instrumental marker: %v", err)
+	}
+	if !strings.Contains(app.String(), "settled=1") {
+		t.Errorf("output should report the settle:\n%s", app.String())
+	}
+	if !strings.Contains(app.String(), "backup of changed rows written to") {
+		t.Errorf("output should point at the backup file:\n%s", app.String())
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var status string
+	var result *int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT status, instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done", status)
+	}
+	if result == nil || *result != 1 {
+		t.Errorf("instrumental_result = %v; want 1", result)
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_VersionMismatchResets: a row scored
+// by a different detector version must be reset to never-classified rather
+// than settled on stale telemetry.
+func TestRunReconcileInstrumentalRecalibrate_VersionMismatchResets(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, "0.0.1-stale")
+
+	var app bytes.Buffer
+	if code := runReconcileInstrumentalRecalibrate(ctx, &app, ScanReconcileInstrumentalRecalibrateCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, app.String())
+	}
+	if !strings.Contains(app.String(), "reset-stale=1") {
+		t.Errorf("output should report the reset:\n%s", app.String())
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open verify: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var result *int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&result); err != nil {
+		t.Fatalf("verify row: %v", err)
+	}
+	if result != nil {
+		t.Errorf("instrumental_result = %v; want NULL (reset to never-classified)", *result)
+	}
+}

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -143,7 +143,7 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 
 	for _, row := range rows {
 		if err := ctx.Err(); err != nil {
-			return res, err
+			return res, fmt.Errorf("instrumentalrecalib: stop recalibration: %w", err)
 		}
 
 		pass := detector.Instrumental(row.Tel.MusicSum, row.Tel.VocalPeak, row.Tel.SpeechMean,

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -1,0 +1,303 @@
+// Package instrumentalrecalib re-decides vocal-gate rejections from stored
+// telemetry, without re-scanning audio.
+//
+// It exists because a track the OLD (too-tight) detector thresholds buried as
+// "not instrumental" is never revisited: instrumentalbackfill only ever looks
+// at rows the detector has NEVER scored, and `scan reconcile` only re-checks
+// verdicts the detector already confirmed positive. A row stamped
+// instrumental_result=0 sits in that gap forever, even after the thresholds
+// are loosened, unless something re-applies the new thresholds to what the
+// detector already measured.
+//
+// Every candidate row already carries its five telemetry scores from the
+// original detection pass (music_sum/vocal_peak/speech_mean/vocal_class/
+// detector_version), so re-deciding needs no audio and no detector sidecar --
+// it is pure arithmetic over queue.ListVocalGateRejections' stored numbers
+// against the caller's (presumably loosened) Options thresholds.
+package instrumentalrecalib
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/doxazo-net/canticle/internal/detector"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+// Resetter clears a stamped not-instrumental verdict back to "never
+// classified" so a version-mismatched row is picked up by the next
+// reconcile/backfill pass instead of being settled on stale telemetry.
+// Satisfied by *queue.DBQueue.
+type Resetter interface {
+	ResetInstrumentalToUnclassified(ctx context.Context, id int64) (bool, error)
+}
+
+// Store is the durable-queue surface a recalibration run needs. Satisfied by
+// *queue.DBQueue; narrowed to a seam so every path is testable without a live
+// database beyond the in-memory/temp-file SQLite the queue package already
+// uses in its own tests.
+type Store interface {
+	Resetter
+	ListVocalGateRejections(ctx context.Context, opts queue.ListVocalGateRejectionsOptions) ([]queue.StampedRejection, error)
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error)
+}
+
+// Writer writes the instrumental marker sidecar. Satisfied by lyrics.Writer.
+//
+// A vocal-gate rejection carries only its SourcePath, not the enqueued
+// Outdir/Filename/OutputPaths (queue.StampedRejection is a narrow projection
+// of work_queue, not the full Inputs) -- so the marker lands next to the
+// source audio file, exactly like directory-mode fetch output. A fake Writer
+// in a test only needs to record that it was called; the marker PATH is
+// computed by this package's markerPath, mirroring
+// instrumentalbackfill.MarkerPaths' use of lyrics.SidecarName.
+type Writer interface {
+	WriteLRC(song models.Song, filename, outdir string) error
+}
+
+// Change is one row this run acted on. It is the unit handed to
+// Options.Report (the durable backup record) and Options.Preview (the
+// dry-run line), so both describe exactly the same thing.
+type Change struct {
+	QueueID    int64
+	Artist     string
+	Title      string
+	SourcePath string
+	VocalPeak  float64
+	// Action is "settle" (version-matched pass: marker written, row
+	// completed) or "reset-stale" (version-mismatched pass: row dropped back
+	// to never-classified for a real re-scan).
+	Action string
+	// MarkerPaths is the sidecar this change writes. Empty for a reset-stale
+	// change: no marker exists until the row is re-scanned and re-decided
+	// under the current detector version.
+	MarkerPaths []string
+}
+
+// Result counts one Run.
+type Result struct {
+	Total          int // candidate vocal-gate rejections considered
+	Settled        int // rows settled instrumental and completed
+	MarkersWritten int // marker sidecars written and still on disk
+	ResetStale     int // rows reset to never-classified (cross-version pass)
+	SkippedClaimed int // rows a serve-mode worker claimed mid-recalibration
+	Errors         int // non-fatal per-row failures
+}
+
+// Options controls a Run.
+type Options struct {
+	// LibraryID, when non-nil, limits the run to one library's rows.
+	LibraryID *int64
+	// Limit caps the candidate set when > 0.
+	Limit int
+	// DryRun previews without mutating anything.
+	DryRun bool
+	// MinConfidence, VocalMax, SpeechMax are the (presumably loosened)
+	// re-decision thresholds fed to detector.Instrumental alongside each
+	// row's stored telemetry.
+	MinConfidence, VocalMax, SpeechMax float64
+	// CurrentVersion is the running detector version. A row scored by any
+	// other version is not settled directly on its stale telemetry -- it is
+	// reset for a real re-scan instead.
+	CurrentVersion string
+	// Report is invoked once per change BEFORE the row is mutated, so an
+	// applied change always has its restorable record first. A Report error
+	// aborts that row's mutation and counts an error; it never aborts the
+	// Run. Nil disables it.
+	Report func(Change) error
+	// Preview is invoked once per change in a dry run instead of mutating.
+	// Nil disables it.
+	Preview func(Change)
+}
+
+// Recalibrator re-decides vocal-gate rejections from stored telemetry.
+type Recalibrator struct {
+	store Store
+	w     Writer
+}
+
+// New builds a Recalibrator over store, writing markers with w.
+func New(store Store, w Writer) *Recalibrator {
+	return &Recalibrator{store: store, w: w}
+}
+
+// Run re-decides the vocal-gate-rejection backlog under opts' thresholds.
+// Per-row failures are counted in Result.Errors and do not abort the run;
+// only a failure to enumerate the backlog returns an error.
+func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
+	var res Result
+
+	rows, err := r.store.ListVocalGateRejections(ctx, queue.ListVocalGateRejectionsOptions{
+		LibraryID: opts.LibraryID,
+		Limit:     opts.Limit,
+	})
+	if err != nil {
+		return res, fmt.Errorf("instrumentalrecalib: list vocal-gate rejections: %w", err)
+	}
+	res.Total = len(rows)
+
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+
+		pass := detector.Instrumental(row.Tel.MusicSum, row.Tel.VocalPeak, row.Tel.SpeechMean,
+			opts.MinConfidence, opts.VocalMax, opts.SpeechMax)
+		if !pass {
+			// Still correctly not-instrumental under the new thresholds: nothing to
+			// do, and no mutation means no Report/backup is warranted either.
+			continue
+		}
+
+		versionMatch := row.Tel.DetectorVersion == opts.CurrentVersion
+		change := Change{
+			QueueID:    row.ID,
+			Artist:     row.Artist,
+			Title:      row.Title,
+			SourcePath: row.SourcePath,
+			VocalPeak:  row.Tel.VocalPeak,
+		}
+		if versionMatch {
+			change.Action = "settle"
+			change.MarkerPaths = markerPaths(row)
+		} else {
+			change.Action = "reset-stale"
+		}
+
+		if opts.DryRun {
+			if opts.Preview != nil {
+				opts.Preview(change)
+			}
+			continue
+		}
+
+		// Backup first: an applied change must always have its restorable record
+		// on disk before the change exists.
+		if opts.Report != nil {
+			if err := opts.Report(change); err != nil {
+				res.Errors++
+				continue
+			}
+		}
+
+		if !versionMatch {
+			reset, err := r.store.ResetInstrumentalToUnclassified(ctx, row.ID)
+			if err != nil {
+				res.Errors++
+				continue
+			}
+			if !reset {
+				// A worker claimed the row (it is no longer 'deferred') between the
+				// list and here: nothing to reset.
+				res.SkippedClaimed++
+				continue
+			}
+			res.ResetStale++
+			continue
+		}
+
+		written, werr := r.writeMarkers(row)
+		res.MarkersWritten += len(written)
+		if werr != nil {
+			res.Errors++
+			// Never settle a verdict whose marker did not fully land.
+			res.MarkersWritten -= r.rollback(written, &res)
+			continue
+		}
+
+		outcome, err := r.store.SettleInstrumental(ctx, row.ID, row.Tel)
+		if err != nil {
+			// AMBIGUOUS: the error may have come from Commit itself, so the settle
+			// may or may not have landed. Keep the marker and report the error --
+			// an orphan marker is recoverable by a later run, a deleted valid
+			// result is not.
+			res.Errors++
+			slog.Warn("instrumentalrecalib: settle failed after the marker was written; leaving the marker in place because the commit outcome is unknown",
+				"id", row.ID, "markers", written, "error", err)
+			continue
+		}
+
+		switch outcome {
+		case queue.Settled:
+			res.Settled++
+		case queue.SettleAlreadyInstrumental:
+			// A PEER settled this row first with the same verdict; the marker on
+			// disk is correct (byte-identical). Do not remove it.
+		case queue.SettleClaimed, queue.SettleRowGone:
+			// A worker owns the row, or it is gone. Nothing was written to the DB,
+			// so our marker is an orphan: take it back.
+			res.MarkersWritten -= r.rollback(written, &res)
+			res.SkippedClaimed++
+		case queue.SettleFailed:
+			// Unreachable: a failure returns a non-nil error, handled above.
+			res.Errors++
+		}
+	}
+
+	return res, nil
+}
+
+// writeMarkers writes the instrumental marker for row next to its source
+// audio file, returning the paths that ACTUALLY landed.
+//
+// A StampedRejection carries only SourcePath (see the Writer doc comment), so
+// the output directory and filename are derived from it directly -- the
+// same "next to the audio file" placement directory-mode fetch output uses.
+func (r *Recalibrator) writeMarkers(row queue.StampedRejection) (written []string, err error) {
+	outdir, filename := outputPath(row)
+	song := models.Song{Track: models.Track{
+		ArtistName:   row.Artist,
+		TrackName:    row.Title,
+		Instrumental: 1,
+	}}
+	if werr := r.w.WriteLRC(song, filename, outdir); werr != nil {
+		return nil, fmt.Errorf("instrumentalrecalib: write marker for %d: %w", row.ID, werr)
+	}
+	name, nerr := lyrics.SidecarName(row.Artist, row.Title, filename, false)
+	if nerr != nil {
+		return nil, fmt.Errorf("instrumentalrecalib: resolve marker name for %d: %w", row.ID, nerr)
+	}
+	return []string{filepath.Join(outdir, name)}, nil
+}
+
+// rollback removes markers this run wrote and reports how many came off, so
+// the caller can keep MarkersWritten honest. A rollback failure is counted as
+// an error rather than swallowed: it means a sidecar the database has no
+// record of survived on disk, which an operator needs to know about.
+func (r *Recalibrator) rollback(written []string, res *Result) int {
+	for _, p := range written {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			res.Errors++
+			slog.Warn("instrumentalrecalib: could not remove an orphaned marker; a sidecar the database has no record of remains on disk",
+				"marker", p, "error", err)
+			return 0
+		}
+	}
+	return len(written)
+}
+
+// outputPath derives the marker's output directory and base filename from
+// row.SourcePath, mirroring the "write next to the audio file" placement of
+// directory-mode fetch output.
+func outputPath(row queue.StampedRejection) (outdir, filename string) {
+	return filepath.Dir(row.SourcePath), filepath.Base(row.SourcePath)
+}
+
+// markerPaths returns the sidecar path a settle change will write, derived
+// with lyrics.SidecarName -- the same function the writer uses -- rather
+// than the raw source filename, so the backup record names a path that
+// actually exists after the write (see
+// instrumentalbackfill.MarkerPaths for the identical reasoning).
+func markerPaths(row queue.StampedRejection) []string {
+	outdir, filename := outputPath(row)
+	name, err := lyrics.SidecarName(row.Artist, row.Title, filename, false)
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(outdir, name)}
+}

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -178,6 +178,52 @@ func TestRun_DryRunDoesNotMutate(t *testing.T) {
 	}
 }
 
+// TestRun_SkipsGuardDegradedRow verifies a guard-degraded row (the vocal gate
+// could not run cleanly, e.g. a legacy mean-only sidecar with
+// maxAvailable=false: stored vocal_class="" and vocal_peak=0) is not settled
+// by Run, because ListVocalGateRejections no longer returns it. Re-deciding
+// such a row from detector.Instrumental(music, vocalPeak, speechMean, ...)
+// alone would ignore the live detector's maxAvailable/baselineComplete guards
+// and could wrongly settle it as instrumental even though music/speech both
+// pass, since vocal_peak=0 spuriously satisfies the vocal-gate check.
+func TestRun_SkipsGuardDegradedRow(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	id := seedRejection(t, q, "/music/degraded.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.0, SpeechMean: 0.001, VocalClass: "", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 0 || res.MarkersWritten != 0 || w.calls != 0 {
+		t.Fatalf("expected the guard-degraded row not to be settled, got %+v (writer calls %d)", res, w.calls)
+	}
+
+	// SettleInstrumental (the only path that would flip instrumental_result to 1)
+	// also flips status to 'done', so the row remaining 'deferred' confirms it
+	// was never settled and instrumental_result is untouched at 0.
+	deferred, err := q.List(ctx, queue.ListFilter{Status: "deferred"})
+	if err != nil {
+		t.Fatalf("list deferred: %v", err)
+	}
+	found := false
+	for _, item := range deferred {
+		if item.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected guard-degraded row %d to remain deferred (instrumental_result=0), got deferred rows %+v", id, deferred)
+	}
+}
+
 func TestRun_ReportErrorSkipsRowButNotFatal(t *testing.T) {
 	ctx := context.Background()
 	q := openTestQueue(t)

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -12,9 +12,52 @@ import (
 	"github.com/doxazo-net/canticle/internal/queue"
 )
 
-type fakeWriter struct{ calls int }
+type fakeWriter struct {
+	calls int
+	err   error
+}
 
-func (f *fakeWriter) WriteLRC(_ models.Song, _ string, _ string) error { f.calls++; return nil }
+func (f *fakeWriter) WriteLRC(_ models.Song, _ string, _ string) error {
+	f.calls++
+	return f.err
+}
+
+// fakeStore wraps a real *queue.DBQueue so the common paths (list, reset)
+// behave exactly like production, while letting a test force
+// ListVocalGateRejections/SettleInstrumental/ResetInstrumentalToUnclassified
+// into an outcome or error a live SQLite queue will not produce on demand
+// (a peer-claim race, a vanished row, a listing/settle/reset failure).
+type fakeStore struct {
+	*queue.DBQueue
+	listErr       error
+	settleOutcome *queue.SettleOutcome
+	settleErr     error
+	resetErr      error
+}
+
+func (f *fakeStore) ListVocalGateRejections(ctx context.Context, opts queue.ListVocalGateRejectionsOptions) ([]queue.StampedRejection, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.DBQueue.ListVocalGateRejections(ctx, opts)
+}
+
+func (f *fakeStore) SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error) {
+	if f.settleErr != nil {
+		return queue.SettleFailed, f.settleErr
+	}
+	if f.settleOutcome != nil {
+		return *f.settleOutcome, nil
+	}
+	return f.DBQueue.SettleInstrumental(ctx, id, tel)
+}
+
+func (f *fakeStore) ResetInstrumentalToUnclassified(ctx context.Context, id int64) (bool, error) {
+	if f.resetErr != nil {
+		return false, f.resetErr
+	}
+	return f.DBQueue.ResetInstrumentalToUnclassified(ctx, id)
+}
 
 // seedRejection mirrors the queue-package seed pattern (see
 // internal/queue/queue_recalib_test.go's seedDeferredRow +
@@ -243,5 +286,186 @@ func TestRun_ReportErrorSkipsRowButNotFatal(t *testing.T) {
 	}
 	if res.Errors != 1 || res.Settled != 0 || w.calls != 0 {
 		t.Fatalf("expected a counted error and no mutation, got %+v (writer calls %d)", res, w.calls)
+	}
+}
+
+func TestRun_ListErrorReturnsError(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	store := &fakeStore{DBQueue: q, listErr: errors.New("list failed")}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	_, err := r.Run(ctx, Options{MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0"})
+	if err == nil {
+		t.Fatal("expected an error from a failing list")
+	}
+}
+
+// TestRun_WriteMarkerErrorCountsErrorNoSettle verifies a Writer failure is
+// counted as a non-fatal per-row error and never reaches SettleInstrumental
+// (the row stays deferred, not done).
+func TestRun_WriteMarkerErrorCountsErrorNoSettle(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	id := seedRejection(t, q, "/music/bassoon.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{err: errors.New("write failed")}
+	r := New(q, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Errors != 1 || res.Settled != 0 || res.MarkersWritten != 0 {
+		t.Fatalf("expected a counted error and no settle, got %+v", res)
+	}
+
+	deferred, err := q.List(ctx, queue.ListFilter{Status: "deferred"})
+	if err != nil {
+		t.Fatalf("list deferred: %v", err)
+	}
+	found := false
+	for _, item := range deferred {
+		if item.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected row %d to remain deferred (a marker-write failure must not settle the row), got deferred rows %+v", id, deferred)
+	}
+}
+
+// TestRun_SettleErrorLeavesMarkerAndCountsError covers the AMBIGUOUS branch:
+// SettleInstrumental itself errors after the marker was written. The marker
+// must be left in place (an orphan is recoverable; a wrongly-deleted valid
+// result is not) and the row counted as an error.
+func TestRun_SettleErrorLeavesMarkerAndCountsError(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/clarinet.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	store := &fakeStore{DBQueue: q, settleErr: errors.New("commit failed")}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Errors != 1 || res.Settled != 0 || res.MarkersWritten != 1 || w.calls != 1 {
+		t.Fatalf("expected 1 counted error and the marker left in place, got %+v (writer calls %d)", res, w.calls)
+	}
+}
+
+// TestRun_SettleClaimedRollsBackMarker covers the SettleClaimed arm: a
+// serve-mode worker claimed the row mid-recalibration, so nothing was
+// written to the DB and this run's orphan marker must be rolled back.
+func TestRun_SettleClaimedRollsBackMarker(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/trombone.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	outcome := queue.SettleClaimed
+	store := &fakeStore{DBQueue: q, settleOutcome: &outcome}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.SkippedClaimed != 1 || res.Settled != 0 || res.MarkersWritten != 0 || res.Errors != 0 {
+		t.Fatalf("expected the orphan marker rolled back and 1 skipped-claimed, got %+v", res)
+	}
+}
+
+// TestRun_SettleRowGoneRollsBackMarker covers the SettleRowGone arm: the row
+// vanished (e.g. pruned) mid-recalibration, so the marker this run wrote is
+// an orphan and must come back off.
+func TestRun_SettleRowGoneRollsBackMarker(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/tuba.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	outcome := queue.SettleRowGone
+	store := &fakeStore{DBQueue: q, settleOutcome: &outcome}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.SkippedClaimed != 1 || res.Settled != 0 || res.MarkersWritten != 0 || res.Errors != 0 {
+		t.Fatalf("expected the orphan marker rolled back and 1 skipped-claimed, got %+v", res)
+	}
+}
+
+// TestRun_SettleAlreadyInstrumentalKeepsMarker covers the
+// SettleAlreadyInstrumental arm: a peer backfill settled the row first with
+// the same verdict, so this run's (byte-identical) marker is correct and
+// must NOT be removed.
+func TestRun_SettleAlreadyInstrumentalKeepsMarker(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/piccolo.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	outcome := queue.SettleAlreadyInstrumental
+	store := &fakeStore{DBQueue: q, settleOutcome: &outcome}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 0 || res.SkippedClaimed != 0 || res.Errors != 0 || res.MarkersWritten != 1 {
+		t.Fatalf("expected the marker kept and no error/skip/settle counted, got %+v", res)
+	}
+}
+
+// TestRun_ResetInstrumentalToUnclassifiedErrorCountsError covers the
+// reset-stale path's error branch: ResetInstrumentalToUnclassified itself
+// errors.
+func TestRun_ResetInstrumentalToUnclassifiedErrorCountsError(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/viola.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0",
+	})
+	store := &fakeStore{DBQueue: q, resetErr: errors.New("reset failed")}
+
+	w := &fakeWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Errors != 1 || res.ResetStale != 0 || w.calls != 0 {
+		t.Fatalf("expected a counted reset error, got %+v (writer calls %d)", res, w.calls)
 	}
 }

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -3,11 +3,13 @@ package instrumentalrecalib
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	dbpkg "github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/lyrics"
 	"github.com/doxazo-net/canticle/internal/models"
 	"github.com/doxazo-net/canticle/internal/queue"
 )
@@ -20,6 +22,28 @@ type fakeWriter struct {
 func (f *fakeWriter) WriteLRC(_ models.Song, _ string, _ string) error {
 	f.calls++
 	return f.err
+}
+
+// fsWriter writes a REAL sidecar file at the exact path writeMarkers will later
+// try to roll back, and records it, so a test can assert on-disk state (the
+// marker preserved on an ambiguous settle error, removed on a claimed/gone
+// rollback) rather than only the Result counters. It derives the name the same
+// way writeMarkers does, so created[i] is precisely the path rollback removes.
+type fsWriter struct {
+	created []string
+}
+
+func (w *fsWriter) WriteLRC(song models.Song, filename, outdir string) error {
+	name, err := lyrics.SidecarName(song.Track.ArtistName, song.Track.TrackName, filename, false)
+	if err != nil {
+		return err
+	}
+	p := filepath.Join(outdir, name)
+	if err := os.WriteFile(p, []byte("[au:instrumental]\n"), 0o644); err != nil {
+		return err
+	}
+	w.created = append(w.created, p)
+	return nil
 }
 
 // fakeStore wraps a real *queue.DBQueue so the common paths (list, reset)
@@ -415,6 +439,71 @@ func TestRun_SettleRowGoneRollsBackMarker(t *testing.T) {
 	}
 	if res.SkippedClaimed != 1 || res.Settled != 0 || res.MarkersWritten != 0 || res.Errors != 0 {
 		t.Fatalf("expected the orphan marker rolled back and 1 skipped-claimed, got %+v", res)
+	}
+}
+
+// TestRun_SettleClaimedRemovesMarkerFile is the on-disk counterpart to
+// TestRun_SettleClaimedRollsBackMarker: with a writer that actually creates the
+// sidecar, a claimed row's orphan marker must be gone from the filesystem after
+// the rollback, not merely uncounted.
+func TestRun_SettleClaimedRemovesMarkerFile(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	src := filepath.Join(t.TempDir(), "trombone.flac")
+	seedRejection(t, q, src, queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	outcome := queue.SettleClaimed
+	store := &fakeStore{DBQueue: q, settleOutcome: &outcome}
+
+	w := &fsWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("expected the writer to create exactly 1 marker, got %d", len(w.created))
+	}
+	if _, statErr := os.Stat(w.created[0]); !os.IsNotExist(statErr) {
+		t.Fatalf("claimed rollback must remove the orphan marker %s (stat err = %v)", w.created[0], statErr)
+	}
+	if res.SkippedClaimed != 1 || res.MarkersWritten != 0 {
+		t.Fatalf("expected 1 skipped-claimed and 0 markers retained, got %+v", res)
+	}
+}
+
+// TestRun_SettleErrorPreservesMarkerFile is the on-disk counterpart to
+// TestRun_SettleErrorLeavesMarkerAndCountsError: an ambiguous settle error must
+// leave the marker on disk (a recoverable orphan beats a wrongly-deleted valid
+// result).
+func TestRun_SettleErrorPreservesMarkerFile(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	src := filepath.Join(t.TempDir(), "clarinet.flac")
+	seedRejection(t, q, src, queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	store := &fakeStore{DBQueue: q, settleErr: errors.New("commit failed")}
+
+	w := &fsWriter{}
+	r := New(store, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("expected the writer to create exactly 1 marker, got %d", len(w.created))
+	}
+	if _, statErr := os.Stat(w.created[0]); statErr != nil {
+		t.Fatalf("ambiguous settle error must preserve the marker %s (stat err = %v)", w.created[0], statErr)
+	}
+	if res.Errors != 1 || res.MarkersWritten != 1 {
+		t.Fatalf("expected 1 counted error and the marker kept, got %+v", res)
 	}
 }
 

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -1,0 +1,201 @@
+package instrumentalrecalib
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	dbpkg "github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+type fakeWriter struct{ calls int }
+
+func (f *fakeWriter) WriteLRC(_ models.Song, _ string, _ string) error { f.calls++; return nil }
+
+// seedRejection mirrors the queue-package seed pattern (see
+// internal/queue/queue_recalib_test.go's seedDeferredRow +
+// TestListVocalGateRejections): enqueue, dequeue, defer, then stamp the
+// not-instrumental verdict with the given telemetry. Returns the row id.
+func seedRejection(t *testing.T, q *queue.DBQueue, sourcePath string, tel queue.InstrumentalTelemetry) int64 {
+	t.Helper()
+	ctx := context.Background()
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: sourcePath,
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.StampUnclassifiedMiss(ctx, item.ID, tel); err != nil {
+		t.Fatalf("stamp unclassified miss: %v", err)
+	}
+	return item.ID
+}
+
+func openTestQueue(t *testing.T) *queue.DBQueue {
+	t.Helper()
+	ctx := context.Background()
+	sqlDB, err := dbpkg.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return queue.NewDBQueue(sqlDB)
+}
+
+func TestRun_SettlesPassingVersionMatchedRow(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	id := seedRejection(t, q, "/music/violin.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	// New threshold 0.30 > stored 0.04 => now passes; version matches => settle.
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 1 || res.MarkersWritten != 1 || w.calls != 1 {
+		t.Fatalf("expected 1 settled + 1 marker, got %+v (writer calls %d)", res, w.calls)
+	}
+
+	// The settled row must no longer appear as a vocal-gate rejection: it is
+	// 'done' now, not 'deferred'.
+	rows, err := q.ListVocalGateRejections(ctx, queue.ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, row := range rows {
+		if row.ID == id {
+			t.Fatalf("expected settled row %d to no longer be a vocal-gate rejection", id)
+		}
+	}
+}
+
+func TestRun_ResetsPassingVersionMismatchedRow(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/cello.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.ResetStale != 1 || res.Settled != 0 || res.MarkersWritten != 0 || w.calls != 0 {
+		t.Fatalf("expected 1 reset-stale and no marker, got %+v (writer calls %d)", res, w.calls)
+	}
+
+	// The next reconcile should see it as never-classified (instrumental_result = NULL).
+	rows, err := q.ListVocalGateRejections(ctx, queue.ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected the reset row to no longer appear as a vocal-gate rejection, got %+v", rows)
+	}
+}
+
+func TestRun_SkipsStillNonPassingRow(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/spoken.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.50, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	// VocalMax 0.30 < stored VocalPeak 0.50 => still fails the vocal gate.
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 0 || res.ResetStale != 0 || res.MarkersWritten != 0 || w.calls != 0 {
+		t.Fatalf("expected a full skip, got %+v (writer calls %d)", res, w.calls)
+	}
+}
+
+func TestRun_DryRunDoesNotMutate(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/harp.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	previewed := 0
+	res, err := r.Run(ctx, Options{
+		DryRun: true, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Preview: func(c Change) {
+			previewed++
+			if c.Action != "settle" {
+				t.Fatalf("expected settle preview, got %q", c.Action)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 0 || res.ResetStale != 0 || res.MarkersWritten != 0 || w.calls != 0 || previewed != 1 {
+		t.Fatalf("expected a preview-only pass, got %+v (writer calls %d, previewed %d)", res, w.calls, previewed)
+	}
+
+	// Nothing mutated: the row is still listed as a vocal-gate rejection.
+	rows, err := q.ListVocalGateRejections(ctx, queue.ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected the row to still be a vocal-gate rejection after a dry run, got %+v", rows)
+	}
+}
+
+func TestRun_ReportErrorSkipsRowButNotFatal(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/oboe.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Report: func(Change) error { return errors.New("backup failed") },
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Errors != 1 || res.Settled != 0 || w.calls != 0 {
+		t.Fatalf("expected a counted error and no mutation, got %+v (writer calls %d)", res, w.calls)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1784,14 +1784,17 @@ func (q *DBQueue) ResetInstrumental(ctx context.Context, id int64) (int64, error
 // to "never classified" and picked up by the next reconcile/backfill pass,
 // which re-scans it with the current detector instead.
 //
-// Guarded on status = 'deferred' -- the same guard StampUnclassifiedMiss
-// uses -- so a row a worker has since claimed is left alone. Returns whether
-// the row was reset.
+// Guarded on status = 'deferred' AND instrumental_result = 0 -- so a row a
+// worker has since claimed, or one concurrently re-stamped to a positive verdict
+// or already cleared, is left alone rather than having its verdict clobbered.
+// Returns whether the row was reset.
 func (q *DBQueue) ResetInstrumentalToUnclassified(ctx context.Context, id int64) (bool, error) {
 	res, err := q.db.ExecContext(ctx,
 		`UPDATE work_queue
          SET instrumental_result = NULL
-         WHERE id = ? AND status = 'deferred'`,
+         WHERE id = ?
+           AND status = 'deferred'
+           AND instrumental_result = 0`,
 		id,
 	)
 	if err != nil {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1628,13 +1628,38 @@ type StampedRejection struct {
 // not-instrumental (instrumental_result=0) that carry re-decidable stored
 // telemetry (music_sum/vocal_peak/speech_mean non-NULL). Legacy rows missing
 // those scores are skipped: they cannot be re-decided from stored scores alone.
+//
+// The re-decision engine calls detector.Instrumental(music, vocalPeak,
+// speechMean, ...) using only these three stored scores, which deliberately
+// omits the live detector's maxAvailable/baselineComplete sidecar-completeness
+// guards (internal/detector/http.go) -- those guards are not reconstructable
+// from the three stored scores alone. A row where the vocal gate could not run
+// cleanly (a legacy mean-only sidecar, maxAvailable=false) is stamped with
+// vocal_peak=0.0 and an empty vocal_class, which can spuriously satisfy
+// detector.Instrumental's vocal-gate check and cause the re-decision engine to
+// settle it as instrumental -- a false instrumental marker that suppresses
+// real lyric fetches. Excluding empty vocal_class rows drops exactly that
+// degraded population: a genuine vocal-gate-buried instrumental always has a
+// non-empty vocal_class (the faint vocal class that peaked is why it was
+// rejected in the first place), and a complete detection with vocal_peak=0.0
+// that still resulted in instrumental_result=0 must have failed the
+// music/speech gates rather than the vocal gate, so it would be excluded from
+// re-decision anyway -- this filter is harmless to legitimate candidates. This
+// preserves the "any doubt resolves to not-instrumental" invariant.
+//
+// Residual gap: the rarer partial-baseline case (baselineComplete=false with a
+// non-empty vocal_class) is NOT fully closed by this guard. Closing it would
+// need a durable persisted "gate-complete" telemetry bit, tracked as a
+// follow-up.
+//
 // Read-only.
 func (q *DBQueue) ListVocalGateRejections(ctx context.Context, opts ListVocalGateRejectionsOptions) (out []StampedRejection, retErr error) {
 	query := `SELECT id, COALESCE(artist,''), COALESCE(title,''), COALESCE(source_path,''),
 	                 music_sum, vocal_peak, speech_mean, COALESCE(vocal_class,''), COALESCE(detector_version,'')
 	          FROM work_queue
 	          WHERE instrumental_result = 0 AND status = 'deferred'
-	            AND music_sum IS NOT NULL AND vocal_peak IS NOT NULL AND speech_mean IS NOT NULL`
+	            AND music_sum IS NOT NULL AND vocal_peak IS NOT NULL AND speech_mean IS NOT NULL
+	            AND TRIM(COALESCE(vocal_class,'')) <> ''`
 	var args []any
 	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
 	query += libClause //nolint:gosec // G202: libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1608,6 +1608,65 @@ func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOpt
 	return items, nil
 }
 
+// ListVocalGateRejectionsOptions narrows the stamped-not-instrumental listing.
+type ListVocalGateRejectionsOptions struct {
+	LibraryID *int64
+	Limit     int
+}
+
+// StampedRejection is one instrumental_result=0 row with its stored telemetry,
+// for re-deciding under a recalibrated threshold without re-scanning audio.
+type StampedRejection struct {
+	ID         int64
+	Artist     string
+	Title      string
+	SourcePath string
+	Tel        InstrumentalTelemetry
+}
+
+// ListVocalGateRejections returns deferred rows the detector previously marked
+// not-instrumental (instrumental_result=0) that carry re-decidable stored
+// telemetry (music_sum/vocal_peak/speech_mean non-NULL). Legacy rows missing
+// those scores are skipped: they cannot be re-decided from stored scores alone.
+// Read-only.
+func (q *DBQueue) ListVocalGateRejections(ctx context.Context, opts ListVocalGateRejectionsOptions) (out []StampedRejection, retErr error) {
+	query := `SELECT id, COALESCE(artist,''), COALESCE(title,''), COALESCE(source_path,''),
+	                 music_sum, vocal_peak, speech_mean, COALESCE(vocal_class,''), COALESCE(detector_version,'')
+	          FROM work_queue
+	          WHERE instrumental_result = 0 AND status = 'deferred'
+	            AND music_sum IS NOT NULL AND vocal_peak IS NOT NULL AND speech_mean IS NOT NULL`
+	var args []any
+	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
+	query += libClause //nolint:gosec // G202: libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL
+	args = append(args, libArgs...)
+	query += ` ORDER BY id`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: fragments are package constants / fixed clauses, never user-built SQL
+	if err != nil {
+		return nil, fmt.Errorf("queue: list vocal-gate rejections: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close list vocal-gate rejections rows: %w", err)
+		}
+	}()
+	for rows.Next() {
+		var r StampedRejection
+		if err := rows.Scan(&r.ID, &r.Artist, &r.Title, &r.SourcePath,
+			&r.Tel.MusicSum, &r.Tel.VocalPeak, &r.Tel.SpeechMean, &r.Tel.VocalClass, &r.Tel.DetectorVersion); err != nil {
+			return nil, fmt.Errorf("queue: scan vocal-gate rejection: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list vocal-gate rejections rows: %w", err)
+	}
+	return out, nil
+}
+
 // CountInstrumentalNarrowed returns how many instrumental_result = 1 rows the
 // telemetry-narrowed prefilter would select (the same predicate ListInstrumental
 // applies when opts.All is false), so reconcile can report prefiltered-vs-total

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1750,6 +1750,35 @@ func (q *DBQueue) ResetInstrumental(ctx context.Context, id int64) (int64, error
 	return n, nil
 }
 
+// ResetInstrumentalToUnclassified clears a stamped not-instrumental verdict
+// (instrumental_result = 0) back to NULL, without touching status, priority,
+// or the stored telemetry columns. Used by instrumentalrecalib when a
+// vocal-gate rejection now PASSES the reconfigured thresholds but was scored
+// by a detector_version other than the current one: the stale telemetry is
+// not trustworthy enough to settle on directly, so the row is dropped back
+// to "never classified" and picked up by the next reconcile/backfill pass,
+// which re-scans it with the current detector instead.
+//
+// Guarded on status = 'deferred' -- the same guard StampUnclassifiedMiss
+// uses -- so a row a worker has since claimed is left alone. Returns whether
+// the row was reset.
+func (q *DBQueue) ResetInstrumentalToUnclassified(ctx context.Context, id int64) (bool, error) {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET instrumental_result = NULL
+         WHERE id = ? AND status = 'deferred'`,
+		id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("queue: reset instrumental to unclassified: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("queue: reset instrumental to unclassified rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
 // CancelByLibrary rebuilds or deletes pending/failed/deferred work_queue rows whose
 // output_paths derive from libraryID. Each affected row's output_paths JSON is
 // filtered to retain only entries that appear in scan_results from libraries

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -50,6 +50,49 @@ func TestListVocalGateRejections(t *testing.T) {
 	}
 }
 
+// TestListVocalGateRejections_ExcludesEmptyVocalClass verifies a row whose
+// vocal gate could not run cleanly (e.g. a legacy mean-only sidecar with
+// maxAvailable=false, stamped with an empty vocal_class) is excluded, since
+// that guard-completeness state cannot be reconstructed from stored scores
+// alone and re-deciding it risks a false instrumental marker.
+func TestListVocalGateRejections_ExcludesEmptyVocalClass(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Degraded Artist", "Degraded", "/music/degraded.flac")
+	if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.0, SpeechMean: 0.001, VocalClass: "", DetectorVersion: "1.17.0"}); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty-vocal_class row to be excluded, got: %+v", got)
+	}
+}
+
+// TestListVocalGateRejections_ExcludesNullTelemetry verifies a legacy row
+// stamped not-instrumental before the telemetry columns were populated
+// (instrumental_result=0 but music_sum/vocal_peak/speech_mean still NULL) is
+// excluded: it cannot be re-decided from stored scores alone. Raw SQL is used
+// here (rather than StampUnclassifiedMiss, which always writes concrete
+// telemetry values) to reproduce that legacy NULL-telemetry shape.
+func TestListVocalGateRejections_ExcludesNullTelemetry(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "NeverScored", "/music/never-scored.flac")
+	if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET instrumental_result = 0 WHERE id = ?`, id); err != nil {
+		t.Fatalf("stamp legacy null telemetry: %v", err)
+	}
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected NULL-telemetry row to be excluded, got: %+v", got)
+	}
+}
+
 func TestResetInstrumentalToUnclassified(t *testing.T) {
 	q := NewDBQueue(openQueueTestDB(t))
 	ctx := context.Background()

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -154,6 +154,39 @@ func TestResetInstrumentalToUnclassified_NonDeferredRowNotReset(t *testing.T) {
 	}
 }
 
+// TestResetInstrumentalToUnclassified_NonZeroVerdictNotReset verifies the
+// instrumental_result = 0 guard: a row concurrently re-stamped to a positive
+// verdict (result = 1) while still deferred must not have that verdict cleared
+// out from under a peer settle.
+func TestResetInstrumentalToUnclassified_NonZeroVerdictNotReset(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	// Simulate a concurrent positive settle (still deferred) landing between the
+	// engine's selection and this reset.
+	if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET instrumental_result = 1 WHERE id = ?`, id); err != nil {
+		t.Fatalf("set positive: %v", err)
+	}
+
+	reset, err := q.ResetInstrumentalToUnclassified(ctx, id)
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if reset {
+		t.Fatalf("expected a row with a positive verdict not to be reset")
+	}
+	var result *int
+	if err := q.db.QueryRowContext(ctx, `SELECT instrumental_result FROM work_queue WHERE id = ?`, id).Scan(&result); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if result == nil || *result != 1 {
+		t.Fatalf("instrumental_result = %v; want 1 (preserved)", result)
+	}
+}
+
 // TestListVocalGateRejections_ScopesToLibrary verifies the --library
 // narrowing actually filters the candidate set, mirroring
 // TestDBQueue_ListUnclassifiedScopesToLibrary.

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,5 +103,124 @@ func TestResetInstrumentalToUnclassified(t *testing.T) {
 	}
 	if reset, err := q.ResetInstrumentalToUnclassified(ctx, id); err != nil || !reset {
 		t.Fatalf("reset: got %v, %v", reset, err)
+	}
+
+	// The reset must actually clear instrumental_result to NULL, not merely
+	// report success, and must leave status/telemetry untouched.
+	var status string
+	var result *int
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred (unchanged)", status)
+	}
+	if result != nil {
+		t.Errorf("instrumental_result = %v; want NULL after reset", *result)
+	}
+}
+
+// TestResetInstrumentalToUnclassified_NonDeferredRowNotReset verifies the
+// status='deferred' guard: a row a worker has since claimed (status =
+// 'processing', not deferred) must not be reset out from under it.
+func TestResetInstrumentalToUnclassified_NonDeferredRowNotReset(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	// Simulate a worker claiming the row mid-recalibration.
+	if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET status = 'processing' WHERE id = ?`, id); err != nil {
+		t.Fatalf("mark processing: %v", err)
+	}
+
+	reset, err := q.ResetInstrumentalToUnclassified(ctx, id)
+	if err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if reset {
+		t.Fatalf("expected a non-deferred row not to be reset")
+	}
+
+	var result *int
+	if err := q.db.QueryRowContext(ctx, `SELECT instrumental_result FROM work_queue WHERE id = ?`, id).Scan(&result); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if result == nil || *result != 0 {
+		t.Errorf("instrumental_result = %v; want unchanged 0", result)
+	}
+}
+
+// TestListVocalGateRejections_ScopesToLibrary verifies the --library
+// narrowing actually filters the candidate set, mirroring
+// TestDBQueue_ListUnclassifiedScopesToLibrary.
+func TestListVocalGateRejections_ScopesToLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA, srA := insertLibraryAndScanResult(t, sqlDB, "/libA", "/libA/a.mp3")
+	_, srB := insertLibraryAndScanResult(t, sqlDB, "/libB", "/libB/b.mp3")
+
+	mk := func(title, src string, scanResultID int64) int64 {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:        models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:       "out",
+			Filename:     title + ".lrc",
+			SourcePath:   src,
+			ScanResultID: scanResultID,
+		}, PriorityScan)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %s: %v", title, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+			t.Fatalf("defer %s: %v", title, err)
+		}
+		if _, err := q.StampUnclassifiedMiss(ctx, item.ID, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+			t.Fatalf("stamp %s: %v", title, err)
+		}
+		return item.ID
+	}
+	inA := mk("in-lib-a", "/libA/a.mp3", srA)
+	_ = mk("in-lib-b", "/libB/b.mp3", srB)
+
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{LibraryID: &libA})
+	if err != nil {
+		t.Fatalf("ListVocalGateRejections: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != inA {
+		var ids []int64
+		for _, r := range got {
+			ids = append(ids, r.ID)
+		}
+		t.Fatalf("scoped list = %v; want only the libA row %d", ids, inA)
+	}
+}
+
+// TestListVocalGateRejections_Limit verifies the Limit option actually caps
+// the result set.
+func TestListVocalGateRejections_Limit(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	for i := 0; i < 3; i++ {
+		id := seedDeferredRow(t, q, "Artist", fmt.Sprintf("Title%d", i), fmt.Sprintf("/music/%d.flac", i))
+		if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+			t.Fatalf("stamp: %v", err)
+		}
+	}
+
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d; want 2 (Limit must cap the result set)", len(got))
 	}
 }

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -49,3 +49,15 @@ func TestListVocalGateRejections(t *testing.T) {
 		t.Fatalf("unexpected rows: %+v", got)
 	}
 }
+
+func TestResetInstrumentalToUnclassified(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	if reset, err := q.ResetInstrumentalToUnclassified(ctx, id); err != nil || !reset {
+		t.Fatalf("reset: got %v, %v", reset, err)
+	}
+}

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/doxazo-net/canticle/internal/models"
+)
+
+// seedDeferredRow enqueues a work_queue row, claims it (Dequeue), then defers
+// it (the standard path other queue tests use to reach StatusDeferred; see
+// TestDBQueue_NoResultRequeueIsDeferredButReprocessable), returning its id.
+func seedDeferredRow(t *testing.T, q *DBQueue, artist, title, sourcePath string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: artist, TrackName: title},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: sourcePath,
+	}, PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	return item.ID
+}
+
+func TestListVocalGateRejections(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	// Seed one deferred row, stamp it not-instrumental with telemetry.
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || got[0].Tel.VocalPeak != 0.04 || got[0].ID != id {
+		t.Fatalf("unexpected rows: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

The **reopen** half of vocal-gate calibration (#510). The tooling half shipped as #512 (now on `main`); this reopens the rows the too-tight vocal gate buried, re-deciding them from STORED telemetry (no audio re-scan):

- **feat(queue):** `ListVocalGateRejections` (instrumental_result=0 rows carrying re-decidable stored telemetry) + `ResetInstrumentalToUnclassified`.
- **feat(instrumentalrecalib):** engine that re-decides each buried row with `detector.Instrumental` against the configured thresholds - version-match -> settle + write marker; version-mismatch -> reset to NULL for a future re-scan; backup-first; dry-run by default.
- **feat(commands):** `scan reconcile-instrumental-recalibrate` (mirrors reconcile-instrumental; pure-DB, no sidecar needed).
- **fix(queue):** exclude guard-degraded rows (empty `vocal_class`) from the reopen set. A whole-branch-review finding: without it the engine could settle a false instrumental on a row the live detector refused via its `maxAvailable`/`baselineComplete` guards, which stored scores cannot reconstruct. The residual partial-baseline case is tracked in #511.

Does NOT change the `0.03` threshold or run the sweep (the held operational half). The reopen apply on prod is a manual, dry-run-gated, held step.

## Linked issue

Closes #510.

## PR size

~1240 LOC (about 37% tests). Over the 800-LOC guideline by agreement: this is the agreed split boundary of #510. The reopen engine plus its SettleOutcome-race and edge-branch tests are irreducibly ~1k LOC, and the tooling half already shipped separately as #512.

## Test plan

- [x] `make gate` green: race tests, patch coverage 78.75% (over the 70% gate), golangci-lint, actionlint, govulncheck
- [x] TDD across the engine (settle / version-mismatch reset / non-passing skip / dry-run / report-error / guard-degraded skip), both queue methods, and the CLI (dry-run vs --yes)
- [x] Whole-branch opus review: found and fixed the guard-divergence bug; all Minors triaged as acceptable-followup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `scan reconcile-instrumental-recalibrate` command to reassess previously rejected tracks using stored telemetry.
  * Supports library scoping, result limits, dry-run previews, and explicit approval before applying changes.
  * Matching tracks can be settled with markers; tracks from outdated detector versions are reset for rescanning.
  * Creates safety backups before applying updates and reports reconciliation results.

* **Tests**
  * Added coverage for dry runs, library filtering, stale versions, invalid configuration, backup failures, and queue safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->