### PR TITLE
feat: reversible instrumental marker provenance (part of #502)

### DIFF
--- a/internal/lyrics/instrumental_provenance.go
+++ b/internal/lyrics/instrumental_provenance.go
@@ -1,0 +1,21 @@
+package lyrics
+
+// SourceDetector is the [source:] token stamped into an instrumental marker that
+// the audio detector wrote. Any other source token (a provider lane name) marks
+// a provider-written, editorial-authoritative instrumental. Kept here so the
+// writer and the scanner agree on one spelling.
+const SourceDetector = "canticle-detector"
+
+// InstrumentalProvenance is the provenance read from an instrumental .txt marker.
+// A detector marker carries Source == SourceDetector and a DetectorVersion; a
+// provider marker carries the provider lane name and an empty DetectorVersion.
+type InstrumentalProvenance struct {
+	Source          string
+	DetectorVersion string
+}
+
+// IsDetector reports whether the marker was written by the audio detector, i.e.
+// whether it is provisional (re-checkable) rather than editorially terminal.
+func (p InstrumentalProvenance) IsDetector() bool {
+	return p.Source == SourceDetector
+}

--- a/internal/lyrics/instrumental_provenance.go
+++ b/internal/lyrics/instrumental_provenance.go
@@ -1,5 +1,7 @@
 package lyrics
 
+import "strings"
+
 // SourceDetector is the [source:] token stamped into an instrumental marker that
 // the audio detector wrote. Any other source token (a provider lane name) marks
 // a provider-written, editorial-authoritative instrumental. Kept here so the
@@ -18,4 +20,36 @@ type InstrumentalProvenance struct {
 // whether it is provisional (re-checkable) rather than editorially terminal.
 func (p InstrumentalProvenance) IsDetector() bool {
 	return p.Source == SourceDetector
+}
+
+// ReadInstrumentalProvenance reads the file at path and reports whether it is an
+// instrumental marker and, if so, its provenance ([source:]/[dv:]). A legacy bare
+// marker (no header) returns a zero-value InstrumentalProvenance. A file with no
+// marker line returns isMarker=false. Any read error is returned.
+func ReadInstrumentalProvenance(path string) (prov InstrumentalProvenance, isMarker bool, err error) {
+	tags, lyricLines, err := parseLRCHeader(path)
+	if err != nil {
+		return InstrumentalProvenance{}, false, err
+	}
+	for _, t := range tags {
+		switch strings.ToLower(t.key) {
+		case "source":
+			prov.Source = strings.TrimSpace(t.value)
+		case "dv":
+			prov.DetectorVersion = strings.TrimSpace(t.value)
+		}
+		if strings.Contains(t.raw, InstrumentalMarker) {
+			isMarker = true
+		}
+	}
+	for _, l := range lyricLines {
+		if strings.Contains(l, InstrumentalMarker) {
+			isMarker = true
+			break
+		}
+	}
+	if !isMarker {
+		return InstrumentalProvenance{}, false, nil
+	}
+	return prov, true, nil
 }

--- a/internal/lyrics/instrumental_provenance_test.go
+++ b/internal/lyrics/instrumental_provenance_test.go
@@ -1,0 +1,15 @@
+package lyrics
+
+import "testing"
+
+func TestInstrumentalProvenance_IsDetector(t *testing.T) {
+	if !(InstrumentalProvenance{Source: SourceDetector}).IsDetector() {
+		t.Fatal("marker with SourceDetector should be detector-sourced")
+	}
+	if (InstrumentalProvenance{Source: "musixmatch"}).IsDetector() {
+		t.Fatal("provider source must not be detector-sourced")
+	}
+	if (InstrumentalProvenance{}).IsDetector() {
+		t.Fatal("empty (legacy) source must not be detector-sourced")
+	}
+}

--- a/internal/lyrics/instrumental_provenance_test.go
+++ b/internal/lyrics/instrumental_provenance_test.go
@@ -1,6 +1,10 @@
 package lyrics
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestInstrumentalProvenance_IsDetector(t *testing.T) {
 	if !(InstrumentalProvenance{Source: SourceDetector}).IsDetector() {
@@ -11,5 +15,37 @@ func TestInstrumentalProvenance_IsDetector(t *testing.T) {
 	}
 	if (InstrumentalProvenance{}).IsDetector() {
 		t.Fatal("empty (legacy) source must not be detector-sourced")
+	}
+}
+
+func TestReadInstrumentalProvenance(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name       string
+		body       string
+		wantMarker bool
+		wantSource string
+		wantDV     string
+	}{
+		{"detector", "[by:canticle]\n[source:canticle-detector]\n[dv:9.9.9]\n" + InstrumentalMarker + "\n", true, "canticle-detector", "9.9.9"},
+		{"provider", "[by:canticle]\n[source:musixmatch]\n" + InstrumentalMarker + "\n", true, "musixmatch", ""},
+		{"legacy-bare", InstrumentalMarker + "\n", true, "", ""},
+		{"not-a-marker", "[00:01.00]la la\n", false, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(dir, tc.name+".txt")
+			if err := os.WriteFile(p, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			prov, isMarker, err := ReadInstrumentalProvenance(p)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if isMarker != tc.wantMarker || prov.Source != tc.wantSource || prov.DetectorVersion != tc.wantDV {
+				t.Fatalf("got (marker=%v src=%q dv=%q), want (marker=%v src=%q dv=%q)",
+					isMarker, prov.Source, prov.DetectorVersion, tc.wantMarker, tc.wantSource, tc.wantDV)
+			}
+		})
 	}
 }

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -129,6 +129,7 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 	var writeContent func(*bufio.Writer) error
 	var writeTags bool
 	var synced bool
+	var instrumental bool
 	// kind labels the per-track outcome on the "lyrics saved" log so instrumental
 	// writes are visible at the default Info level, not just under Debug.
 	var kind string
@@ -138,6 +139,7 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 		// the flag, so this case must precede the subtitles check.
 		kind = "instrumental"
 		writeContent = writeInstrumental
+		instrumental = true
 	case len(song.Subtitles.Lines) > 0:
 		kind = "synced"
 		writeContent = func(buf *bufio.Writer) error { return writeSyncedLRC(song, buf, w.bilingual) }
@@ -202,6 +204,20 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 		}
 		if song.Track.RecordingMBID != "" {
 			tags = append(tags, fmt.Sprintf("[mbid:%s]", song.Track.RecordingMBID))
+		}
+	}
+
+	if instrumental {
+		src := song.WinningLane
+		if song.DetectorVersion != "" {
+			src = SourceDetector
+		}
+		tags = append(tags, "[by:canticle]")
+		if src != "" {
+			tags = append(tags, fmt.Sprintf("[source:%s]", src))
+		}
+		if song.DetectorVersion != "" {
+			tags = append(tags, fmt.Sprintf("[dv:%s]", song.DetectorVersion))
 		}
 	}
 

--- a/internal/lyrics/writer_confine_test.go
+++ b/internal/lyrics/writer_confine_test.go
@@ -169,16 +169,18 @@ func TestWriteLRC_ConfinedUnsyncedAndInstrumental(t *testing.T) {
 		t.Fatalf("reading instrumental: %v", err)
 	}
 	content := string(got)
-	// Plain marker: no timestamp, no tag headers.
-	const want = "♪ Instrumental ♪\n"
+	// Marker with a provenance header (#502): [by:canticle] but no
+	// [source:]/[dv:] since neither WinningLane nor DetectorVersion is set,
+	// and no [ar:]/[ti:] (those belong only to the synced-tag block).
+	const want = "[by:canticle]\n♪ Instrumental ♪\n"
 	if content != want {
 		t.Fatalf("instrumental content = %q, want %q", content, want)
 	}
 	if strings.Contains(content, "[00:00.00]") {
 		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
 	}
-	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
-		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	if strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain synced tag headers, got: %q", content)
 	}
 }
 

--- a/internal/lyrics/writer_test.go
+++ b/internal/lyrics/writer_test.go
@@ -68,17 +68,17 @@ func TestWriteLRC_Instrumental(t *testing.T) {
 	if len(content) == 0 {
 		t.Fatal("expected non-empty file content for instrumental")
 	}
-	// Instrumentals are a plain marker: the single line with no timestamp and no
-	// tag headers.
-	const want = "\u266a Instrumental \u266a\n"
+	// Instrumentals carry a provenance header (#502): [by:canticle] but no
+	// [source:]/[dv:] since neither WinningLane nor DetectorVersion is set.
+	const want = "[by:canticle]\n\u266a Instrumental \u266a\n"
 	if content != want {
 		t.Fatalf("expected content to equal %q, got: %q", want, content)
 	}
 	if strings.Contains(content, "[00:00.00]") {
 		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
 	}
-	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
-		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	if strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain synced tag headers, got: %q", content)
 	}
 
 	// No .lrc file should have been created for an instrumental.
@@ -111,15 +111,15 @@ func TestWriteLRC_InstrumentalExplicitFilename(t *testing.T) {
 		t.Fatalf("expected file song.txt to exist: %v", err)
 	}
 	content := string(data)
-	const want = "♪ Instrumental ♪\n"
+	const want = "[by:canticle]\n♪ Instrumental ♪\n"
 	if content != want {
 		t.Fatalf("expected content to equal %q, got: %q", want, content)
 	}
 	if strings.Contains(content, "[00:00.00]") {
 		t.Fatalf("instrumental marker must not contain an LRC timestamp, got: %q", content)
 	}
-	if strings.Contains(content, "[by:") || strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
-		t.Fatalf("instrumental marker must not contain tag headers, got: %q", content)
+	if strings.Contains(content, "[ar:") || strings.Contains(content, "[ti:") {
+		t.Fatalf("instrumental marker must not contain synced tag headers, got: %q", content)
 	}
 	if _, err := os.Stat(filepath.Join(tmpDir, "song.lrc")); err == nil {
 		t.Fatal("expected no .lrc file for instrumental, but one was created")
@@ -353,7 +353,7 @@ func TestWriteLRC_InstrumentalWithSubtitles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected song.txt to exist: %v", err)
 	}
-	const want = "♪ Instrumental ♪\n"
+	const want = "[by:canticle]\n♪ Instrumental ♪\n"
 	if got := string(data); got != want {
 		t.Fatalf("content = %q; want %q", got, want)
 	}
@@ -399,4 +399,55 @@ func TestWriteLRC_Synced(t *testing.T) {
 	if !strings.Contains(content, "[ar:Test Artist]") {
 		t.Fatalf("expected LRC tags in .lrc, got: %q", content)
 	}
+}
+
+func TestWriteLRC_InstrumentalDetectorProvenance(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLRCWriter()
+	song := models.Song{
+		Track:           models.Track{ArtistName: "A", TrackName: "T", Instrumental: 1},
+		DetectorVersion: "9.9.9",
+	}
+	if err := w.WriteLRC(song, "", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+	got := readOnlyTxt(t, dir)
+	for _, want := range []string{"[source:canticle-detector]", "[dv:9.9.9]", InstrumentalMarker} {
+		if !strings.Contains(got, want) {
+			t.Errorf("detector marker missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteLRC_InstrumentalProviderProvenance(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLRCWriter()
+	song := models.Song{
+		Track:       models.Track{ArtistName: "A", TrackName: "T", Instrumental: 1},
+		WinningLane: "musixmatch",
+	}
+	if err := w.WriteLRC(song, "", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+	got := readOnlyTxt(t, dir)
+	if !strings.Contains(got, "[source:musixmatch]") {
+		t.Errorf("provider marker missing [source:musixmatch]; got:\n%s", got)
+	}
+	if strings.Contains(got, "[dv:") {
+		t.Errorf("provider marker must not carry [dv:]; got:\n%s", got)
+	}
+}
+
+// readOnlyTxt returns the contents of the single .txt file written into dir.
+func readOnlyTxt(t *testing.T, dir string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.txt"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected exactly one .txt in %s, got %v (err %v)", dir, matches, err)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read %s: %v", matches[0], err)
+	}
+	return string(data)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -75,6 +75,13 @@ type Song struct {
 	// all output formats share one consistent timestamp. Zero on cache hits
 	// (timestamp not available without a live fetch). Transient: not persisted.
 	FetchedAt time.Time `json:"-"`
+	// DetectorVersion is the audio detector's version string when this song is an
+	// instrumental verdict written by the detector (Track.Instrumental == 1 via the
+	// detector path). Empty for provider-sourced instrumentals and all other songs.
+	// The writer uses it to stamp [source:canticle-detector] + [dv:] provenance so
+	// a detector marker is later distinguishable from an editorial provider marker.
+	// Transient: not persisted, not serialized.
+	DetectorVersion string `json:"-"`
 }
 
 // LaneAttempt is one provider lane's outcome for a single track: the lane name

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -29,3 +29,10 @@ func TestSongTranslationFieldsAssignable(t *testing.T) {
 		t.Errorf("RomanizationSubtitles text = %q, want %q", got, "romaji")
 	}
 }
+
+func TestSong_DetectorVersionField(t *testing.T) {
+	s := Song{DetectorVersion: "1.2.3"}
+	if s.DetectorVersion != "1.2.3" {
+		t.Fatalf("DetectorVersion not carried: %q", s.DetectorVersion)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -741,6 +741,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 						AlbumName:    resolvedTrack.AlbumName,
 						Instrumental: 1,
 					},
+					DetectorVersion: detResult.Version,
 				}
 				encoded, encErr := encodeSong(instrumentalSong)
 				if encErr != nil {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -272,11 +272,13 @@ func (r *fakeProviderRecorder) RecordLaneAttempts(_ context.Context, queueID int
 
 type fakeWriter struct {
 	writes []models.OutputPath
+	songs  []models.Song
 	err    error
 }
 
-func (w *fakeWriter) WriteLRC(_ models.Song, filename string, outdir string) error {
+func (w *fakeWriter) WriteLRC(song models.Song, filename string, outdir string) error {
 	w.writes = append(w.writes, models.OutputPath{Outdir: outdir, Filename: filename})
+	w.songs = append(w.songs, song)
 	return w.err
 }
 
@@ -1816,6 +1818,7 @@ func TestSetMaxMissAttemptsClampNegative(t *testing.T) {
 // fakeDetector is a test detector.Detector that returns a fixed result or error.
 type fakeDetector struct {
 	instrumental bool
+	version      string
 	err          error
 	calls        []string
 }
@@ -1825,7 +1828,7 @@ func (d *fakeDetector) Detect(_ context.Context, audioPath string) (detector.Res
 	if d.err != nil {
 		return detector.Result{}, d.err
 	}
-	return detector.Result{Instrumental: d.instrumental}, nil
+	return detector.Result{Instrumental: d.instrumental, Version: d.version}, nil
 }
 
 // TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes verifies that when
@@ -1846,7 +1849,7 @@ func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
 	c := &fakeCache{}
 	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
 	writer := &fakeWriter{}
-	det := &fakeDetector{instrumental: true}
+	det := &fakeDetector{instrumental: true, version: "9.9.9"}
 
 	w := New(q, c, fetcher, writer)
 	w.EnableAudioDetector(det)
@@ -1873,6 +1876,16 @@ func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
 	// Writer must have produced exactly one write (the instrumental .txt).
 	if len(writer.writes) != 1 {
 		t.Fatalf("writes = %v; want one instrumental marker write", writer.writes)
+	}
+	// The instrumental song handed to the writer must carry the detector version
+	// so the marker is stamped with detector provenance (#502).
+	if len(writer.songs) != 1 || writer.songs[0].DetectorVersion != "9.9.9" {
+		t.Fatalf("written song DetectorVersion = %q; want \"9.9.9\"", func() string {
+			if len(writer.songs) == 1 {
+				return writer.songs[0].DetectorVersion
+			}
+			return "<no song captured>"
+		}())
 	}
 	// Cache must have stored the encoded instrumental song.
 	if len(c.stores) != 1 {


### PR DESCRIPTION
## Summary
- Foundation slice of #502: instrumental `.txt` markers now carry provenance, so a later scanner can distinguish a detector-written (provisional, re-checkable) marker from a provider-written (editorial, terminal) one. This is the precondition that makes putting the detector in front of the providers (#501) safe: a wrong detector verdict becomes cheap to undo.
- Adds `lyrics.SourceDetector` + `InstrumentalProvenance`/`IsDetector`; a transient `models.Song.DetectorVersion`; a writer header on instrumental markers (`[by:canticle]` + `[source:<lane>]`, plus detector-only `[dv:<version>]`); `ReadInstrumentalProvenance` to read it back; and the worker stamping the detector version onto the instrumental song.
- No scan/skip behavior change in this PR: it only writes and reads provenance. Provider markers, detector markers, and legacy bare markers are all still treated exactly as before. The scanner reopen-model (Unit B) and the DB-discriminator backfill of existing markers (Unit C) follow as separate PRs.

## Linked issue
Part of #502

## Gates (run locally; CI enforces)
- [x] gofmt, go build
- [x] go test -race (full suite: 2369 tests across 50 packages)
- [x] patch coverage 84.62% (> 70% threshold)
- [x] coverage floor (all packages at or above)
- [x] golangci-lint (0 issues)
- [x] actionlint
- [x] govulncheck (0 vulnerabilities)

## Test plan
- [x] TDD per task (A1-A5): failing test -> minimal implementation -> pass
- [x] Provenance round-trip covered: detector / provider / legacy-bare / not-a-marker
- [x] Worker seam: the instrumental song handed to the writer carries the detector version
- [x] Whole-branch adversarial review (verdict: ship; no Critical/Important findings)
