### PR TITLE
feat: provenance-aware scanner reopen model (part of #502)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1589,17 +1589,29 @@ func configureWriterBilingual(w lyrics.Writer, cfg config.Config) {
 	}
 }
 
+// detectorScanVersion returns the app version to stamp into a scan's ScanOptions
+// for detector-marker version invalidation (#502), or "" when the audio detector
+// is disabled -- so a disabled detector never reopens provisional markers on a
+// version bump. It is the same value fed to detector.Config.Version.
+func detectorScanVersion(cfg config.Config) string {
+	if cfg.InstrumentalDetector.Enabled {
+		return version
+	}
+	return ""
+}
+
 func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd, cacheRepo *cache.CacheRepo) {
 	// serve has no per-run detect override; resolve per library against the global
 	// default (and the per-library setting) at enqueue time.
 	// Periodic scans realign only when realign.enabled AND realign.on_scan.
 	rlg, rlgBackup := serveRealigner(sqlDB, cfg, true)
 	s := scheduler(sqlDB, scanner.ScanOptions{
-		Update:         args.Update,
-		Upgrade:        args.Upgrade,
-		MaxDepth:       args.Depth,
-		BFS:            args.BFS,
-		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		Update:          args.Update,
+		Upgrade:         args.Upgrade,
+		MaxDepth:        args.Depth,
+		BFS:             args.BFS,
+		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		DetectorVersion: detectorScanVersion(cfg),
 	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
 	// serve has no per-run enrichment override; resolve per library against the
 	// global default (and the per-library setting) inside the scheduler.
@@ -1666,11 +1678,12 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 	// on_scan, which governs full periodic/manual scans).
 	rlg, rlgBackup := serveRealigner(sqlDB, cfg, false)
 	sched := scheduler(sqlDB, scanner.ScanOptions{
-		Update:         args.Update,
-		Upgrade:        args.Upgrade,
-		MaxDepth:       args.Depth,
-		BFS:            args.BFS,
-		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		Update:          args.Update,
+		Upgrade:         args.Upgrade,
+		MaxDepth:        args.Depth,
+		BFS:             args.BFS,
+		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		DetectorVersion: detectorScanVersion(cfg),
 	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
 	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	pruner := prune.New(sqlDB)
@@ -1796,11 +1809,12 @@ func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 	// off by default, so no behavior change unless opted in).
 	rlg, rlgBackup := serveRealigner(sqlDB, cfg, true)
 	s := scheduler(sqlDB, scanner.ScanOptions{
-		Update:         args.Update,
-		Upgrade:        args.Upgrade,
-		MaxDepth:       args.Depth,
-		BFS:            args.BFS,
-		EmbeddedLyrics: embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		Update:          args.Update,
+		Upgrade:         args.Upgrade,
+		MaxDepth:        args.Depth,
+		BFS:             args.BFS,
+		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
+		DetectorVersion: detectorScanVersion(cfg),
 	}, detectOverride, cfg.InstrumentalDetector.Enabled, nil, rlg, rlgBackup)
 	s.EnrichOverride = enrichOverride
 	s.GlobalEnrichDefault = cfg.Enrichment.Enabled

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2576,3 +2576,14 @@ func TestServeHandlerWiresMetricsReporter(t *testing.T) {
 		t.Errorf("response body missing mxlrcgo_queue_failures\nbody:\n%s", body)
 	}
 }
+
+func TestDetectorScanVersion(t *testing.T) {
+	enabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{Enabled: true}}
+	if got := detectorScanVersion(enabled); got != version {
+		t.Errorf("enabled: detectorScanVersion = %q, want current app version %q", got, version)
+	}
+	disabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{Enabled: false}}
+	if got := detectorScanVersion(disabled); got != "" {
+		t.Errorf("disabled: detectorScanVersion = %q, want empty (no version-invalidation churn)", got)
+	}
+}

--- a/internal/scanner/reopen.go
+++ b/internal/scanner/reopen.go
@@ -1,0 +1,45 @@
+package scanner
+
+import "github.com/doxazo-net/canticle/internal/lyrics"
+
+// reopenClasses is the set of settled .txt states a scan is willing to reconsider.
+// Modeling re-check eligibility as classes (not a single bool) keeps the
+// instrumental-provenance distinction expressible: a provider marker is
+// authoritative and a detector marker is provisional, and only the requested
+// classes are reopened. See #502.
+type reopenClasses struct {
+	Unsynced                  bool
+	ProvisionalInstrumental   bool
+	AuthoritativeInstrumental bool
+}
+
+// reopenClassesFor derives the reopen set from the scan flags. --update is a full
+// re-fetch (reopens every class); --upgrade reopens unsynced .txt and provisional
+// (detector-written) instrumental markers, but not authoritative provider markers.
+func reopenClassesFor(opts ScanOptions) reopenClasses {
+	switch {
+	case opts.Update:
+		return reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}
+	case opts.Upgrade:
+		return reopenClasses{Unsynced: true, ProvisionalInstrumental: true}
+	default:
+		return reopenClasses{}
+	}
+}
+
+// instrumentalReopenable reports whether a settled instrumental .txt should be
+// reconsidered. A detector-written (provisional) marker reopens when the
+// ProvisionalInstrumental class is requested, or when the detector version has
+// moved on since the marker was written (version invalidation, mirroring
+// providers_version cache retirement) -- but only when both the current and the
+// stored versions are known. A provider-written or legacy bare marker
+// (authoritative) reopens only on a full --update.
+func instrumentalReopenable(prov lyrics.InstrumentalProvenance, r reopenClasses, currentDetectorVersion string) bool {
+	if prov.IsDetector() {
+		if r.ProvisionalInstrumental {
+			return true
+		}
+		return currentDetectorVersion != "" && prov.DetectorVersion != "" && prov.DetectorVersion != currentDetectorVersion
+	}
+	return r.AuthoritativeInstrumental
+}

--- a/internal/scanner/reopen_test.go
+++ b/internal/scanner/reopen_test.go
@@ -1,0 +1,68 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/lyrics"
+)
+
+func TestReopenClassesFor(t *testing.T) {
+	cases := []struct {
+		name            string
+		update, upgrade bool
+		want            reopenClasses
+	}{
+		{"neither", false, false, reopenClasses{}},
+		{"upgrade", false, true, reopenClasses{Unsynced: true, ProvisionalInstrumental: true}},
+		{"update", true, false, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}},
+		{"both", true, true, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reopenClassesFor(ScanOptions{Update: tc.update, Upgrade: tc.upgrade})
+			if got != tc.want {
+				t.Fatalf("reopenClassesFor(update=%v,upgrade=%v) = %+v, want %+v", tc.update, tc.upgrade, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstrumentalReopenable(t *testing.T) {
+	det := func(dv string) lyrics.InstrumentalProvenance {
+		return lyrics.InstrumentalProvenance{Source: lyrics.SourceDetector, DetectorVersion: dv}
+	}
+	provider := lyrics.InstrumentalProvenance{Source: "musixmatch"}
+	legacy := lyrics.InstrumentalProvenance{} // bare marker, no header
+
+	cases := []struct {
+		name       string
+		prov       lyrics.InstrumentalProvenance
+		r          reopenClasses
+		curVersion string
+		want       bool
+	}{
+		// Detector marker + upgrade -> provisional class reopens it.
+		{"detector_upgrade", det("1.0"), reopenClasses{Unsynced: true, ProvisionalInstrumental: true}, "1.0", true},
+		// Detector marker, no upgrade, same version -> stays.
+		{"detector_neither_sameversion", det("1.0"), reopenClasses{}, "1.0", false},
+		// Detector marker, no upgrade, but detector version moved on -> invalidated.
+		{"detector_versionbump", det("1.0"), reopenClasses{}, "2.0", true},
+		// Detector marker, no upgrade, no current version known (dir mode) -> no invalidation.
+		{"detector_noversion", det("1.0"), reopenClasses{}, "", false},
+		// Detector marker with empty dv, version known -> cannot compare -> not invalidated by version.
+		{"detector_emptydv", det(""), reopenClasses{}, "2.0", false},
+		// Provider marker: only a full --update (AuthoritativeInstrumental) reopens it.
+		{"provider_upgrade", provider, reopenClasses{Unsynced: true, ProvisionalInstrumental: true}, "2.0", false},
+		{"provider_update", provider, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}, "2.0", true},
+		// Legacy bare marker behaves like a provider (authoritative) marker.
+		{"legacy_upgrade", legacy, reopenClasses{Unsynced: true, ProvisionalInstrumental: true}, "2.0", false},
+		{"legacy_update", legacy, reopenClasses{AuthoritativeInstrumental: true}, "2.0", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := instrumentalReopenable(tc.prov, tc.r, tc.curVersion); got != tc.want {
+				t.Fatalf("instrumentalReopenable(%+v, %+v, %q) = %v, want %v", tc.prov, tc.r, tc.curVersion, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -417,8 +417,7 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			// reopens on --upgrade or a detector-version bump.
 			prov, _, provErr := lyrics.ReadInstrumentalProvenance(filepath.Join(dir, txtFile))
 			if provErr != nil {
-				// Treat an unreadable header as terminal (conservative: do not reopen
-				// on a read error), matching isInstrumentalTxt's fail-safe.
+				// Treat an unreadable header as terminal: fail conservatively toward terminal so a transient read error never reopens a settled marker.
 				slog.Warn("could not read instrumental provenance; treating marker as terminal", "file", file.Name(), "error", provErr)
 			}
 			if !instrumentalReopenable(prov, reopen, opts.DetectorVersion) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -149,6 +149,12 @@ type ScanOptions struct {
 	// The zero value is false, so direct callers that want the historical
 	// always-on behavior must set it true explicitly.
 	EnrichRecording bool
+	// DetectorVersion is the current audio-detector version. When set (serve mode
+	// with the detector enabled), a provisional (detector-written) instrumental
+	// marker whose stored [dv:] differs is invalidated and re-checked, mirroring
+	// providers_version cache retirement. Empty (dir/CLI mode, or detector off)
+	// disables version invalidation. See #502.
+	DetectorVersion string
 }
 
 // NewScanner creates a new Scanner with the supplied options.
@@ -399,17 +405,28 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			txtExists = true
 		}
 
+		reopen := reopenClassesFor(opts)
 		switch {
 		case lrcExists && !opts.Update:
 			// Synced lyrics already present and not asked to update -- skip.
 			slog.Debug("skipping file, lyrics exist", "file", file.Name())
 			continue
-		case txtExists && !lrcExists && !opts.Update && isInstrumentalTxt(filepath.Join(dir, txtFile)):
-			// Instrumental markers are terminal -- re-fetching would produce the same result.
-			// Skip regardless of --upgrade; only --update (explicit full re-fetch) overrides.
-			slog.Debug("skipping file, instrumental marker", "file", file.Name())
-			continue
-		case txtExists && !opts.Upgrade && !opts.Update && !lrcExists:
+		case txtExists && !lrcExists && isInstrumentalTxt(filepath.Join(dir, txtFile)):
+			// Instrumental markers are re-checkable by provenance (#502): a provider
+			// marker is authoritative (terminal), a detector marker is provisional and
+			// reopens on --upgrade or a detector-version bump.
+			prov, _, provErr := lyrics.ReadInstrumentalProvenance(filepath.Join(dir, txtFile))
+			if provErr != nil {
+				// Treat an unreadable header as terminal (conservative: do not reopen
+				// on a read error), matching isInstrumentalTxt's fail-safe.
+				slog.Warn("could not read instrumental provenance; treating marker as terminal", "file", file.Name(), "error", provErr)
+			}
+			if !instrumentalReopenable(prov, reopen, opts.DetectorVersion) {
+				slog.Debug("skipping file, instrumental marker (terminal)", "file", file.Name())
+				continue
+			}
+			// Provisional marker eligible for re-check: fall through to enqueue.
+		case txtExists && !lrcExists && !reopen.Unsynced:
 			// Unsynced .txt present and not asked to upgrade or update -- skip.
 			slog.Debug("skipping file, unsynced lyrics exist", "file", file.Name())
 			continue

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -372,6 +372,9 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		return opts.BFS != id1
 	})
 
+	// reopen is loop-invariant for this directory scan (opts is fixed), so compute
+	// it once rather than per file.
+	reopen := reopenClassesFor(opts)
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -405,7 +408,6 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 			txtExists = true
 		}
 
-		reopen := reopenClassesFor(opts)
 		switch {
 		case lrcExists && !opts.Update:
 			// Synced lyrics already present and not asked to update -- skip.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -282,7 +282,6 @@ func TestScanLibrary_InstrumentalProvenanceReopen(t *testing.T) {
 		{"detector_no_flags_terminal", lyrics.SourceDetector, "1.0", ScanOptions{}, false},
 		{"detector_version_bump_reopens", lyrics.SourceDetector, "1.0", ScanOptions{DetectorVersion: "2.0"}, true},
 		{"detector_same_version_terminal", lyrics.SourceDetector, "1.0", ScanOptions{DetectorVersion: "1.0"}, false},
-		{"detector_no_current_version_terminal", lyrics.SourceDetector, "1.0", ScanOptions{}, false},
 		{"provider_upgrade_terminal", "musixmatch", "", ScanOptions{Upgrade: true}, false},
 		{"provider_update_reopens", "musixmatch", "", ScanOptions{Update: true}, true},
 		{"legacy_bare_upgrade_terminal", "", "", ScanOptions{Upgrade: true}, false},

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/doxazo-net/canticle/internal/lyrics"
@@ -243,5 +244,63 @@ func TestAudioFileTypeForExt(t *testing.T) {
 		if !ok && ft != 0 {
 			t.Errorf("audioFileTypeForExt(%q) returned non-zero type on miss: %d", tc.ext, ft)
 		}
+	}
+}
+
+// writeMarkerWithHeader writes an instrumental .txt with a provenance header,
+// mirroring what the Unit A writer emits: [by:canticle], an optional [source:],
+// an optional [dv:], then the marker line.
+func writeMarkerWithHeader(t *testing.T, dir, name, source, dv string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("[by:canticle]\n")
+	if source != "" {
+		b.WriteString("[source:" + source + "]\n")
+	}
+	if dv != "" {
+		b.WriteString("[dv:" + dv + "]\n")
+	}
+	b.WriteString(lyrics.InstrumentalMarker + "\n")
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("writeMarkerWithHeader %s: %v", name, err)
+	}
+}
+
+// TestScanLibrary_InstrumentalProvenanceReopen verifies provenance-aware
+// re-check eligibility (#502): a detector marker is provisional (reopens on
+// --upgrade or a detector-version bump), a provider/legacy marker is terminal
+// (reopens only on --update).
+func TestScanLibrary_InstrumentalProvenanceReopen(t *testing.T) {
+	cases := []struct {
+		name        string
+		source      string
+		dv          string
+		opts        ScanOptions
+		wantEnqueue bool
+	}{
+		{"detector_upgrade_reopens", lyrics.SourceDetector, "1.0", ScanOptions{Upgrade: true}, true},
+		{"detector_no_flags_terminal", lyrics.SourceDetector, "1.0", ScanOptions{}, false},
+		{"detector_version_bump_reopens", lyrics.SourceDetector, "1.0", ScanOptions{DetectorVersion: "2.0"}, true},
+		{"detector_same_version_terminal", lyrics.SourceDetector, "1.0", ScanOptions{DetectorVersion: "1.0"}, false},
+		{"detector_no_current_version_terminal", lyrics.SourceDetector, "1.0", ScanOptions{}, false},
+		{"provider_upgrade_terminal", "musixmatch", "", ScanOptions{Upgrade: true}, false},
+		{"provider_update_reopens", "musixmatch", "", ScanOptions{Update: true}, true},
+		{"legacy_bare_upgrade_terminal", "", "", ScanOptions{Upgrade: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeAudioFile(t, dir, "song.mp3")
+			writeMarkerWithHeader(t, dir, "song.txt", tc.source, tc.dv)
+			sc := NewScanner()
+			results, err := sc.ScanLibrary(context.Background(), dir, tc.opts)
+			if err != nil {
+				t.Fatalf("ScanLibrary: %v", err)
+			}
+			gotEnqueue := len(results) > 0
+			if gotEnqueue != tc.wantEnqueue {
+				t.Errorf("source=%q dv=%q opts=%+v: enqueued=%v, want %v", tc.source, tc.dv, tc.opts, gotEnqueue, tc.wantEnqueue)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Second slice of #502: the library scanner's instrumental-marker terminal-skip is now provenance-aware. A provider-written (editorial) marker stays terminal; a detector-written (probabilistic) marker is provisional and reopens on `--upgrade` or a detector-version bump. Builds on the merged Unit A (#517) provenance write/read.
- Models re-check eligibility as a set of settled-state classes (`reopenClasses{Unsynced, ProvisionalInstrumental, AuthoritativeInstrumental}`), not a single bool, per #502's acceptance criteria: `--update` reopens every class, `--upgrade` reopens unsynced + provisional (detector) markers, and neither reopens nothing.
- Adds a `DetectorVersion` scan option, stamped from the app version in serve mode only when the detector is enabled, so a detector-version bump invalidates stale provisional markers (mirroring `providers_version` cache retirement) while a disabled detector never churns them.
- No behavior change for pre-Unit-A markers: bare/legacy markers (no `[source:]`) classify as authoritative, so the existing skip-logic matrix is unchanged. New behavior activates only for markers carrying `[source:canticle-detector]`, which the backfill (Unit C) will apply to existing rows.

## Linked issue
Part of #502

## Gates (run locally; CI enforces)
- [x] gofmt, go build
- [x] go test -race (full suite: 2394 tests across 50 packages)
- [x] patch coverage 80.77% (> 70% threshold)
- [x] coverage floor (all packages at or above; scanner +7%)
- [x] golangci-lint (0 issues)
- [x] actionlint
- [x] govulncheck (0 vulnerabilities)

## Test plan
- [x] TDD per task: reopen-classification helpers (table tests), provenance-aware skip switch (8-case ScanLibrary integration test over detector/provider/legacy markers + version-bump), version-threading helper (enabled/disabled gate)
- [x] Existing `TestGetSongDir_SkipLogic` matrix passes unchanged (bare/legacy markers = authoritative)
- [x] Whole-branch adversarial review (verdict: ship; no Critical/Important findings)

## Stacking
Independent of Unit A on `main` (A is merged). The backfill (Unit C) will be stacked on top of this branch, since both touch `commands.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved instrumental scan handling by tracking detector versions.
  * Automatically rechecks provisional detector results when the detector version changes.
  * Supports targeted rechecks through upgrade and full-update scans.
  * Preserves authoritative provider results unless a full update is requested.

* **Bug Fixes**
  * Prevents unnecessary repeated invalidation when detector-generated results cannot be produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->