### PR TITLE
feat: backfill provenance onto existing detector markers (part of #502)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -141,6 +141,7 @@ type ScanCmd struct {
 	ReconcilePaths                   *ScanReconcilePathsCmd                   `arg:"subcommand:reconcile-paths" help:"delete queue/scan rows whose source audio file has vanished (renamed/merged/deleted)"`
 	ReconcileIdentity                *ScanReconcileIdentityCmd                `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
 	ReconcileLRC                     *ScanReconcileLRCCmd                     `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
+	ReconcileMarkerProvenance        *ScanReconcileMarkerProvenanceCmd        `arg:"subcommand:reconcile-marker-provenance" help:"backfill provenance headers onto detector-written instrumental markers (#502)"`
 }
 
 // ScanReconcileLRCCmd walks the configured library roots and rewrites any .lrc
@@ -151,6 +152,16 @@ type ScanReconcileLRCCmd struct {
 	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default reconciles every library"`
 	Yes        bool   `arg:"--yes" help:"actually rewrite files (without it, prints what would change)"`
 	Backup     string `arg:"--backup" help:"path for the JSONL record of rewritten files (default: <db-dir>/reconcile-lrc-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// ScanReconcileMarkerProvenanceCmd backfills provenance headers onto detector-
+// written instrumental markers so the scanner treats them as re-checkable (#502).
+type ScanReconcileMarkerProvenanceCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default all"`
+	Yes        bool   `arg:"--yes" help:"actually stamp markers (without it, prints what would change)"`
+	Limit      int    `arg:"--limit" help:"cap the number of detector rows considered (0 = no cap)" default:"0"`
+	Backup     string `arg:"--backup" help:"path for the JSONL backup of stamped markers (default: <db-dir>/reconcile-marker-provenance-backup-<ts>.jsonl)" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
@@ -1777,6 +1788,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runReconcileLRC(ctx, out, sub)
+	case args.ReconcileMarkerProvenance != nil:
+		sub := *args.ReconcileMarkerProvenance
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runReconcileMarkerProvenance(ctx, out, sub)
 	default:
 		return runScan(ctx, out, args)
 	}

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "reconcile-marker-provenance", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/reconcile_marker_provenance.go
+++ b/internal/commands/reconcile_marker_provenance.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/doxazo-net/canticle/internal/instrumentalbackfill"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+type markerProvenanceBackupRecord struct {
+	FilePath        string `json:"file_path"`
+	Source          string `json:"source"`
+	DetectorVersion string `json:"detector_version,omitempty"`
+}
+
+func appendMarkerProvenanceBackup(f *os.File, rec markerProvenanceBackupRecord) error {
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal marker-provenance backup record: %w", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write marker-provenance backup record: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync marker-provenance backup record: %w", err)
+	}
+	return nil
+}
+
+func dvNote(dv string) string {
+	if dv == "" {
+		return ""
+	}
+	return fmt.Sprintf(" [dv:%s]", dv)
+}
+
+// runReconcileMarkerProvenance backfills [source:canticle-detector]/[dv:] headers
+// onto bare detector-written instrumental markers (#502), so the scanner treats
+// them as provisional/re-checkable rather than terminal. Dry-run by default;
+// --yes applies and appends a JSONL backup of each stamped file.
+func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanReconcileMarkerProvenanceCmd) int {
+	env, code := openQueueEnv(ctx, out, args.ConfigPath, args.Library)
+	if env == nil {
+		return code
+	}
+	defer env.Close()
+
+	rows, err := env.queue.ListDetectorInstrumentalMarkers(ctx, queue.ListInstrumentalMarkersOptions{
+		LibraryID: env.libraryID,
+		Limit:     args.Limit,
+	})
+	if err != nil {
+		slog.Error("reconcile-marker-provenance: list failed", "error", err)
+		return 1
+	}
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		backupPath = filepath.Join(filepath.Dir(env.cfg.DB.Path),
+			fmt.Sprintf("reconcile-marker-provenance-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	var backupFile *os.File
+	defer func() {
+		if backupFile != nil {
+			if cerr := backupFile.Close(); cerr != nil {
+				slog.Warn("failed to close reconcile-marker-provenance backup file", "path", backupPath, "error", cerr)
+			}
+		}
+	}()
+
+	var stamped, skipped int
+	for _, r := range rows {
+		for _, p := range instrumentalbackfill.MarkerPaths(r.Inputs) {
+			prov, isMarker, rerr := lyrics.ReadInstrumentalProvenance(p)
+			if rerr != nil {
+				// Marker absent or unreadable -- nothing to backfill at this path.
+				continue
+			}
+			if !isMarker || prov.Source != "" {
+				// Not a bare marker (already headed, or not a marker) -- skip.
+				continue
+			}
+			_, _ = fmt.Fprintf(out, "  %s -> [source:%s]%s\n", p, lyrics.SourceDetector, dvNote(r.DetectorVersion))
+			if !args.Yes {
+				stamped++
+				continue
+			}
+			changed, werr := lyrics.WriteMarkerProvenance(p, lyrics.InstrumentalProvenance{
+				Source:          lyrics.SourceDetector,
+				DetectorVersion: r.DetectorVersion,
+			})
+			if werr != nil {
+				slog.Warn("reconcile-marker-provenance: stamp failed", "path", p, "error", werr)
+				continue
+			}
+			if !changed {
+				skipped++
+				continue
+			}
+			stamped++
+			if backupFile == nil {
+				f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied or derived from the configured db dir
+				if ferr != nil {
+					slog.Error("reconcile-marker-provenance: open backup failed", "path", backupPath, "error", ferr)
+					return 1
+				}
+				backupFile = f
+			}
+			if berr := appendMarkerProvenanceBackup(backupFile, markerProvenanceBackupRecord{
+				FilePath:        p,
+				Source:          lyrics.SourceDetector,
+				DetectorVersion: r.DetectorVersion,
+			}); berr != nil {
+				slog.Error("reconcile-marker-provenance: write backup failed", "error", berr)
+				return 1
+			}
+		}
+	}
+
+	verb := "would stamp"
+	if args.Yes {
+		verb = "stamped"
+	}
+	_, _ = fmt.Fprintf(out, "reconcile-marker-provenance: scanned %d detector marker row(s)%s; %s %d, skipped %d%s\n",
+		len(rows), env.libLabel, verb, stamped, skipped, suffixDryRun(args.Yes))
+	if backupFile != nil {
+		_, _ = fmt.Fprintf(out, "backup written to %s\n", backupPath)
+	}
+	return 0
+}

--- a/internal/commands/reconcile_marker_provenance.go
+++ b/internal/commands/reconcile_marker_provenance.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -79,13 +80,40 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 	var stamped, skipped, errored int
 	for _, r := range rows {
 		for _, p := range instrumentalbackfill.MarkerPaths(r.Inputs) {
+			// Match WriteMarkerProvenance's eligibility exactly so dry-run previews
+			// only what apply will stamp: it Lstat-skips symlinks, whereas
+			// ReadInstrumentalProvenance follows them.
+			fi, lerr := os.Lstat(p)
+			if lerr != nil {
+				if errors.Is(lerr, os.ErrNotExist) {
+					// Marker absent -- nothing to backfill at this path.
+					skipped++
+					continue
+				}
+				slog.Warn("reconcile-marker-provenance: lstat failed", "path", p, "error", lerr)
+				errored++
+				continue
+			}
+			if fi.Mode()&os.ModeSymlink != 0 {
+				// WriteMarkerProvenance is a no-op on symlinks; skip to keep dry-run honest.
+				skipped++
+				continue
+			}
 			prov, isMarker, rerr := lyrics.ReadInstrumentalProvenance(p)
 			if rerr != nil {
-				// Marker absent or unreadable -- nothing to backfill at this path.
+				if errors.Is(rerr, os.ErrNotExist) {
+					// Vanished between the Lstat and the read (e.g. a concurrent
+					// prune) -- same benign "absent" case as the Lstat branch.
+					skipped++
+					continue
+				}
+				slog.Warn("reconcile-marker-provenance: read failed", "path", p, "error", rerr)
+				errored++
 				continue
 			}
 			if !isMarker || prov.Source != "" {
 				// Not a bare marker (already headed, or not a marker) -- skip.
+				skipped++
 				continue
 			}
 			_, _ = fmt.Fprintf(out, "  %s -> [source:%s]%s\n", p, lyrics.SourceDetector, dvNote(r.DetectorVersion))
@@ -93,21 +121,12 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 				stamped++
 				continue
 			}
-			changed, werr := lyrics.WriteMarkerProvenance(p, lyrics.InstrumentalProvenance{
-				Source:          lyrics.SourceDetector,
-				DetectorVersion: r.DetectorVersion,
-			})
-			if werr != nil {
-				slog.Warn("reconcile-marker-provenance: stamp failed", "path", p, "error", werr)
-				errored++
-				continue
-			}
-			if !changed {
-				skipped++
-				continue
-			}
-			stamped++
-			// Backup is an audit log, not a recovery necessity: WriteMarkerProvenance is purely additive and trivially reversible (strip the [by:]/[source:]/[dv:] header lines), so it is written after the stamp rather than before.
+			// Write-ahead: secure the backup record before mutating the marker, so a
+			// stamped file is never left unrecorded (a rerun idempotently skips it and
+			// could not recreate the record). The JSONL is therefore a superset of the
+			// files actually mutated: a record whose stamp then no-ops or errors is
+			// harmless, since restore just strips the additive header (a no-op on an
+			// unstamped file) and a rerun re-stamps and re-records.
 			if backupFile == nil {
 				f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied or derived from the configured db dir
 				if ferr != nil {
@@ -124,6 +143,20 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 				slog.Error("reconcile-marker-provenance: write backup failed", "error", berr)
 				return 1
 			}
+			changed, werr := lyrics.WriteMarkerProvenance(p, lyrics.InstrumentalProvenance{
+				Source:          lyrics.SourceDetector,
+				DetectorVersion: r.DetectorVersion,
+			})
+			if werr != nil {
+				slog.Warn("reconcile-marker-provenance: stamp failed", "path", p, "error", werr)
+				errored++
+				continue
+			}
+			if !changed {
+				skipped++
+				continue
+			}
+			stamped++
 		}
 	}
 
@@ -135,6 +168,9 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 		len(rows), env.libLabel, verb, stamped, skipped, errored, suffixDryRun(args.Yes))
 	if backupFile != nil {
 		_, _ = fmt.Fprintf(out, "backup written to %s\n", backupPath)
+	}
+	if errored > 0 {
+		return 1
 	}
 	return 0
 }

--- a/internal/commands/reconcile_marker_provenance.go
+++ b/internal/commands/reconcile_marker_provenance.go
@@ -76,7 +76,7 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 		}
 	}()
 
-	var stamped, skipped int
+	var stamped, skipped, errored int
 	for _, r := range rows {
 		for _, p := range instrumentalbackfill.MarkerPaths(r.Inputs) {
 			prov, isMarker, rerr := lyrics.ReadInstrumentalProvenance(p)
@@ -99,6 +99,7 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 			})
 			if werr != nil {
 				slog.Warn("reconcile-marker-provenance: stamp failed", "path", p, "error", werr)
+				errored++
 				continue
 			}
 			if !changed {
@@ -106,6 +107,7 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 				continue
 			}
 			stamped++
+			// Backup is an audit log, not a recovery necessity: WriteMarkerProvenance is purely additive and trivially reversible (strip the [by:]/[source:]/[dv:] header lines), so it is written after the stamp rather than before.
 			if backupFile == nil {
 				f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied or derived from the configured db dir
 				if ferr != nil {
@@ -129,8 +131,8 @@ func runReconcileMarkerProvenance(ctx context.Context, out io.Writer, args ScanR
 	if args.Yes {
 		verb = "stamped"
 	}
-	_, _ = fmt.Fprintf(out, "reconcile-marker-provenance: scanned %d detector marker row(s)%s; %s %d, skipped %d%s\n",
-		len(rows), env.libLabel, verb, stamped, skipped, suffixDryRun(args.Yes))
+	_, _ = fmt.Fprintf(out, "reconcile-marker-provenance: scanned %d detector marker row(s)%s; %s %d, skipped %d, errored %d%s\n",
+		len(rows), env.libLabel, verb, stamped, skipped, errored, suffixDryRun(args.Yes))
 	if backupFile != nil {
 		_, _ = fmt.Fprintf(out, "backup written to %s\n", backupPath)
 	}

--- a/internal/commands/reconcile_marker_provenance_test.go
+++ b/internal/commands/reconcile_marker_provenance_test.go
@@ -26,6 +26,15 @@ func writeMarkerProvCfg(t *testing.T, path, dbPath string) {
 // done, dv set), and writes a BARE marker .txt at its output location.
 func seedDetectorMarker(t *testing.T, ctx context.Context, dbPath, outdir, detectorVersion string) {
 	t.Helper()
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "song", detectorVersion, true)
+}
+
+// seedDetectorMarkerRow is the general form of seedDetectorMarker: it enqueues
+// a row under a caller-chosen basename, marks it detector-instrumental, and
+// optionally writes a bare marker .txt at its output location (writeMarker=false
+// lets a test cover the marker-absent-on-disk skip path).
+func seedDetectorMarkerRow(t *testing.T, ctx context.Context, dbPath, outdir, basename, detectorVersion string, writeMarker bool) {
+	t.Helper()
 	sqlDB, err := db.Open(ctx, dbPath)
 	if err != nil {
 		t.Fatalf("db.Open seed: %v", err)
@@ -33,11 +42,11 @@ func seedDetectorMarker(t *testing.T, ctx context.Context, dbPath, outdir, detec
 	defer func() { _ = sqlDB.Close() }()
 	q := queue.NewDBQueue(sqlDB)
 	item, err := q.Enqueue(ctx, models.Inputs{
-		Track:       models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Track:       models.Track{ArtistName: "Artist", TrackName: basename},
 		Outdir:      outdir,
-		Filename:    "song.lrc",
-		SourcePath:  filepath.Join(outdir, "song.flac"),
-		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.lrc"}},
+		Filename:    basename + ".lrc",
+		SourcePath:  filepath.Join(outdir, basename+".flac"),
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: basename + ".lrc"}},
 	}, queue.PriorityScan)
 	if err != nil {
 		t.Fatalf("Enqueue: %v", err)
@@ -53,8 +62,11 @@ func seedDetectorMarker(t *testing.T, ctx context.Context, dbPath, outdir, detec
 		detectorVersion, item.ID); err != nil {
 		t.Fatalf("mark detector-instrumental: %v", err)
 	}
+	if !writeMarker {
+		return
+	}
 	// Bare marker on disk (old writeInstrumental format).
-	if err := os.WriteFile(filepath.Join(outdir, "song.txt"), []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(outdir, basename+".txt"), []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
 		t.Fatalf("write bare marker: %v", err)
 	}
 }
@@ -108,5 +120,341 @@ func TestRunReconcileMarkerProvenance_DryRunThenApply(t *testing.T) {
 	}
 	if !strings.Contains(again.String(), "stamped 0") {
 		t.Errorf("second apply should stamp 0 (already headed):\n%s", again.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_MarkerAbsent verifies a detector row whose
+// .txt marker is missing from disk is skipped cleanly (no crash, no false
+// stamp), and the summary reports 0 stamped.
+func TestRunReconcileMarkerProvenance_MarkerAbsent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "absent", "1.5.0", false)
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "would stamp 0") {
+		t.Errorf("summary missing 'would stamp 0' for an absent marker:\n%s", out.String())
+	}
+
+	// Apply too: still nothing to stamp, still exits clean.
+	var applyOut bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &applyOut, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, applyOut.String())
+	}
+	if !strings.Contains(applyOut.String(), "stamped 0") {
+		t.Errorf("apply summary missing 'stamped 0' for an absent marker:\n%s", applyOut.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_MixedBatchStampsOnlyBare seeds one bare
+// marker and one already-headed marker, applies, and asserts only the bare
+// one gets stamped while the headed one is left byte-for-byte untouched.
+func TestRunReconcileMarkerProvenance_MixedBatchStampsOnlyBare(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "bare", "1.5.0", true)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "headed", "1.5.0", false)
+	headedPath := filepath.Join(outdir, "headed.txt")
+	headedOrig := "[by:canticle]\n[source:canticle-detector]\n[dv:9.9.9]\n" + lyrics.InstrumentalMarker + "\n"
+	if err := os.WriteFile(headedPath, []byte(headedOrig), 0o644); err != nil {
+		t.Fatalf("write headed marker: %v", err)
+	}
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "stamped 1") {
+		t.Errorf("summary missing 'stamped 1' for a mixed batch:\n%s", out.String())
+	}
+
+	barePath := filepath.Join(outdir, "bare.txt")
+	prov, isMarker, err := lyrics.ReadInstrumentalProvenance(barePath)
+	if err != nil || !isMarker || prov.Source != lyrics.SourceDetector {
+		t.Fatalf("bare marker not stamped: isMarker=%v prov=%+v err=%v", isMarker, prov, err)
+	}
+
+	headedData, err := os.ReadFile(headedPath)
+	if err != nil {
+		t.Fatalf("read headed marker: %v", err)
+	}
+	if string(headedData) != headedOrig {
+		t.Fatalf("already-headed marker must be untouched:\n%s", headedData)
+	}
+}
+
+// TestRunReconcileMarkerProvenance_EmptyDetectorVersionOmitsDVTag verifies a
+// detector row with an empty stored detector_version gets [source:] stamped
+// but no [dv:] header.
+func TestRunReconcileMarkerProvenance_EmptyDetectorVersionOmitsDVTag(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "nodv", "", true)
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "stamped 1") {
+		t.Errorf("summary missing 'stamped 1':\n%s", out.String())
+	}
+
+	markerPath := filepath.Join(outdir, "nodv.txt")
+	prov, isMarker, err := lyrics.ReadInstrumentalProvenance(markerPath)
+	if err != nil || !isMarker {
+		t.Fatalf("re-read: isMarker=%v err=%v", isMarker, err)
+	}
+	if prov.Source != lyrics.SourceDetector {
+		t.Fatalf("Source = %q, want %q", prov.Source, lyrics.SourceDetector)
+	}
+	if prov.DetectorVersion != "" {
+		t.Fatalf("DetectorVersion = %q, want empty", prov.DetectorVersion)
+	}
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if strings.Contains(string(data), "[dv:") {
+		t.Fatalf("empty detector_version must not emit a [dv:] header:\n%s", data)
+	}
+}
+
+// TestRunReconcileMarkerProvenance_LimitCapsRowsConsidered verifies --limit
+// caps how many detector rows are even considered, not just how many markers
+// end up stamped.
+func TestRunReconcileMarkerProvenance_LimitCapsRowsConsidered(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "one", "1.0.0", true)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "two", "1.0.0", true)
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Limit: 1}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "scanned 1 detector marker row") {
+		t.Errorf("summary must report exactly 1 row scanned under --limit 1:\n%s", out.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_BackupFileContainsStampedPath verifies the
+// JSONL backup file is created on apply and records the stamped file's path.
+func TestRunReconcileMarkerProvenance_BackupFileContainsStampedPath(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "backup", "2.0.0", true)
+	backupPath := filepath.Join(dir, "backup.jsonl")
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true, Backup: backupPath}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "backup written to "+backupPath) {
+		t.Errorf("summary missing backup-path line:\n%s", out.String())
+	}
+
+	data, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	markerPath := filepath.Join(outdir, "backup.txt")
+	if !strings.Contains(string(data), markerPath) {
+		t.Fatalf("backup file missing stamped path %q:\n%s", markerPath, data)
+	}
+	if !strings.Contains(string(data), lyrics.SourceDetector) {
+		t.Fatalf("backup file missing source token:\n%s", data)
+	}
+}
+
+// TestRunScanCmd_DispatchesReconcileMarkerProvenance verifies the scan
+// subcommand switch routes to runReconcileMarkerProvenance, both with an
+// explicit sub-config and with the parent --config inherited (mirrors
+// the reconcile-lrc dispatch test).
+func TestRunScanCmd_DispatchesReconcileMarkerProvenance(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarker(t, ctx, dbPath, outdir, "1.5.0")
+
+	// Direct sub-config.
+	var buf bytes.Buffer
+	if rc := runScanCmd(ctx, &buf, ScanCmd{ReconcileMarkerProvenance: &ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath}}); rc != 0 {
+		t.Fatalf("dispatch rc=%d out=%s", rc, buf.String())
+	}
+	if !strings.Contains(buf.String(), "would stamp 1") {
+		t.Errorf("dispatch output: %q", buf.String())
+	}
+
+	// Parent --config inherited when the subcommand omits it.
+	var buf2 bytes.Buffer
+	if rc := runScanCmd(ctx, &buf2, ScanCmd{ConfigPath: cfgPath, ReconcileMarkerProvenance: &ScanReconcileMarkerProvenanceCmd{}}); rc != 0 {
+		t.Fatalf("inherited-config rc=%d out=%s", rc, buf2.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_UnknownLibraryFailsClean verifies an
+// unresolvable --library value fails the shared env setup and returns a
+// non-zero exit rather than proceeding against every library.
+func TestRunReconcileMarkerProvenance_UnknownLibraryFailsClean(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	// Touch the DB so it exists with the schema before the command opens it.
+	seedDetectorMarkerRow(t, ctx, dbPath, t.TempDir(), "unused", "1.0.0", false)
+
+	var out bytes.Buffer
+	code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Library: "no-such-library"})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for an unresolvable library, got 0: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "library") {
+		t.Errorf("expected an operator-facing library-not-found message, got: %q", out.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_SymlinkedMarkerIsSkippedNotStamped
+// verifies a detector row whose marker path resolves through a symlink is
+// read successfully (isMarker=true through the symlink) but is left
+// unstamped: WriteMarkerProvenance intentionally refuses to rewrite through a
+// symlink, so the command must count it as skipped, not stamped or errored.
+func TestRunReconcileMarkerProvenance_SymlinkedMarkerIsSkippedNotStamped(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "linked", "1.5.0", false)
+
+	real := filepath.Join(dir, "real-marker.txt")
+	if err := os.WriteFile(real, []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
+		t.Fatalf("write real marker: %v", err)
+	}
+	linkPath := filepath.Join(outdir, "linked.txt")
+	if err := os.Symlink(real, linkPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	var out bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "stamped 0") || !strings.Contains(out.String(), "skipped 1") {
+		t.Errorf("expected a symlinked marker to be skipped, not stamped:\n%s", out.String())
+	}
+	// The symlink target must be untouched (still bare, no header).
+	prov, isMarker, err := lyrics.ReadInstrumentalProvenance(real)
+	if err != nil || !isMarker {
+		t.Fatalf("re-read real marker: isMarker=%v err=%v", isMarker, err)
+	}
+	if prov.Source != "" {
+		t.Fatalf("symlinked marker must not be stamped: %+v", prov)
+	}
+}
+
+// TestRunReconcileMarkerProvenance_MissingWorkQueueTableFailsClean covers a
+// corrupted/mismatched database (the work_queue table gone, e.g. from a
+// botched manual migration) failing the row listing cleanly instead of
+// panicking.
+func TestRunReconcileMarkerProvenance_MissingWorkQueueTableFailsClean(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `DROP TABLE work_queue`); err != nil {
+		t.Fatalf("drop work_queue: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath})
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 for a missing work_queue table: %s", code, out.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_BackupPathIsDirectoryFailsClean covers an
+// operator-supplied --backup path that collides with an existing directory:
+// os.OpenFile(O_CREATE) on it fails, and the command must exit non-zero
+// rather than silently drop the stamp record.
+func TestRunReconcileMarkerProvenance_BackupPathIsDirectoryFailsClean(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarker(t, ctx, dbPath, outdir, "1.5.0")
+
+	backupDir := filepath.Join(dir, "backup-is-a-dir")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		t.Fatalf("mkdir backupDir: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true, Backup: backupDir})
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 when --backup collides with a directory: %s", code, out.String())
 	}
 }

--- a/internal/commands/reconcile_marker_provenance_test.go
+++ b/internal/commands/reconcile_marker_provenance_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doxazo-net/canticle/internal/db"
+	"github.com/doxazo-net/canticle/internal/lyrics"
+	"github.com/doxazo-net/canticle/internal/models"
+	"github.com/doxazo-net/canticle/internal/queue"
+)
+
+func writeMarkerProvCfg(t *testing.T, path, dbPath string) {
+	t.Helper()
+	content := "[db]\npath = \"" + strings.ReplaceAll(dbPath, `\`, `\\`) + "\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeMarkerProvCfg: %v", err)
+	}
+}
+
+// seedDetectorMarker enqueues a row, marks it detector-instrumental (result=1,
+// done, dv set), and writes a BARE marker .txt at its output location.
+func seedDetectorMarker(t *testing.T, ctx context.Context, dbPath, outdir, detectorVersion string) {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	q := queue.NewDBQueue(sqlDB)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:       models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:      outdir,
+		Filename:    "song.lrc",
+		SourcePath:  filepath.Join(outdir, "song.flac"),
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.lrc"}},
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result=1, status='done', outcome_type='instrumental', detector_version=? WHERE id=?`,
+		detectorVersion, item.ID); err != nil {
+		t.Fatalf("mark detector-instrumental: %v", err)
+	}
+	// Bare marker on disk (old writeInstrumental format).
+	if err := os.WriteFile(filepath.Join(outdir, "song.txt"), []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
+		t.Fatalf("write bare marker: %v", err)
+	}
+}
+
+func TestRunReconcileMarkerProvenance_DryRunThenApply(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarker(t, ctx, dbPath, outdir, "1.5.0")
+	markerPath := filepath.Join(outdir, "song.txt")
+
+	// Dry run: previews, changes nothing.
+	var dry bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &dry, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("dry-run exit=%d out=%s", code, dry.String())
+	}
+	if !strings.Contains(dry.String(), "would stamp 1") {
+		t.Errorf("dry-run summary missing 'would stamp 1':\n%s", dry.String())
+	}
+	prov, _, _ := lyrics.ReadInstrumentalProvenance(markerPath)
+	if prov.Source != "" {
+		t.Fatalf("dry-run must not modify the marker; got source %q", prov.Source)
+	}
+
+	// Apply.
+	var apply bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &apply, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("apply exit=%d out=%s", code, apply.String())
+	}
+	if !strings.Contains(apply.String(), "stamped 1") {
+		t.Errorf("apply summary missing 'stamped 1':\n%s", apply.String())
+	}
+	prov, isMarker, err := lyrics.ReadInstrumentalProvenance(markerPath)
+	if err != nil || !isMarker {
+		t.Fatalf("re-read after apply: isMarker=%v err=%v", isMarker, err)
+	}
+	if prov.Source != lyrics.SourceDetector || prov.DetectorVersion != "1.5.0" {
+		t.Fatalf("marker not stamped: %+v", prov)
+	}
+
+	// Idempotent: a second apply stamps nothing.
+	var again bytes.Buffer
+	if code := runReconcileMarkerProvenance(ctx, &again, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("second apply exit=%d", code)
+	}
+	if !strings.Contains(again.String(), "stamped 0") {
+		t.Errorf("second apply should stamp 0 (already headed):\n%s", again.String())
+	}
+}

--- a/internal/commands/reconcile_marker_provenance_test.go
+++ b/internal/commands/reconcile_marker_provenance_test.go
@@ -305,6 +305,69 @@ func TestRunReconcileMarkerProvenance_BackupFileContainsStampedPath(t *testing.T
 	}
 }
 
+// TestRunReconcileMarkerProvenance_UnreadableMarkerErrorsNonZero verifies a
+// marker path that exists but cannot be read (here a directory occupying the
+// .txt slot, which Lstat sees as a non-symlink but ReadInstrumentalProvenance
+// fails to scan) is counted as errored and forces a non-zero exit -- a real
+// read failure must not be silently swallowed behind exit 0.
+func TestRunReconcileMarkerProvenance_UnreadableMarkerErrorsNonZero(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+	seedDetectorMarkerRow(t, ctx, dbPath, outdir, "unreadable", "1.5.0", false)
+
+	// A directory in the marker's .txt slot: Lstat succeeds (not a symlink) but
+	// reading it as an LRC file fails (EISDIR on scan).
+	if err := os.MkdirAll(filepath.Join(outdir, "unreadable.txt"), 0o755); err != nil {
+		t.Fatalf("mkdir marker slot: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath})
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 for an unreadable marker: %s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "errored 1") {
+		t.Errorf("summary must report 'errored 1' for an unreadable marker:\n%s", out.String())
+	}
+}
+
+// TestRunReconcileMarkerProvenance_LstatErrorErrorsNonZero verifies a marker
+// path whose Lstat fails for a reason other than "absent" (here ENOTDIR: a
+// regular file sits where the marker's parent directory is expected) is counted
+// as errored and forces a non-zero exit -- only os.ErrNotExist is the benign
+// skip case.
+func TestRunReconcileMarkerProvenance_LstatErrorErrorsNonZero(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeMarkerProvCfg(t, cfgPath, dbPath)
+
+	// A regular file standing in for the marker's parent directory: Lstat of
+	// blocker/song.txt fails with ENOTDIR (not ErrNotExist, not a symlink).
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	seedDetectorMarkerRow(t, ctx, dbPath, blocker, "song", "1.5.0", false)
+
+	var out bytes.Buffer
+	code := runReconcileMarkerProvenance(ctx, &out, ScanReconcileMarkerProvenanceCmd{ConfigPath: cfgPath})
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 for a non-absent lstat failure: %s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "errored 1") {
+		t.Errorf("summary must report 'errored 1' for an lstat failure:\n%s", out.String())
+	}
+}
+
 // TestRunScanCmd_DispatchesReconcileMarkerProvenance verifies the scan
 // subcommand switch routes to runReconcileMarkerProvenance, both with an
 // explicit sub-config and with the parent --config inherited (mirrors

--- a/internal/lyrics/instrumental_provenance.go
+++ b/internal/lyrics/instrumental_provenance.go
@@ -1,6 +1,11 @@
 package lyrics
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // SourceDetector is the [source:] token stamped into an instrumental marker that
 // the audio detector wrote. Any other source token (a provider lane name) marks
@@ -52,4 +57,73 @@ func ReadInstrumentalProvenance(path string) (prov InstrumentalProvenance, isMar
 		return InstrumentalProvenance{}, false, nil
 	}
 	return prov, true, nil
+}
+
+// WriteMarkerProvenance stamps a provenance header onto a bare instrumental
+// marker .txt so a detector-written marker becomes distinguishable on disk (and
+// re-checkable by the scanner). It prepends [by:canticle], [source:<prov.Source>],
+// and (when set) [dv:<prov.DetectorVersion>] ahead of the existing content,
+// preserving the marker line. It is a no-op (changed=false) when the file is not
+// a marker, already carries a [source:] header (idempotent), or is a symlink.
+// The rewrite is atomic (temp file + rename + parent-dir fsync) and preserves the
+// original file mode.
+func WriteMarkerProvenance(path string, prov InstrumentalProvenance) (changed bool, err error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return false, fmt.Errorf("lstat %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+	existing, isMarker, err := ReadInstrumentalProvenance(path)
+	if err != nil {
+		return false, err
+	}
+	if !isMarker || existing.Source != "" {
+		return false, nil
+	}
+
+	raw, err := os.ReadFile(path) //nolint:gosec // path is a caller-controlled marker file
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var hdr strings.Builder
+	hdr.WriteString("[by:canticle]\n")
+	fmt.Fprintf(&hdr, "[source:%s]\n", prov.Source)
+	if prov.DetectorVersion != "" {
+		fmt.Fprintf(&hdr, "[dv:%s]\n", prov.DetectorVersion)
+	}
+	newContent := append([]byte(hdr.String()), raw...)
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp") //nolint:gosec // dir is the marker's own directory
+	if err != nil {
+		return false, fmt.Errorf("create temp for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, werr := tmp.Write(newContent); werr != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("write %s: %w", tmpPath, werr)
+	}
+	if serr := tmp.Sync(); serr != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("sync %s: %w", tmpPath, serr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return false, fmt.Errorf("close %s: %w", tmpPath, cerr)
+	}
+	if cherr := os.Chmod(tmpPath, fi.Mode().Perm()); cherr != nil { //nolint:gosec // mode copied from the original file
+		return false, fmt.Errorf("chmod %s: %w", tmpPath, cherr)
+	}
+	if rerr := os.Rename(tmpPath, path); rerr != nil {
+		return false, fmt.Errorf("rename %s -> %s: %w", tmpPath, path, rerr)
+	}
+	fsyncDir(dir)
+	return true, nil
 }

--- a/internal/lyrics/instrumental_provenance.go
+++ b/internal/lyrics/instrumental_provenance.go
@@ -77,7 +77,7 @@ func WriteMarkerProvenance(path string, prov InstrumentalProvenance) (changed bo
 	}
 	existing, isMarker, err := ReadInstrumentalProvenance(path)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("read marker provenance %s: %w", path, err)
 	}
 	if !isMarker || existing.Source != "" {
 		return false, nil

--- a/internal/lyrics/instrumental_provenance_test.go
+++ b/internal/lyrics/instrumental_provenance_test.go
@@ -3,6 +3,7 @@ package lyrics
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -48,4 +49,90 @@ func TestReadInstrumentalProvenance(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteMarkerProvenance(t *testing.T) {
+	t.Run("bare_marker_gets_detector_header", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "track.txt")
+		if err := os.WriteFile(p, []byte(InstrumentalMarker+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		changed, err := WriteMarkerProvenance(p, InstrumentalProvenance{Source: SourceDetector, DetectorVersion: "1.2.3"})
+		if err != nil || !changed {
+			t.Fatalf("changed=%v err=%v; want changed=true nil", changed, err)
+		}
+		prov, isMarker, err := ReadInstrumentalProvenance(p)
+		if err != nil || !isMarker {
+			t.Fatalf("re-read: isMarker=%v err=%v", isMarker, err)
+		}
+		if prov.Source != SourceDetector || prov.DetectorVersion != "1.2.3" {
+			t.Fatalf("provenance = %+v; want detector/1.2.3", prov)
+		}
+		data, _ := os.ReadFile(p)
+		if !strings.Contains(string(data), InstrumentalMarker) {
+			t.Fatalf("marker line lost:\n%s", data)
+		}
+	})
+
+	t.Run("empty_dv_omits_dv_tag", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "track.txt")
+		_ = os.WriteFile(p, []byte(InstrumentalMarker+"\n"), 0o644)
+		changed, err := WriteMarkerProvenance(p, InstrumentalProvenance{Source: SourceDetector})
+		if err != nil || !changed {
+			t.Fatalf("changed=%v err=%v", changed, err)
+		}
+		data, _ := os.ReadFile(p)
+		if strings.Contains(string(data), "[dv:") {
+			t.Fatalf("empty dv must not emit [dv:]:\n%s", data)
+		}
+		if !strings.Contains(string(data), "[source:canticle-detector]") {
+			t.Fatalf("missing source header:\n%s", data)
+		}
+	})
+
+	t.Run("already_headed_is_noop", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "track.txt")
+		orig := "[by:canticle]\n[source:canticle-detector]\n[dv:9.9.9]\n" + InstrumentalMarker + "\n"
+		_ = os.WriteFile(p, []byte(orig), 0o644)
+		changed, err := WriteMarkerProvenance(p, InstrumentalProvenance{Source: SourceDetector, DetectorVersion: "1.2.3"})
+		if err != nil || changed {
+			t.Fatalf("changed=%v err=%v; want changed=false (idempotent)", changed, err)
+		}
+		data, _ := os.ReadFile(p)
+		if string(data) != orig {
+			t.Fatalf("already-headed file must be untouched:\n%s", data)
+		}
+	})
+
+	t.Run("not_a_marker_is_noop", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "lyrics.txt")
+		orig := "just some unsynced lyrics\n"
+		_ = os.WriteFile(p, []byte(orig), 0o644)
+		changed, err := WriteMarkerProvenance(p, InstrumentalProvenance{Source: SourceDetector})
+		if err != nil || changed {
+			t.Fatalf("changed=%v err=%v; want changed=false (not a marker)", changed, err)
+		}
+		data, _ := os.ReadFile(p)
+		if string(data) != orig {
+			t.Fatalf("non-marker must be untouched:\n%s", data)
+		}
+	})
+
+	t.Run("symlink_is_skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		real := filepath.Join(dir, "real.txt")
+		_ = os.WriteFile(real, []byte(InstrumentalMarker+"\n"), 0o644)
+		link := filepath.Join(dir, "link.txt")
+		if err := os.Symlink(real, link); err != nil {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+		changed, err := WriteMarkerProvenance(link, InstrumentalProvenance{Source: SourceDetector})
+		if err != nil || changed {
+			t.Fatalf("changed=%v err=%v; want changed=false (symlink skipped)", changed, err)
+		}
+	})
 }

--- a/internal/lyrics/instrumental_provenance_test.go
+++ b/internal/lyrics/instrumental_provenance_test.go
@@ -32,6 +32,7 @@ func TestReadInstrumentalProvenance(t *testing.T) {
 		{"provider", "[by:canticle]\n[source:musixmatch]\n" + InstrumentalMarker + "\n", true, "musixmatch", ""},
 		{"legacy-bare", InstrumentalMarker + "\n", true, "", ""},
 		{"not-a-marker", "[00:01.00]la la\n", false, "", ""},
+		{"marker-text-inside-a-header-tag", "[note:" + InstrumentalMarker + "]\n", true, "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -119,6 +120,23 @@ func TestWriteMarkerProvenance(t *testing.T) {
 		data, _ := os.ReadFile(p)
 		if string(data) != orig {
 			t.Fatalf("non-marker must be untouched:\n%s", data)
+		}
+	})
+
+	t.Run("read_error_is_propagated", func(t *testing.T) {
+		// A directory Lstats successfully (not a symlink), but reading it as a
+		// marker file fails cleanly at the header-parse step.
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "not-a-file")
+		if err := os.Mkdir(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		changed, err := WriteMarkerProvenance(sub, InstrumentalProvenance{Source: SourceDetector})
+		if err == nil {
+			t.Fatal("expected an error reading a directory as a marker file")
+		}
+		if changed {
+			t.Fatalf("changed=%v; want false on a read error", changed)
 		}
 	})
 

--- a/internal/lyrics/instrumental_provenance_test.go
+++ b/internal/lyrics/instrumental_provenance_test.go
@@ -140,6 +140,20 @@ func TestWriteMarkerProvenance(t *testing.T) {
 		}
 	})
 
+	t.Run("nonexistent_path_returns_lstat_error", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "missing", "track.txt")
+		changed, err := WriteMarkerProvenance(p, InstrumentalProvenance{Source: SourceDetector})
+		if err == nil {
+			t.Fatal("expected an lstat error for a nonexistent path")
+		}
+		if changed {
+			t.Fatalf("changed=%v; want false on a nonexistent path", changed)
+		}
+		if !strings.Contains(err.Error(), "lstat") {
+			t.Fatalf("error = %q; want it to reference lstat", err.Error())
+		}
+	})
+
 	t.Run("symlink_is_skipped", func(t *testing.T) {
 		dir := t.TempDir()
 		real := filepath.Join(dir, "real.txt")

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1692,6 +1692,70 @@ func (q *DBQueue) ListVocalGateRejections(ctx context.Context, opts ListVocalGat
 	return out, nil
 }
 
+// ListInstrumentalMarkersOptions narrows ListDetectorInstrumentalMarkers.
+type ListInstrumentalMarkersOptions struct {
+	LibraryID *int64
+	Limit     int
+}
+
+// InstrumentalMarkerRow is one detector-written instrumental row with the fields
+// needed to locate its on-disk .txt marker and its stored detector version.
+type InstrumentalMarkerRow struct {
+	ID              int64
+	Inputs          models.Inputs
+	DetectorVersion string
+}
+
+// ListDetectorInstrumentalMarkers returns the detector-written instrumental rows
+// (instrumental_result = 1, status = 'done'), each with its resolved output paths
+// and stored detector_version, so the marker-provenance backfill (#502) can stamp
+// [source:canticle-detector]/[dv:] onto the ones still lacking a header. Provider-
+// written instrumentals (outcome_type='instrumental' with instrumental_result
+// NULL) are excluded: a bare provider marker is already authoritative to the
+// scanner and the DB does not record which provider wrote it.
+//
+// Read-only.
+func (q *DBQueue) ListDetectorInstrumentalMarkers(ctx context.Context, opts ListInstrumentalMarkersOptions) (out []InstrumentalMarkerRow, retErr error) {
+	query := `SELECT id, artist, title, outdir, filename, source_path, output_paths, COALESCE(detector_version,'')
+	          FROM work_queue
+	          WHERE instrumental_result = 1 AND status = 'done'`
+	var args []any
+	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
+	query += libClause //nolint:gosec // G202: recheckLibraryClause returns a fixed parameterized clause, not user-built SQL
+	args = append(args, libArgs...)
+	query += ` ORDER BY id`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: fragments are package constants / recheckLibraryClause's fixed clause
+	if err != nil {
+		return nil, fmt.Errorf("queue: list detector instrumental markers: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close detector instrumental markers rows: %w", err)
+		}
+	}()
+	for rows.Next() {
+		var r InstrumentalMarkerRow
+		var outputPaths string
+		if err := rows.Scan(&r.ID, &r.Inputs.Track.ArtistName, &r.Inputs.Track.TrackName,
+			&r.Inputs.Outdir, &r.Inputs.Filename, &r.Inputs.SourcePath, &outputPaths, &r.DetectorVersion); err != nil {
+			return nil, fmt.Errorf("queue: scan detector instrumental marker: %w", err)
+		}
+		r.Inputs.OutputPaths, err = unmarshalOutputPaths(outputPaths, r.Inputs.Outdir, r.Inputs.Filename)
+		if err != nil {
+			return nil, fmt.Errorf("queue: unmarshal output paths for row %d: %w", r.ID, err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list detector instrumental markers rows: %w", err)
+	}
+	return out, nil
+}
+
 // CountInstrumentalNarrowed returns how many instrumental_result = 1 rows the
 // telemetry-narrowed prefilter would select (the same predicate ListInstrumental
 // applies when opts.All is false), so reconcile can report prefiltered-vs-total

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -410,3 +410,24 @@ func TestListDetectorInstrumentalMarkers_MalformedOutputPathsErrors(t *testing.T
 		t.Fatal("expected an error for malformed output_paths JSON, got nil")
 	}
 }
+
+// TestListDetectorInstrumentalMarkers_ClosedDBErrors verifies the query error
+// path is wrapped cleanly (not panicked) when the underlying connection is
+// already closed, a real failure mode distinct from the malformed-JSON scan
+// error covered above.
+func TestListDetectorInstrumentalMarkers_ClosedDBErrors(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	markDetectorInstrumental(t, q, id, "1.0.0")
+
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if _, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{}); err == nil {
+		t.Fatal("expected an error querying a closed database, got nil")
+	}
+}

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -302,3 +302,111 @@ func TestListDetectorInstrumentalMarkers(t *testing.T) {
 		t.Errorf("OutputPaths = %+v, want one {out, a.lrc}", r.Inputs.OutputPaths)
 	}
 }
+
+// markDetectorInstrumental flips an existing work_queue row into the
+// detector-instrumental shape ListDetectorInstrumentalMarkers selects on
+// (instrumental_result=1, status='done').
+func markDetectorInstrumental(t *testing.T, q *DBQueue, id int64, detectorVersion string) {
+	t.Helper()
+	if _, err := q.db.ExecContext(context.Background(),
+		`UPDATE work_queue SET instrumental_result=1, status='done', outcome_type='instrumental', detector_version=? WHERE id=?`,
+		detectorVersion, id); err != nil {
+		t.Fatalf("mark detector-instrumental: %v", err)
+	}
+}
+
+// TestListDetectorInstrumentalMarkers_ScopesToLibrary verifies the --library
+// narrowing filters the candidate set, mirroring
+// TestListVocalGateRejections_ScopesToLibrary.
+func TestListDetectorInstrumentalMarkers_ScopesToLibrary(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	libA, srA := insertLibraryAndScanResult(t, sqlDB, "/libA", "/libA/a.mp3")
+	_, srB := insertLibraryAndScanResult(t, sqlDB, "/libB", "/libB/b.mp3")
+
+	mk := func(title, src string, scanResultID int64) int64 {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:        models.Track{ArtistName: "Artist", TrackName: title},
+			Outdir:       "out",
+			Filename:     title + ".lrc",
+			SourcePath:   src,
+			ScanResultID: scanResultID,
+		}, PriorityScan)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", title, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %s: %v", title, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, 0, nil); err != nil {
+			t.Fatalf("defer %s: %v", title, err)
+		}
+		markDetectorInstrumental(t, q, item.ID, "1.5.0")
+		return item.ID
+	}
+	inA := mk("in-lib-a", "/libA/a.mp3", srA)
+	_ = mk("in-lib-b", "/libB/b.mp3", srB)
+
+	got, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{LibraryID: &libA})
+	if err != nil {
+		t.Fatalf("ListDetectorInstrumentalMarkers: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != inA {
+		var ids []int64
+		for _, r := range got {
+			ids = append(ids, r.ID)
+		}
+		t.Fatalf("scoped list = %v; want only the libA row %d", ids, inA)
+	}
+}
+
+// TestListDetectorInstrumentalMarkers_Limit verifies the Limit option caps
+// the result set, and that LibraryID=nil returns all rows when unset.
+func TestListDetectorInstrumentalMarkers_Limit(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	for i := 0; i < 2; i++ {
+		id := seedDeferredRow(t, q, "Artist", fmt.Sprintf("Title%d", i), fmt.Sprintf("/music/%d.flac", i))
+		markDetectorInstrumental(t, q, id, "1.0.0")
+	}
+
+	all, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{})
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("len(all) = %d; want 2 (nil LibraryID must not filter)", len(all))
+	}
+
+	limited, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("list limited: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("len(limited) = %d; want 1 (Limit must cap the result set)", len(limited))
+	}
+}
+
+// TestListDetectorInstrumentalMarkers_MalformedOutputPathsErrors verifies a
+// row whose stored output_paths column holds malformed JSON (a real form of
+// data corruption, not a fault-injected I/O failure) surfaces a clean error
+// rather than a panic or a silently wrong row.
+func TestListDetectorInstrumentalMarkers_MalformedOutputPathsErrors(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openQueueTestDB(t)
+	q := NewDBQueue(sqlDB)
+
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+	markDetectorInstrumental(t, q, id, "1.0.0")
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET output_paths='not-json' WHERE id=?`, id); err != nil {
+		t.Fatalf("corrupt output_paths: %v", err)
+	}
+
+	if _, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{}); err == nil {
+		t.Fatal("expected an error for malformed output_paths JSON, got nil")
+	}
+}

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -257,3 +257,48 @@ func TestListVocalGateRejections_Limit(t *testing.T) {
 		t.Fatalf("len(got) = %d; want 2 (Limit must cap the result set)", len(got))
 	}
 }
+
+func TestListDetectorInstrumentalMarkers(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+
+	// Detector-written instrumental: instrumental_result=1, status=done, dv set.
+	detID := seedDeferredRow(t, q, "Det Artist", "Det Title", "/music/det.flac")
+	if _, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result=1, status='done', outcome_type='instrumental', detector_version='1.5.0' WHERE id=?`, detID); err != nil {
+		t.Fatalf("seed detector row: %v", err)
+	}
+	// Provider-written instrumental: outcome_type='instrumental', instrumental_result NULL. Must be EXCLUDED.
+	provID := seedDeferredRow(t, q, "Prov Artist", "Prov Title", "/music/prov.flac")
+	if _, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET outcome_type='instrumental', status='done' WHERE id=?`, provID); err != nil {
+		t.Fatalf("seed provider row: %v", err)
+	}
+	// Never-detected row: instrumental_result NULL, still deferred. Must be EXCLUDED.
+	_ = seedDeferredRow(t, q, "Never", "Scored", "/music/never.flac")
+
+	got, err := q.ListDetectorInstrumentalMarkers(ctx, ListInstrumentalMarkersOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly the detector row, got %d: %+v", len(got), got)
+	}
+	r := got[0]
+	if r.ID != detID {
+		t.Errorf("ID = %d, want %d", r.ID, detID)
+	}
+	if r.DetectorVersion != "1.5.0" {
+		t.Errorf("DetectorVersion = %q, want 1.5.0", r.DetectorVersion)
+	}
+	if r.Inputs.Track.ArtistName != "Det Artist" || r.Inputs.Track.TrackName != "Det Title" {
+		t.Errorf("track = %q/%q, want Det Artist/Det Title", r.Inputs.Track.ArtistName, r.Inputs.Track.TrackName)
+	}
+	if r.Inputs.Outdir != "out" || r.Inputs.Filename != "a.lrc" {
+		t.Errorf("outdir/filename = %q/%q, want out/a.lrc", r.Inputs.Outdir, r.Inputs.Filename)
+	}
+	// OutputPaths hydrates from the empty output_paths column via the (outdir, filename) fallback.
+	if len(r.Inputs.OutputPaths) != 1 || r.Inputs.OutputPaths[0].Outdir != "out" || r.Inputs.OutputPaths[0].Filename != "a.lrc" {
+		t.Errorf("OutputPaths = %+v, want one {out, a.lrc}", r.Inputs.OutputPaths)
+	}
+}


### PR DESCRIPTION
## Summary
- Third and final slice of #502: a one-shot `scan reconcile-marker-provenance` CLI that backfills provenance headers onto existing bare instrumental markers so the Unit B scanner treats detector-written ones as provisional/re-checkable. Dry-run by default; `--yes` applies and writes a JSONL backup.
- Scope decision (more correct than the original outline): it backfills **only detector-written markers** (`instrumental_result = 1`). A bare provider/legacy marker is already correctly authoritative to the scanner, and the DB does not persist which provider wrote a provider marker (the winning lane is transient) - so stamping providers would be a behavioral no-op and could only fabricate a source token we do not have.
- Three pieces: `lyrics.WriteMarkerProvenance` (atomically prepend `[by:canticle]`/`[source:canticle-detector]`/`[dv:]` to a bare marker; idempotent; symlink/non-marker no-op), `queue.ListDetectorInstrumentalMarkers` (the `instrumental_result=1` population with hydrated output paths + `detector_version`), and the command wiring it together (registered as a `scan` subcommand).

## Linked issue
Part of #502

## Base
Rebased onto `main` after Unit A (#517) and Unit B (#518) merged - this now targets `main` directly and contains only the Unit C delta.

## Size note
~1050 LoC, of which only **~297 is production code** (the primitive, the query, the command). The rest is tests, most of it clearing the 70% patch-coverage gate on the command's skip/absent/limit/error branches. Patch coverage (measured against post-B main): 71.65%.

## Gates (run locally; CI enforces)
- [x] gofmt, go build
- [x] go test -race (full suite green)
- [x] patch coverage 71.65% (> 70% threshold)
- [x] coverage floor (all packages at or above)
- [x] golangci-lint (0 issues)
- [x] actionlint
- [x] govulncheck (0 vulnerabilities)

## Test plan
- [x] TDD per task: WriteMarkerProvenance (no-op/idempotency/preservation + lstat/read error paths), ListDetectorInstrumentalMarkers (detector-vs-provider-vs-never discriminator + library scope + limit + malformed-output_paths error), command (dry-run/apply/idempotent + absent/mixed-batch/empty-dv/limit/backup/symlink/error paths)
- [x] Whole-branch adversarial review (verdict: ship; no Critical/Important; detector-only scope validated as sound)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `scan reconcile-marker-provenance` to identify detector-created instrumental markers missing provenance headers.
  - Supports dry-run previews, optional application, library filtering, scan limits, and configurable JSONL backups.
  - Safely skips non-marker, already-provenanced, missing, and symlinked files.
  - Added automatic provenance headers with detector source and optional version details.

- **Bug Fixes**
  - Improved marker provenance detection for markers embedded in surrounding tags.

- **Tests**
  - Added comprehensive coverage for dry runs, backups, filtering, limits, failures, and idempotent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->