### PR TITLE
chore(release): point GoReleaser at the sydlexius owner after the repo transfer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,8 +60,8 @@ homebrew_casks:
     # Renamed from the pre-rebrand "mxlrcgo-svc" cask (issue #388). Unlike the
     # nfpm packages, a cask cannot self-replace the old token; conflicts_with
     # just prevents both being installed at once. Auto-migration of an existing
-    # `brew install doxazo-net/tap/mxlrcgo-svc` needs a cask_renames entry in the
-    # doxazo-net/homebrew-tap repo (tracked separately) plus removal of the stale
+    # `brew install sydlexius/tap/mxlrcgo-svc` needs a cask_renames entry in the
+    # sydlexius/homebrew-tap repo (tracked separately) plus removal of the stale
     # Casks/mxlrcgo-svc.rb there.
     conflicts:
       - cask: mxlrcgo-svc
@@ -70,12 +70,12 @@ homebrew_casks:
     binaries:
       - canticle
     repository:
-      owner: doxazo-net
+      owner: sydlexius
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
-    homepage: https://doxazo-net.github.io/canticle/
+    homepage: https://sydlexius.github.io/canticle/
     description: Fetch synced lyrics from Musixmatch and save them as .lrc files
     caveats: |
       Set your Musixmatch token via MUSIXMATCH_TOKEN or in the config file:
@@ -113,8 +113,8 @@ nfpms:
       - mxlrcgo-svc
     provides:
       - mxlrcgo-svc
-    vendor: doxazo-net
-    homepage: https://doxazo-net.github.io/canticle/
+    vendor: sydlexius
+    homepage: https://sydlexius.github.io/canticle/
     maintainer: sydlexius <maintainer@placeholder.example>
     description: Fetch synced lyrics from Musixmatch and save them as .lrc files
     license: GPL-3.0
@@ -168,7 +168,7 @@ nfpms:
 dockers_v2:
   - id: canticle
     images:
-      - "ghcr.io/doxazo-net/canticle"
+      - "ghcr.io/sydlexius/canticle"
     # dockers_v2 ignores empty tag templates, so prerelease gating is encoded
     # by emitting "" for the disallowed branch:
     #   :VERSION       always
@@ -244,15 +244,17 @@ changelog:
 
 release:
   github:
-    owner: doxazo-net
+    owner: sydlexius
     name: canticle
   # Create the GitHub release as a DRAFT so every asset uploads to a mutable
-  # release, then flip it to published in a follow-up step (release.yml). The
-  # doxazo-net org has GitHub "immutable releases" enabled, which locks a
-  # PUBLISHED release immediately -- so the default publish-first flow 422s on
-  # asset upload ("Cannot upload assets to an immutable release"), leaving CI red
-  # even though the assets land. Uploading to a draft and publishing last applies
-  # immutability only after all assets are attached, so the run goes green.
+  # release, then flip it to published in a follow-up step (release.yml). This
+  # was originally required because the former doxazo-net org had GitHub
+  # "immutable releases" enabled, which locks a PUBLISHED release immediately --
+  # the default publish-first flow then 422s on asset upload ("Cannot upload
+  # assets to an immutable release"), leaving CI red even though the assets land.
+  # Whether that setting is in effect on the sydlexius account is unverified, so
+  # the draft-first flow is kept: it is correct either way (immutability, when
+  # present, applies only after all assets are attached) and costs nothing.
   draft: true
   # Remove a leftover draft from a failed prior run so a re-run starts clean.
   replace_existing_draft: true
@@ -265,10 +267,10 @@ release:
 
     {{ if .Prerelease }}> This is a pre-release version. Use the `beta` Docker tag to try it out.{{ end }}
   footer: |
-    **Docker:** `docker pull ghcr.io/doxazo-net/canticle:{{ .Version }}`
+    **Docker:** `docker pull ghcr.io/sydlexius/canticle:{{ .Version }}`
 
     {{- if .PreviousTag }}
-    **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/doxazo-net/canticle/compare/{{ .PreviousTag }}...{{ .Tag }})
+    **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/sydlexius/canticle/compare/{{ .PreviousTag }}...{{ .Tag }})
     {{- else }}
-    **Full Changelog:** [{{ .Tag }}](https://github.com/doxazo-net/canticle/releases/tag/{{ .Tag }})
+    **Full Changelog:** [{{ .Tag }}](https://github.com/sydlexius/canticle/releases/tag/{{ .Tag }})
     {{- end }}


### PR DESCRIPTION
Unblocks cutting a release after the repo moved from the `doxazo-net` org to the `sydlexius` account. GoReleaser still targeted the old owner, so the next release would publish to the wrong namespace.

Updated: the GHCR image, the GitHub release owner, the Homebrew tap repo owner, the Pages homepage, the nfpm vendor/maintainer, and the Docker + changelog URLs in the release notes.

## Deliberately NOT changed

The three `-X` ldflags still read `github.com/doxazo-net/canticle/internal/version`. Those are the Go **module path** from `go.mod`, not the repo owner. Rewriting them would point at a package path that does not exist, and Go **silently ignores** an `-X` flag whose symbol does not resolve, so version stamping would break with no error and no failing build. Renaming the module is a separate change touching 176 files and is not done here; GitHub's redirect keeps the current path working.

## Also

The draft-first release comment is reworded. Immutable releases were an org-level setting; whether it applies to a personal account is unverified. The draft-first flow is kept regardless, since it is correct either way and costs nothing.

Verified with `goreleaser check` (1 configuration file validated).

Note: publishing under the new namespace means the deployed container still pulling `ghcr.io/doxazo-net/canticle:latest` will need re-pointing once a release lands.