### PR TITLE
fix(web): point the setup page's token-help link at the sydlexius docs site

### DIFF
--- a/internal/web/setup_test.go
+++ b/internal/web/setup_test.go
@@ -122,7 +122,7 @@ func TestSetupRendersTokenHelpLink(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		"https://doxazo-net.github.io/canticle/GETTING_STARTED/#get-a-musixmatch-token",
+		"https://sydlexius.github.io/canticle/GETTING_STARTED/#get-a-musixmatch-token",
 		`target="_blank"`,
 		`rel="noopener noreferrer"`,
 		"How do I get a token?",

--- a/web/templates/setup.templ
+++ b/web/templates/setup.templ
@@ -94,7 +94,7 @@ templ SetupPage(version string, errMsg string, username string, csrfToken string
 							autocomplete="off"
 						/>
 						<span class="mx-auth-hint">
-							<a class="mx-auth-link" href="https://doxazo-net.github.io/canticle/GETTING_STARTED/#get-a-musixmatch-token" target="_blank" rel="noopener noreferrer">How do I get a token?</a>
+							<a class="mx-auth-link" href="https://sydlexius.github.io/canticle/GETTING_STARTED/#get-a-musixmatch-token" target="_blank" rel="noopener noreferrer">How do I get a token?</a>
 						</span>
 					</div>
 					<div class="mx-auth-field">


### PR DESCRIPTION
The "How do I get a token?" link on the first-run setup page still pointed at `https://doxazo-net.github.io/canticle/`, which **404s** after the org transfer. The sydlexius site returns 200.

Verified by request rather than inspection:

```
doxazo-net.github.io -> 404
sydlexius.github.io  -> 200
```

Missed by #529, which migrated repo URLs and container image refs. The reason it was missed is worth noting: `TestSetupRendersTokenHelpLink` was asserting the old URL, so the stale value looked intentional and kept CI green. Fixing only the source turned the gate red, which is how it surfaced. Both source and test are updated here.

Found post-merge on #524, one commit before it would have shipped in v1.19.0.

Remaining `doxazo-net` hits in the tree are historical `.planning/` records and a `.goreleaser.yml` comment describing the former org. Those are correct as history and deliberately left alone.

`make gate` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)