### PR TITLE
feat(deploy): cap the yamnet sidecar's CPU and memory

### DIFF
--- a/deploy/yamnet-detector/README.md
+++ b/deploy/yamnet-detector/README.md
@@ -35,6 +35,21 @@ with `tf.saved_model.load` -- `tensorflow-hub` is deliberately not a dependency
 docker build -t canticle-yamnet:local .
 ```
 
+### Resource limits (cap this container)
+
+TensorFlow parallelizes a forward pass across every core it can see, so an
+uncapped sidecar will consume the whole host during a library scan and starve
+everything else running on it. `docker-compose.example.yml` therefore ships a
+`deploy.resources.limits` block with a conservative `cpus: "4"` and `memory: 4G`
+(the SavedModel plus the TF runtime sit around 1.5GB resident).
+
+Treat 4 as a floor for good-neighbor behavior, not a performance target.
+Inference is the dominant cost in the detector path, so this limit trades
+detector throughput for isolation: raise it on a host with cores to spare, lower
+it on a busy one. Nothing breaks either way -- a slower sidecar just means a
+longer per-track detection, and Canticle's own detector cooldown and circuit
+breaker already bound how hard it is driven.
+
 The deployed copy lives on the Unraid host at
 `/mnt/vms/dockerappdata/yamnet-detector/`; Canticle reaches it at
 `http://yamnet:8080` on the shared compose network.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,6 +18,10 @@ services:
       # Supply MXLRC_WEBAUTH_ADMIN_PASSWORD from an uncommitted .env file -- never hardcode it here.
       # MXLRC_WEBAUTH_ADMIN_USER: "admin"
       # MXLRC_WEBAUTH_ADMIN_PASSWORD: "${MXLRC_WEBAUTH_ADMIN_PASSWORD}"
+      # Optional: enable the instrumental-detection sidecar defined below. Both
+      # are needed -- the detector stays off unless explicitly enabled.
+      # MXLRC_INSTRUMENTAL_DETECTOR_ENABLED: "true"
+      # MXLRC_INSTRUMENTAL_DETECTOR_CLASSIFIER_URL: "http://yamnet:8080"
       PUID: "99"
       PGID: "100"
       MUSIXMATCH_TOKEN: "${MUSIXMATCH_TOKEN}"
@@ -34,6 +38,46 @@ services:
     volumes:
       - canticle-config:/config
       - /path/to/your/data:/data:rw
+
+  # Optional instrumental-detection sidecar. Canticle POSTs a 16 kHz mono WAV to
+  # http://yamnet:8080/classify and uses the AudioSet scores to decide whether to
+  # write an instrumental marker. Omit this service to run without detection --
+  # the detector is strictly opt-in and Canticle degrades cleanly without it.
+  #
+  # There is no published image yet (see issue #498), so this builds from the
+  # vendored source under deploy/yamnet-detector/.
+  yamnet:
+    build:
+      context: ./deploy/yamnet-detector
+    image: canticle-yamnet:local
+    container_name: canticle-yamnet
+    restart: unless-stopped
+    # No published port: Canticle reaches it by service name on the shared
+    # compose network. Do not expose it -- the endpoint is unauthenticated.
+    expose:
+      - "8080"
+    deploy:
+      resources:
+        limits:
+          # TensorFlow parallelizes a forward pass across every core it can see,
+          # so an uncapped sidecar will happily consume the whole host during a
+          # scan and starve everything else on it. Cap it.
+          #
+          # 4 CPUs is a deliberately conservative default that keeps the sidecar
+          # a good neighbor on a modest host. Inference is the dominant cost in
+          # the detector path (measured at ~40-67s per track), so this limit
+          # trades detector throughput for isolation: raise it on a host with
+          # cores to spare, lower it on a busy one.
+          cpus: "4"
+          # The SavedModel plus the TF runtime sit around 1.5GB resident.
+          memory: 4G
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      # The model is loaded at startup, so the first probe must not race it.
+      start_period: 60s
 
 volumes:
   canticle-config:


### PR DESCRIPTION
## Summary

Caps the yamnet sidecar's CPU and memory, and adds the service to `docker-compose.example.yml` so there is somewhere for the limit to live.

## Why

The sidecar ran uncapped. TensorFlow parallelizes a forward pass across every core it can see, so during a library scan it will consume the whole host and starve everything else running on it. On a 40-core host that is a lot of collateral damage from an optional sidecar.

`docker-compose.example.yml` had no yamnet service at all - the sidecar's deployment lived only in prose in its README, so there was no shipped artifact that could carry a resource limit. This adds the service with:

- `deploy.resources.limits`: `cpus: "4"`, `memory: 4G` (the SavedModel plus the TF runtime sit around 1.5GB resident)
- a healthcheck whose `start_period` does not race model load at startup
- commented env wiring on the `canticle` service, so the sidecar is not orphaned in the example

## On the number

4 CPUs is a good-neighbor floor, not a performance target.

Inference is the dominant cost in the detector path, so this limit trades detector throughput for isolation. The README explains which way to move it and why nothing breaks either way: a slower sidecar just means a longer per-track detection, and Canticle's own detector cooldown and circuit breaker already bound how hard it is driven.

Measured on a live deployment for context: the detector adds roughly 40-67s per track against ~20s of total configured pacing, so the detector path is inference-cost-bound rather than pacing-bound. That is what makes the CPU limit a real throughput lever in both directions, and why it is documented rather than silently set.

## Verification

- `docker compose -f docker-compose.example.yml config -q` passes (warnings are unset secret vars, expected in an example)
- Parsed the file and confirmed the limit resolves: `services: ['canticle', 'yamnet']`, `yamnet cpus: 4`
- `make gate` - exit 0

The equivalent cap was applied to a live deployment at a host-appropriate 12 CPUs and verified: `NanoCpus=12000000000`, container healthy 20s after recreate. Note a plain `compose up` does not reliably recreate on a service-definition change - an explicit stop/rm/up was needed.

## Notes

The sidecar has no published image (#498), so this service builds from the vendored source under `deploy/yamnet-detector/`. No Go changes.
