### PR TITLE
fix(watcher): explain an inotify watch-quota failure instead of reporting ENOSPC

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -100,7 +100,11 @@ func (w *Watcher) Run(ctx context.Context) error {
 		// which also covers directories created after registration.
 		if err := notify.Watch(filepath.Join(lib.Path, "..."), c, notify.Create, notify.Write, notify.Rename, notify.Remove); err != nil {
 			notify.Stop(c)
-			return fmt.Errorf("watcher: watch %s: %w", lib.Path, err)
+			// An exhausted inotify quota arrives as ENOSPC ("no space left on
+			// device"), which sends the reader to disk usage instead of a sysctl.
+			// annotateWatchErr says what actually happened; other errors pass
+			// through unchanged.
+			return annotateWatchErr(fmt.Errorf("watcher: watch %s: %w", lib.Path, err), dirs)
 		}
 	}
 	defer notify.Stop(c)

--- a/internal/watcher/watcherr.go
+++ b/internal/watcher/watcherr.go
@@ -1,0 +1,45 @@
+package watcher
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// annotateWatchErr explains an inotify watch-quota failure in terms an operator
+// can act on, and passes every other error through untouched.
+//
+// The kernel reports an exhausted inotify watch quota as ENOSPC, which
+// stringifies as "no space left on device". On a media server with terabytes
+// free that reads as a disk problem, and the resulting investigation goes
+// looking at storage rather than at a sysctl. The raw error is technically
+// accurate and practically misleading, which is the worst combination.
+//
+// Two details the message carries deliberately:
+//
+//   - fs.inotify.max_user_watches is a per-UID kernel limit, NOT a per-process
+//     or per-container one. Every container running as the same uid draws from
+//     one pool, so this process can be refused a watch purely because a
+//     different one exhausted the quota first. A container CPU or memory limit
+//     cannot prevent it, which is a common wrong turn.
+//   - the watch count this process asked for, so the reader can immediately see
+//     whether this process is the greedy one or an innocent bystander.
+//
+// The original error is wrapped, not replaced, so errors.Is still matches.
+func annotateWatchErr(err error, dirs int) error {
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.ENOSPC) {
+		return err
+	}
+	return fmt.Errorf(
+		"%w -- inotify watch limit reached while registering %d directories. "+
+			"This is not a disk-space problem despite the errno. "+
+			"fs.inotify.max_user_watches is a per-UID kernel limit shared by every "+
+			"process running as this user, so another container may have consumed it; "+
+			"a container CPU/memory cap cannot prevent this. "+
+			"Raise fs.inotify.max_user_watches, narrow the configured library roots, "+
+			"or lower %s to keep this process within budget",
+		err, dirs, EnvMaxDirs)
+}

--- a/internal/watcher/watcherr_test.go
+++ b/internal/watcher/watcherr_test.go
@@ -1,0 +1,54 @@
+package watcher
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestAnnotateWatchErr_ENOSPCExplainsInotifyLimit is the point of this helper.
+// inotify reports an exhausted watch quota as ENOSPC, whose stringification is
+// "no space left on device" -- on a host with terabytes free. An operator who
+// reads that goes looking at disk usage, which is the wrong place entirely.
+func TestAnnotateWatchErr_ENOSPCExplainsInotifyLimit(t *testing.T) {
+	err := annotateWatchErr(fmt.Errorf("watch /music: %w", syscall.ENOSPC), 7457)
+	got := err.Error()
+
+	for _, want := range []string{
+		"fs.inotify.max_user_watches",
+		"not a disk-space problem",
+		"7457",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("annotated error missing %q:\n%s", want, got)
+		}
+	}
+	// The original error must stay matchable: callers and logs still need the
+	// underlying cause, and errors.Is must keep working through the wrap.
+	if !errors.Is(err, syscall.ENOSPC) {
+		t.Error("annotation broke errors.Is(err, syscall.ENOSPC)")
+	}
+}
+
+// TestAnnotateWatchErr_OtherErrorsPassThroughUnchanged keeps the annotation
+// narrow. Attaching an inotify explanation to a permission or path error would
+// send the reader somewhere just as wrong as the ENOSPC string does today.
+func TestAnnotateWatchErr_OtherErrorsPassThroughUnchanged(t *testing.T) {
+	orig := fmt.Errorf("watch /music: %w", syscall.EACCES)
+	err := annotateWatchErr(orig, 7457)
+
+	if err.Error() != orig.Error() {
+		t.Errorf("non-ENOSPC error was modified:\ngot  %s\nwant %s", err, orig)
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Error("annotation broke errors.Is for a non-ENOSPC error")
+	}
+}
+
+func TestAnnotateWatchErr_NilIsNil(t *testing.T) {
+	if err := annotateWatchErr(nil, 0); err != nil {
+		t.Errorf("annotateWatchErr(nil) = %v; want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces a technically-accurate but misleading error with one an operator can act on. Behavior is unchanged; this only changes what gets logged.

## The problem

The kernel reports an exhausted inotify watch quota as `ENOSPC`, which stringifies as **"no space left on device"**. On a media server with terabytes free, that reads as a disk problem, so the investigation goes looking at storage instead of at a sysctl.

Two things about this limit are easy to get wrong, and the raw errno tells you neither:

- **`fs.inotify.max_user_watches` is a per-UID kernel limit, not a per-process or per-container one.** Every container running as the same uid draws from a single pool, so this process can be refused a watch purely because a *different* one exhausted the quota first.
- **A container CPU or memory cap cannot prevent it.** That is a natural thing to reach for and it does nothing here, because watches are not a cgroup-accounted resource.

Measured on a real Unraid host for context: four containers sharing uid 99 held ~61,000 watches between them (two media tools at 18.3k and 16.3k, plus two at 7.5k each). Any one of them could be the process that gets the ENOSPC while another is the cause.

## What changed

`annotateWatchErr` wraps **only** the ENOSPC case and states what actually happened, including the directory count this process requested so the reader can tell at a glance whether it is the greedy one or a bystander.

Every other error passes through untouched. Attaching an inotify explanation to a permission or path failure would misdirect just as badly as the current message does. The original error is wrapped rather than replaced, so `errors.Is` still matches.

## What this does NOT change

The watcher already handles this failure correctly and that is untouched: `runWatcher` logs at error level and `serve` continues, with the periodic scheduler remaining the source of truth. There is also already a pre-flight guard (`countDirs` against `MaxDirs`, plus `dedupeRoots` so nested roots are not watched twice), so the process refuses to over-subscribe on its own account.

The gap this closes is diagnosability, not resilience.

## Test plan

- [x] `TestAnnotateWatchErr_ENOSPCExplainsInotifyLimit` - the annotation names the sysctl, denies the disk-space reading, includes the count, and preserves `errors.Is`
- [x] `TestAnnotateWatchErr_OtherErrorsPassThroughUnchanged` - a non-ENOSPC error is byte-identical after annotation, keeping the change narrow
- [x] `TestAnnotateWatchErr_NilIsNil`
- [x] Cross-compiled `internal/watcher` for linux, darwin and windows to confirm `syscall.ENOSPC` is portable
- [x] `make gate` - exit 0
- [ ] Reviewer follow-ups

## Notes

Tests were written before the implementation and confirmed failing (`undefined: annotateWatchErr`) first.
