### PR TITLE
fix(cli): make the admin subcommand reachable, and document password reset

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -97,6 +97,21 @@ canticle keys revoke <raw-api-key>
 
 `keys` has three subcommands: `create` (`--name`, repeatable `--scope` of `webhook` or `admin`; prints the raw key once), `list` (tab-separated public ID, name, scopes, revoked-at), and `revoke <raw-api-key>`. All accept `--config`. See [Webhook API keys](USER_GUIDE.md#webhook-api-keys) for the full workflow and the web UI equivalent.
 
+## Web UI admin password
+
+```sh
+printf '%s' 'your-new-password' | canticle admin set-password --user admin
+canticle admin set-password --user admin < newpass.txt
+```
+
+`admin set-password` changes an existing web-UI admin's password. It is the only supported way to do so: there is no password-change screen in the web UI yet (#545), and editing `MXLRC_WEBAUTH_ADMIN_PASSWORD` does nothing once an admin exists, because the environment bootstrap never overwrites an existing account.
+
+The password is read from **standard input, never a flag**, so it stays out of shell history and the host process list. Prefer a file or secret manager over an inline `printf`, which still lands in history. One trailing newline is stripped; leading and trailing spaces are preserved.
+
+The update and the revocation of that user's existing sessions happen in a single transaction, so a rotation cannot half-apply. Everyone signed in with the old password is signed out immediately, including you. No restart is required. Accepts `--config`.
+
+This also works when you are locked out, since it acts on the database rather than requiring a login. See [Changing or resetting the admin password](USER_GUIDE.md#changing-or-resetting-the-admin-password).
+
 ## Secrets
 
 The Musixmatch token and the webhook API key can be stored encrypted at rest in the database instead of as plaintext in `config.toml` or environment variables. The encrypted store is the lowest-precedence source, so CLI flags, env vars, and TOML still win over it.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5,7 +5,7 @@ This page documents every subcommand and flag. For operational guidance (running
 ## Usage
 
 ```text
-Usage: canticle [fetch|serve|scan|library|keys|secrets|config|queue|provenance|completion]
+Usage: canticle [fetch|serve|scan|library|keys|admin|secrets|config|queue|provenance|realign|completion]
 
 Commands:
   fetch       fetch lyrics once without HTTP server or DB queue
@@ -13,10 +13,12 @@ Commands:
   scan        scan configured libraries and enqueue missing lyrics
   library     manage library roots
   keys        manage API keys
+  admin       manage the web-UI admin account
   secrets     manage encrypted-at-rest secrets
   config      inspect or update configuration
   queue       inspect or maintain the durable work queue
   provenance  embed or inspect provenance tags in .lrc files
+  realign     re-attach orphaned .lrc/.txt sidecars to renamed audio files
   completion  output a shell completion script (bash, zsh, or fish)
 
 Global flags:
@@ -100,13 +102,13 @@ canticle keys revoke <raw-api-key>
 ## Web UI admin password
 
 ```sh
-printf '%s' 'your-new-password' | canticle admin set-password --user admin
 canticle admin set-password --user admin < newpass.txt
+docker exec -i canticle canticle admin set-password --user admin < newpass.txt
 ```
 
 `admin set-password` changes an existing web-UI admin's password. It is the only supported way to do so: there is no password-change screen in the web UI yet (#545), and editing `MXLRC_WEBAUTH_ADMIN_PASSWORD` does nothing once an admin exists, because the environment bootstrap never overwrites an existing account.
 
-The password is read from **standard input, never a flag**, so it stays out of shell history and the host process list. Prefer a file or secret manager over an inline `printf`, which still lands in history. One trailing newline is stripped; leading and trailing spaces are preserved.
+The password is read from **standard input, never a flag**, so it stays out of the host process list where any other user could read it. Read it from a file or a secret manager; never embed it in the command itself, including inside a `docker exec ... sh -c '...'` wrapper, since anything on the command line is visible in `ps` and recorded in shell history. This matches `canticle secrets set`, which rejects a value passed on the command line for the same reason. One trailing newline is stripped; leading and trailing spaces are preserved.
 
 The update and the revocation of that user's existing sessions happen in a single transaction, so a rotation cannot half-apply. Everyone signed in with the old password is signed out immediately, including you. No restart is required. Accepts `--config`.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -253,8 +253,36 @@ Bootstrap behavior:
 - **Both vars required.** Setting only one logs a warning and skips the bootstrap.
 - **Password floor.** The password must be at least 8 characters. A shorter one is a **fatal startup error** (the container will not start), not a silent skip.
 - **Idempotent.** The bootstrap runs only when no admin exists yet. Once any admin account is present it is skipped (never an overwrite), so leaving the vars set across restarts is harmless. The password is never logged.
+- **It is a bootstrap, not a rotation control.** Changing `MXLRC_WEBAUTH_ADMIN_PASSWORD` after an admin exists and restarting **does not change the password**. The bootstrap is skipped, the service starts healthy, and the previous password stays active. Since v1.20.1 that skip is logged at warning level and names the command below; older builds logged it at info level, where it read as reassurance. To change an existing password, use [Changing or resetting the admin password](#changing-or-resetting-the-admin-password).
 
-**First login and cleanup.** After the container is up, browse to `http://[host]:[port]/login` and sign in with the bootstrapped credentials. Then **rotate the password from inside the UI and remove the `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` env vars** (and restart). Because the bootstrap is idempotent, the stale vars do nothing on the next start, but removing them keeps the plaintext password out of the container environment.
+**First login and cleanup.** After the container is up, browse to `http://[host]:[port]/login` and sign in with the bootstrapped credentials. Then **rotate the password with `canticle admin set-password` (see below) and remove the `MXLRC_WEBAUTH_ADMIN_USER` / `MXLRC_WEBAUTH_ADMIN_PASSWORD` env vars**. Because the bootstrap is idempotent, the stale vars do nothing on the next start, but removing them keeps the plaintext password out of the container environment.
+
+### Changing or resetting the admin password
+
+Use `canticle admin set-password`. This is the only supported way to change an existing admin password: there is no password-change screen in the web UI yet (tracked in issue #545), and editing the bootstrap environment variable does nothing once an admin exists.
+
+```sh
+printf '%s' 'your-new-password' | canticle admin set-password --user admin
+```
+
+In Docker or Unraid, run it inside the running container:
+
+```sh
+docker exec -i canticle sh -c 'printf "%s" "your-new-password" | canticle admin set-password --user admin'
+```
+
+Notes on how it behaves:
+
+- **The password is read from standard input, never a flag.** A `--password` flag would place the credential in your shell history and in the host's process list, where any other user on the machine can read it. Piping keeps it out of both. Prefer reading from a file (`canticle admin set-password --user admin < newpass.txt`) or a secret manager over typing it inline, since an inline `printf` still lands in shell history.
+- **A trailing newline is stripped**, so the usual `echo` and heredoc forms behave as expected. Leading and trailing spaces are preserved, because they may be part of the passphrase.
+- **Existing sessions are revoked.** Anyone signed in with the old password is signed out immediately. That is the point of rotating a compromised credential, and it means you will need to sign in again yourself.
+- **The change is atomic.** The password update and the session revocation happen in one database transaction, so a rotation either fully applies or leaves the account untouched. It cannot half-apply.
+- **No restart is needed.** The change takes effect immediately.
+- **The password is never printed**, and the minimum length is 8 characters.
+
+**If you are locked out entirely** (password lost, and no session), the same command works because it acts directly on the database rather than requiring a login. Run it on the host or inside the container as shown above. You do not need to delete anything from the database, and you should not: on releases before v1.20.1 the only route was removing the admin row by hand, which is no longer necessary and is easy to get wrong.
+
+**If your build predates v1.20.1**, `canticle admin set-password` is either absent or unreachable (in v1.20.0 the subcommand shipped but could not be invoked, falling through to the legacy argument parser with `unknown argument --user`). Upgrade to v1.20.1 or later, then use the command above.
 
 If the UI is reachable beyond your local machine, also read [Security considerations](#security-considerations) below: put it behind TLS so the session cookie is not sent in cleartext.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -250,6 +250,7 @@ The browser UI is **off by default**. The serve listener only mounts the web rou
 
 Bootstrap behavior:
 
+- **The web UI must be enabled.** The bootstrap only runs when `web_ui_enabled = true` under `[server]` (or `MXLRC_WEB_UI_ENABLED=true`). With the UI off the variables are ignored and no admin is created; since v1.20.1 that is logged at warning level naming the setting to change.
 - **Both vars required.** Setting only one logs a warning and skips the bootstrap.
 - **Password floor.** The password must be at least 8 characters. A shorter one is a **fatal startup error** (the container will not start), not a silent skip.
 - **Idempotent.** The bootstrap runs only when no admin exists yet. Once any admin account is present it is skipped (never an overwrite), so leaving the vars set across restarts is harmless. The password is never logged.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -262,18 +262,20 @@ Bootstrap behavior:
 Use `canticle admin set-password`. This is the only supported way to change an existing admin password: there is no password-change screen in the web UI yet (tracked in issue #545), and editing the bootstrap environment variable does nothing once an admin exists.
 
 ```sh
-printf '%s' 'your-new-password' | canticle admin set-password --user admin
+canticle admin set-password --user admin < newpass.txt
 ```
 
-In Docker or Unraid, run it inside the running container:
+In Docker or Unraid, run it inside the running container, piping the password in from the host so it never appears in the `docker exec` arguments:
 
 ```sh
-docker exec -i canticle sh -c 'printf "%s" "your-new-password" | canticle admin set-password --user admin'
+docker exec -i canticle canticle admin set-password --user admin < newpass.txt
 ```
+
+Do **not** embed the password in the command itself (for example inside `sh -c '... printf "your-password" ...'`). Anything on the command line is visible in the host's process list to every other user on the machine, and lands in your shell history, which are exactly the channels reading from stdin avoids.
 
 Notes on how it behaves:
 
-- **The password is read from standard input, never a flag.** A `--password` flag would place the credential in your shell history and in the host's process list, where any other user on the machine can read it. Piping keeps it out of both. Prefer reading from a file (`canticle admin set-password --user admin < newpass.txt`) or a secret manager over typing it inline, since an inline `printf` still lands in shell history.
+- **The password is read from standard input, never a flag.** A `--password` flag would place the credential in your shell history and in the host's process list, where any other user on the machine can read it. Read it from a file or a secret manager. Typing it inline (`printf '%s' 'pw' | ...`) keeps it off the process list but still records it in shell history, so treat that as a last resort and clear the entry afterwards. This mirrors `canticle secrets set`, which rejects a value passed on the command line for the same reason.
 - **A trailing newline is stripped**, so the usual `echo` and heredoc forms behave as expected. Leading and trailing spaces are preserved, because they may be part of the passphrase.
 - **Existing sessions are revoked.** Anyone signed in with the old password is signed out immediately. That is the point of rotating a compromised credential, and it means you will need to sign in again yourself.
 - **The change is atomic.** The password update and the session revocation happen in one database transaction, so a rotation either fully applies or leaves the account untouched. It cannot half-apply.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -551,6 +552,42 @@ func Run(ctx context.Context, rawArgs []string, out io.Writer, deps Deps) int {
 	}
 }
 
+// topLevelSubcommands is the set of subcommand names declared on Args, derived
+// from its struct tags rather than hand-maintained.
+//
+// It used to be a hardcoded map, and that shipped a broken command in v1.20.0:
+// `admin` was added to Args, to the dispatch switch, and to the completion
+// tables, but not to the map. Because this function decides whether to parse the
+// modern subcommand tree or the legacy CLI, an unlisted command fell through to
+// the legacy parser and died with "unknown argument --user" -- it could not be
+// invoked at all. Unit tests missed it because they called the handlers
+// directly, never through the parser.
+//
+// Deriving the set from the same struct the parser uses removes the drift
+// entirely: a new subcommand is recognized the moment it is declared, with no
+// second place to remember. Computed once at init; Args is static.
+var topLevelSubcommands = func() map[string]bool {
+	out := make(map[string]bool)
+	t := reflect.TypeOf(Args{})
+	for i := range t.NumField() {
+		if name := subcommandTagName(t.Field(i).Tag.Get("arg")); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}()
+
+// subcommandTagName extracts the name from a go-arg `subcommand:<name>` tag,
+// returning "" for any tag that does not declare one.
+func subcommandTagName(tag string) string {
+	for part := range strings.SplitSeq(tag, ",") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(part), "subcommand:"); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
+
 func usesSubcommand(rawArgs []string) bool {
 	if len(rawArgs) == 0 {
 		return false
@@ -558,10 +595,7 @@ func usesSubcommand(rawArgs []string) bool {
 	if rawArgs[0] == "-h" || rawArgs[0] == "--help" {
 		return true
 	}
-	commands := map[string]bool{
-		"fetch": true, "serve": true, "scan": true, "library": true, "keys": true, "secrets": true, "config": true, "queue": true, "provenance": true, "realign": true, "completion": true,
-	}
-	return commands[rawArgs[0]]
+	return topLevelSubcommands[rawArgs[0]]
 }
 
 func legacyFetch(args LegacyArgs) FetchCmd {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1259,6 +1259,22 @@ func buildRedirectServer(redirectAddr, tlsAddr string) *http.Server {
 // error.
 func buildWebAuth(ctx context.Context, cfg config.Config, sqlDB *sql.DB, store secrets.Store, policy *trustnet.Policy, version string) (*webauth.Service, *web.Auth, *web.Onboarding, error) {
 	if !cfg.Server.WebUIEnabled {
+		// Credentials were supplied for a feature that is switched off. Without
+		// this warning the operator gets a healthy startup, no admin account, and
+		// no explanation: the bootstrap below is never reached, so the variables
+		// silently do nothing. That is the same failure shape as editing the
+		// password variable after first run and believing a rotation happened
+		// (#545), and it is worth naming rather than inferring from an absence.
+		//
+		// Deliberately NOT bootstrapping anyway: an admin account is meaningless
+		// with no UI to sign in to, and creating one would make the later
+		// idempotent skip fire on a genuine first run once the UI is enabled.
+		if os.Getenv(envWebAdminUser) != "" || os.Getenv(envWebAdminPass) != "" {
+			slog.Warn("web admin bootstrap IGNORED: " + envWebAdminUser + "/" + envWebAdminPass +
+				" are set but the web UI is disabled, so no admin account is created. " +
+				"Enable it with web_ui_enabled = true under [server] (or MXLRC_WEB_UI_ENABLED=true), " +
+				"or remove the variables to keep the password out of the environment")
+		}
 		return nil, nil, nil, nil
 	}
 	svc := webauth.NewService(webauth.NewSQLUserStore(sqlDB), webauth.NewSQLSessionStore(sqlDB))

--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -171,3 +171,26 @@ func TestRunCompletion_Scripts(t *testing.T) {
 		t.Fatalf("unsupported shell: code=%d want 2", code)
 	}
 }
+
+// TestUsesSubcommandCoversCommandTree guards the registration point that shipped
+// a broken command in v1.20.0.
+//
+// Adding a subcommand requires touching FOUR places: the Args struct, the
+// dispatch switch, the completion tables, and the usesSubcommand map that
+// decides whether to parse the modern subcommand tree or the legacy CLI. The
+// `admin` subcommand was added to the first three and missed here, so
+// `canticle admin set-password --user x` fell through to the legacy parser and
+// died with "unknown argument --user" -- a command that could not be invoked at
+// all, while every unit test passed because they called the handlers directly
+// and never went through the parser.
+//
+// The completion tables had a guard like this one and it caught their omission
+// immediately. This map had none, which is the only reason the bug shipped.
+func TestUsesSubcommandCoversCommandTree(t *testing.T) {
+	for _, name := range subcommandNames(reflect.TypeOf(Args{})) {
+		if !usesSubcommand([]string{name}) {
+			t.Errorf("usesSubcommand does not recognize %q (declared in Args); add it to the commands map in commands.go, "+
+				"or the command silently falls through to the legacy parser and cannot be invoked", name)
+		}
+	}
+}

--- a/internal/commands/subcommand_reachability_test.go
+++ b/internal/commands/subcommand_reachability_test.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// legacyUsageMarker is the one string unique to the pre-subcommand CLI's usage
+// line: a flag bracket immediately after the program name. A subcommand always
+// renders "Usage: canticle <name> [...", so seeing this means the parser fell
+// through to LegacyArgs.
+//
+// Deliberately not matching on a flag like "[--outdir OUTDIR]" -- fetch and
+// serve declare their own --outdir, so that marker produces false positives.
+const legacyUsageMarker = "Usage: canticle ["
+
+// TestEverySubcommandIsReachableThroughRun is the test whose absence let a
+// broken command ship in v1.20.0.
+//
+// Every existing test drove the handlers directly (runAdmin, runKeys, ...),
+// which proves a handler works and says nothing about whether anything can
+// REACH it. `admin` was declared on Args, wired into the dispatch switch, and
+// listed in the completion tables, but missing from the subcommand-recognition
+// set -- so `canticle admin set-password --user x` fell through to the legacy
+// parser and failed with "unknown argument --user". The command could not be
+// invoked at all, and the whole suite passed.
+//
+// This drives the real entry point with real argv, and asserts the legacy
+// parser never claims a declared subcommand. It is deliberately behavioral
+// rather than a table lookup: a future refactor of the recognition mechanism
+// still has to keep every command reachable.
+func TestEverySubcommandIsReachableThroughRun(t *testing.T) {
+	names := subcommandNames(reflect.TypeOf(Args{}))
+	if len(names) == 0 {
+		t.Fatal("no subcommands discovered on Args; the reflection helper is broken")
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			var out bytes.Buffer
+			// --help makes every subcommand terminate immediately without doing
+			// any work: no config load, no database, no network. What matters is
+			// only which parser claimed the argv.
+			Run(t.Context(), []string{name, "--help"}, &out, Deps{})
+
+			if strings.Contains(out.String(), legacyUsageMarker) {
+				t.Errorf("subcommand %q fell through to the LEGACY parser and is unreachable.\n"+
+					"It is declared on Args but the subcommand-recognition set does not know it.\n"+
+					"got:\n%s", name, out.String())
+			}
+		})
+	}
+}
+
+// TestUnknownCommandStillUsesLegacyParser is the other half of the contract:
+// the fallback must keep working. A bare song argument is the legacy CLI's
+// positional form and must NOT be mistaken for a subcommand.
+func TestUnknownCommandStillUsesLegacyParser(t *testing.T) {
+	if usesSubcommand([]string{"Some Artist,Some Title"}) {
+		t.Error("a positional song argument was treated as a subcommand; the legacy CLI would break")
+	}
+	if usesSubcommand([]string{"definitely-not-a-command"}) {
+		t.Error("an unknown word was treated as a subcommand")
+	}
+	if !usesSubcommand([]string{"--help"}) {
+		t.Error("--help should route to the subcommand parser so the full tree is shown")
+	}
+	if usesSubcommand(nil) {
+		t.Error("empty argv should use the legacy parser")
+	}
+}

--- a/internal/commands/webauth_bootstrap_disabled_test.go
+++ b/internal/commands/webauth_bootstrap_disabled_test.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/config"
+)
+
+// TestWebAuthBootstrapVarsIgnoredWhenWebUIDisabled covers a silent no-op of the
+// same family as the one that shipped in v1.20.0.
+//
+// buildWebAuth returns early when the web UI is disabled, before
+// bootstrapAdminFromEnv is ever reached. So an operator who sets both
+// MXLRC_WEBAUTH_ADMIN_* variables but leaves web_ui_enabled at its default gets
+// no admin account, no error, and no explanation: the service starts healthy and
+// the credentials they supplied did nothing.
+//
+// That is the same shape as editing the password variable after first run and
+// believing a rotation happened. The fix is not to bootstrap anyway (an admin
+// account is meaningless with no UI to sign into) but to say plainly that the
+// variables are being ignored and why.
+func TestWebAuthBootstrapVarsIgnoredWhenWebUIDisabled(t *testing.T) {
+	t.Setenv(envWebAdminUser, "admin")
+	t.Setenv(envWebAdminPass, "a-long-enough-password")
+	buf := captureLogs(t)
+
+	cfg := config.Config{}
+	cfg.Server.WebUIEnabled = false
+
+	svc, auth, onboarding, err := buildWebAuth(t.Context(), cfg, nil, nil, nil, "test")
+	if err != nil {
+		t.Fatalf("buildWebAuth: %v", err)
+	}
+	if svc != nil || auth != nil || onboarding != nil {
+		t.Fatal("web UI disabled must still yield all-nil components")
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, envWebAdminPass) {
+		t.Errorf("log does not name the ignored variable %s:\n%s", envWebAdminPass, got)
+	}
+	if !strings.Contains(got, "web_ui_enabled") {
+		t.Errorf("log does not name the setting to change:\n%s", got)
+	}
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("ignored credentials must be reported at WARN, not buried at INFO:\n%s", got)
+	}
+}
+
+// The warning must not fire for the overwhelmingly common case of running with
+// the web UI off and no bootstrap variables set. A warning on every startup
+// would train operators to ignore it.
+func TestWebAuthNoWarningWhenBootstrapVarsUnset(t *testing.T) {
+	t.Setenv(envWebAdminUser, "")
+	t.Setenv(envWebAdminPass, "")
+	buf := captureLogs(t)
+
+	cfg := config.Config{}
+	cfg.Server.WebUIEnabled = false
+
+	if _, _, _, err := buildWebAuth(t.Context(), cfg, nil, nil, nil, "test"); err != nil {
+		t.Fatalf("buildWebAuth: %v", err)
+	}
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("warned with no bootstrap vars set:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

`canticle admin set-password`, shipped in v1.20.0, could not be invoked. Running it produced the legacy CLI's usage text and `unknown argument --user`.

This fixes the command, removes the class of defect that caused it, and corrects documentation that actively misdirected operators.

## What went wrong

Adding a subcommand required touching **four** places:

| Place | Done in v1.20.0 |
|---|---|
| The `Args` struct | yes |
| The dispatch switch | yes |
| The completion tables | yes |
| `usesSubcommand`'s hardcoded map | **no** |

That map decides whether argv is parsed as the modern subcommand tree or the legacy CLI. With `admin` absent, it fell through to the legacy parser, which knows nothing about `--user`.

The completion tables have a reflection-based guard that caught their omission immediately during development. The map had no such guard, which is the only reason this reached a release.

**Why the tests passed.** Every test drove the handlers directly (`runAdmin`, `runAdminSetPassword`). They proved the handler works and said nothing about whether anything could reach it. No test, and no manual run, ever exercised the command through the argument parser.

## The fix

Rather than add the missing map entry, this removes the possibility of drift.

`usesSubcommand` now derives the subcommand set from the `Args` struct tags, the same declaration the parser itself uses. A new subcommand is recognized the moment it is declared. Deleting a field breaks the build instead, because the dispatch switch references it, so the declaration and the recognition set cannot diverge.

## The test that was missing

`TestEverySubcommandIsReachableThroughRun` drives the real entry point with real argv for every subcommand declared on `Args`, and fails if the legacy parser claims one.

It was verified to catch the original bug: hiding `admin` from the derivation makes it fail with `subcommand "admin" fell through to the LEGACY parser and is unreachable`. It is deliberately behavioral rather than a table lookup, so a future refactor of the recognition mechanism still has to keep every command reachable.

A companion test pins the other half of the contract: a bare song argument and an unknown word must still route to the legacy parser, so the pre-subcommand CLI keeps working.

## Documentation

The user guide told operators to **"rotate the password from inside the UI"**. That has never been possible. There is no password-change screen, so following that instruction leads to editing `MXLRC_WEBAUTH_ADMIN_PASSWORD` instead, which silently does nothing once an admin exists: the service starts healthy, logs a skip, and keeps the old password. That is how an operator ends up locked out believing they rotated a credential.

- Corrected that instruction.
- The bootstrap section now states plainly that changing the variable after first run does **not** rotate anything, and points at the command that does.
- New **Changing or resetting the admin password** section: the command, the `docker exec` form, why the password comes from stdin rather than a flag, session revocation, atomicity, the locked-out case, and the v1.20.0 caveat.
- `CLI_REFERENCE.md` gains a matching section, cross-linked both ways.

## Verification

Beyond the gate, this was exercised end to end against a built binary and a real SQLite database, which is precisely the step whose absence let the bug ship:

```
hash before:  $argon2id$...z
rotate:       password updated for "admin"; existing sessions revoked
hash after:   $argon2id$...n          <- actually changed
unknown user:    rejected
short password:  rejected
```

- [x] 343 tests passing in `internal/commands`
- [x] `make gate` - exit 0
- [x] Real-binary end-to-end rotation against a real database
- [x] Reachability test verified to fail against the original defect
- [ ] Reviewer follow-ups

## Release

This warrants a **v1.20.1** patch. v1.20.0 advertises a command that cannot be run, and the documented recovery path for a lost admin password does not work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for changing the Web UI administrator password using the CLI, including Docker and Unraid usage.
  - Clarified stdin-only password entry, immediate session sign-out, no restart requirement, lockout recovery, and bootstrap behavior.

- **Bug Fixes**
  - Improved command recognition so available CLI subcommands consistently route through the correct parser while preserving legacy command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->