### PR TITLE
feat(scan): attribute historical audio detections to the detector lane

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -144,6 +144,23 @@ type ScanCmd struct {
 	ReconcileIdentity                *ScanReconcileIdentityCmd                `arg:"subcommand:reconcile-identity" help:"re-read tags and correct run-together multi-value artist rows ingested before the fix (issue #466)"`
 	ReconcileLRC                     *ScanReconcileLRCCmd                     `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
 	ReconcileMarkerProvenance        *ScanReconcileMarkerProvenanceCmd        `arg:"subcommand:reconcile-marker-provenance" help:"backfill provenance headers onto detector-written instrumental markers (#502)"`
+	ReconcileDetectorStats           *ScanReconcileDetectorStatsCmd           `arg:"subcommand:reconcile-detector-stats" help:"attribute historical audio detections to the detector lane's statistics; reads recorded verdicts only, makes no detector-sidecar requests (issue #537)"`
+}
+
+// ScanReconcileDetectorStatsCmd attributes historical audio detections to the
+// detector lane in lane_attempts, correcting an under-count left by instrumentals
+// that settled before the detector became a lane (#537). Driven entirely from
+// work_queue.instrumental_result; never re-runs detection. Dry-run unless --yes.
+//
+// There is no --library flag: work_queue rows reach a library only through the
+// work_queue_scan_results junction, and a row whose scan_results link has since
+// been cleared would silently drop out of a library-scoped run. Since the
+// counters this corrects are global, scoping would introduce a partial-fill
+// hazard for no operator benefit.
+type ScanReconcileDetectorStatsCmd struct {
+	Yes        bool   `arg:"--yes" help:"actually write the attributions (without it, prints what would change)"`
+	Backup     string `arg:"--backup" help:"path for the JSONL backup of attributed rows (default: <db-dir>/reconcile-detector-stats-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
 // ScanReconcileLRCCmd walks the configured library roots and rewrites any .lrc
@@ -1877,6 +1894,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runReconcileMarkerProvenance(ctx, out, sub)
+	case args.ReconcileDetectorStats != nil:
+		sub := *args.ReconcileDetectorStats
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runReconcileDetectorStats(ctx, out, sub)
 	default:
 		return runScan(ctx, out, args)
 	}

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "reconcile-marker-provenance", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "reconcile-marker-provenance", "reconcile-detector-stats", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/reconcile_detector_stats.go
+++ b/internal/commands/reconcile_detector_stats.go
@@ -57,7 +57,7 @@ func runReconcileDetectorStats(ctx context.Context, out io.Writer, args ScanReco
 		slog.Error("failed to open database", "error", err)
 		return 1
 	}
-	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+	defer sqlDB.Close() //nolint:errcheck // reason: best-effort close on shutdown
 
 	backupPath := args.Backup
 	if backupPath == "" {
@@ -84,7 +84,7 @@ func runReconcileDetectorStats(ctx context.Context, out io.Writer, args ScanReco
 			return nil
 		}
 		if backupFile == nil {
-			f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+			f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // reason: G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
 			if ferr != nil {
 				return fmt.Errorf("open reconcile-detector-stats backup %q: %w", backupPath, ferr)
 			}

--- a/internal/commands/reconcile_detector_stats.go
+++ b/internal/commands/reconcile_detector_stats.go
@@ -1,0 +1,120 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/config"
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
+)
+
+// appendReconcileDetectorStatsBackup writes one attributed row as a JSONL
+// record. The record is the lane_attempts row that was inserted; the backfill
+// only ever inserts (ON CONFLICT DO NOTHING), so there is no pre-image to
+// preserve.
+//
+// RESTORE HAZARD: deleting these (queue_id, lane) pairs undoes the backfill only
+// while the rows are still the ones it wrote. queue.RecordLaneAttempts upserts
+// with DO UPDATE, so once the worker runs again it may overwrite a backfilled
+// row IN PLACE with an authoritative live outcome. A delete after that point
+// destroys live-recorded history, which this backfill otherwise treats as
+// inviolable. Restore promptly, or reconcile against attempted_at first.
+func appendReconcileDetectorStatsBackup(f *os.File, ch detectorbackfill.Change) error {
+	b, err := json.Marshal(ch)
+	if err != nil {
+		return fmt.Errorf("marshal detector-stats backup record: %w", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write detector-stats backup record: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync detector-stats backup: %w", err)
+	}
+	return nil
+}
+
+// runReconcileDetectorStats attributes historical audio detections to the
+// detector lane in lane_attempts, correcting an under-count left by instrumentals
+// that settled before the detector became a lane (issue #537). It is driven
+// entirely from work_queue.instrumental_result, never by re-running detection.
+// Dry-run by default; --yes applies and writes a JSONL backup of every row
+// written.
+func runReconcileDetectorStats(ctx context.Context, out io.Writer, args ScanReconcileDetectorStatsCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	backupPath := args.Backup
+	if backupPath == "" {
+		backupPath = filepath.Join(filepath.Dir(cfg.DB.Path), fmt.Sprintf("reconcile-detector-stats-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	var backupFile *os.File
+	defer func() {
+		if backupFile != nil {
+			if cerr := backupFile.Close(); cerr != nil {
+				slog.Warn("failed to close reconcile-detector-stats backup file", "path", backupPath, "error", cerr)
+			}
+		}
+	}()
+	// report is invoked once per attributed row. In dry-run it previews the
+	// attribution; under --yes it appends a restorable backup record from inside
+	// the backfill's transaction, before commit.
+	report := func(ch detectorbackfill.Change) error {
+		verdict := "miss"
+		if ch.Hit {
+			verdict = "hit"
+		}
+		_, _ = fmt.Fprintf(out, "  queue row %d -> %s %s (attempted_at %s)\n", ch.QueueID, ch.Lane, verdict, ch.AttemptedAt)
+		if !args.Yes {
+			return nil
+		}
+		if backupFile == nil {
+			f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+			if ferr != nil {
+				return fmt.Errorf("open reconcile-detector-stats backup %q: %w", backupPath, ferr)
+			}
+			backupFile = f
+		}
+		return appendReconcileDetectorStatsBackup(backupFile, ch)
+	}
+
+	res, err := detectorbackfill.New(sqlDB).Run(ctx, detectorbackfill.Options{
+		DryRun: !args.Yes,
+		Report: report,
+	})
+	if err != nil {
+		slog.Error("reconcile-detector-stats failed", "error", err)
+		return 1
+	}
+
+	verb := "would attribute"
+	if args.Yes {
+		verb = "attributed"
+	}
+	_, _ = fmt.Fprintf(out, "reconcile-detector-stats: scanned %d row(s); %s %d (%d hits, %d misses, %d already recorded)%s\n",
+		res.Scanned, verb, res.Hits+res.Misses, res.Hits, res.Misses, res.AlreadyRecorded, suffixDryRun(args.Yes))
+	// Both remainders are stated explicitly. The NULL tally is countable; the
+	// ClearDone tail is not visible from work_queue at all, so reporting only the
+	// former would imply a completeness the backfill cannot claim.
+	_, _ = fmt.Fprintf(out, "uncovered: %d row(s) have no recorded detection verdict and are left untouched (not estimated)\n", res.UncoveredNull)
+	_, _ = fmt.Fprintln(out, "uncovered: detections on work_queue rows already removed by ClearDone cannot be recovered or counted")
+	if backupFile != nil {
+		_, _ = fmt.Fprintf(out, "backup of attributed rows written to %s\n", backupPath)
+	}
+	return 0
+}

--- a/internal/commands/reconcile_detector_stats.go
+++ b/internal/commands/reconcile_detector_stats.go
@@ -40,6 +40,37 @@ func appendReconcileDetectorStatsBackup(f *os.File, ch detectorbackfill.Change) 
 	return nil
 }
 
+// truncateReconcileDetectorStatsBackup restores the backup file to size,
+// discarding whatever the failed run appended.
+//
+// It is the failure-path counterpart to the engine's backup-first ordering.
+// detectorbackfill.runApply reports every row from inside one transaction,
+// before the single commit, so each record is durable on disk before the write
+// it protects lands. When a later row fails, that transaction rolls back EVERY
+// row -- and the records already synced describe attributions that were never
+// applied. A restore driven from that file would delete lane_attempts rows the
+// backfill never created, so the over-recording has to be undone here.
+//
+// Truncation is to the pre-run size, never to zero and never by deleting the
+// file: --backup may point at a file already holding earlier runs' records
+// (it is opened O_APPEND), and destroying those would be a worse bug than the
+// one this repairs.
+func truncateReconcileDetectorStatsBackup(f *os.File, size int64) error {
+	// The file is opened lazily on the first record, so f is nil exactly when
+	// this run wrote nothing -- including when the failure WAS the open itself.
+	// There is no over-recording to undo, and the file may not even exist.
+	if f == nil {
+		return nil
+	}
+	if err := f.Truncate(size); err != nil {
+		return fmt.Errorf("truncate detector-stats backup to %d bytes: %w", size, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync truncated detector-stats backup: %w", err)
+	}
+	return nil
+}
+
 // runReconcileDetectorStats attributes historical audio detections to the
 // detector lane in lane_attempts, correcting an under-count left by instrumentals
 // that settled before the detector became a lane (issue #537). It is driven
@@ -62,6 +93,13 @@ func runReconcileDetectorStats(ctx context.Context, out io.Writer, args ScanReco
 	backupPath := args.Backup
 	if backupPath == "" {
 		backupPath = filepath.Join(filepath.Dir(cfg.DB.Path), fmt.Sprintf("reconcile-detector-stats-backup-%s.jsonl", time.Now().UTC().Format("20060102-150405")))
+	}
+	// Size the backup BEFORE the run writes anything, so a failure can restore it
+	// to exactly that. A missing file sizes as 0, which is the correct target: a
+	// failed run that created the file leaves it empty rather than absent.
+	var backupPreSize int64
+	if fi, serr := os.Stat(backupPath); serr == nil {
+		backupPreSize = fi.Size()
 	}
 	var backupFile *os.File
 	defer func() {
@@ -99,6 +137,12 @@ func runReconcileDetectorStats(ctx context.Context, out io.Writer, args ScanReco
 	})
 	if err != nil {
 		slog.Error("reconcile-detector-stats failed", "error", err)
+		// The engine rolled every row back, so any record this run appended
+		// describes an attribution that was never applied. Undo it.
+		if terr := truncateReconcileDetectorStatsBackup(backupFile, backupPreSize); terr != nil {
+			slog.Error("failed to roll back the reconcile-detector-stats backup; it may describe attributions that were never applied",
+				"path", backupPath, "error", terr)
+		}
 		return 1
 	}
 

--- a/internal/commands/reconcile_detector_stats_test.go
+++ b/internal/commands/reconcile_detector_stats_test.go
@@ -206,3 +206,78 @@ func TestRunReconcileDetectorStats_UnwritableBackupRollsBack(t *testing.T) {
 		t.Errorf("lane_attempts rows = %d; want 0 -- an unrecordable attribution must not be applied", got)
 	}
 }
+
+// failSecondAttribution installs a trigger that aborts the insert for the second
+// attributable row. The first row is then fully reported -- its backup record
+// written AND synced -- before the failure rolls the whole transaction back,
+// which is the only ordering that exposes an over-recording backup.
+func failSecondAttribution(t *testing.T, ctx context.Context, dbPath string) {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // reason: test cleanup
+
+	if _, err := sqlDB.ExecContext(ctx,
+		`CREATE TRIGGER fail_second_attribution BEFORE INSERT ON lane_attempts
+         WHEN NEW.queue_id = (SELECT id FROM work_queue WHERE title = 'NotInstrumental')
+         BEGIN SELECT RAISE(ABORT, 'simulated insert failure'); END`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+}
+
+// A run that fails partway must leave the backup file exactly as it found it.
+//
+// The engine reports each row from inside its transaction, before the single
+// commit, so by the time row 2 fails row 1's record is already durable on disk
+// -- describing an attribution the rollback then discarded. Left in place, a
+// restore driven from this file would delete lane_attempts rows the backfill
+// never created.
+func TestRunReconcileDetectorStats_FailedRunLeavesBackupUnchanged(t *testing.T) {
+	// Prior content is the load-bearing case: --backup may name a file holding
+	// earlier runs' records, so the cleanup must truncate to the pre-run size
+	// rather than emptying or removing the file.
+	prior := []byte(`{"queue_id":99,"lane":"detector","hit":true,"attempted_at":"2025-01-01T00:00:00Z"}` + "\n")
+
+	for _, tc := range []struct {
+		name  string
+		seed  []byte // nil means the backup file does not exist yet
+		want  []byte
+		exist bool
+	}{
+		{name: "with prior records", seed: prior, want: prior, exist: true},
+		{name: "no prior file", seed: nil, want: []byte{}, exist: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cfgPath, dbPath := setupDetectorStats(t)
+			backup := filepath.Join(t.TempDir(), "backup.jsonl")
+			if tc.seed != nil {
+				if err := os.WriteFile(backup, tc.seed, 0o600); err != nil {
+					t.Fatalf("seed backup: %v", err)
+				}
+			}
+			failSecondAttribution(t, ctx, dbPath)
+
+			var out bytes.Buffer
+			code := runReconcileDetectorStats(ctx, &out, ScanReconcileDetectorStatsCmd{
+				ConfigPath: cfgPath, Yes: true, Backup: backup,
+			})
+			if code != 1 {
+				t.Fatalf("exit code = %d; want 1 when a row fails to attribute. output:\n%s", code, out.String())
+			}
+			if got := countRows(t, ctx, dbPath, "lane_attempts"); got != 0 {
+				t.Fatalf("lane_attempts rows = %d; want 0 (the run rolled back)", got)
+			}
+
+			got, err := os.ReadFile(backup) //nolint:gosec // reason: G304: test-controlled path
+			if err != nil {
+				t.Fatalf("read backup: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("backup content = %q; want %q -- a rolled-back run must not leave records for attributions it never applied",
+					got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/commands/reconcile_detector_stats_test.go
+++ b/internal/commands/reconcile_detector_stats_test.go
@@ -96,7 +96,7 @@ func TestRunReconcileDetectorStats_ApplyWritesBothBucketsAndBackup(t *testing.T)
 		t.Errorf("output should state the uncountable ClearDone remainder:\n%s", s)
 	}
 
-	data, err := os.ReadFile(backup) //nolint:gosec // G304: test-controlled path
+	data, err := os.ReadFile(backup) //nolint:gosec // reason: G304: test-controlled path
 	if err != nil {
 		t.Fatalf("read backup: %v", err)
 	}

--- a/internal/commands/reconcile_detector_stats_test.go
+++ b/internal/commands/reconcile_detector_stats_test.go
@@ -1,0 +1,208 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/db"
+)
+
+// seedDetectorStatsDB creates a database with one detected-instrumental row, one
+// detector-miss row, and one never-detected row, and writes a config pointing at
+// it.
+func setupDetectorStats(t *testing.T) (ctx context.Context, cfgPath, dbPath string) {
+	t.Helper()
+	ctx = context.Background()
+	dir := t.TempDir()
+	dbPath = filepath.Join(dir, "test.db")
+	cfgPath = filepath.Join(dir, "config.toml")
+	reconcilePathsCfg(t, cfgPath, dbPath)
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	rows := []struct {
+		title  string
+		result any
+	}{
+		{"Detected", 1},
+		{"NotInstrumental", 0},
+		{"NeverDetected", nil},
+	}
+	for _, r := range rows {
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO work_queue (artist, title, artist_key, title_key, instrumental_result, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+			"Artist", r.title, "Artist", r.title, r.result, "2026-01-01T00:00:00Z"); err != nil {
+			t.Fatalf("seed %q: %v", r.title, err)
+		}
+	}
+	return ctx, cfgPath, dbPath
+}
+
+func TestRunReconcileDetectorStats_DryRunWritesNothing(t *testing.T) {
+	ctx, cfgPath, dbPath := setupDetectorStats(t)
+
+	var out bytes.Buffer
+	if code := runReconcileDetectorStats(ctx, &out, ScanReconcileDetectorStatsCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("exit code = %d; want 0. output:\n%s", code, out.String())
+	}
+
+	if got := countRows(t, ctx, dbPath, "lane_attempts"); got != 0 {
+		t.Errorf("lane_attempts rows = %d after dry run; want 0", got)
+	}
+	s := out.String()
+	if !strings.Contains(s, "dry run") {
+		t.Errorf("output lacks the dry-run suffix:\n%s", s)
+	}
+	if !strings.Contains(s, "would attribute 2") {
+		t.Errorf("output should report 2 attributable rows:\n%s", s)
+	}
+}
+
+func TestRunReconcileDetectorStats_ApplyWritesBothBucketsAndBackup(t *testing.T) {
+	ctx, cfgPath, dbPath := setupDetectorStats(t)
+	backup := filepath.Join(t.TempDir(), "backup.jsonl")
+
+	var out bytes.Buffer
+	code := runReconcileDetectorStats(ctx, &out, ScanReconcileDetectorStatsCmd{
+		ConfigPath: cfgPath, Yes: true, Backup: backup,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0. output:\n%s", code, out.String())
+	}
+
+	if got := countRows(t, ctx, dbPath, "lane_attempts"); got != 2 {
+		t.Errorf("lane_attempts rows = %d; want 2", got)
+	}
+	s := out.String()
+	if !strings.Contains(s, "attributed 2 (1 hits, 1 misses") {
+		t.Errorf("output should report both buckets:\n%s", s)
+	}
+
+	// Both uncovered remainders must be stated, not just the countable one.
+	if !strings.Contains(s, "1 row(s) have no recorded detection verdict") {
+		t.Errorf("output should report the NULL remainder:\n%s", s)
+	}
+	if !strings.Contains(s, "ClearDone") {
+		t.Errorf("output should state the uncountable ClearDone remainder:\n%s", s)
+	}
+
+	data, err := os.ReadFile(backup) //nolint:gosec // G304: test-controlled path
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("backup has %d record(s); want 2", len(lines))
+	}
+	for _, ln := range lines {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(ln), &rec); err != nil {
+			t.Fatalf("backup record is not JSON: %v (%q)", err, ln)
+		}
+		if rec["lane"] != "detector" {
+			t.Errorf("backup record lane = %v; want detector", rec["lane"])
+		}
+	}
+}
+
+func TestRunReconcileDetectorStats_RerunIsNoOp(t *testing.T) {
+	ctx, cfgPath, dbPath := setupDetectorStats(t)
+
+	var first bytes.Buffer
+	if code := runReconcileDetectorStats(ctx, &first, ScanReconcileDetectorStatsCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first run exit = %d", code)
+	}
+	before := countRows(t, ctx, dbPath, "lane_attempts")
+
+	var second bytes.Buffer
+	if code := runReconcileDetectorStats(ctx, &second, ScanReconcileDetectorStatsCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("second run exit = %d", code)
+	}
+
+	if got := countRows(t, ctx, dbPath, "lane_attempts"); got != before {
+		t.Errorf("lane_attempts rows = %d after rerun; want %d (no double-count)", got, before)
+	}
+	if !strings.Contains(second.String(), "2 already recorded") {
+		t.Errorf("rerun should report the rows as already recorded:\n%s", second.String())
+	}
+}
+
+// The dispatch case is only exercised through the real parser with real argv.
+// Driving runReconcileDetectorStats directly proves the handler works and says
+// nothing about whether anything can reach it -- the exact gap that let a
+// declared-but-unreachable subcommand ship in v1.20.0.
+func TestReconcileDetectorStats_ReachableThroughRun(t *testing.T) {
+	_, cfgPath, dbPath := setupDetectorStats(t)
+
+	var out bytes.Buffer
+	code := Run(context.Background(),
+		[]string{"scan", "reconcile-detector-stats", "--config", cfgPath}, &out, Deps{})
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0. output:\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "reconcile-detector-stats:") {
+		t.Errorf("real argv did not reach the handler:\n%s", out.String())
+	}
+	if got := countRows(t, context.Background(), dbPath, "lane_attempts"); got != 0 {
+		t.Errorf("lane_attempts rows = %d; want 0 (no --yes means dry run)", got)
+	}
+}
+
+func TestRunReconcileDetectorStats_UnreadableConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("this is not = valid toml ["), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	if code := runReconcileDetectorStats(context.Background(), &out, ScanReconcileDetectorStatsCmd{ConfigPath: cfgPath}); code != 1 {
+		t.Errorf("exit code = %d; want 1 on an unparsable config", code)
+	}
+}
+
+func TestRunReconcileDetectorStats_UnopenableDatabase(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	// A db path under a file (not a directory) cannot be opened.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	reconcilePathsCfg(t, cfgPath, filepath.Join(blocker, "nested.db"))
+
+	var out bytes.Buffer
+	if code := runReconcileDetectorStats(context.Background(), &out, ScanReconcileDetectorStatsCmd{ConfigPath: cfgPath}); code != 1 {
+		t.Errorf("exit code = %d; want 1 when the database cannot be opened", code)
+	}
+}
+
+// An unwritable backup path must abort the run and leave nothing attributed.
+// This exercises the backup-first ordering end to end: report runs inside the
+// engine's transaction before commit, so a backup failure rolls the whole
+// attribution back rather than applying it without a restorable record.
+func TestRunReconcileDetectorStats_UnwritableBackupRollsBack(t *testing.T) {
+	ctx, cfgPath, dbPath := setupDetectorStats(t)
+	// A path under a non-existent directory cannot be created.
+	backup := filepath.Join(t.TempDir(), "no-such-dir", "backup.jsonl")
+
+	var out bytes.Buffer
+	code := runReconcileDetectorStats(ctx, &out, ScanReconcileDetectorStatsCmd{
+		ConfigPath: cfgPath, Yes: true, Backup: backup,
+	})
+	if code != 1 {
+		t.Errorf("exit code = %d; want 1 when the backup cannot be written", code)
+	}
+	if got := countRows(t, ctx, dbPath, "lane_attempts"); got != 0 {
+		t.Errorf("lane_attempts rows = %d; want 0 -- an unrecordable attribution must not be applied", got)
+	}
+}

--- a/internal/detectorbackfill/detectorbackfill.go
+++ b/internal/detectorbackfill/detectorbackfill.go
@@ -1,0 +1,345 @@
+// Package detectorbackfill attributes historical audio detections to the
+// detector lane in lane_attempts (migration 022), correcting an under-count that
+// exists because instrumentals settled before the detector became a lane (#501,
+// #524) were resolved inline on the provider-miss path and never attributed to
+// any lane (issue #537).
+//
+// This is a reporting artifact, not a behavioral bug: the tracks were detected
+// correctly and their markers were written correctly. Only the attribution is
+// missing.
+//
+// # The key, and why not the source tag
+//
+// The backfill is driven from work_queue.instrumental_result (migration 018),
+// which records the audio-detection verdict independently of lane attribution:
+//
+//	1    -> the detector served the track          -> lane_attempts hit=1
+//	0    -> the detector ran and lost              -> lane_attempts hit=0
+//	NULL -> detection did not run for this item    -> no row
+//
+// It is deliberately NOT driven from a missing [source:] marker tag. On the
+// instrumental branch of internal/lyrics/writer.go the source is song.WinningLane,
+// replaced by lyrics.SourceDetector (the string "canticle-detector", NOT this
+// package's LaneName) when song.DetectorVersion is set. Both a detector settle
+// and a provider-flagged instrumental therefore carry a [source:] tag. A record
+// with no source is one where NEITHER was recorded, which includes provider-flagged
+// instrumentals predating WinningLane; attributing those to the detector would
+// credit provider work to the detector and inflate the very figure this package
+// exists to correct.
+//
+// # Both buckets, always
+//
+// reports.ProviderEffectiveness renders Hits/attempts where attempts = hits +
+// misses, so filling only the hits would drive the displayed hit rate toward
+// 100% and read worse than the current under-count. Hits and misses derive from
+// a single scan of the same column here, so a hits-only fill is structurally
+// impossible rather than merely avoided by care.
+//
+// # Recorded history wins over reconstruction
+//
+// Unlike queue.RecordLaneAttempts, which upserts with DO UPDATE so an --upgrade
+// re-run refreshes the outcome, this package inserts with ON CONFLICT DO
+// NOTHING. A lane_attempts row that already exists was recorded live and is
+// authoritative; derived historical data must never overwrite it. That also
+// makes the backfill idempotent at the row level: re-running it is a no-op.
+//
+// # Two uncovered remainders
+//
+// Rows with a NULL instrumental_result have no discriminator in the database and
+// none in the marker files either, since the absent source tag is what makes
+// them identifiable as a gap in the first place. They are counted and reported,
+// never estimated: a guessed value written into a counter the dashboard presents
+// as fact is worse than a known gap.
+//
+// The second remainder is invisible from here. lane_attempts deliberately
+// carries no foreign key to work_queue so its history survives ClearDone, but
+// this backfill reads work_queue, so detections on rows already swept cannot be
+// recovered or even counted. Callers should say so rather than presenting the
+// NULL tally as the whole remainder.
+package detectorbackfill
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// LaneName is the lane string this package writes into lane_attempts.
+//
+// It is a fourth copy of the "detector" literal (alongside the unexported
+// constants in internal/worker and internal/orchestrator, which a third package
+// cannot import). Duplicating it is deliberate: issue #539 renames the Go
+// identifiers only, and the persisted lane string stays "detector" precisely
+// because it is the primary key of provider_outcomes and the value written to
+// work_queue.provider_lane. Exporting one of the existing constants would invite
+// that rename to move the stored value.
+const LaneName = "detector"
+
+// Change describes one work_queue row about to be attributed to the detector
+// lane. It is reported to the caller once per row, for a preview under DryRun or
+// a durable record under apply.
+type Change struct {
+	QueueID     int64  `json:"queue_id"`
+	Lane        string `json:"lane"`
+	Hit         bool   `json:"hit"`
+	AttemptedAt string `json:"attempted_at"`
+}
+
+// Result tallies the outcome of a Run.
+type Result struct {
+	// Scanned counts work_queue rows carrying a usable instrumental_result.
+	Scanned int
+	// Hits and Misses count rows attributed as hit=1 and hit=0 respectively.
+	// Both move together or the rendered hit rate is corrupted.
+	Hits int
+	// Misses counts rows attributed as hit=0 (the detector ran and lost).
+	Misses int
+	// AlreadyRecorded counts rows skipped because lane_attempts already held a
+	// row for (queue_id, "detector"). Those were recorded live and are
+	// authoritative; the backfill leaves them untouched.
+	AlreadyRecorded int
+	// UncoveredNull counts work_queue rows whose instrumental_result is NULL or
+	// otherwise unusable. These are the recoverable-remainder-that-isn't: they
+	// are reported, never estimated.
+	UncoveredNull int
+}
+
+// Options controls a Run.
+type Options struct {
+	// DryRun computes and reports the attributions without writing them.
+	DryRun bool
+	// Report is invoked once per change: under DryRun before returning (a
+	// preview), under apply inside the transaction before commit (a durable
+	// record). Nil disables it. A Report error aborts the Run and rolls back.
+	//
+	// There is deliberately no Progress hook: measured at 72ms for 12k rows, the
+	// run is far too short for a liveness signal to earn its keep.
+	Report func(Change) error
+}
+
+// Backfiller attributes historical audio detections to the detector lane.
+type Backfiller struct {
+	db *sql.DB
+}
+
+// New builds a Backfiller over db.
+func New(db *sql.DB) *Backfiller {
+	return &Backfiller{db: db}
+}
+
+// row is one work_queue row's detection verdict, loaded up front so the writes
+// do not hold a query cursor open on the single pooled connection.
+type row struct {
+	id          int64
+	hit         bool
+	attemptedAt string
+}
+
+// Run attributes every recoverable historical detection to the detector lane and
+// returns the tally of what was written (or would be, under DryRun).
+func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
+	var res Result
+
+	uncovered, err := b.countUncovered(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	res.UncoveredNull = uncovered
+
+	rows, err := b.load(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if opts.DryRun {
+		return b.runDry(ctx, rows, res, opts)
+	}
+	return b.runApply(ctx, rows, res, opts)
+}
+
+// runDry previews the attributions without writing. It still consults
+// lane_attempts so AlreadyRecorded reflects what an apply would actually skip,
+// rather than over-promising the number of rows that would change.
+func (b *Backfiller) runDry(ctx context.Context, rows []row, res Result, opts Options) (Result, error) {
+	for _, rw := range rows {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		res.Scanned++
+
+		exists, err := b.alreadyRecorded(ctx, rw.id)
+		if err != nil {
+			return res, err
+		}
+		if exists {
+			res.AlreadyRecorded++
+			continue
+		}
+
+		tally(&res, rw.hit)
+		if opts.Report != nil {
+			if err := opts.Report(change(rw)); err != nil {
+				return res, fmt.Errorf("detectorbackfill: report change for queue row %d: %w", rw.id, err)
+			}
+		}
+	}
+	return res, nil
+}
+
+// runApply writes the attributions in one transaction. opts.Report runs INSIDE
+// that transaction, before commit, so the restorable record is durable before
+// the write it protects commits (backup-first) and a report failure rolls the
+// whole run back. A single transaction is safe here because ON CONFLICT DO
+// NOTHING makes a re-run after an abort a no-op rather than a double-count.
+func (b *Backfiller) runApply(ctx context.Context, rows []row, res Result, opts Options) (Result, error) {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return res, fmt.Errorf("detectorbackfill: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, rw := range rows {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		res.Scanned++
+
+		hit := 0
+		if rw.hit {
+			hit = 1
+		}
+		// DO NOTHING, not DO UPDATE: a row already present was recorded live by
+		// queue.RecordLaneAttempts and outranks this reconstruction.
+		out, err := tx.ExecContext(ctx,
+			`INSERT INTO lane_attempts(queue_id, lane, hit, attempted_at) VALUES(?, ?, ?, ?)
+             ON CONFLICT(queue_id, lane) DO NOTHING`,
+			rw.id, LaneName, hit, rw.attemptedAt,
+		)
+		if err != nil {
+			return res, fmt.Errorf("detectorbackfill: insert attempt for queue row %d: %w", rw.id, err)
+		}
+		affected, err := out.RowsAffected()
+		if err != nil {
+			return res, fmt.Errorf("detectorbackfill: rows affected for queue row %d: %w", rw.id, err)
+		}
+		if affected == 0 {
+			res.AlreadyRecorded++
+			continue
+		}
+
+		tally(&res, rw.hit)
+		if opts.Report != nil {
+			if err := opts.Report(change(rw)); err != nil {
+				return res, fmt.Errorf("detectorbackfill: report change for queue row %d: %w", rw.id, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return res, fmt.Errorf("detectorbackfill: commit: %w", err)
+	}
+	return res, nil
+}
+
+// tally records one attributed row in the hit or miss bucket.
+func tally(res *Result, hit bool) {
+	if hit {
+		res.Hits++
+		return
+	}
+	res.Misses++
+}
+
+// change shapes a loaded row into the reported Change.
+func change(rw row) Change {
+	return Change{QueueID: rw.id, Lane: LaneName, Hit: rw.hit, AttemptedAt: rw.attemptedAt}
+}
+
+// alreadyRecorded reports whether lane_attempts already holds a detector row for
+// this work_queue id.
+func (b *Backfiller) alreadyRecorded(ctx context.Context, queueID int64) (bool, error) {
+	var one int
+	err := b.db.QueryRowContext(ctx,
+		`SELECT 1 FROM lane_attempts WHERE queue_id = ? AND lane = ?`, queueID, LaneName).Scan(&one)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	default:
+		return false, fmt.Errorf("detectorbackfill: check existing attempt for queue row %d: %w", queueID, err)
+	}
+}
+
+// countUncovered counts work_queue rows that carry no usable detection verdict.
+// These cannot be attributed from recorded data and are reported as a remainder
+// rather than estimated into the counters.
+func (b *Backfiller) countUncovered(ctx context.Context) (int, error) {
+	var n int
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue
+          WHERE instrumental_result IS NULL OR instrumental_result NOT IN (0, 1)`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("detectorbackfill: count uncovered rows: %w", err)
+	}
+	return n, nil
+}
+
+// load reads every work_queue row carrying a usable detection verdict.
+//
+// attempted_at is sourced from work_queue.updated_at, which is a PROXY, not an
+// observation: the true detection time was never recorded. It is an upper bound,
+// since updated_at advances on every later touch of the row.
+//
+// completed_at is deliberately NOT used, because it correlates with the verdict
+// being counted. Traced across EVERY writer of instrumental_result, not just one
+// path per verdict:
+//
+//	HIT  (=1): queue.SettleInstrumental stamps completed_at in the same UPDATE
+//	           (status -> 'done'); the worker's detector-settle path reaches
+//	           queue.Complete, which also stamps it. Both hit writers set it.
+//	MISS (=0): queue.StampUnclassifiedMiss is the only writer. Its UPDATE is
+//	           guarded `AND status = 'deferred'` -- the row is ALREADY deferred
+//	           when the 0 is stamped -- and it touches neither completed_at nor
+//	           status, so completed_at stays NULL.
+//
+// Both verdicts are stamped on rows that reached 'deferred'; the asymmetry is
+// purely that the hit writers promote the row to 'done' with a timestamp and the
+// miss writer leaves it deferred and untimestamped.
+//
+// Keying on completed_at would therefore drop misses at a higher rate than hits
+// and reintroduce exactly the ratio skew this package exists to prevent. That is
+// the same failure mode as a hits-only fill, arriving by a subtler route: a
+// filter that correlates with the outcome corrupts a rendered rate far more than
+// it costs precision.
+//
+// The choice does not affect the corrected figures in any case:
+// reports.ProviderEffectiveness groups by lane and never filters or sorts on
+// attempted_at.
+func (b *Backfiller) load(ctx context.Context) ([]row, error) {
+	rows, err := b.db.QueryContext(ctx,
+		`SELECT id, instrumental_result, updated_at FROM work_queue
+          WHERE instrumental_result IN (0, 1)
+          ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("detectorbackfill: query work_queue: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []row
+	for rows.Next() {
+		var (
+			rw     row
+			result int
+		)
+		if err := rows.Scan(&rw.id, &result, &rw.attemptedAt); err != nil {
+			return nil, fmt.Errorf("detectorbackfill: scan work_queue row: %w", err)
+		}
+		rw.hit = result == 1
+		out = append(out, rw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("detectorbackfill: iterate work_queue: %w", err)
+	}
+	return out, nil
+}

--- a/internal/detectorbackfill/detectorbackfill.go
+++ b/internal/detectorbackfill/detectorbackfill.go
@@ -164,7 +164,7 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 func (b *Backfiller) runDry(ctx context.Context, rows []row, res Result, opts Options) (Result, error) {
 	for _, rw := range rows {
 		if err := ctx.Err(); err != nil {
-			return res, err
+			return res, fmt.Errorf("detectorbackfill: dry run canceled: %w", err)
 		}
 		res.Scanned++
 
@@ -201,7 +201,7 @@ func (b *Backfiller) runApply(ctx context.Context, rows []row, res Result, opts 
 
 	for _, rw := range rows {
 		if err := ctx.Err(); err != nil {
-			return res, err
+			return res, fmt.Errorf("detectorbackfill: apply canceled: %w", err)
 		}
 		res.Scanned++
 

--- a/internal/detectorbackfill/detectorbackfill_test.go
+++ b/internal/detectorbackfill/detectorbackfill_test.go
@@ -1,0 +1,379 @@
+package detectorbackfill
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	dbpkg "github.com/sydlexius/canticle/internal/db"
+)
+
+var errReport = errors.New("report boom")
+
+func openDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := dbpkg.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+// seedQueue inserts one work_queue row. instrumentalResult is an int (0/1) or
+// nil. updatedAt seeds the column the backfill reads for attempted_at.
+func seedQueue(t *testing.T, sqlDB *sql.DB, title string, instrumentalResult any, updatedAt string) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue (artist, title, artist_key, title_key, instrumental_result, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+		"Artist", title, "Artist", title, instrumentalResult, updatedAt)
+	if err != nil {
+		t.Fatalf("insert work_queue %q: %v", title, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+// seedAttempt inserts a pre-existing lane_attempts row, standing in for one
+// recorded live by queue.RecordLaneAttempts.
+func seedAttempt(t *testing.T, sqlDB *sql.DB, queueID int64, lane string, hit int, at string) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (?, ?, ?, ?)`,
+		queueID, lane, hit, at); err != nil {
+		t.Fatalf("insert lane_attempts: %v", err)
+	}
+}
+
+// readAttempt returns the stored hit and attempted_at for one queue row's
+// detector attempt. Assertions only ever concern the detector lane; a
+// pre-existing row on another lane is seeded, never read back.
+func readAttempt(t *testing.T, sqlDB *sql.DB, queueID int64) (hit int, at string, found bool) {
+	t.Helper()
+	err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT hit, attempted_at FROM lane_attempts WHERE queue_id = ? AND lane = ?`,
+		queueID, LaneName).Scan(&hit, &at)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, "", false
+	}
+	if err != nil {
+		t.Fatalf("read lane_attempts: %v", err)
+	}
+	return hit, at, true
+}
+
+func countAttempts(t *testing.T, sqlDB *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM lane_attempts`).Scan(&n); err != nil {
+		t.Fatalf("count lane_attempts: %v", err)
+	}
+	return n
+}
+
+func TestRun_BackfillsBothBuckets(t *testing.T) {
+	sqlDB := openDB(t)
+	hitID := seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+	missID := seedQueue(t, sqlDB, "NotInstrumental", 0, "2026-01-02T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.Hits != 1 || res.Misses != 1 {
+		t.Errorf("Hits/Misses = %d/%d; want 1/1 -- both buckets must move together", res.Hits, res.Misses)
+	}
+	if res.Scanned != 2 {
+		t.Errorf("Scanned = %d; want 2", res.Scanned)
+	}
+
+	if hit, _, found := readAttempt(t, sqlDB, hitID); !found || hit != 1 {
+		t.Errorf("hit row: hit=%d found=%v; want 1/true", hit, found)
+	}
+	if hit, _, found := readAttempt(t, sqlDB, missID); !found || hit != 0 {
+		t.Errorf("miss row: hit=%d found=%v; want 0/true", hit, found)
+	}
+}
+
+// A recorded live attempt is authoritative. This test discriminates ON CONFLICT
+// DO NOTHING from the DO UPDATE clause used by queue.RecordLaneAttempts: under
+// DO UPDATE the stored hit would be clobbered from 1 to 0 by the backfill's
+// reconstructed verdict.
+func TestRun_DoesNotOverwriteRecordedAttempt(t *testing.T) {
+	sqlDB := openDB(t)
+	id := seedQueue(t, sqlDB, "LiveRecorded", 0, "2026-01-02T00:00:00Z")
+	seedAttempt(t, sqlDB, id, LaneName, 1, "2026-06-01T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.AlreadyRecorded != 1 {
+		t.Errorf("AlreadyRecorded = %d; want 1", res.AlreadyRecorded)
+	}
+	if res.Hits != 0 || res.Misses != 0 {
+		t.Errorf("Hits/Misses = %d/%d; want 0/0 -- a skipped row must not be tallied", res.Hits, res.Misses)
+	}
+
+	hit, at, found := readAttempt(t, sqlDB, id)
+	if !found {
+		t.Fatal("recorded attempt vanished")
+	}
+	if hit != 1 {
+		t.Errorf("hit = %d; want 1 -- the backfill clobbered a live-recorded attempt", hit)
+	}
+	if at != "2026-06-01T00:00:00Z" {
+		t.Errorf("attempted_at = %q; want the live value preserved", at)
+	}
+}
+
+func TestRun_IsIdempotent(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+	seedQueue(t, sqlDB, "NotInstrumental", 0, "2026-01-02T00:00:00Z")
+
+	b := New(sqlDB)
+	if _, err := b.Run(context.Background(), Options{}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	afterFirst := countAttempts(t, sqlDB)
+
+	second, err := b.Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	if got := countAttempts(t, sqlDB); got != afterFirst {
+		t.Errorf("lane_attempts rows = %d after second run; want %d (no double-count)", got, afterFirst)
+	}
+	if second.Hits != 0 || second.Misses != 0 {
+		t.Errorf("second run Hits/Misses = %d/%d; want 0/0", second.Hits, second.Misses)
+	}
+	if second.AlreadyRecorded != 2 {
+		t.Errorf("second run AlreadyRecorded = %d; want 2", second.AlreadyRecorded)
+	}
+}
+
+func TestRun_NullResultIsUncoveredAndUntouched(t *testing.T) {
+	sqlDB := openDB(t)
+	nullID := seedQueue(t, sqlDB, "NeverDetected", nil, "2026-01-03T00:00:00Z")
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.UncoveredNull != 1 {
+		t.Errorf("UncoveredNull = %d; want 1", res.UncoveredNull)
+	}
+	if res.Scanned != 1 {
+		t.Errorf("Scanned = %d; want 1 -- a NULL row must not be scanned", res.Scanned)
+	}
+	if _, _, found := readAttempt(t, sqlDB, nullID); found {
+		t.Error("a NULL instrumental_result row was attributed; it must be left untouched")
+	}
+}
+
+func TestRun_AttemptedAtComesFromUpdatedAt(t *testing.T) {
+	sqlDB := openDB(t)
+	id := seedQueue(t, sqlDB, "Detected", 1, "2026-05-04T03:02:01Z")
+
+	if _, err := New(sqlDB).Run(context.Background(), Options{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	_, at, found := readAttempt(t, sqlDB, id)
+	if !found {
+		t.Fatal("attempt not written")
+	}
+	if at != "2026-05-04T03:02:01Z" {
+		t.Errorf("attempted_at = %q; want the row's updated_at", at)
+	}
+}
+
+func TestRun_DryRunWritesNothing(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+	seedQueue(t, sqlDB, "NotInstrumental", 0, "2026-01-02T00:00:00Z")
+
+	var reported []Change
+	res, err := New(sqlDB).Run(context.Background(), Options{
+		DryRun: true,
+		Report: func(c Change) error { reported = append(reported, c); return nil },
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.Hits != 1 || res.Misses != 1 {
+		t.Errorf("Hits/Misses = %d/%d; want 1/1", res.Hits, res.Misses)
+	}
+	if len(reported) != 2 {
+		t.Errorf("reported %d changes; want 2", len(reported))
+	}
+	if got := countAttempts(t, sqlDB); got != 0 {
+		t.Errorf("lane_attempts rows = %d after dry run; want 0", got)
+	}
+}
+
+// A dry run must consult lane_attempts too, so its preview does not promise
+// changes that an apply would skip.
+func TestRun_DryRunCountsAlreadyRecorded(t *testing.T) {
+	sqlDB := openDB(t)
+	id := seedQueue(t, sqlDB, "LiveRecorded", 1, "2026-01-01T00:00:00Z")
+	seedAttempt(t, sqlDB, id, LaneName, 1, "2026-06-01T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{DryRun: true})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.AlreadyRecorded != 1 {
+		t.Errorf("AlreadyRecorded = %d; want 1", res.AlreadyRecorded)
+	}
+	if res.Hits != 0 {
+		t.Errorf("Hits = %d; want 0 -- dry run must not promise a skipped row", res.Hits)
+	}
+}
+
+// A pre-existing attempt on a DIFFERENT lane must not shield the detector row:
+// UNIQUE(queue_id, lane) is per-lane, so the detector attempt still lands.
+func TestRun_OtherLaneAttemptDoesNotBlock(t *testing.T) {
+	sqlDB := openDB(t)
+	id := seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+	seedAttempt(t, sqlDB, id, "musixmatch", 0, "2026-06-01T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.Hits != 1 {
+		t.Errorf("Hits = %d; want 1", res.Hits)
+	}
+	if hit, _, found := readAttempt(t, sqlDB, id); !found || hit != 1 {
+		t.Errorf("detector attempt: hit=%d found=%v; want 1/true", hit, found)
+	}
+}
+
+// Report runs inside the transaction before commit, so a report failure must
+// leave the database untouched (backup-first: never apply without a record).
+func TestRun_ReportFailureRollsBack(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+	seedQueue(t, sqlDB, "NotInstrumental", 0, "2026-01-02T00:00:00Z")
+
+	_, err := New(sqlDB).Run(context.Background(), Options{
+		Report: func(Change) error { return errReport },
+	})
+	if err == nil {
+		t.Fatal("expected a report error")
+	}
+	if !errors.Is(err, errReport) {
+		t.Errorf("error = %v; want it to wrap errReport", err)
+	}
+	if got := countAttempts(t, sqlDB); got != 0 {
+		t.Errorf("lane_attempts rows = %d after a failed report; want 0 (rolled back)", got)
+	}
+}
+
+func TestRun_ContextCanceled(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := New(sqlDB).Run(ctx, Options{}); err == nil {
+		t.Fatal("expected a context error")
+	}
+	if got := countAttempts(t, sqlDB); got != 0 {
+		t.Errorf("lane_attempts rows = %d after cancellation; want 0", got)
+	}
+}
+
+func TestRun_EmptyQueue(t *testing.T) {
+	sqlDB := openDB(t)
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res != (Result{}) {
+		t.Errorf("Result = %+v; want the zero value", res)
+	}
+}
+
+func TestRun_DryRunContextCanceled(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := New(sqlDB).Run(ctx, Options{DryRun: true}); err == nil {
+		t.Fatal("expected a context error")
+	}
+}
+
+// A dry run previews into the same Report sink an apply writes a backup to, so
+// a sink failure must surface rather than being reported as a clean preview.
+func TestRun_DryRunReportFailureAborts(t *testing.T) {
+	sqlDB := openDB(t)
+	seedQueue(t, sqlDB, "Detected", 1, "2026-01-01T00:00:00Z")
+
+	_, err := New(sqlDB).Run(context.Background(), Options{
+		DryRun: true,
+		Report: func(Change) error { return errReport },
+	})
+	if err == nil {
+		t.Fatal("expected a report error")
+	}
+	if !errors.Is(err, errReport) {
+		t.Errorf("error = %v; want it to wrap errReport", err)
+	}
+}
+
+// The package's core invariant is that hits and misses move TOGETHER. Every
+// other both-buckets test seeds 1 hit and 1 miss, so a swap of the two counters
+// in tally() leaves 1/1 as 1/1 and survives them all. This fixture is
+// deliberately ASYMMETRIC so the buckets cannot be confused for one another.
+func TestRun_BucketsAreNotTransposed(t *testing.T) {
+	sqlDB := openDB(t)
+	hitA := seedQueue(t, sqlDB, "DetectedA", 1, "2026-01-01T00:00:00Z")
+	hitB := seedQueue(t, sqlDB, "DetectedB", 1, "2026-01-02T00:00:00Z")
+	missID := seedQueue(t, sqlDB, "NotInstrumental", 0, "2026-01-03T00:00:00Z")
+
+	res, err := New(sqlDB).Run(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.Hits != 2 {
+		t.Errorf("Hits = %d; want 2 (buckets transposed?)", res.Hits)
+	}
+	if res.Misses != 1 {
+		t.Errorf("Misses = %d; want 1 (buckets transposed?)", res.Misses)
+	}
+
+	// Assert the stored verdict per row, not just the totals: a tally that is
+	// right in aggregate can still write the wrong hit value per row.
+	for _, id := range []int64{hitA, hitB} {
+		if hit, _, found := readAttempt(t, sqlDB, id); !found || hit != 1 {
+			t.Errorf("queue row %d: hit=%d found=%v; want 1/true", id, hit, found)
+		}
+	}
+	if hit, _, found := readAttempt(t, sqlDB, missID); !found || hit != 0 {
+		t.Errorf("miss row: hit=%d found=%v; want 0/true", hit, found)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `scan reconcile-detector-stats`, attributing historical audio detections to the detector lane so its statistics stop reading artificially low. Dry-run by default, `--yes` to apply, JSONL backup, matching the sibling reconcile commands.
- **The issue's stated premise was wrong and this diverges from it.** #537 specified backfilling `provider_outcomes`, citing the dashboard's `Hits/attempts` tile. That tile (`internal/web/dashboard.go:138`) consumes `reports.ProviderEffectiveness`, which queries **`lane_attempts`** (migration 022), not `provider_outcomes` (018) -- `internal/reports/reports.go:196-204` records that decision explicitly. Implementing the issue literally would have moved `/metrics` and left the tile it argues about unchanged. The rescope is recorded on the issue; the issue body still reads the old way.
- Size override: single cohesive concern (one issue: engine + its CLI driver + tests). 453 of 935 LOC are tests and 133 are package documentation; splitting engine from CLI would land a caller-less package and make the dry-run/apply split unreviewable.

Three decisions worth reviewing on their merits:

**`ON CONFLICT DO NOTHING`, not the `DO UPDATE` in `queue.RecordLaneAttempts`.** That clause is correct for live traffic, where an `--upgrade` re-run should refresh the outcome, but wrong here: it would let reconstructed history clobber a live-recorded attempt. Recorded history outranks reconstruction. It also yields row-level idempotency for free, so a re-run is a no-op.

**`attempted_at` comes from `work_queue.updated_at`**, documented at the write site as a proxy upper bound rather than an observation. `completed_at` is rejected because it correlates with the verdict being counted: both hit writers (`queue.SettleInstrumental`, and the detector-settle path through `queue.Complete`) stamp it, while the sole miss writer (`queue.StampUnclassifiedMiss`) does not. Keying on it would drop misses at a higher rate than hits and reintroduce the ratio skew the issue exists to prevent.

**Two uncovered remainders, reported and never estimated.** Rows with a NULL `instrumental_result` are counted. Rows already swept by `ClearDone` are invisible from `work_queue` entirely, so the summary says so rather than implying the NULL tally is the whole gap.

## Linked issue

Closes #537

The rescoped acceptance criteria posted on the issue are all met. The original body's criteria referenced `provider_outcomes` and are superseded; that surface is #548.

## Out of scope

`/metrics` reads `provider_outcomes` and remains undercounted. Tracked in #548, deliberately separate rather than a second half of this PR: `recordMisses` (`internal/worker/worker.go:622`, called only at `:883`) credits every lane but only when all lanes missed, so a detector miss followed by a provider win records nothing in `provider_outcomes` while `lane_attempts` records `hit=0`. This PR's key does not transfer, and #548's first task is deciding whether that subset is recoverable at all.

## Gates

- [x] `make gate` -- full pre-push chain, exit 0
- [x] conflict markers, typos, gofmt, go build
- [x] `go test` race + coverage, all packages
- [x] patch coverage 77.62% (threshold 70%)
- [x] coverage floor ratchet -- all packages at or above floor
- [x] golangci-lint -- 0 issues
- [x] actionlint
- [x] govulncheck -- 0 vulnerabilities called

## Test plan

- [x] Engine tests over real SQLite via `dbpkg.Open` (temp file, real migrations): both buckets, idempotency, NULL remainder, `attempted_at` provenance, dry-run isolation, report-failure rollback, context cancellation.
- [x] **Tests verified to discriminate.** The `DO NOTHING` behavior was checked against a `DO UPDATE` implementation and the guarding tests fail there. A transposed `tally()` was likewise checked and is caught by an asymmetric 2-hit/1-miss fixture, added after review found the symmetric 1/1 fixtures could not detect it.
- [x] CLI tests: dry-run writes nothing, apply writes both buckets plus backup, re-run is a no-op, unparsable config, unopenable database, unwritable backup rolls back.
- [x] Reachability through the real parser with real argv, not just the handler -- the gap that let a declared-but-unreachable subcommand ship in v1.20.0.
- [x] Driven end to end against the built binary: seeded rows, dry run, apply, re-run. A live-recorded attempt that disagreed with the reconstructed verdict survived untouched; the re-run attributed 0. The dashboard's exact query was run against the result to confirm the read path sees the backfill.
- [ ] Reviewer follow-ups

## Review notes

An adversarial pre-push review ran and found no Critical issues. Four Important findings were fixed: two doc comments asserted incorrect claims about other packages (the `writer.go` source-tag override is nested inside the instrumental branch and `SourceDetector` is `"canticle-detector"`, not `"detector"`; the `completed_at` trace named only one writer per verdict and had the miss ordering backwards), the test-vacuity gap above, and a restore-procedure hazard now documented (deleting backed-up pairs is only safe before a subsequent worker run, since `RecordLaneAttempts` may overwrite a backfilled row in place). An unwired `Options.Progress` hook was removed rather than left as dead code.

One finding was declined: "sibling commands are documented" is not accurate -- none of the five sibling `reconcile-*` subcommands appear in any non-design doc, so documenting this one alone would break precedent. These maintenance commands are discoverable through `--help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `scan reconcile-detector-stats` command to review and reconcile historical detector statistics.
  - Supports safe dry runs, optional application with `--yes`, configuration selection, and JSONL backups.
  - Reports detector hits, misses, previously recorded entries, and uncovered results.
  - Added shell completion support for the new command.

- **Bug Fixes**
  - Reconciliation is idempotent and preserves existing records.
  - Failed backups or processing errors prevent partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->