### PR TITLE
fix(musixmatch): let the adaptive pacer ratchet back down

### DIFF
--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -29,6 +29,20 @@ const (
 	// required before the adaptive level steps down by one. Requiring a sustained
 	// clean streak prevents premature recovery that would restart the sawtooth.
 	adaptiveSuccessThreshold = 5
+	// adaptiveDecayInterval is how long the pacer must go without a fresh
+	// OnThrottle before it eases the adaptive level down by one step, evaluated
+	// lazily on each pace() call (see decayLocked) rather than by a background
+	// goroutine/ticker. It exists because adaptiveSuccessThreshold alone can
+	// starve: measured production traffic settled 52 items in the window after
+	// the last ratchet with only 2 reaching OnSuccess (most were benign misses,
+	// which never reach the pacer), so the consecutive-streak path is
+	// effectively unreachable and the level would otherwise be permanent until
+	// restart (#492). 20 minutes is a deliberate middle ground: a full unwind
+	// from adaptiveMaxLevel takes 3 * this (60 minutes), which is long enough
+	// that a short lull between genuine 401s does not immediately erase the
+	// ratchet and re-provoke the provider, but short enough to recover within a
+	// single day of serve-mode operation even when catalog-hit luck is poor.
+	adaptiveDecayInterval = 20 * time.Minute
 )
 
 // Sentinel errors returned by the Musixmatch client. Callers should use
@@ -139,6 +153,12 @@ type Client struct {
 	// recovery cycles (the breaker's trip count is deliberately NOT used).
 	adaptiveLevel        int
 	consecutiveSuccesses int
+	// lastLevelChange is the time adaptiveLevel last changed (up via OnThrottle,
+	// or down via either the success streak or time decay). The zero value means
+	// "never changed" -- decayLocked will not fire until a throttle has actually
+	// occurred, since there is nothing to decay from and no meaningful elapsed
+	// window to measure.
+	lastLevelChange time.Time
 }
 
 // NewClient creates a new Musixmatch API client.
@@ -169,16 +189,26 @@ func ctxSleep(ctx context.Context, d time.Duration) bool {
 //
 //	client := musixmatch.NewClient(token).WithMinInterval(15 * time.Second)
 //
-// A zero or negative value disables pacing (the default). This method is not
-// goroutine-safe; call it before sharing the client across goroutines.
+// A zero or negative value disables pacing (the default). The write is
+// guarded by the same mutex pace() reads minInterval under (#494), so calling
+// this concurrently with in-flight FindLyrics calls is race-free -- but it is
+// still not a supported runtime reconfiguration knob: a concurrent caller may
+// observe either the old or the new interval for any given pace() call, with
+// no ordering guarantee beyond "no data race." Prefer setting it once before
+// sharing the client across goroutines.
 func (c *Client) WithMinInterval(d time.Duration) *Client {
+	c.mu.Lock()
 	c.minInterval = d
+	c.mu.Unlock()
 	return c
 }
 
 // MinInterval returns the configured minimum request interval. A zero value
-// means pacing is disabled.
+// means pacing is disabled. Guarded by the same mutex WithMinInterval writes
+// under (#494).
 func (c *Client) MinInterval() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.minInterval
 }
 
@@ -197,12 +227,20 @@ func (c *Client) MinInterval() time.Duration {
 // reserved slot best-effort (see the rollback below) so it does not push every
 // later caller back one interval.
 func (c *Client) pace(ctx context.Context) error {
+	c.mu.Lock()
+	// minInterval is read under the lock (#494): it is written by
+	// WithMinInterval, which also takes c.mu, so reading it before Lock (as this
+	// used to) was a bare data race against any concurrent setter, independent
+	// of the adaptive-state fields below.
 	if c.minInterval <= 0 {
+		c.mu.Unlock()
 		return nil
 	}
-
-	c.mu.Lock()
 	now := c.now()
+	// Lazily evaluate time-based ratchet-down before reading the level: this is
+	// the sole checkpoint (no goroutine/ticker), so it must run on every pace()
+	// call, under the same lock that guards adaptiveLevel.
+	c.decayLocked(now)
 	// Adaptive interval: minInterval scaled by the current ratcheting level.
 	// minInterval is the floor (level 0 == 1x), keeping api.cooldown as the
 	// explicit override the operator configured.
@@ -256,7 +294,11 @@ func (c *Client) pace(ctx context.Context) error {
 // takes no parameter: the level is maintained independently of the circuit
 // breaker's trip count so it persists across circuit recovery cycles (using the
 // breaker's trips would snap the multiplier back to 1x on every recovery, the
-// exact sawtooth this fixes).
+// exact sawtooth this fixes). It always resets the decay clock to now, so a
+// fresh throttle re-ratchets immediately and time decay cannot fire again until
+// a full adaptiveDecayInterval of throttle-free time has passed since THIS
+// event -- the provider gets the full benefit of the doubt period after every
+// genuine throttle signal.
 func (c *Client) OnThrottle() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -264,12 +306,16 @@ func (c *Client) OnThrottle() {
 		c.adaptiveLevel++
 	}
 	c.consecutiveSuccesses = 0
+	c.lastLevelChange = c.now()
 }
 
 // OnSuccess implements the providers.AdaptivePacer interface. It records a
 // successful fetch; once consecutiveSuccesses reaches adaptiveSuccessThreshold
 // it steps the adaptive level down by one (floored at 0) and resets the
-// counter, gradually easing the effective interval back toward the floor.
+// counter, gradually easing the effective interval back toward the floor. This
+// streak-based path and decayLocked's time-based path are independent triggers
+// for the same step-down action; either one firing resets the decay clock so
+// the two do not double-count the same window.
 func (c *Client) OnSuccess() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -277,8 +323,32 @@ func (c *Client) OnSuccess() {
 	if c.consecutiveSuccesses >= adaptiveSuccessThreshold {
 		if c.adaptiveLevel > 0 {
 			c.adaptiveLevel--
+			c.lastLevelChange = c.now()
 		}
 		c.consecutiveSuccesses = 0
+	}
+}
+
+// decayLocked steps the adaptive level down by one for each full
+// adaptiveDecayInterval that has elapsed, throttle-free, since lastLevelChange.
+// Called under c.mu from pace() -- the natural per-request checkpoint -- so no
+// goroutine or lifecycle is needed to drive it. Looping (rather than a single
+// step) bounds the catch-up to however much wall-clock time has genuinely
+// elapsed, e.g. after an idle period with no requests at all, while never
+// stepping down faster than one level per adaptiveDecayInterval. It does not
+// consult minInterval: the floor guarantee comes from level 0 already being the
+// operator's configured minInterval (1x multiplier) -- adaptiveLevel cannot go
+// negative, so decay can never make the effective interval faster than that
+// floor. OnThrottle must still win a race with decay: it is the only path that
+// raises the level, and it always runs to completion under the same lock decay
+// runs under, so worst case is one extra request slips through at the eased
+// interval before the next throttle re-ratchets (an intentional, bounded cost
+// per the design constraints, not a bug).
+func (c *Client) decayLocked(now time.Time) {
+	for c.adaptiveLevel > 0 && !c.lastLevelChange.IsZero() && now.Sub(c.lastLevelChange) >= adaptiveDecayInterval {
+		c.adaptiveLevel--
+		c.consecutiveSuccesses = 0
+		c.lastLevelChange = c.lastLevelChange.Add(adaptiveDecayInterval)
 	}
 }
 

--- a/internal/musixmatch/pacer_decay_test.go
+++ b/internal/musixmatch/pacer_decay_test.go
@@ -1,0 +1,188 @@
+package musixmatch
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAdaptiveLevelStarvesUnderRealisticMissRate reproduces the measured
+// production event mix (2026-07-18, canticle 1.20.1) and asserts the pacer eases
+// back toward its floor once the provider has stopped throttling.
+//
+// The measured window after the last ratcheting throttle contained 52 settled
+// work items: 42 benign misses, 8 detector-lane instrumental settles, and only 2
+// genuine Musixmatch catalog hits. Neither a benign miss nor a detector settle
+// reaches this pacer's OnSuccess -- the orchestrator deliberately withholds
+// notifySuccess for a benign miss (internal/orchestrator/lane.go:67 fires only
+// on the success path), and (before #550) the detector lane was constructed
+// with no pacer at all (internal/orchestrator/detector_lane.go). So only the 2
+// catalog hits call OnSuccess, which is short of adaptiveSuccessThreshold (5),
+// and the streak-based path alone never steps the level down.
+//
+// This test DISCRIMINATES: against the pre-#492 one-way ratchet it fails with
+// level 3 (the observed 8x multiplier) held forever, and it can only pass once
+// a step-down path exists that does not depend on a 5-long run of consecutive
+// catalog hits. It exercises the time-decay path specifically: it injects a
+// fake clock (the now/sleep seam) and drives recovery through c.pace(), the
+// sole checkpoint decayLocked runs from -- not through OnSuccess, which stays
+// below threshold throughout, proving decay (not the streak counter) is what
+// recovers the level.
+func TestAdaptiveLevelStarvesUnderRealisticMissRate(t *testing.T) {
+	const (
+		throttles        = 3  // measured: 3 ratcheting 401s -> level 3
+		catalogHits      = 2  // measured: kind=synced saves
+		benignMisses     = 42 // measured: "benign miss deferred"
+		detectorSettles  = 8  // measured: kind=instrumental saves
+		wantAfterRecover = 0  // provider stopped throttling; expect a return to the floor
+	)
+
+	base := time.Unix(9000, 0)
+	var mu sync.Mutex
+	fakeNow := base
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	sleepFn := func(_ context.Context, d time.Duration) bool {
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+
+	c := NewClient("token")
+	c.WithMinInterval(15 * time.Second)
+	c.now = nowFn
+	c.sleep = sleepFn
+
+	for range throttles {
+		c.OnThrottle()
+	}
+	if got := readAdaptiveLevel(c); got != adaptiveMaxLevel {
+		t.Fatalf("after %d throttles: level = %d; want %d (precondition)", throttles, got, adaptiveMaxLevel)
+	}
+
+	// Replay the post-throttle window. Benign misses and detector settles are
+	// deliberately NOT delivered to the pacer's OnSuccess -- that is what
+	// production did before #550, and modeling them as OnSuccess here would fake
+	// a recovery the pre-fix system never got. They are counted only to
+	// document the true settle volume.
+	settled := benignMisses + detectorSettles
+	for range catalogHits {
+		c.OnSuccess()
+	}
+	if got := readConsecutiveSuccesses(c); got != catalogHits {
+		t.Fatalf("success counter = %d; want %d (precondition: must stay below the %d threshold, so any recovery below comes from decay, not the streak path)",
+			got, catalogHits, adaptiveSuccessThreshold)
+	}
+
+	// Advance the clock past the full multi-level decay window and let pace()
+	// evaluate it lazily -- exactly as the next queued item's FindLyrics call
+	// would in production. No goroutine, no ticker: pace() is the sole
+	// checkpoint (decayLocked).
+	mu.Lock()
+	fakeNow = fakeNow.Add(adaptiveMaxLevel * adaptiveDecayInterval)
+	mu.Unlock()
+	if err := c.pace(context.Background()); err != nil {
+		t.Fatalf("pace: %v", err)
+	}
+
+	if got := readAdaptiveLevel(c); got != wantAfterRecover {
+		t.Errorf("after a throttle-free window of %d settled items (%d catalog hits, %d benign misses, %d detector settles) spanning %d decay intervals: level = %d, multiplier = %dx; want level %d",
+			settled+catalogHits, catalogHits, benignMisses, detectorSettles, adaptiveMaxLevel, got, 1<<got, wantAfterRecover)
+	}
+}
+
+// TestDecayLockedStepsOneLevelPerInterval pins the STEPPING behavior of
+// decayLocked, not just its eventual endpoint: it must ease the level down by
+// exactly one per full adaptiveDecayInterval elapsed, never jump straight to
+// the floor. The comment above adaptiveDecayInterval justifies its 20-minute
+// value specifically because a full unwind from adaptiveMaxLevel takes 3x
+// that -- "long enough that a short lull between genuine 401s does not
+// immediately erase the ratchet and re-provoke the provider." A slam-to-zero
+// implementation (reset to 0 the instant any decay window elapses, rather
+// than stepping down one level at a time) defeats exactly that property:
+// after a single 20-minute lull the level would go straight from 3 to 0
+// instead of 3 to 2. TestAdaptiveLevelStarvesUnderRealisticMissRate cannot
+// catch this because it advances the clock by the whole
+// adaptiveMaxLevel*adaptiveDecayInterval window in one jump, which cannot
+// distinguish gradual stepping from an instant reset.
+//
+// This test drives decay through c.pace() (the same now/sleep seam
+// TestAdaptiveLevelStarvesUnderRealisticMissRate uses -- decayLocked has no
+// other caller), advancing the fake clock by ONE adaptiveDecayInterval per
+// pace() call and asserting the level after each step.
+func TestDecayLockedStepsOneLevelPerInterval(t *testing.T) {
+	base := time.Unix(9000, 0)
+	var mu sync.Mutex
+	fakeNow := base
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	sleepFn := func(_ context.Context, d time.Duration) bool {
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+
+	c := NewClient("token")
+	c.WithMinInterval(15 * time.Second)
+	c.now = nowFn
+	c.sleep = sleepFn
+
+	for range adaptiveMaxLevel {
+		c.OnThrottle()
+	}
+	if got := readAdaptiveLevel(c); got != adaptiveMaxLevel {
+		t.Fatalf("after %d throttles: level = %d; want %d (precondition)", adaptiveMaxLevel, got, adaptiveMaxLevel)
+	}
+
+	// Advancing less than a full interval must not step the level at all.
+	mu.Lock()
+	fakeNow = fakeNow.Add(adaptiveDecayInterval - time.Second)
+	mu.Unlock()
+	if err := c.pace(context.Background()); err != nil {
+		t.Fatalf("pace: %v", err)
+	}
+	if got := readAdaptiveLevel(c); got != adaptiveMaxLevel {
+		t.Fatalf("after less than one full decay interval: level = %d; want unchanged %d", got, adaptiveMaxLevel)
+	}
+
+	// One more second completes the first full interval: level steps down by
+	// exactly one, not to zero.
+	wantLevels := []int{adaptiveMaxLevel - 1, adaptiveMaxLevel - 2, 0, 0}
+	for i, want := range wantLevels {
+		mu.Lock()
+		fakeNow = fakeNow.Add(time.Second)
+		mu.Unlock()
+		if err := c.pace(context.Background()); err != nil {
+			t.Fatalf("pace (step %d): %v", i, err)
+		}
+		if got := readAdaptiveLevel(c); got != want {
+			t.Fatalf("step %d (after %d full decay interval(s) plus this one second): level = %d; want %d",
+				i, i+1, got, want)
+		}
+		if i < len(wantLevels)-1 {
+			mu.Lock()
+			fakeNow = fakeNow.Add(adaptiveDecayInterval - time.Second)
+			mu.Unlock()
+		}
+	}
+
+	// A fourth interval beyond the unwind must not underflow below the floor.
+	mu.Lock()
+	fakeNow = fakeNow.Add(adaptiveDecayInterval)
+	mu.Unlock()
+	if err := c.pace(context.Background()); err != nil {
+		t.Fatalf("pace (floor check): %v", err)
+	}
+	if got := readAdaptiveLevel(c); got != 0 {
+		t.Fatalf("after a decay interval beyond full unwind: level = %d; want 0 (floor, no underflow)", got)
+	}
+}

--- a/internal/musixmatch/pacer_test.go
+++ b/internal/musixmatch/pacer_test.go
@@ -335,6 +335,50 @@ func TestPacerConcurrentSlotAllocation(t *testing.T) {
 	}
 }
 
+func TestMinIntervalConcurrentSetAndPaceRaceFree(t *testing.T) {
+	// #494: minInterval used to be read in pace() BEFORE acquiring c.mu, racing
+	// against any concurrent WithMinInterval write. Run under -race: this test's
+	// purpose is to be caught by the race detector against the pre-fix code, not
+	// to assert a particular observed interval (there is no ordering guarantee
+	// between the setter and any given pace() call, only race-freedom).
+	base := time.Unix(4000, 0)
+	var mu sync.Mutex
+	fakeNow := base
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+	sleepFn := func(ctx context.Context, d time.Duration) bool {
+		mu.Lock()
+		fakeNow = fakeNow.Add(d)
+		mu.Unlock()
+		return true
+	}
+	c := newPacerTestClient(time.Millisecond, nowFn, sleepFn)
+
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c.WithMinInterval(time.Duration(i+1) * time.Millisecond)
+		}(i)
+	}
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.pace(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	if got := c.MinInterval(); got <= 0 {
+		t.Fatalf("MinInterval = %v after concurrent sets; want a positive value set by one of the goroutines", got)
+	}
+}
+
 func TestWithMinIntervalReturnsClient(t *testing.T) {
 	c := NewClient("token")
 	got := c.WithMinInterval(5 * time.Second)

--- a/internal/orchestrator/detector_lane.go
+++ b/internal/orchestrator/detector_lane.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sydlexius/canticle/internal/circuit"
 	"github.com/sydlexius/canticle/internal/detector"
 	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/providers"
 )
 
 // detectorLaneName is the lane name a detector-backed lane reports.
@@ -19,15 +20,38 @@ const detectorLaneName = "detector"
 // carrying detector telemetry; a gate-negative verdict (or an empty path)
 // returns ErrLaneBenignMiss so the providers run; a detector call failure
 // returns ErrLaneOutage so the breaker trips.
-func NewDetectorLane(d detector.Detector, breaker *circuit.Breaker) *Lane {
+//
+// pacer is optional (nil is valid, and every existing call site predating #550
+// passed none): when non-nil it is credited on a gate-positive settle so the
+// detector's throughput helps ease the SHARED provider pacer's ratchet back
+// down (see the local/pacer split below). Callers should pass the SAME pacer
+// instance the primary provider lane uses (Lane.Pacer() on that lane), not a
+// detector-owned one -- the detector has no throttle concept of its own; it is
+// only ever crediting recovery of the provider's adaptive interval.
+func NewDetectorLane(d detector.Detector, breaker *circuit.Breaker, pacer providers.AdaptivePacer) *Lane {
 	return &Lane{
 		name:        detectorLaneName,
 		breaker:     breaker,
 		classifyErr: detectorClassifier,
-		// The detector settles a track from local audio analysis: no outbound
-		// provider request, so an item settled here must not spend the
-		// provider-request pacing budget (#534).
+		// local=true: the detector settles a track from local audio analysis, no
+		// outbound provider request, so an item settled here must not SPEND the
+		// provider-request pacing budget (#534) -- Lane.FindLyrics never calls
+		// pace() for this lane regardless of pacer below.
 		local: true,
+		// pacer decision (#550): a local lane SHOULD still CREDIT decay. Spending
+		// and crediting are separable: local=true controls only whether pace() is
+		// paid (it is not, for any lane -- pace() is invoked exclusively inside the
+		// musixmatch client's own FindLyrics, never by Lane), while pacer here
+		// controls only whether Lane.notifySuccess() fires OnSuccess on a genuine
+		// settle. A detector settle proves the work item was disposed of without
+		// needing a provider round-trip at all, so crediting it costs nothing (no
+		// extra request is made to earn the credit) and helps the ratchet unwind
+		// faster when detector settles make up a large share of traffic, exactly
+		// the measured production gap (8 of 52 settles in the starved window were
+		// detector instrumentals, per #492's pacer_decay_test.go). The next local
+		// lane added to this package should make the same call explicitly rather
+		// than silently inheriting whatever this constructor happens to do.
+		pacer: pacer,
 		resolve: func(ctx context.Context, track models.Track, sourcePath string) (models.Song, error) {
 			// An empty sourcePath means instrumental detection is disabled for this
 			// item (e.g. no audio path on the work item); the detector must never be

--- a/internal/orchestrator/detector_lane_test.go
+++ b/internal/orchestrator/detector_lane_test.go
@@ -33,7 +33,7 @@ func TestDetectorLane_GatePositiveIsSuitableWithTelemetry(t *testing.T) {
 		Instrumental: true, Confidence: 0.9, VocalConfidence: 0.01,
 		SpeechConfidence: 0.02, WinningVocalClass: "Singing", Version: "1.5.0",
 	}}
-	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour))
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
 	song, err := lane.FindLyrics(context.Background(), models.Track{TrackName: "x"}, "/music/x.flac")
 	if err != nil {
 		t.Fatalf("err = %v", err)
@@ -55,7 +55,7 @@ func TestDetectorLane_GatePositiveIsSuitableWithTelemetry(t *testing.T) {
 
 func TestDetectorLane_GateNegativeIsBenignMiss(t *testing.T) {
 	d := &stubDetector{res: detector.Result{Instrumental: false, Version: "1.5.0"}}
-	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour))
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
 	_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
 	if ClassifyOutcome(err) != OutcomeBenignMiss {
 		t.Fatalf("gate-negative outcome = %v, want OutcomeBenignMiss", ClassifyOutcome(err))
@@ -64,7 +64,7 @@ func TestDetectorLane_GateNegativeIsBenignMiss(t *testing.T) {
 
 func TestDetectorLane_EmptyPathIsBenignMiss(t *testing.T) {
 	d := &stubDetector{res: detector.Result{Instrumental: true, Version: "1.5.0"}}
-	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour))
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
 	_, err := lane.FindLyrics(context.Background(), models.Track{}, "")
 	if ClassifyOutcome(err) != OutcomeBenignMiss {
 		t.Fatalf("empty-path outcome = %v, want OutcomeBenignMiss", ClassifyOutcome(err))
@@ -76,7 +76,7 @@ func TestDetectorLane_EmptyPathIsBenignMiss(t *testing.T) {
 
 func TestDetectorClassifier_OtherErrorWrapsAndLeavesBreakerUntouched(t *testing.T) {
 	br := circuit.New(time.Minute, time.Hour)
-	lane := NewDetectorLane(&stubDetector{}, br)
+	lane := NewDetectorLane(&stubDetector{}, br, nil)
 	cause := errors.New("unexpected decode failure")
 
 	wrapped := detectorClassifier(lane, cause)
@@ -95,10 +95,73 @@ func TestDetectorClassifier_OtherErrorWrapsAndLeavesBreakerUntouched(t *testing.
 	}
 }
 
+// stubPacer is a minimal providers.AdaptivePacer recording notification
+// counts, used to prove which lane notifications actually reach a shared
+// pacer instance (as opposed to a lane's own mock ratchet).
+type stubPacer struct {
+	throttles int
+	successes int
+}
+
+func (p *stubPacer) OnThrottle() { p.throttles++ }
+func (p *stubPacer) OnSuccess()  { p.successes++ }
+
+// TestDetectorLane_GatePositiveCreditsSharedPacer is the #550 discriminator: a
+// detector settle must credit the SAME pacer instance the primary provider
+// lane uses, so the measured production gap (8 of 52 settles were detector
+// instrumentals crediting nothing) is closed. Against the pre-#550
+// constructor (no pacer parameter, Lane.pacer always nil for a detector lane)
+// this fails because OnSuccess is never reachable -- there was no pacer to
+// call it on.
+func TestDetectorLane_GatePositiveCreditsSharedPacer(t *testing.T) {
+	d := &stubDetector{res: detector.Result{Instrumental: true, Version: "1.5.0"}}
+	pacer := &stubPacer{}
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), pacer)
+
+	_, err := lane.FindLyrics(context.Background(), models.Track{TrackName: "x"}, "/music/x.flac")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if pacer.successes != 1 {
+		t.Fatalf("pacer.successes = %d; want 1 (a gate-positive detector settle must credit decay)", pacer.successes)
+	}
+	if pacer.throttles != 0 {
+		t.Fatalf("pacer.throttles = %d; want 0 (a detector settle is never a throttle signal)", pacer.throttles)
+	}
+}
+
+// TestDetectorLane_GateNegativeDoesNotCreditPacer asserts the credit is scoped
+// to a genuine gate-positive settle: a benign miss must not fake a success
+// signal into the shared pacer, mirroring the provider lane's existing
+// "no OnSuccess on a benign miss" rule (lane.go's notifySuccess is reached
+// only on the FindLyrics success path).
+func TestDetectorLane_GateNegativeDoesNotCreditPacer(t *testing.T) {
+	d := &stubDetector{res: detector.Result{Instrumental: false, Version: "1.5.0"}}
+	pacer := &stubPacer{}
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), pacer)
+
+	_, _ = lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
+	if pacer.successes != 0 {
+		t.Fatalf("pacer.successes = %d; want 0 (a benign miss must not credit decay)", pacer.successes)
+	}
+}
+
+// TestDetectorLane_NilPacerIsSafe covers every pre-#550 call site (nil pacer):
+// a detector settle must not panic or otherwise misbehave when no pacer is
+// wired in.
+func TestDetectorLane_NilPacerIsSafe(t *testing.T) {
+	d := &stubDetector{res: detector.Result{Instrumental: true, Version: "1.5.0"}}
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
+
+	if _, err := lane.FindLyrics(context.Background(), models.Track{TrackName: "x"}, "/music/x.flac"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestDetectorLane_OutageTripsBreaker(t *testing.T) {
 	d := &stubDetector{err: errors.New("connection refused")}
 	br := circuit.New(time.Minute, time.Hour)
-	lane := NewDetectorLane(d, br)
+	lane := NewDetectorLane(d, br, nil)
 	_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
 	if ClassifyOutcome(err) != OutcomeLaneOutage {
 		t.Fatalf("outage outcome = %v, want OutcomeLaneOutage", ClassifyOutcome(err))

--- a/internal/orchestrator/detector_no_regression_test.go
+++ b/internal/orchestrator/detector_no_regression_test.go
@@ -40,7 +40,7 @@ func vocalTrackDetector() *stubDetector {
 // detectorLaneFront builds the lane order a high-lyric-coverage library runs:
 // the detector first, the provider behind it.
 func detectorLaneFront(d detector.Detector, provider *Lane) []*Lane {
-	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour))
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
 	return []*Lane{lane, provider}
 }
 

--- a/internal/orchestrator/lane.go
+++ b/internal/orchestrator/lane.go
@@ -44,6 +44,13 @@ func (l *Lane) Local() bool { return l.local }
 // Breaker exposes the lane's breaker (construction + tests asserting ramp state).
 func (l *Lane) Breaker() *circuit.Breaker { return l.breaker }
 
+// Pacer exposes the lane's optional adaptive pacer (nil when the lane has
+// none), so a caller building a second lane can share the SAME pacer instance
+// -- e.g. wiring the primary provider lane's pacer into a local lane
+// (NewDetectorLane) so that lane's settles can credit ratchet-down decay
+// without themselves spending the provider-request pacing budget (#550).
+func (l *Lane) Pacer() providers.AdaptivePacer { return l.pacer }
+
 // FindLyrics drives the lane's breaker around a resolve call. An open breaker
 // returns ErrLaneUnavailable without calling resolve. Errors run through the
 // lane's injected classifier; success records recovery and pacer stabilization.

--- a/internal/orchestrator/lane_test.go
+++ b/internal/orchestrator/lane_test.go
@@ -256,6 +256,25 @@ func (p *adaptiveStubProvider) OnThrottle() {
 }
 func (p *adaptiveStubProvider) OnSuccess() { p.successes++ }
 
+// TestLanePacerExposesWiredPacer covers Lane.Pacer(), added for #550 so a
+// second lane (e.g. NewDetectorLane) can share the primary lane's pacer
+// instance. A provider lane that does not implement providers.AdaptivePacer
+// must expose a nil pacer; one that does must expose that exact instance.
+func TestLanePacerExposesWiredPacer(t *testing.T) {
+	plain := &stubProvider{name: "plain"}
+	plainLane, _ := newTestLane(plain)
+	if got := plainLane.Pacer(); got != nil {
+		t.Fatalf("Pacer() = %v; want nil for a non-adaptive provider", got)
+	}
+
+	adaptive := &adaptiveStubProvider{name: "adaptive"}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	adaptiveLane := NewProviderLane(adaptive, cb)
+	if got := adaptiveLane.Pacer(); got != adaptive {
+		t.Fatalf("Pacer() = %v; want the exact adaptiveStubProvider instance %v", got, adaptive)
+	}
+}
+
 func TestLaneCallsOnThrottleOnTripAfterSuccess(t *testing.T) {
 	// A 401 AFTER the token has succeeded this session is an egress-IP throttle:
 	// the pacer must ratchet.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -325,7 +325,11 @@ func (w *Worker) rebuildOrchestrator() error {
 		} else {
 			cb := circuit.New(w.circuitBackoffBase, w.circuitOpenDuration)
 			cb.SetClock(w.now)
-			detLane := orchestrator.NewDetectorLane(w.audioDetector, cb)
+			// Share the primary provider lane's pacer so a detector settle credits
+			// the same ratchet-down counter the musixmatch client's OnThrottle
+			// ratchets up (#550) -- this is a decay CREDIT only; the detector lane
+			// stays local:true and never pays the provider-request pacing pause.
+			detLane := orchestrator.NewDetectorLane(w.audioDetector, cb, w.lane.Pacer())
 			if w.detectorOrdering == "front" {
 				lanes = append([]*orchestrator.Lane{detLane}, lanes...)
 			} else {


### PR DESCRIPTION
## Summary

- The Musixmatch adaptive pacer ratchets up on a throttle signal but had no step-down path production could actually reach, so a transient burst of genuine 401s permanently degraded throughput until restart. This adds time-based decay, fixes the lane that was silently starving it, and closes a racy read found along the way.
- **Measured on a live deployment before the fix:** three genuine throttle events had driven the pacer to `level=3 multiplier=8`, turning a 15s base interval into 120s and holding it. Throughput was 31 rows/hr against ~0.2s of real work per item -- essentially the whole cycle was pacing wait.
- The throttle classifier is deliberately **untouched**. Those 401s are genuine provider pushback; loosening classification would risk hammering a provider that really is rate-limiting. The fix is entirely on the recovery side.

## Why the existing step-down could not fire

`adaptiveSuccessThreshold` (5) requires that many *consecutive* successes reaching `OnSuccess`; 15 to unwind three levels. In the measured window after the last ratchet, 52 items settled and **2** qualified:

| settled outcome | count | credited decay? |
|---|---|---|
| benign miss, deferred | 42 | no -- `notifySuccess` fires only on the success path |
| instrumental, detector lane | 8 | no -- the lane was built with no pacer |
| real catalog hit | 2 | yes |

At a ~4% catalog-hit rate the counter is effectively unreachable, so the level was permanent until restart.

## Changes

**Time-based decay (#492).** The level steps down one per throttle-free `adaptiveDecayInterval`, evaluated lazily inside `pace()` under the existing mutex -- no goroutine, no ticker, no new lifecycle. 20 minutes is a deliberate middle ground: a full unwind takes 3x that, long enough that a short lull between genuine 401s does not erase the ratchet and re-provoke the provider, short enough to recover within a day of serve-mode operation when catalog-hit luck is poor. Decay is bounded below by the configured `minInterval`, and `OnThrottle` re-ratchets immediately, so the worst case after a decay step is one extra request before the ratchet reasserts.

**A local lane now credits decay (#550).** `NewDetectorLane` built its `Lane` with no pacer, so a detector-settled instrumental credited nothing. That was correct for *spending* pacing budget -- `local: true` exists precisely so a lane issuing no provider request does not pay the provider-request pause -- but nothing noticed the same omission also stopped the lane *crediting* decay. Spend and credit are now explicit rather than incidentally coupled. Sharing the primary lane's pacer needs an accessor, hence `Lane.Pacer()`.

**A racy read (part of #494).** `pace()` read `minInterval` outside the mutex before acquiring it, so a guarded setter alone would still leave the read racy. It now happens inside the existing critical section. The rest of #494 (runtime knob reconfiguration) is out of scope and stays open.

## Linked issues

Closes #492, closes #550

Refs #494 -- only the racy read is fixed here; the issue stays open for the reconfiguration work. A correction to that issue's own text (it claimed the read side was already correct) is posted there.

## Gates

- [x] `make gate` -- full pre-push chain, exit 0
- [x] conflict markers, typos, gofmt, whole-module build
- [x] `go test` race + coverage, all packages
- [x] `go test -race ./internal/musixmatch/ ./internal/orchestrator/` -- 163 tests
- [x] patch coverage 100.00% (47/47)
- [x] coverage floor ratchet -- no floor lowered
- [x] golangci-lint -- 0 issues
- [x] actionlint, govulncheck -- 0 vulnerabilities called

## Test plan

- [x] Every new guard was checked against the defect's **absence**, not just the fix's presence.
- [x] The starvation test replays the measured production event mix and was verified RED against the pre-fix one-way ratchet.
- [x] The stepping guard was verified against a slam-to-zero mutation of `decayLocked`. This matters: that mutation passes the starvation test, because advancing the clock past the whole window cannot distinguish gradual stepping from an instant reset -- and a slam-to-zero would defeat the exact safety property the 20-minute interval is chosen for, erasing the ratchet after one lull.
- [x] Detector-lane credit covered on the gate-positive, gate-negative, and nil-pacer paths.
- [x] `-race` coverage for concurrent `SetMinInterval` + `pace()`.
- [ ] Reviewer follow-ups

Worth flagging for review: **patch coverage is 100% and did not catch the stepping gap.** Every line ran while the behavior between them went unasserted. Line coverage and mutation resistance are different properties, and only the second one was load-bearing here.

## Notes

Not included, deliberately: whether a **benign miss** should credit decay (42 of the 52 settles above). A throttling provider can return misses, so counting them risks reintroducing signal confusion that a prior fix removed. This PR covers only the local-lane case, where no provider was contacted and a throttle signal is impossible by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adaptive request pacing now gradually relaxes after throttle-free periods.
  * Improved pacing stability during concurrent configuration and request activity.
  * Detector activity now shares pacing recovery signals with the primary provider without inheriting its request delays.

* **Tests**
  * Added coverage for pacing decay, concurrency safety, and detector pacing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->