### PR TITLE
fix(detector): calibrate vocal_max_confidence to 0.015

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -309,10 +309,12 @@ min_similarity = 0.35
 # vocal_classes = ["Singing", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
 
 # Maximum sung-vocal-class peak (0-1) tolerated before a track is excluded from
-# being instrumental. Conservative: biased toward "not instrumental". Default 0.03
-# (pinned by the #384 calibration sweep). Values outside (0, 1] reset to 0.03.
+# being instrumental. Conservative: biased toward "not instrumental". Default 0.015
+# (calibrated 2026-07-19 on a 296-track labeled sample: 1.37% false-instrumental
+# on known-vocal tracks, 54% true-instrumental recovery). Values outside (0, 1]
+# reset to 0.015.
 # Env: MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_MAX_CONFIDENCE.
-# vocal_max_confidence = 0.03
+# vocal_max_confidence = 0.015
 
 # AudioSet speech-class names gated on SUSTAINED presence (summed frame MEAN, not
 # peak) so brief incidental speech does not block an instrumental marking.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,7 +112,7 @@ The table below is the complete env-var surface; the watcher and verification se
 | `MXLRC_INSTRUMENTAL_DETECTOR_CLASSES` | `Music,Musical instrument` | Comma-separated AudioSet class names whose probabilities are summed and compared against the confidence threshold. |
 | `MXLRC_INSTRUMENTAL_DETECTOR_COOLDOWN_SECONDS` | `5` | Minimum gap in seconds between consecutive classifier inference calls. `0` disables the cooldown. |
 | `MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_CLASSES` | `Singing,Vocal music,Choir,...` | Comma-separated AudioSet vocal-class names whose peak (max-over-frames) score blocks an instrumental marking (the vocal gate). |
-| `MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_MAX_CONFIDENCE` | `0.03` | Maximum vocal-class peak (0-1) tolerated before a track is excluded from instrumental. Values outside (0, 1] reset to `0.03`. |
+| `MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_MAX_CONFIDENCE` | `0.015` | Maximum vocal-class peak (0-1) tolerated before a track is excluded from instrumental. Values outside (0, 1] reset to `0.015`. |
 | `MXLRC_INSTRUMENTAL_DETECTOR_SPREAD_SAMPLES` | `6` | Number of short windows spread across the track and concatenated into one classifier sample. `< 2` disables spreading (single contiguous window). |
 | `MXLRC_INSTRUMENTAL_DETECTOR_FFPROBE_PATH` | (auto-discover) | Path to `ffprobe` used to read track duration for spread-sample placement. Empty auto-discovers (sibling of ffmpeg, then PATH). Set this when ffmpeg was auto-provisioned (no ffprobe). |
 | `MXLRC_ENRICHMENT_ENABLED` | `true` | Global default for recording enrichment (reading ISRC, MusicBrainz ID, and duration from audio tags). Per-library and per-run flags override this. |
@@ -288,7 +288,7 @@ ffmpeg (used to extract the audio sample) is resolved automatically: see [ffmpeg
 # min_confidence = 0.90
 # instrumental_classes = ["Music", "Musical instrument"]
 # vocal_classes = ["Singing", "Vocal music", "Choir", "A capella", "Chant", "Rapping", "Child singing", "Synthetic singing", "Yodeling", "Humming"]
-# vocal_max_confidence = 0.03
+# vocal_max_confidence = 0.015
 # speech_classes = ["Speech"]
 # speech_max_confidence = 0.20
 # spread_samples = 6
@@ -302,7 +302,7 @@ When enabled and a `classifier_url` is set, the detector samples each track's au
 
 To catch vocals that enter after an instrumental intro (arias, jazz, classical), the detector samples `spread_samples` short windows spread across the **whole** track, concatenated into one sample, and gates on the per-class **max-over-frames** peak (the loudest singing moment), which the frame mean dilutes. This requires the sidecar to return `{"mean": {...}, "max": {...}}`; a legacy mean-only sidecar degrades safely to never-instrumental.
 
-`sample_duration_seconds` is clamped to [30, 60]. `min_confidence` and `vocal_max_confidence` values outside (0, 1] reset to `0.90` and `0.03` respectively. `cooldown_seconds` is the minimum gap between consecutive inference calls; `0` disables the cooldown. Track-duration probing needs `ffprobe`; the auto-provisioned ffmpeg ships none, so set `ffprobe_path` (or rely on a PATH ffprobe) or the detector falls back to a single window. **Deploy order:** upgrade Canticle before the sidecar (new Canticle tolerates the old flat-map response; old Canticle cannot parse `{mean,max}`). See **[Instrumental Detection](instrumental-detection.md)** for the full reference (decision model, sidecar setup, and tuning), and the [Instrumental detection](USER_GUIDE.md#instrumental-detection) guide for the per-library and per-run override controls.
+`sample_duration_seconds` is clamped to [30, 60]. `min_confidence` and `vocal_max_confidence` values outside (0, 1] reset to `0.90` and `0.015` respectively. `cooldown_seconds` is the minimum gap between consecutive inference calls; `0` disables the cooldown. Track-duration probing needs `ffprobe`; the auto-provisioned ffmpeg ships none, so set `ffprobe_path` (or rely on a PATH ffprobe) or the detector falls back to a single window. **Deploy order:** upgrade Canticle before the sidecar (new Canticle tolerates the old flat-map response; old Canticle cannot parse `{mean,max}`). See **[Instrumental Detection](instrumental-detection.md)** for the full reference (decision model, sidecar setup, and tuning), and the [Instrumental detection](USER_GUIDE.md#instrumental-detection) guide for the per-library and per-run override controls.
 
 ffmpeg resolution is shared with `[verification]`; see [ffmpeg resolution](#ffmpeg-resolution) below. Set `ffmpeg_path` here only to pin a binary separately from the verification path.
 

--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -34,7 +34,7 @@ failing means "not instrumental", and the track is left as a normal miss.
 | Gate | Condition | Default |
 |------|-----------|---------|
 | **Music gate** | The **mean** over frames of the summed `instrumental_classes` probabilities is at least `min_confidence`. | `min_confidence = 0.90`, `instrumental_classes = ["Music", "Musical instrument"]` |
-| **Sung-vocal gate** (#384) | The **peak** (max over frames) of *every* `vocal_classes` score stays **below** `vocal_max_confidence`. | `vocal_max_confidence = 0.03`, `vocal_classes` = the singing/vocal set below |
+| **Sung-vocal gate** (#384) | The **peak** (max over frames) of *every* `vocal_classes` score stays **below** `vocal_max_confidence`. | `vocal_max_confidence = 0.015`, `vocal_classes` = the singing/vocal set below |
 | **Speech gate** (#403) | The summed frame **mean** of the `speech_classes` stays **below** `speech_max_confidence`. | `speech_max_confidence = 0.20` (provisional), `speech_classes = ["Speech"]` |
 
 The default `vocal_classes` (sung-vocal) set is:
@@ -93,31 +93,43 @@ safe in that direction.
 
 ### Calibration evidence
 
-The `vocal_max_confidence = 0.03` default was pinned by a sweep over real library
-tracks plus known-vocal controls (issue #384). The separation between
-instrumentals and vocals on the production metric (`vocal_peak` = max over vocal
-classes of each class's max-over-frames):
+The `vocal_max_confidence = 0.015` default was calibrated on 2026-07-19 against a
+296-track labeled sample scored by the live sidecar: 146 tracks that provider
+lyrics prove are vocal, and 150 provider-labeled instrumentals. The music gate
+was held at `0.90` and the speech gate at `0.20`.
 
-| Track type | `vocal_peak` | Verdict |
-|------------|-------------|---------|
-| Baroque oratorio aria | ~0.39 | vocal (scored ~0.004 at a single 30s intro window - a false instrumental that spread sampling fixes) |
-| Jazz vocal | ~0.087 | vocal |
-| Country vocal | ~0.059 | vocal |
-| Orchestral ballet (instr.) | ~0.021 | instrumental |
-| Solo guitar (instr.) | ~0.013 | instrumental |
-| Baroque concerto (instr.) | ~0.005 | instrumental |
+**The two classes overlap; there is no clean separating margin.** An earlier
+6-track sample suggested instrumentals topped out near `0.021` while vocals
+floored near `0.059`, implying a comfortable 3x gap. The larger sample refutes
+that: known-vocal `vocal_peak` ranges from `0.0019` to `0.8861` (median `0.0959`,
+p5 `0.0257`), so genuinely-vocal tracks reach well into what looks like
+instrumental territory. Any threshold trades one error against the other.
 
-Instrumentals top out near `0.021` and vocals floor near `0.059` - roughly a 3x
-margin - so `0.03` sits comfortably between them.
+| `vocal_max_confidence` | False instrumental (of 146 known-vocal) | True instrumental recovered (of 150) |
+|---|---|---|
+| `0.005` | 0.68% | 24.0% |
+| `0.010` | 1.37% | 42.7% |
+| **`0.015`** (default) | **1.37%** | **54.0%** |
+| `0.020` | 2.05% | 58.7% |
+| `0.030` (prior default) | 4.79% | 66.0% |
 
-The speech gate's `speech_max_confidence = 0.20` default (#403) is a different
-kind of value: it is a **provisional placeholder**, chosen conservatively low
-(biased toward "not instrumental", preserving lyric protection) pending a
-#384-style calibration sweep over the audit set to pin the final constant. Because
-the key is configurable, that calibration refines the value without a code change.
-The acceptance criterion - that incidental-speech instrumentals get re-confirmed -
-is satisfied by the **post-calibration** validation gate (re-running the audit
-set), not by the placeholder itself.
+`0.015` is chosen because it recovers the most true instrumentals available at
+its error level: it costs no additional false instrumentals over `0.010`, and
+the prior `0.030` misclassified 4.79% of known-vocal tracks.
+
+Note that `cmd/vocalcalib -mode sweep` returns `0.007589` at its default 1%
+error ceiling. That output is **not** the default, deliberately. It is pinned
+exactly to one sample's `vocal_peak` (moving it by `1e-5` doubles the error
+rate), and it is dominated by `0.015` - same real error count, 22 points less
+recovery. At n=146 a single track is 0.68%, so a 1% ceiling is finer than the
+sample can resolve and pushes the sweep into a strictly worse operating point.
+Treat the sweep as evidence, not as the decision.
+
+**The music gate, not the vocal gate, is now the binding constraint on
+recovery.** 32 of the 150 labeled instrumentals (21%) score `music_sum < 0.90`
+and cannot be recovered at any vocal threshold. The speech gate blocks only 2 of
+150. Further recovery gains have to come from `min_confidence`, which has not
+been calibrated.
 
 ## Sidecar setup
 
@@ -176,7 +188,7 @@ All keys live under `[instrumental_detector]`; each has an
 | `spread_samples` | `6` | Windows spread across the track. `< 2` disables spreading. |
 | `min_confidence` | `0.90` | Music-gate threshold (mean). Values outside (0, 1] reset to `0.90`. |
 | `instrumental_classes` | `["Music", "Musical instrument"]` | Classes summed for the music gate. |
-| `vocal_max_confidence` | `0.03` | Sung-vocal-gate threshold (peak). Values outside (0, 1] reset to `0.03`. |
+| `vocal_max_confidence` | `0.015` | Sung-vocal-gate threshold (peak). Values outside (0, 1] reset to `0.015`. |
 | `vocal_classes` | (the singing/vocal set above) | Sung-vocal classes whose peak blocks an instrumental marking. |
 | `speech_max_confidence` | `0.20` (provisional) | Speech-gate threshold (summed mean). Values outside (0, 1] reset to `0.20`. |
 | `speech_classes` | `["Speech"]` | Speech classes gated on sustained mean (not peak). |
@@ -209,9 +221,9 @@ The decision is logged. Look for the detector decision line, which reports the
 computed `music_sum`, the `vocal_peak`, the `speech_mean`, and the resulting
 verdict, so you can see *why* a track was or was not marked.
 
-- **The borderline band.** A `vocal_peak` of roughly `0.03-0.05` is genuinely
+- **The borderline band.** A `vocal_peak` of roughly `0.015-0.05` is genuinely
   mixed material (quiet backing vocals, sparse vocal samples). The default
-  `0.03` deliberately keeps these on the "not instrumental" side.
+  `0.015` deliberately keeps these on the "not instrumental" side.
 - **A false instrumental** (a vocal track wrongly marked) usually means a vocal
   that the sample under-weighted - check that `ffprobe` is present and spread
   sampling is actually running (a single-window fallback is the common culprit).
@@ -234,7 +246,7 @@ verdict, so you can see *why* a track was or was not marked.
   absent `max` map is the expected legacy mean-only degradation and stays at
   `Warn`, while a present-but-partial map is the unexpected violation at `Error`.
   This fail-safe is scoped to the partial-response case only - it does not explain
-  the conservative `0.03-0.05` borderline band (by design) or other separately
+  the conservative `0.015-0.05` borderline band (by design) or other separately
   tracked refinements (cross-version model drift). `Speech` activation on
   non-lyrical audio is now handled by the dedicated sustained-mean speech gate
   (#403). Per-decision telemetry (the scores, the winning vocal class, and the
@@ -267,7 +279,7 @@ re-inference pass:
 ```sql
 -- borderline sung-vocal tracks worth a human look
 SELECT id, source_path, vocal_peak FROM work_queue
-WHERE instrumental_result = 1 AND vocal_peak BETWEEN 0.03 AND 0.05;
+WHERE instrumental_result = 1 AND vocal_peak BETWEEN 0.015 AND 0.05;
 
 -- markers written by an older detector build (model/threshold drift)
 SELECT id, source_path, detector_version FROM work_queue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -365,7 +365,7 @@ type InstrumentalDetectorConfig struct {
 	VocalClasses []string `toml:"vocal_classes"`
 	// VocalMaxConfidence is the maximum tolerated sung-vocal-class peak before a
 	// track is excluded from being marked instrumental. Conservative (biased
-	// toward "not instrumental"). Values outside (0, 1] reset to the default 0.03.
+	// toward "not instrumental"). Values outside (0, 1] reset to the default 0.015.
 	// Override: MXLRC_INSTRUMENTAL_DETECTOR_VOCAL_MAX_CONFIDENCE.
 	VocalMaxConfidence float64 `toml:"vocal_max_confidence"`
 	// SpeechClasses is the list of AudioSet class names gated on SUSTAINED
@@ -494,7 +494,7 @@ const guardThresholdDefault = 0.20
 // for the instrumental detector's vocal gate. Pinned by the issue #384
 // calibration sweep over the full instrumental-marked corpus (184/352 flipped,
 // 0 known-vocal false-positives). Conservative: biased toward "not instrumental".
-const detectorVocalMaxConfidenceDefault = 0.03
+const detectorVocalMaxConfidenceDefault = 0.015
 
 // detectorSpeechMaxConfidenceDefault is the default summed-frame-MEAN threshold
 // for the instrumental detector's speech gate (sustained spoken-word presence).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1523,7 +1523,7 @@ func TestLoad_InstrumentalDetectorEnvFFmpegPath(t *testing.T) {
 }
 
 // TestLoad_InstrumentalDetectorVocalGateDefaults verifies the vocal-gate
-// defaults (#384): vocal_max_confidence 0.03, spread_samples 6, a non-empty
+// defaults (#384): vocal_max_confidence 0.015, spread_samples 6, a non-empty
 // vocal-class list, and an empty ffprobe_path (auto-discover).
 func TestLoad_InstrumentalDetectorVocalGateDefaults(t *testing.T) {
 	isolateEnv(t)
@@ -1531,8 +1531,8 @@ func TestLoad_InstrumentalDetectorVocalGateDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.InstrumentalDetector.VocalMaxConfidence != 0.03 {
-		t.Errorf("VocalMaxConfidence = %v; want 0.03", cfg.InstrumentalDetector.VocalMaxConfidence)
+	if cfg.InstrumentalDetector.VocalMaxConfidence != 0.015 {
+		t.Errorf("VocalMaxConfidence = %v; want 0.015", cfg.InstrumentalDetector.VocalMaxConfidence)
 	}
 	if cfg.InstrumentalDetector.SpreadSamples != 6 {
 		t.Errorf("SpreadSamples = %d; want 6", cfg.InstrumentalDetector.SpreadSamples)
@@ -1669,8 +1669,8 @@ func TestLoad_InstrumentalDetectorEnvVocalGate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if cfg.InstrumentalDetector.VocalMaxConfidence != 0.03 {
-			t.Errorf("VocalMaxConfidence = %v; want 0.03 (invalid env ignored)", cfg.InstrumentalDetector.VocalMaxConfidence)
+		if cfg.InstrumentalDetector.VocalMaxConfidence != 0.015 {
+			t.Errorf("VocalMaxConfidence = %v; want 0.015 (invalid env ignored)", cfg.InstrumentalDetector.VocalMaxConfidence)
 		}
 	})
 	t.Run("spread samples", func(t *testing.T) {
@@ -1712,8 +1712,8 @@ func TestLoad_InstrumentalDetectorVocalGateFileReDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.InstrumentalDetector.VocalMaxConfidence != 0.03 {
-		t.Errorf("VocalMaxConfidence = %v; want 0.03 (re-defaulted from 0)", cfg.InstrumentalDetector.VocalMaxConfidence)
+	if cfg.InstrumentalDetector.VocalMaxConfidence != 0.015 {
+		t.Errorf("VocalMaxConfidence = %v; want 0.015 (re-defaulted from 0)", cfg.InstrumentalDetector.VocalMaxConfidence)
 	}
 	if cfg.InstrumentalDetector.SpreadSamples != 6 {
 		t.Errorf("SpreadSamples = %d; want 6 (omitted key defaults)", cfg.InstrumentalDetector.SpreadSamples)

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -41,7 +41,23 @@ const (
 // that lands an empty value -- still gets a working vocal gate rather than one
 // silently disabled. Kept in sync with config.defaults() by convention, the same
 // way the instrumental-class default is duplicated.
-const defaultVocalMaxConfidence = 0.03
+//
+// CALIBRATED (2026-07-19, issue #510 methodology): selected from a 296-track
+// labeled sample (146 provider-confirmed vocal, 150 provider-labeled
+// instrumental) scored by the live sidecar, holding the music gate at 0.9 and
+// the speech gate at 0.20. At 0.015 the false-instrumental rate on known-vocal
+// tracks is 1.37% (2/146) and true-instrumental recovery is 54% (81/150).
+//
+// This is deliberately NOT the value cmd/vocalcalib -mode sweep returns
+// (0.007589 at the tool's default 1% ceiling). That output is pinned exactly to
+// a single sample's vocal_peak -- moving it by 1e-5 doubles the error rate --
+// and it is dominated by 0.015, which costs no additional real errors while
+// recovering 22 more percentage points of true instrumentals. At n=146 one
+// track is 0.68%, so a 1% ceiling is finer than the sample can resolve and
+// forces the sweep into a strictly worse operating point.
+//
+// The prior 0.03 misclassified 4.79% (7/146) of known-vocal tracks.
+const defaultVocalMaxConfidence = 0.015
 
 // defaultSpeechMaxConfidence is the default summed-frame-MEAN threshold for the
 // Speech gate: a track is never marked instrumental when the summed mean of the

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -944,8 +944,8 @@ func TestNewHTTPDetectorDefaultsVocalGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ctor: %v", err)
 	}
-	if d.vocalMaxConfidence != 0.03 {
-		t.Errorf("vocalMaxConfidence = %v; want 0.03 (defaulted)", d.vocalMaxConfidence)
+	if d.vocalMaxConfidence != 0.015 {
+		t.Errorf("vocalMaxConfidence = %v; want 0.015 (defaulted)", d.vocalMaxConfidence)
 	}
 	if d.spreadSamples != 0 {
 		t.Errorf("spreadSamples = %d; want 0 (not constructor-defaulted; 0/1 means single window)", d.spreadSamples)
@@ -962,8 +962,8 @@ func TestNewHTTPDetectorDefaultsVocalGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ctor: %v", err)
 	}
-	if d2.vocalMaxConfidence != 0.03 {
-		t.Errorf("vocalMaxConfidence = %v; want 0.03 (out-of-range reset)", d2.vocalMaxConfidence)
+	if d2.vocalMaxConfidence != 0.015 {
+		t.Errorf("vocalMaxConfidence = %v; want 0.015 (out-of-range reset)", d2.vocalMaxConfidence)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Calibrates `vocal_max_confidence` from `0.03` to `0.015`, measured against a 296-track labeled sample scored by the live detector sidecar (146 tracks that provider lyrics prove are vocal, 150 provider-labeled instrumentals), holding the music gate at `0.90` and the speech gate at `0.20`.
- **This sweep refutes the premise of #510.** That issue argued `0.03` was too *tight* and should rise, on the theory that sustained melodic instruments read as faint `Singing` and clear the gate. The larger sample shows the opposite failure dominates, and that the vocal gate is not the lever #510 needs.
- Rewrites the "Calibration evidence" section, which previously claimed a clean 3x separation between the classes that does not exist.

## What the measurement shows

The two classes overlap; there is no separating margin. Known-vocal `vocal_peak` spans `0.0019`-`0.8861` (median `0.0959`, p5 `0.0257`), so genuinely vocal tracks reach well into what looks like instrumental territory. Every threshold trades one error against the other:

| `vocal_max_confidence` | false instrumental (of 146 known-vocal) | true instrumental recovered (of 150) |
|---|---|---|
| `0.005` | 0.68% | 24.0% |
| `0.010` | 1.37% | 42.7% |
| **`0.015`** (this PR) | **1.37%** | **54.0%** |
| `0.020` | 2.05% | 58.7% |
| `0.030` (prior default) | 4.79% | 66.0% |

`0.015` recovers the most true instrumentals available at its error level: it costs no additional false instrumentals over `0.010`, and the prior `0.030` misclassified 4.79% of known-vocal tracks.

The tiebreaker is this repo's own stated principle, in `docs/instrumental-detection.md`: a false instrumental is strictly worse than a missed one, because it permanently suppresses a real lyrics fetch while a missed instrumental just gets retried.

## Why this is not what `vocalcalib -mode sweep` returns

The sweep returns `0.007589` at its default 1% error ceiling. That value is deliberately **not** adopted:

- It is pinned exactly to one sample's `vocal_peak`; moving it by `1e-5` doubles the error rate.
- It is dominated by `0.015` - identical real error count, 22 percentage points less recovery.
- At n=146 a single track is 0.68%, so a 1% ceiling is finer than the sample can resolve and forces the sweep into a strictly worse operating point.

The sweep is evidence, not the decision. This is recorded in the constant's doc comment so the next person does not "correct" it back.

## Consequence for #510 and #501

#510's goal - recovering genuine instrumentals currently buried under a terminal verdict - is real, but the vocal gate cannot deliver it. **32 of the 150 labeled instrumentals (21%) score `music_sum < 0.90` and are unrecoverable at any vocal threshold.** Raising the vocal gate to chase them is punitive: `0.05` would recover 72% while misclassifying 14.38% of known-vocal tracks.

The lever for #510's actual goal is `min_confidence` (the music gate), which has never been calibrated. That is worth its own issue and its own sweep; this PR does not attempt it.

The speech gate's `0.20` is left untouched. It is flagged PROVISIONAL in source, but it blocks only 2 of 150 labeled instrumentals - inert, not wrong - so changing it without its own calibration would be unjustified.

## Linked issue

Refs #510 (the sweep that issue asked for; its stated premise is refuted rather than confirmed, see above). Not `Closes`, as #510 is already closed.

## Test plan

- [x] `make gate` - full pre-push chain, exit 0 ("OK: all pre-push checks passed")
- [x] `go test ./...` - 2551 tests pass across 51 packages
- [x] `golangci-lint run` - no issues
- [x] `govulncheck` - 0 vulnerabilities in called code
- [x] Default-value assertions updated in `internal/config` and `internal/detector` tests
- [x] Verified the tests that pass `0.03` as an explicit gate *argument* (`gate_test.go`, the `detector_test.go` score fixture) were left alone - only defaulting assertions changed
- [ ] Reviewer follow-up: confirm the operating point suits the detector-lane plans in #501

## Notes for the reviewer

The calibration inputs are aggregate scores only (`music_sum`/`vocal_peak`/`speech_mean` per labeled track); no library content is included here or in the repo.

This threshold is already live in the maintainer's deployment, applied ahead of this PR. The code change makes the default match what is running.
