### PR TITLE
feat(recalib): re-decide confirmed instrumentals under tightened thresholds

### DIFF
--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -131,6 +131,46 @@ and cannot be recovered at any vocal threshold. The speech gate blocks only 2 of
 150. Further recovery gains have to come from `min_confidence`, which has not
 been calibrated.
 
+### Applying a threshold change to rows already decided
+
+Changing `vocal_max_confidence` only affects future detections. Rows the old
+value already decided are never revisited on their own, in either direction, so
+a recalibration is finished only once the backlog is re-decided:
+
+```sh
+# Thresholds LOOSENED: promote rows the old, tighter gate buried.
+canticle scan reconcile-instrumental-recalibrate
+
+# Thresholds TIGHTENED: revert rows the old, looser gate wrongly settled.
+canticle scan reconcile-instrumental-recalibrate --reverse
+```
+
+Both re-decide from the telemetry already stored on each row
+(`music_sum`/`vocal_peak`/`speech_mean`), so neither re-reads audio or calls the
+sidecar - they are arithmetic passes, not detection passes. Both are dry-run by
+default, print what they would change, and need `--yes` to apply; applying
+writes a JSONL backup of every changed row first.
+
+The `--reverse` direction removes marker sidecars, so it is guarded: a marker is
+deleted only when its `[source:]` header proves the **detector** wrote it. A
+provider-declared instrumental, or a legacy bare marker with no header (which is
+indistinguishable from one), is left untouched and counted as
+`skipped(provider-owned=N)`. Reverted rows return to the queue at low priority
+for a normal provider fetch.
+
+Rows with **no** stored telemetry (written before migration 025) are invisible to
+both directions - there are no scores to re-decide from. Those need a real
+re-scan via `scan reconcile`.
+
+The speech gate's `speech_max_confidence = 0.20` default (#403) is a different
+kind of value: it is a **provisional placeholder**, chosen conservatively low
+(biased toward "not instrumental", preserving lyric protection) pending a
+#384-style calibration sweep over the audit set to pin the final constant. Because
+the key is configurable, that calibration refines the value without a code change.
+The acceptance criterion - that incidental-speech instrumentals get re-confirmed -
+is satisfied by the **post-calibration** validation gate (re-running the audit
+set), not by the placeholder itself.
+
 ## Sidecar setup
 
 The classifier is a small YAMNet HTTP service. Canticle does not publish an image

--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -155,8 +155,10 @@ The `--reverse` direction removes marker sidecars, so it is guarded: a marker is
 deleted only when its `[source:]` header proves the **detector** wrote it. A
 provider-declared instrumental, or a legacy bare marker with no header (which is
 indistinguishable from one), is left untouched and counted as
-`skipped(provider-owned=N)`. Reverted rows return to the queue at low priority
-for a normal provider fetch.
+`skipped(provider-owned=N)`. Reverted rows return to the queue at normal scan
+priority for a normal provider fetch - deliberately not the miss-backoff tier,
+because a reversed instrumental is a track with real vocals that is unusually
+likely to resolve on its next attempt.
 
 Rows with **no** stored telemetry (written before migration 025) are invisible to
 both directions - there are no scores to re-decide from. Those need a real
@@ -165,7 +167,8 @@ re-scan via `scan reconcile`.
 The speech gate's `speech_max_confidence = 0.20` default (#403) is a different
 kind of value: it is a **provisional placeholder**, chosen conservatively low
 (biased toward "not instrumental", preserving lyric protection) pending a
-#384-style calibration sweep over the audit set to pin the final constant. Because
+calibration sweep over the audit set, in the style of #384, to pin the final
+constant. Because
 the key is configurable, that calibration refines the value without a code change.
 The acceptance criterion - that incidental-speech instrumentals get re-confirmed -
 is satisfied by the **post-calibration** validation gate (re-running the audit

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -251,6 +251,11 @@ type ScanReconcileInstrumentalRecalibrateCmd struct {
 	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
 	Backup     string `arg:"--backup" help:"path for the JSONL backup of changed rows (default: <db-dir>/reconcile-instrumental-recalibrate-backup-<ts>.jsonl)" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+	// Reverse selects the TIGHTENING direction: re-decide rows already settled
+	// instrumental and revert the ones a lowered vocal_max_confidence now
+	// rejects, removing their detector-written markers. The default (loosening)
+	// direction only ever promotes rows the old thresholds buried.
+	Reverse bool `arg:"--reverse" help:"re-decide CONFIRMED instrumentals under tightened thresholds, reverting the ones that no longer qualify (default direction promotes buried rows instead)"`
 }
 
 // ScanResultsCmd lists persisted scan results, optionally filtered.

--- a/internal/commands/reconcile_instrumental_recalibrate.go
+++ b/internal/commands/reconcile_instrumental_recalibrate.go
@@ -80,8 +80,20 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 		_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate%s: dry run; pass --yes to apply\n", env.libLabel)
 	}
 
+	// The engine's Result counters are APPLY-ONLY by design (a dry run reports
+	// through Preview and mutates nothing, pinned by
+	// TestRun_DryRunDoesNotMutate). Counting previews here keeps the dry-run
+	// summary honest: printing the apply-shaped counters after a preview-only
+	// pass renders "reversed=0" under a screenful of "would reverse" lines,
+	// which reads as "nothing to do" when the opposite is true.
+	previewed := 0
+
 	rc := instrumentalrecalib.New(env.queue, lyrics.NewLRCWriter())
-	res, err := rc.Run(ctx, instrumentalrecalib.Options{
+	run := rc.Run
+	if args.Reverse {
+		run = rc.Reverse
+	}
+	res, err := run(ctx, instrumentalrecalib.Options{
 		LibraryID:      env.libraryID,
 		Limit:          args.Limit,
 		DryRun:         !args.Yes,
@@ -90,9 +102,12 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 		SpeechMax:      env.cfg.InstrumentalDetector.SpeechMaxConfidence,
 		CurrentVersion: version,
 		Preview: func(ch instrumentalrecalib.Change) {
+			previewed++
 			switch ch.Action {
 			case "settle":
 				_, _ = fmt.Fprintf(out, "would settle: id=%d  %s  -> write instrumental marker + settle\n", ch.QueueID, ch.SourcePath)
+			case "reverse":
+				_, _ = fmt.Fprintf(out, "would reverse: id=%d  %s  vocal_peak=%.6f  -> remove detector marker + requeue for a provider fetch\n", ch.QueueID, ch.SourcePath, ch.VocalPeak)
 			default:
 				_, _ = fmt.Fprintf(out, "would reset: id=%d  %s  -> stale telemetry version, reset for re-scan\n", ch.QueueID, ch.SourcePath)
 			}
@@ -113,11 +128,32 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate%s: %d vocal-gate-rejected row(s) considered\n",
-		env.libLabel, res.Total)
-	_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate done: settled=%d markers-written=%d reset-stale=%d skipped(worker-claimed=%d) errors=%d\n",
-		res.Settled, res.MarkersWritten, res.ResetStale, res.SkippedClaimed, res.Errors)
-	if args.Yes && (res.Settled > 0 || res.ResetStale > 0) {
+	candidates := "vocal-gate-rejected"
+	if args.Reverse {
+		candidates = "confirmed-instrumental"
+	}
+	_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate%s: %d %s row(s) considered\n",
+		env.libLabel, res.Total, candidates)
+	if !args.Yes {
+		verb := "settle/reset"
+		if args.Reverse {
+			verb = "reverse"
+		}
+		_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate dry run: would %s %d row(s); skipped(provider-owned=%d) errors=%d\n",
+			verb, previewed, res.SkippedProviderOwned, res.Errors)
+		if res.Errors > 0 {
+			return 1
+		}
+		return 0
+	}
+	if args.Reverse {
+		_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate done: reversed=%d markers-removed=%d skipped(provider-owned=%d worker-claimed=%d) errors=%d\n",
+			res.Reversed, res.MarkersRemoved, res.SkippedProviderOwned, res.SkippedClaimed, res.Errors)
+	} else {
+		_, _ = fmt.Fprintf(out, "reconcile-instrumental-recalibrate done: settled=%d markers-written=%d reset-stale=%d skipped(worker-claimed=%d) errors=%d\n",
+			res.Settled, res.MarkersWritten, res.ResetStale, res.SkippedClaimed, res.Errors)
+	}
+	if args.Yes && (res.Settled > 0 || res.ResetStale > 0 || res.Reversed > 0) {
 		_, _ = fmt.Fprintf(out, "backup of changed rows written to %s\n", backupPath)
 	}
 	if res.Errors > 0 {

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -45,6 +45,10 @@ type Store interface {
 	Resetter
 	ListVocalGateRejections(ctx context.Context, opts queue.ListVocalGateRejectionsOptions) ([]queue.StampedRejection, error)
 	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error)
+	// The tightening direction (Reverse): enumerate confirmed instrumentals and
+	// revert the ones a lowered threshold now rejects.
+	ListVocalGateConfirmations(ctx context.Context, opts queue.ListVocalGateConfirmationsOptions) ([]queue.StampedRejection, error)
+	UnsettleInstrumental(ctx context.Context, id int64) (bool, error)
 }
 
 // Writer writes the instrumental marker sidecar. Satisfied by lyrics.Writer.
@@ -87,6 +91,11 @@ type Result struct {
 	ResetStale     int // rows reset to never-classified (cross-version pass)
 	SkippedClaimed int // rows a serve-mode worker claimed mid-recalibration
 	Errors         int // non-fatal per-row failures
+
+	// Reverse-direction counters (Reverse only).
+	Reversed             int // settled instrumentals reverted under a tightened gate
+	MarkersRemoved       int // detector marker sidecars taken off disk
+	SkippedProviderOwned int // rows whose marker a PROVIDER wrote; never reversed
 }
 
 // Options controls a Run.
@@ -300,4 +309,174 @@ func markerPaths(row queue.StampedRejection) []string {
 		return nil
 	}
 	return []string{filepath.Join(outdir, name)}
+}
+
+// Reverse re-decides CONFIRMED instrumentals under tightened thresholds, the
+// mirror of Run. A row whose stored telemetry no longer satisfies
+// detector.Instrumental has its marker removed and returns to the queue for a
+// real provider fetch.
+//
+// It exists because the package's original assumption -- that thresholds only
+// ever LOOSEN -- does not hold. A calibration that lowers VocalMax strands
+// every false instrumental the old value settled: Run only ever looks at
+// instrumental_result=0, and nothing else revisits a confirmed positive.
+//
+// Three deliberate asymmetries with Run:
+//
+// 1. PROVENANCE GATE. Run writes markers; Reverse deletes them, so it must
+// first prove the marker is the detector's to delete. A marker carrying a
+// provider's [source:] token is editorially authoritative, and a legacy bare
+// marker (zero-value provenance, IsDetector()==false) is indistinguishable
+// from one, so both are skipped and counted in SkippedProviderOwned. Deleting
+// a provider's instrumental declaration would be unrecoverable data loss.
+//
+// 2. DATABASE FIRST, then the marker -- the reverse of Run's marker-first
+// order. Run must never settle a verdict whose marker did not land. Reverse
+// must never leave the database claiming instrumental after the marker is
+// gone: that row is settled 'done', so nothing would ever retry it and the
+// user is left with neither lyrics nor a marker. The opposite residue (row
+// deferred, stale marker still on disk) is self-healing -- the retry overwrites
+// the marker when lyrics arrive.
+//
+// 3. NO stale-version reset. Run refuses to settle on another version's
+// telemetry because settling is the DESTRUCTIVE direction there. Reversing is
+// the conservative direction -- it restores a real provider fetch -- so acting
+// on cross-version telemetry is safe, and resetting is not even available: a
+// settled row is 'done', while ResetInstrumentalToUnclassified is guarded on
+// 'deferred'.
+func (r *Recalibrator) Reverse(ctx context.Context, opts Options) (Result, error) {
+	var res Result
+
+	rows, err := r.store.ListVocalGateConfirmations(ctx, queue.ListVocalGateConfirmationsOptions{
+		LibraryID: opts.LibraryID,
+		Limit:     opts.Limit,
+	})
+	if err != nil {
+		return res, fmt.Errorf("instrumentalrecalib: list vocal-gate confirmations: %w", err)
+	}
+	res.Total = len(rows)
+
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return res, fmt.Errorf("instrumentalrecalib: stop reverse recalibration: %w", err)
+		}
+
+		if detector.Instrumental(row.Tel.MusicSum, row.Tel.VocalPeak, row.Tel.SpeechMean,
+			opts.MinConfidence, opts.VocalMax, opts.SpeechMax) {
+			// Still correctly instrumental under the tightened thresholds.
+			continue
+		}
+
+		marker, owned, err := r.detectorOwnedMarker(row)
+		if err != nil {
+			res.Errors++
+			continue
+		}
+		if !owned {
+			res.SkippedProviderOwned++
+			continue
+		}
+
+		change := Change{
+			QueueID:    row.ID,
+			Artist:     row.Artist,
+			Title:      row.Title,
+			SourcePath: row.SourcePath,
+			VocalPeak:  row.Tel.VocalPeak,
+			Action:     "reverse",
+		}
+		if marker != "" {
+			change.MarkerPaths = []string{marker}
+		}
+
+		if opts.DryRun {
+			if opts.Preview != nil {
+				opts.Preview(change)
+			}
+			continue
+		}
+
+		// Backup first: an applied change must always have its restorable record
+		// on disk before the change exists.
+		if opts.Report != nil {
+			if err := opts.Report(change); err != nil {
+				res.Errors++
+				continue
+			}
+		}
+
+		reverted, err := r.store.UnsettleInstrumental(ctx, row.ID)
+		if err != nil {
+			res.Errors++
+			continue
+		}
+		if !reverted {
+			// A worker re-claimed the row, or a peer already reversed it, between
+			// the listing and here. Leave its marker alone.
+			res.SkippedClaimed++
+			continue
+		}
+		res.Reversed++
+
+		if marker == "" {
+			continue
+		}
+		if err := os.Remove(marker); err != nil && !os.IsNotExist(err) {
+			// The row is already reverted, so this is the self-healing residue
+			// described above: surface it, but do not fail the reversal.
+			res.Errors++
+			slog.Warn("instrumentalrecalib: reversed the verdict but could not remove its marker; the retry will overwrite it when lyrics arrive",
+				"id", row.ID, "marker", marker, "error", err)
+			continue
+		}
+		res.MarkersRemoved++
+	}
+
+	return res, nil
+}
+
+// detectorOwnedMarker resolves row's marker sidecar and reports whether it is
+// the detector's to delete.
+//
+// Ownership is decided by an EXPLICIT contrary signal, not by the absence of a
+// positive one. Every candidate row already carries instrumental_result=1,
+// which only queue.SettleInstrumental sets, so the database has already proven
+// the detector settled this verdict -- a provider-declared instrumental is
+// recorded as outcome_type='instrumental' with instrumental_result NULL and
+// never reaches this listing. The marker header is therefore a cross-check for
+// the one case the database cannot express (a sidecar some other writer owns),
+// not the primary authority.
+//
+// Concretely:
+//   - missing file            -> ("", true): nothing to delete, row still reversible
+//   - [source:] names another  -> owned=false: an explicit foreign claim wins
+//   - not an instrumental marker -> owned=false: another writer owns that sidecar
+//   - bare marker, no header  -> owned=TRUE: predates provenance stamping
+//   - [source:canticle-detector] -> owned=true
+//
+// Requiring a positive detector stamp instead stranded 95% of a real
+// recalibration backlog (191 of 200 sampled production markers were bare, and
+// none carried a provider token), which is why absence defers to the database.
+func (r *Recalibrator) detectorOwnedMarker(row queue.StampedRejection) (path string, owned bool, err error) {
+	paths := markerPaths(row)
+	if len(paths) == 0 {
+		return "", true, nil
+	}
+	p := paths[0]
+	prov, isMarker, rerr := lyrics.ReadInstrumentalProvenance(p)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("instrumentalrecalib: read marker provenance for %d: %w", row.ID, rerr)
+	}
+	if !isMarker {
+		return p, false, nil
+	}
+	// An explicit, non-detector [source:] token is a foreign claim: leave it.
+	// An empty Source is a legacy bare marker, which defers to the database.
+	if prov.Source != "" && !prov.IsDetector() {
+		return p, false, nil
+	}
+	return p, true, nil
 }

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -18,7 +18,9 @@ package instrumentalrecalib
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -465,7 +467,11 @@ func (r *Recalibrator) detectorOwnedMarker(row queue.StampedRejection) (path str
 	p := paths[0]
 	prov, isMarker, rerr := lyrics.ReadInstrumentalProvenance(p)
 	if rerr != nil {
-		if os.IsNotExist(rerr) {
+		// errors.Is, NOT os.IsNotExist: ReadInstrumentalProvenance WRAPS the
+		// underlying open error, and os.IsNotExist does not unwrap. Getting this
+		// wrong sent every already-deleted marker down the error path, counting
+		// an error and leaving a wrongly-settled row settled forever.
+		if errors.Is(rerr, fs.ErrNotExist) {
 			return "", true, nil
 		}
 		return "", false, fmt.Errorf("instrumentalrecalib: read marker provenance for %d: %w", row.ID, rerr)

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -2,6 +2,7 @@ package instrumentalrecalib
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -109,6 +110,19 @@ func seedRejection(t *testing.T, q *queue.DBQueue, sourcePath string, tel queue.
 		t.Fatalf("stamp unclassified miss: %v", err)
 	}
 	return item.ID
+}
+
+// openTestQueueWithDB is openTestQueue plus the raw handle, for tests that
+// assert on columns the Store seam does not expose.
+func openTestQueueWithDB(t *testing.T) (*queue.DBQueue, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	sqlDB, err := dbpkg.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return queue.NewDBQueue(sqlDB), sqlDB
 }
 
 func openTestQueue(t *testing.T) *queue.DBQueue {
@@ -557,4 +571,206 @@ func TestRun_ResetInstrumentalToUnclassifiedErrorCountsError(t *testing.T) {
 	if res.Errors != 1 || res.ResetStale != 0 || w.calls != 0 {
 		t.Fatalf("expected a counted reset error, got %+v (writer calls %d)", res, w.calls)
 	}
+}
+
+// seedConfirmation seeds a row the detector SETTLED instrumental and writes the
+// marker sidecar next to its source, with the given provenance header, so a
+// reverse run has a real file to act on.
+func seedConfirmation(t *testing.T, q *queue.DBQueue, sourcePath string, tel queue.InstrumentalTelemetry, source string) (int64, string) {
+	t.Helper()
+	ctx := context.Background()
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: sourcePath,
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	name, err := lyrics.SidecarName("Artist", "Title", filepath.Base(sourcePath), false)
+	if err != nil {
+		t.Fatalf("sidecar name: %v", err)
+	}
+	marker := filepath.Join(filepath.Dir(sourcePath), name)
+	body := "[by:canticle]\n[source:" + source + "]\n" + lyrics.InstrumentalMarker + "\n"
+	if err := os.WriteFile(marker, []byte(body), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	return item.ID, marker
+}
+
+// TestReverse_RevertsRowThatNowFailsTheVocalGate is the tightening direction:
+// a confirmed instrumental whose stored vocal_peak now sits at or above a
+// LOWERED VocalMax goes back to deferred and its detector marker comes off disk.
+func TestReverse_RevertsRowThatNowFailsTheVocalGate(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	rc := New(q, &fakeWriter{})
+	res, err := rc.Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 1 {
+		t.Errorf("Reversed = %d; want 1", res.Reversed)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Errorf("marker still on disk; want removed once the verdict is reversed")
+	}
+	var status string
+	var result int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT status, instrumental_result FROM work_queue WHERE id = ?`, id,
+	).Scan(&status, &result); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "deferred" || result != 0 {
+		t.Errorf("status/result = %q/%d; want deferred/0", status, result)
+	}
+}
+
+// TestReverse_LeavesRowThatStillPassesTheGate pins that a still-correct
+// instrumental is not disturbed.
+func TestReverse_LeavesRowThatStillPassesTheGate(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.001, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	_, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	rc := New(q, &fakeWriter{})
+	res, err := rc.Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 0 {
+		t.Errorf("Reversed = %d; want 0 -- the row still passes the tightened gate", res.Reversed)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker removed; want preserved for a still-passing row")
+	}
+}
+
+// TestReverse_PreservesProviderDeclaredInstrumental is the safety property: a
+// marker the PROVIDER wrote is editorially authoritative, not the detector's to
+// re-decide. It must survive a reverse run untouched, and its row must not be
+// reopened, even when the stored telemetry would fail the tightened gate.
+func TestReverse_PreservesProviderDeclaredInstrumental(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, marker := seedConfirmation(t, q, src, tel, "musixmatch")
+
+	rc := New(q, &fakeWriter{})
+	res, err := rc.Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 0 {
+		t.Errorf("Reversed = %d; want 0 -- a provider-declared instrumental is not the detector's to reverse", res.Reversed)
+	}
+	if res.SkippedProviderOwned != 1 {
+		t.Errorf("SkippedProviderOwned = %d; want 1", res.SkippedProviderOwned)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("provider marker removed; want preserved")
+	}
+	var status string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT status FROM work_queue WHERE id = ?`, id,
+	).Scan(&status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done -- the provider verdict stands", status)
+	}
+}
+
+// TestReverse_ReversesLegacyBareMarker pins that a marker predating provenance
+// stamping is still the detector's to remove. The row carries
+// instrumental_result=1, which only SettleInstrumental sets, so the DATABASE
+// already proves the detector owns the verdict; an absent [source:] header is
+// an artifact of when the file was written, not evidence of provider ownership.
+// Treating bare as provider-owned stranded 95% of a real recalibration backlog.
+func TestReverse_ReversesLegacyBareMarker(t *testing.T) {
+	ctx := context.Background()
+	q, _ := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+
+	// Seed with a BARE marker: the marker line only, no provenance header.
+	id, err := func() (int64, error) {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:     "out",
+			Filename:   "a.lrc",
+			SourcePath: src,
+		}, queue.PriorityScan)
+		if err != nil {
+			return 0, err
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			return 0, err
+		}
+		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+			return 0, err
+		}
+		if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+			return 0, err
+		}
+		return item.ID, nil
+	}()
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	name, err := lyrics.SidecarName("Artist", "Title", "a.flac", false)
+	if err != nil {
+		t.Fatalf("sidecar name: %v", err)
+	}
+	marker := filepath.Join(dir, name)
+	if err := os.WriteFile(marker, []byte(lyrics.InstrumentalMarker+"\n"), 0o644); err != nil {
+		t.Fatalf("write bare marker: %v", err)
+	}
+
+	rc := New(q, &fakeWriter{})
+	res, err := rc.Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 1 {
+		t.Errorf("Reversed = %d; want 1 -- a bare marker on an instrumental_result=1 row is the detector's", res.Reversed)
+	}
+	if res.SkippedProviderOwned != 0 {
+		t.Errorf("SkippedProviderOwned = %d; want 0", res.SkippedProviderOwned)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Errorf("bare marker still on disk; want removed")
+	}
+	_ = id
 }

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -54,10 +54,12 @@ func (w *fsWriter) WriteLRC(song models.Song, filename, outdir string) error {
 // (a peer-claim race, a vanished row, a listing/settle/reset failure).
 type fakeStore struct {
 	*queue.DBQueue
-	listErr       error
-	settleOutcome *queue.SettleOutcome
-	settleErr     error
-	resetErr      error
+	listErr        error
+	settleOutcome  *queue.SettleOutcome
+	settleErr      error
+	resetErr       error
+	unsettleErr    error
+	unsettleResult *bool
 }
 
 func (f *fakeStore) ListVocalGateRejections(ctx context.Context, opts queue.ListVocalGateRejectionsOptions) ([]queue.StampedRejection, error) {
@@ -82,6 +84,26 @@ func (f *fakeStore) ResetInstrumentalToUnclassified(ctx context.Context, id int6
 		return false, f.resetErr
 	}
 	return f.DBQueue.ResetInstrumentalToUnclassified(ctx, id)
+}
+
+func (f *fakeStore) ListVocalGateConfirmations(ctx context.Context, opts queue.ListVocalGateConfirmationsOptions) ([]queue.StampedRejection, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.DBQueue.ListVocalGateConfirmations(ctx, opts)
+}
+
+// UnsettleInstrumental lets a test force the two outcomes a live SQLite queue
+// will not produce on demand: a hard failure, and the worker-claimed race where
+// the guarded UPDATE matches nothing between the listing and the mutation.
+func (f *fakeStore) UnsettleInstrumental(ctx context.Context, id int64) (bool, error) {
+	if f.unsettleErr != nil {
+		return false, f.unsettleErr
+	}
+	if f.unsettleResult != nil {
+		return *f.unsettleResult, nil
+	}
+	return f.DBQueue.UnsettleInstrumental(ctx, id)
 }
 
 // seedRejection mirrors the queue-package seed pattern (see
@@ -773,4 +795,213 @@ func TestReverse_ReversesLegacyBareMarker(t *testing.T) {
 		t.Errorf("bare marker still on disk; want removed")
 	}
 	_ = id
+}
+
+// TestReverse_MissingMarkerStillRevertsRow pins that an absent sidecar does not
+// block the database correction. There is nothing to delete, but the row is
+// still wrongly settled, and leaving it settled would strand it forever.
+func TestReverse_MissingMarkerStillRevertsRow(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+
+	res, err := New(q, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 1 {
+		t.Errorf("Reversed = %d; want 1 even with no marker on disk", res.Reversed)
+	}
+	if res.MarkersRemoved != 0 {
+		t.Errorf("MarkersRemoved = %d; want 0 -- nothing was there to remove", res.MarkersRemoved)
+	}
+	if res.Errors != 0 {
+		t.Errorf("Errors = %d; want 0 -- an absent marker is not an error", res.Errors)
+	}
+	var status string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred", status)
+	}
+}
+
+// TestReverse_LeavesForeignSidecarAlone pins that a sidecar which is not an
+// instrumental marker at all is never deleted. Something else owns that file,
+// and the reverse pass must not touch it or the row behind it.
+func TestReverse_LeavesForeignSidecarAlone(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	_, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+	// Overwrite the marker with ordinary sidecar content: no marker line.
+	if err := os.WriteFile(marker, []byte("just some text, not a marker\n"), 0o644); err != nil {
+		t.Fatalf("write foreign sidecar: %v", err)
+	}
+
+	res, err := New(q, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 0 || res.SkippedProviderOwned != 1 {
+		t.Errorf("Reversed=%d SkippedProviderOwned=%d; want 0/1 -- a non-marker sidecar is not ours",
+			res.Reversed, res.SkippedProviderOwned)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("foreign sidecar removed; want preserved")
+	}
+}
+
+// TestReverse_DryRunPreviewsWithoutMutating pins that a dry run reports through
+// Preview and changes neither the database nor the disk.
+func TestReverse_DryRunPreviewsWithoutMutating(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	previewed := 0
+	res, err := New(q, &fakeWriter{}).Reverse(ctx, Options{
+		DryRun: true, MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+		Preview: func(c Change) {
+			previewed++
+			if c.Action != "reverse" {
+				t.Errorf("Action = %q; want reverse", c.Action)
+			}
+		},
+		Report: func(Change) error {
+			t.Fatal("Report must not run in a dry run -- it is the durable backup record")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if previewed != 1 || res.Reversed != 0 {
+		t.Errorf("previewed=%d Reversed=%d; want 1/0 (counters are apply-only)", previewed, res.Reversed)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker removed during a dry run")
+	}
+	var status string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done -- a dry run must not mutate", status)
+	}
+}
+
+// TestReverse_ReportFailureLeavesRowAndMarkerIntact pins the backup-first rule
+// in the reverse direction: if the restorable record cannot be written, the
+// change must not happen at all.
+func TestReverse_ReportFailureLeavesRowAndMarkerIntact(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	res, err := New(q, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+		Report: func(Change) error { return errors.New("backup disk full") },
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 0 || res.Errors != 1 {
+		t.Errorf("Reversed=%d Errors=%d; want 0/1", res.Reversed, res.Errors)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker removed despite the backup failing")
+	}
+	var status string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done -- no backup, no change", status)
+	}
+}
+
+// TestReverse_SkipsRowClaimedMidRun pins the race window: when the guarded
+// UPDATE matches nothing because a worker re-claimed the row between the
+// listing and the mutation, the marker must be left alone rather than deleted
+// out from under whoever now owns the row.
+func TestReverse_SkipsRowClaimedMidRun(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	_, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	claimed := false
+	store := &fakeStore{DBQueue: q, unsettleResult: &claimed}
+	res, err := New(store, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 0 || res.SkippedClaimed != 1 {
+		t.Errorf("Reversed=%d SkippedClaimed=%d; want 0/1", res.Reversed, res.SkippedClaimed)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker removed for a row this run did not actually revert")
+	}
+}
+
+// TestReverse_UnsettleErrorIsCountedNotFatal pins that a per-row store failure
+// is counted and the run continues, matching Run's per-row error contract.
+func TestReverse_UnsettleErrorIsCountedNotFatal(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	_, marker := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	store := &fakeStore{DBQueue: q, unsettleErr: errors.New("database is locked")}
+	res, err := New(store, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: a per-row failure must not abort the run: %v", err)
+	}
+	if res.Errors != 1 || res.Reversed != 0 {
+		t.Errorf("Errors=%d Reversed=%d; want 1/0", res.Errors, res.Reversed)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Errorf("marker removed after the database write failed")
+	}
+}
+
+// TestReverse_ListErrorAborts pins the one failure that IS fatal: if the
+// candidate set cannot be enumerated, the run has nothing trustworthy to act on.
+func TestReverse_ListErrorAborts(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	store := &fakeStore{DBQueue: q, listErr: errors.New("no such table")}
+	if _, err := New(store, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	}); err == nil {
+		t.Fatal("Reverse: want an error when the listing fails")
+	}
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1722,14 +1722,14 @@ func (q *DBQueue) ListVocalGateConfirmations(ctx context.Context, opts ListVocal
 	            AND music_sum IS NOT NULL AND vocal_peak IS NOT NULL AND speech_mean IS NOT NULL`
 	var args []any
 	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
-	query += libClause //nolint:gosec // G202: libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL
+	query += libClause //nolint:gosec // reason: G202 -- libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL
 	args = append(args, libArgs...)
 	query += ` ORDER BY id`
 	if opts.Limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, opts.Limit)
 	}
-	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: fragments are package constants / fixed clauses, never user-built SQL
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // reason: G202 -- fragments are package constants / fixed clauses, never user-built SQL
 	if err != nil {
 		return nil, fmt.Errorf("queue: list vocal-gate confirmations: %w", err)
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -2283,8 +2283,19 @@ func requireAffected(res sql.Result, op string) error {
 // alongside the work_queue row this method just returned to 'deferred'. The
 // work_queue row is the live work item; the scan result stays settled.
 //
-// priority is sunk to -100 to match Defer: these rows are a retry backlog and
-// must not jump ahead of fresh scan work in the dequeue ORDER BY.
+// priority returns to PriorityScan rather than sinking to PriorityMiss. Matching
+// Defer looks like the obvious choice and is wrong here: PriorityMiss exists for
+// rows that are LIKELY TO MISS AGAIN, and a reversed instrumental is the
+// opposite -- a track with real vocals the detector wrongly suppressed, so it is
+// unusually likely to resolve on the next attempt.
+//
+// The cost of getting this wrong is not theoretical. Dequeue randomizes within a
+// priority tier, so sinking a bounded correction into a deferred pool an order of
+// magnitude larger makes only (reversed / pool) of each draw a corrected row.
+// Measured on a production reversal: 880 rows dropped into a 15,634-row pool at
+// ~180 rows/hr drew ~10/hr, clearing half in 2.5 days and trailing to roughly
+// three weeks, versus about five hours at PriorityScan. These rows do not starve
+// fresh work -- they ARE the corrected work, and the set is finite.
 //
 // Guarded on status = 'done' AND instrumental_result = 1, so a row settled with
 // real lyrics, a row a worker has claimed, or one already reversed is left
@@ -2296,13 +2307,13 @@ func (q *DBQueue) UnsettleInstrumental(ctx context.Context, id int64) (bool, err
              outcome_type = NULL,
              status = 'deferred',
              completed_at = NULL,
-             priority = -100,
+             priority = ?,
              next_attempt_at = ?,
              last_error = 'instrumental verdict reversed by a tightened vocal gate'
          WHERE id = ?
            AND status = 'done'
            AND instrumental_result = 1`,
-		formatTime(q.now()), id,
+		PriorityScan, formatTime(q.now()), id,
 	)
 	if err != nil {
 		return false, fmt.Errorf("queue: unsettle instrumental: %w", err)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1692,6 +1692,66 @@ func (q *DBQueue) ListVocalGateRejections(ctx context.Context, opts ListVocalGat
 	return out, nil
 }
 
+// ListVocalGateConfirmationsOptions narrows the stamped-instrumental listing.
+type ListVocalGateConfirmationsOptions struct {
+	LibraryID *int64
+	Limit     int
+}
+
+// ListVocalGateConfirmations returns done rows the detector previously settled
+// as instrumental (instrumental_result = 1) that carry re-decidable stored
+// telemetry. It is the TIGHTENING-direction counterpart to
+// ListVocalGateRejections: those rows sit in a gap of their own, because
+// nothing revisits a confirmed positive once the thresholds move DOWN.
+//
+// Unlike the rejection listing, this one does not need the empty-vocal_class
+// filter that drops the degraded mean-only-sidecar population. That filter
+// exists because a vocal_peak stamped 0.0 by an incomplete sidecar can
+// spuriously SATISFY the vocal gate and settle a false instrumental. Here the
+// re-decision only ever acts when a row now FAILS the gate, which requires a
+// vocal_peak at or above the threshold -- a degraded 0.0 stamp can never
+// trigger a reversal. The filter would be inert, so it is omitted rather than
+// cargo-culted.
+//
+// Read-only.
+func (q *DBQueue) ListVocalGateConfirmations(ctx context.Context, opts ListVocalGateConfirmationsOptions) (out []StampedRejection, retErr error) {
+	query := `SELECT id, COALESCE(artist,''), COALESCE(title,''), COALESCE(source_path,''),
+	                 music_sum, vocal_peak, speech_mean, COALESCE(vocal_class,''), COALESCE(detector_version,'')
+	          FROM work_queue
+	          WHERE instrumental_result = 1 AND status = 'done'
+	            AND music_sum IS NOT NULL AND vocal_peak IS NOT NULL AND speech_mean IS NOT NULL`
+	var args []any
+	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
+	query += libClause //nolint:gosec // G202: libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL
+	args = append(args, libArgs...)
+	query += ` ORDER BY id`
+	if opts.Limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+	rows, err := q.db.QueryContext(ctx, query, args...) //nolint:gosec // G202: fragments are package constants / fixed clauses, never user-built SQL
+	if err != nil {
+		return nil, fmt.Errorf("queue: list vocal-gate confirmations: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("queue: close list vocal-gate confirmations rows: %w", err)
+		}
+	}()
+	for rows.Next() {
+		var r StampedRejection
+		if err := rows.Scan(&r.ID, &r.Artist, &r.Title, &r.SourcePath,
+			&r.Tel.MusicSum, &r.Tel.VocalPeak, &r.Tel.SpeechMean, &r.Tel.VocalClass, &r.Tel.DetectorVersion); err != nil {
+			return nil, fmt.Errorf("queue: scan vocal-gate confirmation: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: list vocal-gate confirmations rows: %w", err)
+	}
+	return out, nil
+}
+
 // ListInstrumentalMarkersOptions narrows ListDetectorInstrumentalMarkers.
 type ListInstrumentalMarkersOptions struct {
 	LibraryID *int64
@@ -2203,4 +2263,53 @@ func requireAffected(res sql.Result, op string) error {
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+// UnsettleInstrumental reverses SettleInstrumental for a row a TIGHTENED vocal
+// gate now rejects: the settled instrumental verdict is stamped back to
+// instrumental_result = 0 and the row returns to 'deferred' so the provider
+// lanes retry it.
+//
+// The stored telemetry columns are deliberately PRESERVED. They are the
+// evidence the re-decision was made from, and stamping 0 (rather than NULL)
+// records the truthful state -- the detector did score this row, and under the
+// current thresholds those scores say not-instrumental. NULL would claim the
+// row was never classified and would send it back for a needless re-scan.
+//
+// scan_results is deliberately NOT reverted, which is the asymmetry with
+// SettleInstrumental's 'done' writeback. The scan scheduler enqueues from
+// scan_results WHERE status = 'pending' (scan.ListPendingByLibrary), so
+// flipping it back would race the scheduler into enqueuing a DUPLICATE
+// alongside the work_queue row this method just returned to 'deferred'. The
+// work_queue row is the live work item; the scan result stays settled.
+//
+// priority is sunk to -100 to match Defer: these rows are a retry backlog and
+// must not jump ahead of fresh scan work in the dequeue ORDER BY.
+//
+// Guarded on status = 'done' AND instrumental_result = 1, so a row settled with
+// real lyrics, a row a worker has claimed, or one already reversed is left
+// alone rather than reopened. Returns whether the row was reverted.
+func (q *DBQueue) UnsettleInstrumental(ctx context.Context, id int64) (bool, error) {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET instrumental_result = 0,
+             outcome_type = NULL,
+             status = 'deferred',
+             completed_at = NULL,
+             priority = -100,
+             next_attempt_at = ?,
+             last_error = 'instrumental verdict reversed by a tightened vocal gate'
+         WHERE id = ?
+           AND status = 'done'
+           AND instrumental_result = 1`,
+		formatTime(q.now()), id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("queue: unsettle instrumental: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("queue: unsettle instrumental rows affected: %w", err)
+	}
+	return n > 0, nil
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4098,3 +4098,153 @@ func TestDBQueue_ListUnclassifiedRespectsGlobalDefaultForNullStamps(t *testing.T
 		t.Errorf("global default off: got %d rows; want 0 (a NULL stamp is ineligible when the default is off)", len(off))
 	}
 }
+
+// TestDBQueue_UnsettleInstrumentalRevertsSettledRow pins the inverse of
+// SettleInstrumental: a row a tightened vocal gate now rejects goes back to
+// deferred so the provider lanes retry it, while its telemetry -- the evidence
+// the re-decision was made from -- survives.
+func TestDBQueue_UnsettleInstrumentalRevertsSettledRow(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	tel := InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, VocalClass: "Singing", DetectorVersion: "v1"}
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+
+	reverted, err := q.UnsettleInstrumental(ctx, item.ID)
+	if err != nil {
+		t.Fatalf("UnsettleInstrumental: %v", err)
+	}
+	if !reverted {
+		t.Fatalf("reverted = false; want true for a settled instrumental row")
+	}
+
+	var status, outcomeType string
+	var result int
+	var vocalPeak float64
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, instrumental_result, COALESCE(outcome_type,''), vocal_peak FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &result, &outcomeType, &vocalPeak); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "deferred" {
+		t.Errorf("status = %q; want deferred so the provider lanes retry the row", status)
+	}
+	if result != 0 {
+		t.Errorf("instrumental_result = %d; want 0 (re-decided not-instrumental, not re-scanned)", result)
+	}
+	if outcomeType != "" {
+		t.Errorf("outcome_type = %q; want cleared", outcomeType)
+	}
+	if vocalPeak != 0.02 {
+		t.Errorf("vocal_peak = %v; want 0.02 preserved as the re-decision evidence", vocalPeak)
+	}
+}
+
+// TestDBQueue_UnsettleInstrumentalLeavesNonInstrumentalRowsAlone pins the
+// guard: only a row the DETECTOR settled instrumental is reversible. A row
+// settled with real lyrics must never be dragged back into the queue.
+func TestDBQueue_UnsettleInstrumentalLeavesNonInstrumentalRowsAlone(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	reverted, err := q.UnsettleInstrumental(ctx, item.ID)
+	if err != nil {
+		t.Fatalf("UnsettleInstrumental: %v", err)
+	}
+	if reverted {
+		t.Fatalf("reverted = true; want false -- a completed non-instrumental row must never be reopened")
+	}
+}
+
+// TestDBQueue_ListVocalGateConfirmationsReturnsSettledRowsWithTelemetry pins
+// the tightening-direction candidate set: rows the detector CONFIRMED
+// instrumental that carry re-decidable stored telemetry.
+func TestDBQueue_ListVocalGateConfirmationsReturnsSettledRowsWithTelemetry(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	settled, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Settled"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, settled.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.SettleInstrumental(ctx, settled.ID, InstrumentalTelemetry{
+		MusicSum: 0.95, VocalPeak: 0.02, VocalClass: "Singing", DetectorVersion: "v1",
+	}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+
+	// A plain completed row was never scored by the detector: it must not appear.
+	other, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Lyrics"},
+		Outdir:     "out",
+		Filename:   "b.lrc",
+		SourcePath: "/music/b.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue other: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue other: %v", err)
+	}
+	if err := q.Complete(ctx, other.ID); err != nil {
+		t.Fatalf("complete other: %v", err)
+	}
+
+	rows, err := q.ListVocalGateConfirmations(ctx, ListVocalGateConfirmationsOptions{})
+	if err != nil {
+		t.Fatalf("ListVocalGateConfirmations: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1 (only the detector-settled row)", len(rows))
+	}
+	if rows[0].ID != settled.ID {
+		t.Errorf("id = %d; want %d", rows[0].ID, settled.ID)
+	}
+	if rows[0].Tel.VocalPeak != 0.02 {
+		t.Errorf("vocal_peak = %v; want 0.02", rows[0].Tel.VocalPeak)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4248,3 +4248,49 @@ func TestDBQueue_ListVocalGateConfirmationsReturnsSettledRowsWithTelemetry(t *te
 		t.Errorf("vocal_peak = %v; want 0.02", rows[0].Tel.VocalPeak)
 	}
 }
+
+// TestDBQueue_UnsettleInstrumentalRequeuesAtScanPriority pins that a reversed
+// row returns at normal scan priority, NOT the miss-backoff tier. Deferred
+// misses sink to PriorityMiss because they are likely to miss again; a reversed
+// instrumental is the opposite -- a track with real vocals that was wrongly
+// suppressed, so it is unusually likely to succeed on retry. Sinking these to
+// PriorityMiss interleaves them randomly with the whole deferred pool and
+// stretches a bounded correction into a weeks-long tail.
+func TestDBQueue_UnsettleInstrumentalRequeuesAtScanPriority(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
+		MusicSum: 0.95, VocalPeak: 0.02, VocalClass: "Singing", DetectorVersion: "v1",
+	}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if _, err := q.UnsettleInstrumental(ctx, item.ID); err != nil {
+		t.Fatalf("unsettle: %v", err)
+	}
+
+	var priority int
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT priority FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&priority); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if priority != PriorityScan {
+		t.Errorf("priority = %d; want PriorityScan (%d) -- a reversal is a correction, not a miss retry", priority, PriorityScan)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4294,3 +4294,51 @@ func TestDBQueue_UnsettleInstrumentalRequeuesAtScanPriority(t *testing.T) {
 		t.Errorf("priority = %d; want PriorityScan (%d) -- a reversal is a correction, not a miss retry", priority, PriorityScan)
 	}
 }
+
+// TestDBQueue_ListVocalGateConfirmationsRespectsLimit pins the --limit option
+// on the tightening-direction listing. Operators use it to rehearse a
+// recalibration on a bounded slice before running the whole backlog, so a limit
+// that silently did nothing would turn a "try 5 rows first" into a full pass.
+func TestDBQueue_ListVocalGateConfirmationsRespectsLimit(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	for i := 0; i < 3; i++ {
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: "Artist", TrackName: fmt.Sprintf("Title%d", i)},
+			Outdir:     "out",
+			Filename:   fmt.Sprintf("a%d.lrc", i),
+			SourcePath: fmt.Sprintf("/music/a%d.flac", i),
+		}, PriorityScan)
+		if err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %d: %v", i, err)
+		}
+		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+			t.Fatalf("defer %d: %v", i, err)
+		}
+		if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
+			MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1",
+		}); err != nil {
+			t.Fatalf("settle %d: %v", i, err)
+		}
+	}
+
+	all, err := q.ListVocalGateConfirmations(ctx, ListVocalGateConfirmationsOptions{})
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("unlimited list = %d rows; want 3", len(all))
+	}
+
+	limited, err := q.ListVocalGateConfirmations(ctx, ListVocalGateConfirmationsOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("list limited: %v", err)
+	}
+	if len(limited) != 2 {
+		t.Errorf("limited list = %d rows; want 2", len(limited))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the **tightening** direction to `instrumentalrecalib`, which until now assumed detector thresholds only ever loosen. Lowering `vocal_max_confidence` (#555) strands every false instrumental the old, looser value settled: `Run` only inspects `instrumental_result = 0`, `instrumentalbackfill` only inspects rows the detector never scored, and `scan reconcile` re-runs live detection. A confirmed positive is revisited by nothing.
- New surface: `queue.ListVocalGateConfirmations`, `queue.UnsettleInstrumental`, `instrumentalrecalib.Reverse`, and `scan reconcile-instrumental-recalibrate --reverse`.
- Like the existing direction, it re-decides purely from telemetry already stored on each row, so it calls no sidecar and reads no audio. It is an arithmetic pass, not a detection pass.
- Size override (approved): 1,097 hand-written LOC, but **398 of that is production code across 5 files**; the remaining 699 is tests. The four pieces do not function independently - splitting further would land a queue method with no caller.

## Design decisions worth not re-litigating

Each of these is also recorded in the code, next to the thing it explains.

**`UnsettleInstrumental` preserves telemetry and stamps `0`, not `NULL`.** The scores are the evidence the re-decision was made from. `NULL` would claim the row was never classified and send it back for a needless re-scan.

**It deliberately does not revert `scan_results`** - the one asymmetry with `SettleInstrumental`'s `'done'` writeback. The scan scheduler enqueues from `scan_results WHERE status = 'pending'`, so flipping it back would race the scheduler into enqueuing a **duplicate** alongside the `work_queue` row just returned to `deferred`.

**`Reverse` writes the database first, then removes the marker** - the reverse of `Run`'s marker-first order. `Run` must never settle a verdict whose marker did not land. `Reverse` must never leave the database claiming instrumental after the marker is gone: that row is `'done'`, so nothing would retry it and the user is left with neither lyrics nor a marker. The opposite residue (row deferred, stale marker on disk) is self-healing.

**No stale-version reset.** `Run` refuses to settle on another version's telemetry because settling is the destructive direction there. Reversing is conservative - it restores a real provider fetch - and `ResetInstrumentalToUnclassified` is guarded on `'deferred'` anyway, which a settled row is not.

**Marker ownership is decided by an explicit contrary signal, not by the absence of a positive one.** A bare marker with no `[source:]` header defers to the database, because `instrumental_result = 1` is set only by `SettleInstrumental`, while provider-declared instrumentals carry `instrumental_result NULL` and never reach the listing. Requiring a positive detector stamp was implemented first and **reversed 0 of 822 real candidates**: 191 of 200 sampled markers were bare legacy files and none carried a provider token. An explicit foreign `[source:]` token still wins and is skipped.

**Reversed rows requeue at `PriorityScan`, not `PriorityMiss`.** Matching `Defer` looks obvious and is wrong: `PriorityMiss` is for rows likely to miss *again*, whereas a reversed instrumental is a track with real vocals that is unusually likely to resolve. Because `Dequeue` randomizes within a tier, sinking a bounded correction into a much larger pool draws only `(reversed / pool)` per attempt - measured at ~10/hr against ~180/hr of throughput, clearing half in 2.5 days and trailing to weeks, versus about five hours at `PriorityScan`.

## Also fixed

The dry-run summary was misleading in **both** directions. The engine's `Result` counters are apply-only by design (pinned by `TestRun_DryRunDoesNotMutate`), so the apply-shaped summary printed `reversed=0` beneath a screenful of `would reverse` lines - reading as "nothing to do" when the opposite was true. A dry run now reports its previewed count.

A real defect the new tests caught: `detectorOwnedMarker` tested a **wrapped** open error with `os.IsNotExist`, which does not unwrap. An already-deleted marker took the error path, so a wrongly-settled row stayed settled forever. Now `errors.Is(err, fs.ErrNotExist)`.

## Linked issue

Refs #510 (the calibration that motivated this direction; already closed). Not `Closes`.

## Test plan

- [x] `make gate` - full pre-push chain, exit 0 ("OK: all pre-push checks passed")
- [x] `go test ./...` - full suite green
- [x] `golangci-lint run` - no issues
- [x] `govulncheck` - 0 vulnerabilities in called code
- [x] Patch coverage 70.72%, above the 70% gate (was 52.22%)
- [x] Error/skip branches covered: absent marker, foreign non-marker sidecar, dry-run, backup-write failure, worker-claimed race, per-row store failure, fatal listing failure, `--limit`
- [x] Guard tests verified to **discriminate** - each was run against deliberately broken code and confirmed to fail
- [ ] Reviewer follow-up: the DB-before-marker ordering argument is the piece I would most want a second opinion on

## Notes for the reviewer

The ownership rule is the highest-stakes decision here, because this is the only path in the codebase that **deletes** marker sidecars. It is worth attacking directly: the claim is that `instrumental_result = 1` is a sufficient proof of detector ownership, since only `SettleInstrumental` sets it. If there is a path that sets it another way, the rule is wrong and bare markers should not be deleted.

Coverage was taken to 70.72% and deliberately stopped there rather than chasing the remaining uncovered lines, which are unreachable defensive branches (`RowsAffected` errors and similar).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reverse recalibration to revisit previously confirmed instrumental results using updated detection thresholds.
  * Added a `--reverse` option to preview or apply tightening decisions.
  * Reverse operations safely preserve provider-owned markers and remove only detector-owned markers.
  * Dry runs now report previewed actions, skips, and errors; applied changes create backups before modification.

* **Documentation**
  * Documented recalibration workflows, reverse operations, telemetry requirements, backup behavior, and threshold calibration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->