### PR TITLE
feat(web): show the detector lane as "Instrumental Detector" (#539)

### DIFF
--- a/internal/web/dashboard.go
+++ b/internal/web/dashboard.go
@@ -138,7 +138,7 @@ func buildProviderTiles(pe []reports.ProviderEffectiveness) []templates.StatTile
 		attempts := p.Hits + p.Misses
 		sub, barPct, barLabel := hitRateBarFields(p.HitRate)
 		tiles = append(tiles, templates.StatTile{
-			Label:    p.Lane,
+			Label:    laneLabel(p.Lane),
 			Value:    fmt.Sprintf("%d/%d", p.Hits, attempts),
 			Sub:      sub,
 			ShowBar:  true,
@@ -160,7 +160,7 @@ func buildRecentRows(recent []reports.RecentOutcome, serverLoc *time.Location) [
 			Title:                o.Title,
 			Album:                o.Album,
 			Result:               string(o.Result),
-			Lane:                 o.ProviderLane,
+			Lane:                 laneLabel(o.ProviderLane),
 			CompletedAt:          display,
 			CompletedAtISO:       iso,
 			CompletedAtTZApplied: tzApplied,

--- a/internal/web/lanelabel.go
+++ b/internal/web/lanelabel.go
@@ -2,27 +2,26 @@ package web
 
 import "github.com/sydlexius/canticle/internal/detectorbackfill"
 
-// laneDisplayNames maps a PERSISTED lane string to the label shown in the UI.
+// laneLabel returns the user-facing name for a PERSISTED lane string, falling
+// back to the raw value so an unmapped lane is still shown rather than blanked.
 //
 // This is a presentation-only mapping (#539). The stored value is deliberately
 // unchanged: it is the primary key of provider_outcomes and the value written to
 // work_queue.provider_lane, so renaming it would split one lane's history across
-// two keys and silently zero any query keyed on the old string. The key here is
-// taken from detectorbackfill.LaneName rather than re-typing the literal, which
-// is exported for exactly this reason (the equivalent constants in
+// two keys and silently zero any query keyed on the old string. The case below
+// is taken from detectorbackfill.LaneName rather than re-typing the literal,
+// which is exported for exactly this reason (the equivalent constants in
 // internal/worker and internal/orchestrator are unexported and unreachable).
 //
-// Lanes absent from this map render as-is, so adding a provider lane needs no
-// change here.
-var laneDisplayNames = map[string]string{
-	detectorbackfill.LaneName: "Instrumental Detector",
-}
-
-// laneLabel returns the user-facing name for a persisted lane string, falling
-// back to the raw value so an unmapped lane is still shown rather than blanked.
+// A switch rather than a package-level map: the mapping is fixed at compile time
+// and nothing should be able to mutate it at runtime, which a package-global map
+// permits and Go cannot prevent. Lanes with no case render as-is, so adding a
+// provider lane is a new case here and needs no change at any call site.
 func laneLabel(lane string) string {
-	if display, ok := laneDisplayNames[lane]; ok {
-		return display
+	switch lane {
+	case detectorbackfill.LaneName:
+		return "Instrumental Detector"
+	default:
+		return lane
 	}
-	return lane
 }

--- a/internal/web/lanelabel.go
+++ b/internal/web/lanelabel.go
@@ -1,0 +1,28 @@
+package web
+
+import "github.com/sydlexius/canticle/internal/detectorbackfill"
+
+// laneDisplayNames maps a PERSISTED lane string to the label shown in the UI.
+//
+// This is a presentation-only mapping (#539). The stored value is deliberately
+// unchanged: it is the primary key of provider_outcomes and the value written to
+// work_queue.provider_lane, so renaming it would split one lane's history across
+// two keys and silently zero any query keyed on the old string. The key here is
+// taken from detectorbackfill.LaneName rather than re-typing the literal, which
+// is exported for exactly this reason (the equivalent constants in
+// internal/worker and internal/orchestrator are unexported and unreachable).
+//
+// Lanes absent from this map render as-is, so adding a provider lane needs no
+// change here.
+var laneDisplayNames = map[string]string{
+	detectorbackfill.LaneName: "Instrumental Detector",
+}
+
+// laneLabel returns the user-facing name for a persisted lane string, falling
+// back to the raw value so an unmapped lane is still shown rather than blanked.
+func laneLabel(lane string) string {
+	if display, ok := laneDisplayNames[lane]; ok {
+		return display
+	}
+	return lane
+}

--- a/internal/web/lanelabel_test.go
+++ b/internal/web/lanelabel_test.go
@@ -112,8 +112,8 @@ func TestLaneLabelDoesNotChangePersistedValue(t *testing.T) {
 		t.Fatalf("persisted detector lane string = %q; want %q -- changing it splits "+
 			"provider_outcomes history and zeroes existing queries", detectorbackfill.LaneName, "detector")
 	}
-	if _, ok := laneDisplayNames[detectorbackfill.LaneName]; !ok {
-		t.Errorf("laneDisplayNames has no entry for the persisted lane string %q; "+
-			"the UI would render the raw value", detectorbackfill.LaneName)
+	if got := laneLabel(detectorbackfill.LaneName); got == detectorbackfill.LaneName {
+		t.Errorf("laneLabel(%q) returned the raw persisted value; the UI would render "+
+			"the stored string instead of a display name", detectorbackfill.LaneName)
 	}
 }

--- a/internal/web/lanelabel_test.go
+++ b/internal/web/lanelabel_test.go
@@ -1,0 +1,119 @@
+package web
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
+	"github.com/sydlexius/canticle/internal/reports"
+)
+
+func TestLaneLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		lane string
+		want string
+	}{
+		{"detector lane gets the full display name", "detector", "Instrumental Detector"},
+		{"provider lanes pass through unchanged", "musixmatch", "musixmatch"},
+		{"unmapped lane passes through rather than blanking", "somefuturelane", "somefuturelane"},
+		{"empty lane stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := laneLabel(tt.lane); got != tt.want {
+				t.Errorf("laneLabel(%q) = %q; want %q", tt.lane, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildProviderTilesAppliesLaneLabel covers the call site, not just the
+// helper. TestLaneLabel alone would still pass if laneLabel were dropped from
+// dashboard.go, since it exercises the function in isolation; this asserts the
+// display name actually reaches the rendered tile.
+func TestBuildProviderTilesAppliesLaneLabel(t *testing.T) {
+	tiles := buildProviderTiles([]reports.ProviderEffectiveness{
+		{Lane: "detector", Hits: 3, Misses: 1, HitRate: 0.75},
+		{Lane: "musixmatch", Hits: 1, Misses: 1, HitRate: 0.5},
+	})
+	if len(tiles) != 2 {
+		t.Fatalf("buildProviderTiles returned %d tiles; want 2", len(tiles))
+	}
+	if tiles[0].Label != "Instrumental Detector" {
+		t.Errorf("detector tile Label = %q; want %q", tiles[0].Label, "Instrumental Detector")
+	}
+	if tiles[1].Label != "musixmatch" {
+		t.Errorf("provider tile Label = %q; want it unchanged", tiles[1].Label)
+	}
+}
+
+// TestBuildRecentRowsAppliesLaneLabel covers the DASHBOARD's recent-activity
+// table, which is a separate surface from the Reports-page "recent outcomes"
+// report even though both build a templates.RecentOutcomeRow. The first pass at
+// #539 fixed only the Reports-page path and left this one rendering the raw
+// "detector" string.
+func TestBuildRecentRowsAppliesLaneLabel(t *testing.T) {
+	rows := buildRecentRows([]reports.RecentOutcome{
+		{Artist: "A", Title: "T", ProviderLane: "detector"},
+		{Artist: "B", Title: "U", ProviderLane: "musixmatch"},
+	}, time.UTC)
+	if len(rows) != 2 {
+		t.Fatalf("buildRecentRows returned %d rows; want 2", len(rows))
+	}
+	if rows[0].Lane != "Instrumental Detector" {
+		t.Errorf("detector row Lane = %q; want %q", rows[0].Lane, "Instrumental Detector")
+	}
+	if rows[1].Lane != "musixmatch" {
+		t.Errorf("provider row Lane = %q; want it unchanged", rows[1].Lane)
+	}
+}
+
+// TestReportFragmentsShowLaneDisplayName covers the two buildReportView call
+// sites end-to-end, through the real render path. Without these, reverting
+// either laneLabel() call in ui.go would pass the whole suite silently: the
+// helper-level tests above exercise the function in isolation, and
+// TestBuildProviderTilesAppliesLaneLabel covers only the dashboard tiles.
+func TestReportFragmentsShowLaneDisplayName(t *testing.T) {
+	t.Run("recent outcomes", func(t *testing.T) {
+		sqlDB := openReportsTestDB(t)
+		insertDone(t, sqlDB, "Song", "detector", `[{"outdir":"/out","filename":"Song.txt"}]`, "2026-06-17T12:00:00Z")
+		body := getFragment(t, newReportsUIServer(t, sqlDB), "recent-outcomes").Body.String()
+		if !strings.Contains(body, "Instrumental Detector") {
+			t.Errorf("recent-outcomes should render the display name; body:\n%s", body)
+		}
+	})
+
+	t.Run("provider effectiveness", func(t *testing.T) {
+		sqlDB := openReportsTestDB(t)
+		insertDone(t, sqlDB, "Song", "detector", `[{"outdir":"/out","filename":"Song.txt"}]`, "2026-06-17T12:00:00Z")
+		if _, err := sqlDB.ExecContext(context.Background(),
+			`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (1, 'detector', 1, ?)`,
+			"2026-06-17T12:00:00Z"); err != nil {
+			t.Fatalf("insert lane_attempts: %v", err)
+		}
+		body := getFragment(t, newReportsUIServer(t, sqlDB), "provider-effectiveness").Body.String()
+		if !strings.Contains(body, "Instrumental Detector") {
+			t.Errorf("provider-effectiveness should render the display name; body:\n%s", body)
+		}
+	})
+}
+
+// TestLaneLabelDoesNotChangePersistedValue pins the invariant that #539 renames
+// only the DISPLAY name. The stored lane string is the primary key of
+// provider_outcomes and the value written to work_queue.provider_lane, so if it
+// ever changes, one lane's history splits across two keys and any query keyed on
+// the old string silently returns zero instead of erroring. This test fails
+// loudly if a future refactor moves the stored value.
+func TestLaneLabelDoesNotChangePersistedValue(t *testing.T) {
+	if detectorbackfill.LaneName != "detector" {
+		t.Fatalf("persisted detector lane string = %q; want %q -- changing it splits "+
+			"provider_outcomes history and zeroes existing queries", detectorbackfill.LaneName, "detector")
+	}
+	if _, ok := laneDisplayNames[detectorbackfill.LaneName]; !ok {
+		t.Errorf("laneDisplayNames has no entry for the persisted lane string %q; "+
+			"the UI would render the raw value", detectorbackfill.LaneName)
+	}
+}

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -44,7 +44,7 @@ var reportDefs = []reportDef{
 	{"queue-summary", "Queue summary", "Work-queue rows grouped by status."},
 	{"recent-outcomes", "Recent outcomes", "The most recently completed tracks and their derived result."},
 	{"provider-effectiveness", "Provider effectiveness", "Per-lane hits, misses, and true per-track hit-rate."},
-	{"instrumental-inventory", "Instrumental inventory", "Tracks the Instrumental Detector confirmed instrumental."},
+	{"instrumental-inventory", "Instrumental inventory", "Tracks confirmed instrumental by the Instrumental Detector."},
 	{"failure-analysis", "Failure analysis", "Failed and deferred tracks grouped by reason."},
 }
 

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -44,7 +44,7 @@ var reportDefs = []reportDef{
 	{"queue-summary", "Queue summary", "Work-queue rows grouped by status."},
 	{"recent-outcomes", "Recent outcomes", "The most recently completed tracks and their derived result."},
 	{"provider-effectiveness", "Provider effectiveness", "Per-lane hits, misses, and true per-track hit-rate."},
-	{"instrumental-inventory", "Instrumental inventory", "Tracks the audio detector confirmed instrumental."},
+	{"instrumental-inventory", "Instrumental inventory", "Tracks the Instrumental Detector confirmed instrumental."},
 	{"failure-analysis", "Failure analysis", "Failed and deferred tracks grouped by reason."},
 }
 
@@ -431,7 +431,7 @@ func (u *UI) buildReportView(ctx context.Context, def reportDef) (templates.Repo
 				Title:       o.Title,
 				Album:       o.Album,
 				Result:      string(o.Result),
-				Lane:        o.ProviderLane,
+				Lane:        laneLabel(o.ProviderLane),
 				CompletedAt: formatReportTime(o.CompletedAt, serverLoc),
 			})
 		}
@@ -443,7 +443,7 @@ func (u *UI) buildReportView(ctx context.Context, def reportDef) (templates.Repo
 		v.ProviderRows = make([]templates.ProviderRow, 0, len(rows))
 		for _, p := range rows {
 			v.ProviderRows = append(v.ProviderRows, templates.ProviderRow{
-				Lane:    p.Lane,
+				Lane:    laneLabel(p.Lane),
 				Hits:    strconv.FormatInt(p.Hits, 10),
 				Misses:  strconv.FormatInt(p.Misses, 10),
 				HitRate: fmt.Sprintf("%.1f%%", p.HitRate*100),


### PR DESCRIPTION
## Summary

- Renames the **display** name of the `detector` lane to "Instrumental Detector" in the web UI, so the surface says what is being detected now that the orchestrator has several lanes.
- Deliberately scoped to UX attribution only. Go identifiers, package names, config keys, env vars, DB columns, and log fields are **unchanged** — the issue as filed would have touched ~1,362 occurrences across 73 files, and that was explicitly cut back to what a user actually sees.
- The mapping lives in one place (`internal/web/lanelabel.go`) and is applied at each view-model boundary that feeds a template.

**The persisted lane string is deliberately NOT changed.** `"detector"` is the primary key of `provider_outcomes` and the value written to `work_queue.provider_lane`. Renaming it would split one lane's history across two keys and silently return zero for any query keyed on the old string. This satisfies #539's acceptance criterion that "a decision is recorded on whether the persisted lane string changes" — it does not, consistent with the Gate 0 decision already recorded on the issue.

The lookup keys off the exported `detectorbackfill.LaneName` rather than re-typing the literal. That constant is exported precisely because the equivalent constants in `internal/worker` and `internal/orchestrator` are unexported and unreachable from a third package; see the comment at `internal/detectorbackfill/detectorbackfill.go:68-77` explaining why the duplication is deliberate.

### Surfaces covered

| Surface | Call site |
|---|---|
| Lyrics Sources tiles (dashboard) | `buildProviderTiles` |
| Recent activity table (dashboard) | `buildRecentRows` |
| Recent outcomes report (reports page) | `buildReportView` |
| Provider effectiveness report | `buildReportView` |
| Instrumental inventory | subtitle prose only |

Worth flagging for review: the dashboard's recent-activity table and the reports-page recent-outcomes report are **separate surfaces that both build a `templates.RecentOutcomeRow`** from different call paths. An adversarial pre-push review caught that the first pass fixed only one of them; both are now covered and each has a test.

### Surfaces deliberately not covered

- **Instrumental inventory rows** carry no lane field (ID, Artist, Title, File, DetectRequested), so only the report's subtitle mentions the detector.
- **Failure analysis** has only Status, Reason, and Count. There is no attribution in that data to relabel.

## Linked issue

Closes #539

## Gates

All run locally via `make gate` (exit 0, "OK: all pre-push checks passed"):

- [x] conflict markers
- [x] gofmt
- [x] generated web UI assets (templ + Tailwind)
- [x] go build
- [x] go test (race + coverage)
- [x] patch coverage — **100.00% (9/9 executable lines)**, threshold 70%
- [x] coverage floor (per-package ratchet)
- [x] codecov report validation (codecovcli dry-run)
- [x] golangci-lint
- [x] actionlint
- [x] govulncheck — 0 vulnerabilities in called code
- [x] adversarial pre-push review (found and fixed one completeness miss)

## Test plan

Every call site is covered, not just the helper — reverting any single `laneLabel()` call fails a test:

- [x] `TestLaneLabel` — mapping, passthrough for unmapped lanes, empty input
- [x] `TestBuildProviderTilesAppliesLaneLabel` — dashboard Lyrics Sources tiles
- [x] `TestBuildRecentRowsAppliesLaneLabel` — dashboard recent-activity table
- [x] `TestReportFragmentsShowLaneDisplayName` — both `buildReportView` call sites, end-to-end through the real render path against seeded SQLite
- [x] `TestLaneLabelDoesNotChangePersistedValue` — fails loudly if a future refactor moves the stored lane string, which would split `provider_outcomes` history
- [x] Discrimination verified: reverting the fixes makes all three new tests FAIL
- [ ] Reviewer follow-ups

## Note for reviewers

The dashboard will now render "Instrumental Detector" alongside lowercase `musixmatch` and `petitlyrics`, since only the one lane is mapped. Adding display names for the provider lanes is a two-line addition to the same map and is intentionally left out of this PR's scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Updated dashboard and report views to display the lane name “Instrumental Detector.”
  * Improved the instrumental inventory report subtitle for clearer wording.
  * Preserved existing labels for known and unrecognized lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->