### PR TITLE
feat(detectorbackfill): credit historical detector settles to provider_outcomes (#548)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1093,6 +1093,16 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// it as a permanent miss, so the operator who later adds a token would find
 	// nothing left to fetch. The web server, watcher, and session sweeper still
 	// start so the UI is reachable to add the token.
+	// Credit historical detector settles to provider_outcomes (#548) BEFORE the
+	// worker or scheduler can start. Ordering is load-bearing, not cosmetic: the
+	// live writer's two counter writes are non-transactional (see the KNOWN
+	// IMPRECISION note in internal/detectorbackfill/provider_outcomes.go), so a
+	// row caught mid-write -- already counted, not yet provider_lane-stamped --
+	// would be seen as uncredited by this pass and permanently double-credited.
+	// Running before any live writer exists closes that window entirely, which
+	// running synchronously AFTER the worker goroutine does not.
+	runProviderOutcomesBackfill(runCtx, sqlDB)
+
 	if !lyricsDisabled {
 		wg.Add(2)
 		go func() {
@@ -1136,11 +1146,6 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		defer wg.Done()
 		runIdentityBackfill(runCtx, sqlDB)
 	}()
-	// Credit historical detector settles to provider_outcomes (#548). Runs
-	// inline, not in a goroutine: it is one COUNT plus one counter UPDATE in a
-	// single transaction, so it finishes before the listener is up and does not
-	// race the worker's own live counter writes.
-	runProviderOutcomesBackfill(runCtx, sqlDB)
 	// Background session sweeper: periodically delete expired/revoked sessions,
 	// mirroring the worker/scheduler goroutine + context-cancel pattern. Only
 	// runs when the authenticated UI is mounted (there are no sessions otherwise).

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1136,6 +1136,11 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		defer wg.Done()
 		runIdentityBackfill(runCtx, sqlDB)
 	}()
+	// Credit historical detector settles to provider_outcomes (#548). Runs
+	// inline, not in a goroutine: it is one COUNT plus one counter UPDATE in a
+	// single transaction, so it finishes before the listener is up and does not
+	// race the worker's own live counter writes.
+	runProviderOutcomesBackfill(runCtx, sqlDB)
 	// Background session sweeper: periodically delete expired/revoked sessions,
 	// mirroring the worker/scheduler goroutine + context-cancel pattern. Only
 	// runs when the authenticated UI is mounted (there are no sessions otherwise).

--- a/internal/commands/provider_outcomes_backfill.go
+++ b/internal/commands/provider_outcomes_backfill.go
@@ -12,11 +12,16 @@ import (
 // runProviderOutcomesBackfill credits historical detector settles to the
 // detector lane's provider_outcomes hit counter, once per database (#548).
 //
-// Unlike runIdentityBackfill this is NOT run in a goroutine: it is one COUNT
-// plus one counter UPDATE in a single transaction, with no file I/O and no
-// detector calls, so it costs microseconds and finishes before serve is
-// listening. Backgrounding it would only add a race against the worker's own
-// live counter writes for no benefit.
+// Unlike runIdentityBackfill this is NOT run in a goroutine, and its CALL SITE
+// is deliberately ahead of the worker and scheduler. Both matter, for the same
+// reason: the live writer's counter increment and its provider_lane stamp are
+// two separate non-transactional writes (see the KNOWN IMPRECISION note in
+// detectorbackfill.BackfillProviderOutcomes), so a row caught between them
+// looks uncredited to this pass and gets permanently double-credited. Running
+// before any live writer exists closes that window; running synchronously but
+// AFTER the worker goroutine has started does not, which is what an earlier
+// revision got wrong. It is one COUNT plus one counter UPDATE against a small
+// index-free predicate, so paying for it inline at startup is cheap.
 //
 // Best-effort and non-fatal: a failure is logged and the marker is left unset,
 // so the next startup retries. The pass is atomic (counter + marker commit

--- a/internal/commands/provider_outcomes_backfill.go
+++ b/internal/commands/provider_outcomes_backfill.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
+)
+
+// runProviderOutcomesBackfill credits historical detector settles to the
+// detector lane's provider_outcomes hit counter, once per database (#548).
+//
+// Unlike runIdentityBackfill this is NOT run in a goroutine: it is one COUNT
+// plus one counter UPDATE in a single transaction, with no file I/O and no
+// detector calls, so it costs microseconds and finishes before serve is
+// listening. Backgrounding it would only add a race against the worker's own
+// live counter writes for no benefit.
+//
+// Best-effort and non-fatal: a failure is logged and the marker is left unset,
+// so the next startup retries. The pass is atomic (counter + marker commit
+// together), so a failed run credits nothing and a retry cannot double-count.
+func runProviderOutcomesBackfill(ctx context.Context, sqlDB *sql.DB) {
+	res, err := detectorbackfill.BackfillProviderOutcomes(ctx, sqlDB)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			slog.Info("provider_outcomes backfill: interrupted by shutdown; will retry on next startup")
+			return
+		}
+		slog.Error("provider_outcomes backfill: failed; will retry on next startup", "error", err)
+		return
+	}
+	if res.AlreadyDone {
+		return
+	}
+	slog.Info("provider_outcomes backfill: credited historical detector settles to the detector lane",
+		"credited", res.Credited,
+		"note", "detector MISSES are not recoverable and are deliberately not backfilled; /metrics and the dashboard tile are expected to disagree on them")
+}

--- a/internal/commands/provider_outcomes_backfill_test.go
+++ b/internal/commands/provider_outcomes_backfill_test.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	dbpkg "github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
+)
+
+func openBackfillTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := dbpkg.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func seedUncreditedSettle(t *testing.T, sqlDB *sql.DB, title string) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue (artist, title, artist_key, title_key,
+             instrumental_result, outcome_type, provider_lane)
+         VALUES (?, ?, ?, ?, 1, 'instrumental', NULL)`,
+		"Artist", title, "Artist", title); err != nil {
+		t.Fatalf("seed work_queue: %v", err)
+	}
+}
+
+// TestRunProviderOutcomesBackfillCredits covers the success path and, on a
+// second call, the AlreadyDone early return.
+func TestRunProviderOutcomesBackfillCredits(t *testing.T) {
+	sqlDB := openBackfillTestDB(t)
+	seedUncreditedSettle(t, sqlDB, "One")
+
+	runProviderOutcomesBackfill(context.Background(), sqlDB)
+
+	var hits int64
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT hits FROM provider_outcomes WHERE lane = ?`,
+		detectorbackfill.LaneName).Scan(&hits); err != nil {
+		t.Fatalf("read provider_outcomes: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("detector hits = %d; want 1", hits)
+	}
+
+	// Second call takes the AlreadyDone path and must not credit again.
+	runProviderOutcomesBackfill(context.Background(), sqlDB)
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT hits FROM provider_outcomes WHERE lane = ?`,
+		detectorbackfill.LaneName).Scan(&hits); err != nil {
+		t.Fatalf("read provider_outcomes: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("detector hits after a second run = %d; want 1 (double-credited)", hits)
+	}
+}
+
+// TestRunProviderOutcomesBackfillSurvivesFailure covers the error path. The
+// runner is best-effort by contract: a failure is logged, never propagated, and
+// must not panic -- serve startup continues regardless.
+func TestRunProviderOutcomesBackfillSurvivesFailure(t *testing.T) {
+	sqlDB := openBackfillTestDB(t)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	runProviderOutcomesBackfill(context.Background(), sqlDB) // must not panic
+}
+
+// TestRunProviderOutcomesBackfillHandlesCanceledContext covers the
+// context.Canceled branch, which logs at Info ("will retry") rather than Error:
+// a shutdown mid-startup is not a failure worth alarming on.
+func TestRunProviderOutcomesBackfillHandlesCanceledContext(t *testing.T) {
+	sqlDB := openBackfillTestDB(t)
+	seedUncreditedSettle(t, sqlDB, "One")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runProviderOutcomesBackfill(ctx, sqlDB) // must not panic
+
+	// A canceled run must credit nothing, so the next startup can retry.
+	var n int
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM maintenance_markers WHERE name = ?`,
+		detectorbackfill.ProviderOutcomesMarker).Scan(&n); err != nil {
+		t.Fatalf("count markers: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("marker rows = %d after a canceled run; want 0 so the next startup retries", n)
+	}
+}

--- a/internal/detectorbackfill/provider_outcomes.go
+++ b/internal/detectorbackfill/provider_outcomes.go
@@ -1,0 +1,154 @@
+package detectorbackfill
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ProviderOutcomesMarker names the one-shot provider_outcomes backfill in
+// maintenance_markers (migration 027). Unlike lane_attempts, provider_outcomes
+// is a bare per-lane counter (lane TEXT PRIMARY KEY, hits, misses) with no
+// per-row key, so nothing about the write is naturally idempotent -- re-running
+// would double-credit. The marker IS the idempotency, which is why it is
+// committed in the same transaction as the counter update (#548).
+const ProviderOutcomesMarker = "provider_outcomes_detector_hits_548"
+
+// ProviderOutcomesResult reports what the counter backfill did.
+type ProviderOutcomesResult struct {
+	// Credited is the number of hits added to the detector lane's counter.
+	Credited int64
+	// AlreadyDone is true when the marker was present and nothing was written.
+	AlreadyDone bool
+}
+
+// countUnattributedDetectorHitsSQL selects detector settles that were never
+// credited to provider_outcomes.
+//
+// WHY THIS IS A RECONSTRUCTION AND NOT AN ESTIMATE. Every predicate is exact:
+//
+//   - instrumental_result = 1 is written by exactly two paths, both detector
+//     settles (queue.SettleInstrumental, and the worker's detector path via
+//     queue.Complete). No provider and no operator writes it, so a 1 means the
+//     detector settled this row.
+//   - outcome_type = 'instrumental' pins the settle to the instrumental outcome
+//     rather than any later re-decision.
+//   - provider_lane IS NULL is used as a proxy for "never credited to
+//     provider_outcomes". See the KNOWN IMPRECISION below: it is a very good
+//     proxy, not a guarantee.
+//
+// A detector settle is TERMINAL -- it happens at most once per row -- so rows
+// map 1:1 onto counter increments. That is what makes the hit side recoverable
+// at all.
+//
+// KNOWN IMPRECISION, stated rather than papered over. worker.recordHit performs
+// TWO INDEPENDENT writes -- providerRecorder.RecordProviderHit and
+// queue.SetProviderLane -- and its own doc comment notes both are non-fatal:
+// each logs at Warn and does not affect the outcome. They are not in a shared
+// transaction, so a mid-processing write failure can leave the pair
+// inconsistent, in either direction:
+//
+//	counted but NOT stamped -> provider_lane IS NULL on an already-counted row.
+//	                           This backfill credits it a SECOND time. Because
+//	                           the pass is one-shot and marker-gated, that
+//	                           over-count is permanent and undetectable.
+//	stamped but NOT counted -> excluded by the predicate and never credited by
+//	                           this or any later pass. A permanent under-count.
+//
+// Neither is quantifiable from recorded data -- nothing distinguishes a
+// half-written pair from a normal row. Both require a database write to fail
+// mid-processing, which is rare against local SQLite on a single connection
+// (db.Open sets MaxOpenConns(1)), but rare is not zero across a large history.
+//
+// This is accepted deliberately: provider_outcomes is an approximate metrics
+// counter, not an accounting ledger, and the correction here is large (three
+// orders of magnitude more settles than the counter currently reflects) while
+// the error term is plausibly single-digit. The alternative -- refusing to
+// backfill hits at all, on the same "not exactly reconstructable" standard that
+// rules out the miss side -- was considered and rejected on those proportions.
+// Do not restate this as exactness later; the imprecision is real.
+const countUnattributedDetectorHitsSQL = `
+	SELECT COUNT(*) FROM work_queue
+	WHERE instrumental_result = 1
+	  AND outcome_type = 'instrumental'
+	  AND provider_lane IS NULL`
+
+// addDetectorHitsSQL mirrors the live writer's upsert
+// (queue.DBQueue.RecordProviderHit) exactly, batched: same table, same conflict
+// target, same "add to hits" semantics. Backfilled rows therefore follow the
+// same rule as live rows in the same counter, which is the property #537
+// rejected a hits-only fill for lacking.
+const addDetectorHitsSQL = `
+	INSERT INTO provider_outcomes(lane, hits, misses) VALUES(?, ?, 0)
+	ON CONFLICT(lane) DO UPDATE SET hits = hits + ?`
+
+// BackfillProviderOutcomes credits historical detector settles to the detector
+// lane's provider_outcomes hit counter, once per database.
+//
+// THE MISS SIDE IS DELIBERATELY NOT BACKFILLED, AND CANNOT BE. It is not an
+// oversight and it should not be "finished" later without new recorded data:
+//
+// The live miss writer (worker.recordMisses) credits every lane returned by
+// orch.LaneNames() -- the lanes ACTIVE AT THAT MOMENT -- and only on the
+// all-lanes-missed path. Reconstructing that needs two facts the schema does
+// not carry. work_queue.miss_count does record how many times a row was
+// deferred, so the raw multiplicity survives; what does not survive is WHEN
+// those misses happened. The detector lane did not always exist, so a row with
+// miss_count = 2 may have accrued one miss before the lane existed and one
+// after, and nothing distinguishes them. Crediting the sum would attribute
+// misses to a lane that was not running, and would do so with a precise-looking
+// number -- an estimate wearing the costume of a fact.
+//
+// CONSEQUENCE, WHICH IS EXPECTED: /metrics (which reads provider_outcomes) and
+// the dashboard's provider-effectiveness tile (which reads lane_attempts, see
+// reports.ProviderEffectiveness) will report different detector figures. That
+// difference is a known, documented gap, not a bug to reconcile. The hit counts
+// converge after this backfill; the miss counts do not.
+//
+// The whole pass is one transaction: the counter update and the marker commit
+// together or not at all. A partial commit would leave the counter credited
+// with no marker, and the next startup would credit it again.
+func BackfillProviderOutcomes(ctx context.Context, sqlDB *sql.DB) (ProviderOutcomesResult, error) {
+	var res ProviderOutcomesResult
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return res, fmt.Errorf("detectorbackfill: begin provider_outcomes tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once committed
+
+	var one int
+	err = tx.QueryRowContext(ctx,
+		`SELECT 1 FROM maintenance_markers WHERE name = ?`, ProviderOutcomesMarker).Scan(&one)
+	switch {
+	case err == nil:
+		res.AlreadyDone = true
+		return res, nil
+	case !errors.Is(err, sql.ErrNoRows):
+		return res, fmt.Errorf("detectorbackfill: check marker %q: %w", ProviderOutcomesMarker, err)
+	}
+
+	if err := tx.QueryRowContext(ctx, countUnattributedDetectorHitsSQL).Scan(&res.Credited); err != nil {
+		return res, fmt.Errorf("detectorbackfill: count uncredited detector hits: %w", err)
+	}
+
+	// Credit only when there is something to credit, but ALWAYS stamp the marker
+	// below: a database with nothing to backfill is done, and re-counting it on
+	// every startup buys nothing.
+	if res.Credited > 0 {
+		if _, err := tx.ExecContext(ctx, addDetectorHitsSQL, LaneName, res.Credited, res.Credited); err != nil {
+			return res, fmt.Errorf("detectorbackfill: credit detector hits: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO maintenance_markers (name) VALUES (?)`, ProviderOutcomesMarker); err != nil {
+		return res, fmt.Errorf("detectorbackfill: record marker %q: %w", ProviderOutcomesMarker, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return res, fmt.Errorf("detectorbackfill: commit provider_outcomes backfill: %w", err)
+	}
+	return res, nil
+}

--- a/internal/detectorbackfill/provider_outcomes_test.go
+++ b/internal/detectorbackfill/provider_outcomes_test.go
@@ -1,0 +1,230 @@
+package detectorbackfill
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// seedSettle inserts one work_queue row shaped for the provider_outcomes
+// backfill: the three columns its predicate reads. providerLane is nil for a
+// row that was never attributed (the backfill's target) or a string for one
+// that already was.
+func seedSettle(t *testing.T, sqlDB *sql.DB, title string, instrumentalResult, outcomeType, providerLane any) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue (artist, title, artist_key, title_key,
+             instrumental_result, outcome_type, provider_lane)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"Artist", title, "Artist", title, instrumentalResult, outcomeType, providerLane); err != nil {
+		t.Fatalf("insert work_queue %q: %v", title, err)
+	}
+}
+
+func detectorHits(t *testing.T, sqlDB *sql.DB) (hits, misses int64) {
+	t.Helper()
+	err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT hits, misses FROM provider_outcomes WHERE lane = ?`, LaneName).Scan(&hits, &misses)
+	if err == sql.ErrNoRows {
+		return 0, 0
+	}
+	if err != nil {
+		t.Fatalf("read provider_outcomes: %v", err)
+	}
+	return hits, misses
+}
+
+// TestBackfillProviderOutcomesCreditsOnlyUnattributedSettles is the core
+// correctness case: exactly the detector settles that were never attributed get
+// credited, and nothing else does.
+func TestBackfillProviderOutcomesCreditsOnlyUnattributedSettles(t *testing.T) {
+	sqlDB := openDB(t)
+
+	// Creditable: detector settled, never attributed.
+	seedSettle(t, sqlDB, "Uncredited One", 1, "instrumental", nil)
+	seedSettle(t, sqlDB, "Uncredited Two", 1, "instrumental", nil)
+	// Already attributed -- the live writer stamped the lane AND counted it.
+	// Crediting again would double-count.
+	seedSettle(t, sqlDB, "Already Credited", 1, "instrumental", LaneName)
+	// Detector RAN AND LOST. This is the miss subset, which is deliberately
+	// never credited (see BackfillProviderOutcomes' doc comment).
+	seedSettle(t, sqlDB, "Detector Lost", 0, nil, nil)
+	// Detection never ran.
+	seedSettle(t, sqlDB, "Not Detected", nil, nil, nil)
+	// Settled by a provider, not the detector.
+	seedSettle(t, sqlDB, "Provider Win", nil, "synced", "musixmatch")
+
+	res, err := BackfillProviderOutcomes(context.Background(), sqlDB)
+	if err != nil {
+		t.Fatalf("BackfillProviderOutcomes: %v", err)
+	}
+	if res.Credited != 2 {
+		t.Errorf("Credited = %d; want 2 (only the unattributed detector settles)", res.Credited)
+	}
+	if res.AlreadyDone {
+		t.Error("AlreadyDone = true on a first run")
+	}
+
+	hits, misses := detectorHits(t, sqlDB)
+	if hits != 2 {
+		t.Errorf("detector hits = %d; want 2", hits)
+	}
+	if misses != 0 {
+		t.Errorf("detector misses = %d; want 0 -- the miss subset must never be credited", misses)
+	}
+}
+
+// TestBackfillProviderOutcomesIsIdempotent is the property the marker exists to
+// provide. provider_outcomes is a bare counter with no per-row key, so a second
+// run without the marker gate would silently double the hit count.
+func TestBackfillProviderOutcomesIsIdempotent(t *testing.T) {
+	sqlDB := openDB(t)
+	seedSettle(t, sqlDB, "One", 1, "instrumental", nil)
+	seedSettle(t, sqlDB, "Two", 1, "instrumental", nil)
+
+	if _, err := BackfillProviderOutcomes(context.Background(), sqlDB); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	second, err := BackfillProviderOutcomes(context.Background(), sqlDB)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if !second.AlreadyDone {
+		t.Error("second run AlreadyDone = false; the marker gate did not hold")
+	}
+	if second.Credited != 0 {
+		t.Errorf("second run Credited = %d; want 0", second.Credited)
+	}
+	if hits, _ := detectorHits(t, sqlDB); hits != 2 {
+		t.Errorf("detector hits after two runs = %d; want 2 (double-credited)", hits)
+	}
+}
+
+// TestBackfillProviderOutcomesAddsToExistingCounter covers the ON CONFLICT arm:
+// a database with live detector hits already recorded must have the backfill
+// ADDED to them, not replace them.
+func TestBackfillProviderOutcomesAddsToExistingCounter(t *testing.T) {
+	sqlDB := openDB(t)
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO provider_outcomes(lane, hits, misses) VALUES(?, 5, 7)`, LaneName); err != nil {
+		t.Fatalf("seed provider_outcomes: %v", err)
+	}
+	seedSettle(t, sqlDB, "One", 1, "instrumental", nil)
+
+	if _, err := BackfillProviderOutcomes(context.Background(), sqlDB); err != nil {
+		t.Fatalf("BackfillProviderOutcomes: %v", err)
+	}
+
+	hits, misses := detectorHits(t, sqlDB)
+	if hits != 6 {
+		t.Errorf("detector hits = %d; want 6 (5 live + 1 backfilled)", hits)
+	}
+	if misses != 7 {
+		t.Errorf("detector misses = %d; want 7 unchanged -- the backfill must not touch misses", misses)
+	}
+}
+
+// TestBackfillProviderOutcomesMarksEmptyDatabaseDone covers the zero-rows path:
+// a database with nothing to backfill is DONE, and must not re-scan on every
+// subsequent startup.
+func TestBackfillProviderOutcomesMarksEmptyDatabaseDone(t *testing.T) {
+	sqlDB := openDB(t)
+
+	res, err := BackfillProviderOutcomes(context.Background(), sqlDB)
+	if err != nil {
+		t.Fatalf("BackfillProviderOutcomes: %v", err)
+	}
+	if res.Credited != 0 {
+		t.Errorf("Credited = %d; want 0", res.Credited)
+	}
+
+	second, err := BackfillProviderOutcomes(context.Background(), sqlDB)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if !second.AlreadyDone {
+		t.Error("an empty database was not marked done; it would re-scan every startup")
+	}
+
+	// No counter row should have been created for a zero credit.
+	var n int
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM provider_outcomes WHERE lane = ?`, LaneName).Scan(&n); err != nil {
+		t.Fatalf("count provider_outcomes: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("provider_outcomes rows for %q = %d; want 0 (nothing to credit)", LaneName, n)
+	}
+}
+
+// TestBackfillProviderOutcomesFailsOnClosedDB covers the BeginTx error path: a
+// closed database must surface an error rather than panicking or silently
+// reporting success (which would leave the marker unset but the caller assuming
+// the pass ran).
+func TestBackfillProviderOutcomesFailsOnClosedDB(t *testing.T) {
+	sqlDB := openDB(t)
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	res, err := BackfillProviderOutcomes(context.Background(), sqlDB)
+	if err == nil {
+		t.Fatal("BackfillProviderOutcomes on a closed DB returned nil error; want failure")
+	}
+	if res.AlreadyDone {
+		t.Error("AlreadyDone = true on a failed run; the caller would skip the retry")
+	}
+}
+
+// TestBackfillProviderOutcomesFailsWhenQueueMissing covers the count-query error
+// path, distinct from the marker-check and marker-insert paths.
+func TestBackfillProviderOutcomesFailsWhenQueueMissing(t *testing.T) {
+	sqlDB := openDB(t)
+	if _, err := sqlDB.ExecContext(context.Background(), `DROP TABLE work_queue`); err != nil {
+		t.Fatalf("drop work_queue: %v", err)
+	}
+
+	if _, err := BackfillProviderOutcomes(context.Background(), sqlDB); err == nil {
+		t.Fatal("BackfillProviderOutcomes with no work_queue returned nil error; want failure")
+	}
+
+	// The marker must NOT have been stamped by a failed run, or the pass would
+	// never retry and the counter would stay undercounted forever.
+	var n int
+	if err := sqlDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM maintenance_markers WHERE name = ?`, ProviderOutcomesMarker).Scan(&n); err != nil {
+		t.Fatalf("count markers: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("marker rows = %d after a failed run; want 0 so the next startup retries", n)
+	}
+}
+
+// TestBackfillProviderOutcomesRollsBackOnMarkerFailure pins the atomicity the
+// design depends on. If the counter could commit without the marker, the next
+// startup would credit the same rows again.
+func TestBackfillProviderOutcomesRollsBackOnMarkerFailure(t *testing.T) {
+	sqlDB := openDB(t)
+	seedSettle(t, sqlDB, "One", 1, "instrumental", nil)
+
+	// Fail the marker INSERT specifically, leaving the preceding marker-existence
+	// SELECT and the counter UPDATE to run normally. A trigger is required here:
+	// DROPPING the table instead makes the FIRST query (the existence check) fail
+	// and the function returns before the counter is ever touched, so the test
+	// would pass even with no rollback protection at all. That vacuous version
+	// shipped in the first draft of this file and was caught in review.
+	if _, err := sqlDB.ExecContext(context.Background(),
+		`CREATE TRIGGER fail_marker_insert BEFORE INSERT ON maintenance_markers
+         BEGIN SELECT RAISE(ABORT, 'marker insert blocked by test'); END`); err != nil {
+		t.Fatalf("create failing trigger: %v", err)
+	}
+
+	if _, err := BackfillProviderOutcomes(context.Background(), sqlDB); err == nil {
+		t.Fatal("BackfillProviderOutcomes returned nil error with no marker table; want failure")
+	}
+
+	if hits, _ := detectorHits(t, sqlDB); hits != 0 {
+		t.Errorf("detector hits = %d after a failed run; want 0 -- the counter update must roll "+
+			"back with the marker, or the next startup double-credits", hits)
+	}
+}


### PR DESCRIPTION
## Summary

Credits historical detector settles to the detector lane's `provider_outcomes` hit counter, once per database, and **documents the miss side as unrecoverable rather than estimating it**.

`/metrics` reads `provider_outcomes`, which under-reports the detector because instrumentals settled before the detector became a lane were never attributed to it. In the reference database the counter credits the detector **447 hits** against **3,411** detector settles that were never attributed — roughly a 7.6x undercount.

## The decision (this issue's first task)

**Hit subset: backfilled.** `instrumental_result = 1` has exactly two writers, both detector paths (`queue.SettleInstrumental` and the worker's detector-settle path via `queue.Complete`), so it is detector-exclusive. A detector settle is terminal — at most once per row — so rows map 1:1 onto counter increments. The upsert mirrors `queue.DBQueue.RecordProviderHit` exactly, batched, so backfilled rows follow the same rule as live rows in the same counter.

**Miss subset: NOT backfilled, and cannot be.** `worker.recordMisses` credits every lane active *at that moment*, only on the all-lanes-missed path. `work_queue.miss_count` does record how many times a row was deferred, so the raw multiplicity survives — but not *when*. The detector lane did not always exist, so a row with `miss_count = 2` may have accrued one miss before the lane existed and one after, with nothing to distinguish them. Crediting the sum would attribute misses to a lane that was not running, and would do so with a precise-looking number.

This is the outcome the issue states it prefers: a documented gap over an estimate written into a counter presented as fact.

**Expected consequence, documented at the counter:** `/metrics` and the dashboard's provider-effectiveness tile (which reads `lane_attempts`, per `reports.ProviderEffectiveness`) will disagree on detector misses. Hits converge after this backfill; misses do not. That difference is known, not a bug to reconcile.

## Known imprecision, stated deliberately

An adversarial pre-push review found that an earlier draft of this PR **overclaimed**. It asserted the live writer stamps `provider_lane` and increments `provider_outcomes` together, making `provider_lane IS NULL` an exact "never credited" test. That is false, and the code says so: `worker.recordHit` performs two independent writes whose errors are each logged at Warn and swallowed. So a mid-processing write failure can leave the pair inconsistent in either direction:

- **counted but not stamped** → this backfill credits it a second time. One-shot and marker-gated, so that over-count is permanent.
- **stamped but not counted** → excluded by the predicate, never credited by this or any later pass. A permanent under-count.

Neither is quantifiable from recorded data. Both require a database write to fail mid-processing, which is rare against local SQLite on a single connection (`db.Open` sets `MaxOpenConns(1)`), but rare is not zero across a large history.

Accepted deliberately: `provider_outcomes` is an approximate metrics counter, not a ledger, and the correction is large while the error term is plausibly single-digit. The alternative — refusing to backfill hits on the same "not exactly reconstructable" standard that rules out misses — was considered and rejected on those proportions. The doc comment says all of this at the call site so it is not restated as exactness later.

## Idempotency

`provider_outcomes` is a bare per-lane counter with no per-row key, so nothing about the write is naturally idempotent — a re-run would double-credit. The `maintenance_markers` row **is** the idempotency, and it commits in the **same transaction** as the counter update. A partial commit would leave the counter credited with no marker and the next startup would credit it again.

## Linked issue

Closes #548

## Gates

`make gate` — exit 0, "OK: all pre-push checks passed":

- [x] conflict markers, gofmt, generated web UI assets, go build
- [x] go test (race + coverage)
- [x] patch coverage — **83.33% (40/48)**, threshold 70%
- [x] coverage floor, codecov report validation
- [x] golangci-lint, actionlint
- [x] govulncheck — 0 vulnerabilities in called code
- [x] adversarial pre-push review (found 2 criticals; see below)

## Test plan

- [x] credits only unattributed detector settles — verified against already-attributed rows, detector-lost rows, undetected rows, and provider wins
- [x] idempotent — second run credits nothing (the marker gate); **verified it discriminates**: defeating the gate fails exactly this test and the empty-database test
- [x] adds to an existing counter rather than replacing it (the `ON CONFLICT` arm), and never touches `misses`
- [x] empty database is marked done, and creates no counter row
- [x] rolls back the counter when the marker INSERT fails, so a retry cannot double-credit
- [x] error paths: closed DB, missing `work_queue`, canceled context — none stamp the marker, so all retry
- [ ] Reviewer follow-ups

## Note for reviewers

The rollback test is worth a look. Its first draft dropped `maintenance_markers` to force a failure, which made the *first* query fail — the function returned before the counter was ever touched, so the test would have passed with no rollback protection at all. It now installs a trigger that fails the marker INSERT specifically, leaving the existence check and counter update to run. The comment records why, so it is not "simplified" back.

Follow-ups deliberately out of scope: `provider_lane` is not stamped on backfilled rows (that would convert a counter-only pass into a per-row mutation), and the dashboard's recent-outcomes table lacks the album column the Reports-page report renders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Historical provider outcome totals are now automatically reconciled during startup.
  - Previously recorded detector successes are added to provider outcome counters without duplicating existing totals.
  - Failed or interrupted reconciliation attempts can safely retry on a later startup.

- **Bug Fixes**
  - Prevented startup races that could cause inaccurate live provider outcome counters.

- **Tests**
  - Added coverage for successful, repeated, interrupted, failed, and rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->