### PR TITLE
fix(db): backfill historical detector verdicts into lane_attempts (#537)

### DIFF
--- a/internal/db/migrations/029_lane_attempts_detector_backfill.sql
+++ b/internal/db/migrations/029_lane_attempts_detector_backfill.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Backfill historical detector verdicts into lane_attempts (issue #537), so the
+-- dashboard's provider-effectiveness tile reflects them.
+--
+-- WHY THIS EXISTS SEPARATELY FROM MIGRATION 028. The two tables feed different
+-- surfaces: /metrics reads provider_outcomes (corrected in 028) while
+-- reports.ProviderEffectiveness -- the dashboard tile -- reads lane_attempts.
+-- Correcting only the counter left the tile still showing a few hundred hits
+-- against several thousand real detections, so an operator upgrading saw no
+-- change on the page they actually look at. A one-time CLI pass
+-- (scan reconcile-detector-stats) could fix a given box, but it corrects one
+-- deployment rather than every upgrade, which is the same reason 028 is a
+-- migration and not startup code.
+--
+-- BOTH VERDICTS, NOT HITS-ONLY. instrumental_result = 1 becomes hit=1 and 0
+-- becomes hit=0. A hits-only fill was explicitly rejected for #537: the tile
+-- renders a per-track hit RATE, so inserting only the wins inflates it. Rows
+-- with NULL instrumental_result carry no verdict and are left out entirely --
+-- detection never ran for them, so there is nothing to attribute.
+--
+-- ON CONFLICT DO NOTHING, NOT DO UPDATE. UNIQUE(queue_id, lane) means a row
+-- recorded live by queue.RecordLaneAttempts already exists for anything the
+-- worker has attributed since migration 022. Recorded history outranks
+-- reconstruction: an observed attempt is always better evidence than one
+-- inferred from a stored verdict, so live rows win and this pass fills only the
+-- gaps. It also makes re-application a no-op independently of goose.
+--
+-- attempted_at IS A PROXY, NOT AN OBSERVATION. The true detection time was never
+-- recorded, so work_queue.updated_at stands in. It is an upper bound, since
+-- updated_at advances on every later touch of the row. completed_at is
+-- deliberately NOT used: it correlates with the verdict (the hit writers promote
+-- the row to 'done' and stamp it; the miss writer leaves it deferred and
+-- untimestamped), so keying on it would drop misses at a higher rate than hits
+-- and reintroduce the very rate skew the both-verdicts rule above prevents.
+INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at)
+SELECT id,
+       'detector',
+       CASE WHEN instrumental_result = 1 THEN 1 ELSE 0 END,
+       updated_at
+FROM work_queue
+WHERE instrumental_result IN (0, 1)
+ON CONFLICT(queue_id, lane) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Irreversible by design, for the same reason as 028: once these rows are in
+-- lane_attempts nothing distinguishes a backfilled attempt from one recorded
+-- live by the worker, so a Down would have to guess which to delete. Restore
+-- from backup if this must be undone.
+SELECT 1;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

v1.23.0's release notes promise that the audio detector's result count "climbs several-fold the moment you upgrade." It doesn't, on the page anyone actually looks at.

Migration 028 corrected `provider_outcomes`, which `/metrics` reads. The dashboard's provider-effectiveness tile reads a **different table** — `lane_attempts`, per `reports.ProviderEffectiveness` — and that was never backfilled. So after upgrading, the tile still showed **402 hits against 3,813 real detections**, an 11% rate, completely unchanged.

Migration 029 fills that gap the same way 028 did, so the correction arrives with the upgrade instead of requiring a manual pass.

## Why not just run the existing CLI command

`scan reconcile-detector-stats` (#549) does this work and still works. But it corrects **one deployment**, not every upgrade. Running it on a single box would have fixed that box's dashboard while every other operator upgrading to v1.23.0 continued to see no change — the same reason the #548 backfill became a migration rather than startup code.

## Decisions carried from #537, not re-litigated

All three are already settled in `internal/detectorbackfill` and are restated in the migration's comments:

- **Both verdicts, not hits-only.** `instrumental_result = 1` becomes `hit=1`, `0` becomes `hit=0`. The tile renders a per-track hit *rate*, so inserting only the wins inflates it. NULL verdicts are excluded — detection never ran, so there is nothing to attribute.
- **`ON CONFLICT DO NOTHING`, not `DO UPDATE`.** `UNIQUE(queue_id, lane)` means anything the worker attributed since migration 022 already has a row. A live-recorded attempt is better evidence than one inferred from a stored verdict, so live rows win and this fills only the gaps. It also makes re-application a no-op independently of goose.
- **`attempted_at = work_queue.updated_at`, a documented proxy.** The true detection time was never recorded. `completed_at` is deliberately not used because it correlates with the verdict — the hit writers promote the row to `done` and stamp it, the miss writer leaves it deferred and untimestamped — so keying on it would drop misses at a higher rate than hits and reintroduce the exact rate skew the both-verdicts rule prevents.

## Verified against a copy of the production database

```
BEFORE  detector hits=402   misses=3137  total=3539   tile renders 11%
AFTER   detector hits=3813  misses=9736  total=13549  tile renders 28.1%
```

- hits now match `work_queue`'s **3,813** recorded settles exactly
- two further opens: unchanged, exactly one `goose_db_version` row for v29
- fresh install: true no-op, `lane_attempts` stays empty

## Linked issue

Part of #537 (the lane_attempts half, which the CLI-only pass left unapplied on upgrade)

## Gates

`make gate` — exit 0, "OK: all pre-push checks passed". Go-specific steps self-skip: the diff is one SQL file.

## Test plan

- [x] Applied to a production snapshot through the real `db.Open` path
- [x] Hit count reconciles exactly against `work_queue`'s recorded settles
- [x] Idempotency: two further opens leave the table unchanged
- [x] Fresh install: no-op
- [x] `Down` is a documented deliberate no-op — once inserted, nothing distinguishes a backfilled attempt from a live-recorded one, so a Down would have to guess which to delete

## Note for reviewers

Worth knowing how this was found: it was **not** caught by any check in this repo. The database numbers were verified correct after v1.23.0 deployed, and they were — for `provider_outcomes`. The maintainer then looked at the actual dashboard and saw 402/3534 unchanged. Every verification in the previous round queried the database and none rendered the page, which is precisely the gap that let a release ship a promise it didn't keep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved historical detector results in lane attempt records.
  * Prevented duplicate entries when historical results have already been recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->