### PR TITLE
fix(queue): preserve pre-claim status across a throttle release

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -299,6 +299,85 @@ func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 // it migrates to v10, seeds a pre-011 row with non-ASCII metadata, applies 011,
 // and asserts the artist_key/title_key backfill and index, then down-migrates
 // and asserts the columns are removed.
+// Migration 030 adds prev_status and repairs rows stranded by the pre-#569
+// Release, which forced every throttle-released row to 'pending' regardless of
+// the status it was claimed from. A deferred row released that way kept its
+// PriorityMiss (-100) but sat in 'pending', where RecheckDeferred and
+// `queue deferred` (both scoped WHERE status='deferred') could not reach it.
+func TestMigration030AddsPrevStatusAndRepairsStrandedRows(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig030.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	sqlDB.SetMaxOpenConns(1)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 29); err != nil {
+		t.Fatalf("UpTo(29): %v", err)
+	}
+
+	// Three rows that must be told apart by the repair:
+	//   stranded  -- ex-deferred, released to pending, still PriorityMiss.
+	//   fresh     -- genuine scan work; must stay pending.
+	//   missfree  -- PriorityMiss but never deferred; must stay pending.
+	seed := func(artist string, priority, missCount int) {
+		t.Helper()
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO work_queue (artist, title, artist_key, title_key, status, priority, miss_count, next_attempt_at)
+             VALUES (?, ?, ?, ?, 'pending', ?, ?, '2026-01-01T00:00:00Z')`,
+			artist, "T", artist, "t", priority, missCount,
+		); err != nil {
+			t.Fatalf("seed %s: %v", artist, err)
+		}
+	}
+	seed("stranded", -100, 1)
+	seed("fresh", 0, 0)
+	seed("missfree", -100, 0)
+
+	if _, err := provider.UpTo(ctx, 30); err != nil {
+		t.Fatalf("UpTo(30): %v", err)
+	}
+
+	for _, tc := range []struct {
+		artist string
+		want   string
+	}{
+		{"stranded", "deferred"},
+		{"fresh", "pending"},
+		{"missfree", "pending"},
+	} {
+		var got string
+		if err := sqlDB.QueryRowContext(ctx,
+			`SELECT status FROM work_queue WHERE artist_key = ?`, tc.artist).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", tc.artist, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s status = %q; want %q", tc.artist, got, tc.want)
+		}
+	}
+
+	// prev_status exists and defaults to the empty sentinel, which Release
+	// treats as 'pending' so pre-migration rows keep the old behavior.
+	var prevStatus string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT prev_status FROM work_queue WHERE artist_key = ?`, "fresh").Scan(&prevStatus); err != nil {
+		t.Fatalf("query prev_status: %v", err)
+	}
+	if prevStatus != "" {
+		t.Errorf("prev_status = %q; want empty sentinel", prevStatus)
+	}
+}
+
 func TestMigration011BackfillsKeysAndDownMigrates(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "mig011.db")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -295,10 +295,33 @@ func TestOpen_WorkQueueBackoffMigration(t *testing.T) {
 	}
 }
 
-// TestMigration011BackfillsKeysAndDownMigrates drives migration 011 directly:
-// it migrates to v10, seeds a pre-011 row with non-ASCII metadata, applies 011,
-// and asserts the artist_key/title_key backfill and index, then down-migrates
-// and asserts the columns are removed.
+// applyOpenPragmas configures a directly-opened test connection with the same
+// pragmas Open applies, so a test that drives goose without going through Open
+// still exercises migrations under the persistence contract they run under in
+// production (WAL, foreign-key enforcement, busy retry). Kept as a helper rather
+// than inline SQL per test so the set cannot drift between call sites.
+func applyOpenPragmas(ctx context.Context, t *testing.T, sqlDB *sql.DB) {
+	t.Helper()
+	// Limit to one connection so per-connection pragmas apply reliably.
+	sqlDB.SetMaxOpenConns(1)
+	var journalMode string
+	if err := sqlDB.QueryRowContext(ctx, "PRAGMA journal_mode=WAL").Scan(&journalMode); err != nil {
+		t.Fatalf("set journal_mode=WAL: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Fatalf("journal_mode = %q; want %q", journalMode, "wal")
+	}
+	for _, p := range []string{
+		"PRAGMA foreign_keys=ON",
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA synchronous=NORMAL",
+	} {
+		if _, err := sqlDB.ExecContext(ctx, p); err != nil {
+			t.Fatalf("pragma %q: %v", p, err)
+		}
+	}
+}
+
 // Migration 030 adds prev_status and repairs rows stranded by the pre-#569
 // Release, which forced every throttle-released row to 'pending' regardless of
 // the status it was claimed from. A deferred row released that way kept its
@@ -312,7 +335,7 @@ func TestMigration030AddsPrevStatusAndRepairsStrandedRows(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	t.Cleanup(func() { _ = sqlDB.Close() })
-	sqlDB.SetMaxOpenConns(1)
+	applyOpenPragmas(ctx, t, sqlDB)
 
 	migFS, err := fs.Sub(migrations, "migrations")
 	if err != nil {
@@ -378,6 +401,10 @@ func TestMigration030AddsPrevStatusAndRepairsStrandedRows(t *testing.T) {
 	}
 }
 
+// TestMigration011BackfillsKeysAndDownMigrates drives migration 011 directly:
+// it migrates to v10, seeds a pre-011 row with non-ASCII metadata, applies 011,
+// and asserts the artist_key/title_key backfill and index, then down-migrates
+// and asserts the columns are removed.
 func TestMigration011BackfillsKeysAndDownMigrates(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "mig011.db")

--- a/internal/db/migrations/030_work_queue_prev_status.sql
+++ b/internal/db/migrations/030_work_queue_prev_status.sql
@@ -1,0 +1,57 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Records the status a row held immediately before Dequeue claimed it, so
+-- Release can restore that status instead of forcing every released row to
+-- 'pending'. SQLite's UPDATE ... RETURNING yields post-update values, so the
+-- pre-claim status is otherwise destroyed at claim time and Release has nothing
+-- to restore to -- it hardcoded 'pending' because that was the only status it
+-- could guess.
+--
+-- The cost of that guess: a deferred row claimed during a breaker-open window
+-- (worker.go OutcomeUnavailable -> Release) landed in status='pending' while
+-- keeping the PriorityMiss (-100) deprioritization Defer had applied -- a
+-- pairing the priority model in internal/queue/priority.go does not describe,
+-- which reserves -100 for deferred rows. Such rows sort with the deferred
+-- backlog rather than as fresh work, and are invisible to both RecheckDeferred
+-- and `queue deferred`, which are scoped WHERE status = 'deferred' -- so the
+-- operator lever built for exactly this situation could not reach them.
+--
+-- Empty string is the "no recorded pre-claim status" sentinel (NOT NULL keeps
+-- the column's read path total). Release treats it as 'pending', preserving the
+-- historical behavior for any row claimed before this migration ran.
+ALTER TABLE work_queue ADD COLUMN prev_status TEXT NOT NULL DEFAULT '';
+
+-- Repair rows already stranded by the old Release behavior. miss_count is
+-- incremented only by Defer, so a pending row carrying both miss_count > 0 and
+-- PriorityMiss has certainly been deferred at some point; returning it to
+-- 'deferred' restores the status its priority already reflects.
+--
+-- The predicate does NOT distinguish the stranded rows from a row an operator
+-- explicitly retried: Retry resets failed -> pending without touching priority
+-- or miss_count, so a previously-missed row that failed and was retried matches
+-- too. That imprecision is accepted because it is inert -- 'pending' and
+-- 'deferred' at priority -100 are dequeued by exactly the same predicate
+-- (status IN ('pending','failed','deferred') AND next_attempt_at <= now) at
+-- exactly the same priority, so a reclassified row is picked up on the same
+-- schedule either way. Only the reporting bucket changes, and 'deferred' is the
+-- honest one for a row that has in fact missed.
+--
+-- next_attempt_at is left untouched: Release does not disturb it, and Retry
+-- already set it to now, so neither class of row has its schedule moved.
+--
+-- (Defer is not the only writer of priority = -100 -- RecheckRetired sets it
+-- too -- but RecheckRetired also writes status='deferred', so those rows never
+-- match this pending-scoped predicate.)
+UPDATE work_queue
+SET status = 'deferred'
+WHERE status = 'pending'
+  AND priority = -100
+  AND miss_count > 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- The repair above is not reversed: returning those rows to 'pending' would
+-- recreate the stranded state this migration exists to clear.
+ALTER TABLE work_queue DROP COLUMN prev_status;
+-- +goose StatementEnd

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -301,7 +301,8 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
 // each variant is a complete, standalone statement (no concatenation, no
 // interpolation -> no gosec concern).
 const dequeueRandomizedSQL = `UPDATE work_queue
-         SET status = 'processing'
+         SET status = 'processing',
+             prev_status = status
          WHERE id = (
              SELECT id
              FROM work_queue
@@ -316,7 +317,8 @@ const dequeueRandomizedSQL = `UPDATE work_queue
 // dequeueDeterministicSQL claims the next ready item in stable FIFO order within
 // a priority tier (created_at, then id).
 const dequeueDeterministicSQL = `UPDATE work_queue
-         SET status = 'processing'
+         SET status = 'processing',
+             prev_status = status
          WHERE id = (
              SELECT id
              FROM work_queue
@@ -540,16 +542,45 @@ func (q *DBQueue) StampUnclassifiedMiss(ctx context.Context, id int64, tel Instr
 	return n > 0, nil
 }
 
-// Release returns a processing item to the pending pool without recording a
-// failure. Used when the worker dequeued the item but cannot process it for a
-// reason that should not count against the row's retry budget (e.g. the
-// global rate-limit circuit breaker tripped). Attempts and next_attempt_at
-// are left untouched so the row is immediately eligible for the next dequeue.
+// Release returns a processing item to the pool it was claimed from, without
+// recording a failure. Used when the worker dequeued the item but cannot
+// process it for a reason that should not count against the row's retry budget
+// (e.g. the global rate-limit circuit breaker tripped). Attempts and
+// next_attempt_at are left untouched so the row is immediately eligible for the
+// next dequeue.
+//
+// The restored status is prev_status, which Dequeue stamps with the row's
+// pre-claim status. A throttle release is therefore a true no-op round-trip: a
+// deferred row goes back to 'deferred', a failed row back to 'failed'. Forcing
+// every release to 'pending' (the pre-#569 behavior) stranded deferred rows in
+// status='pending' with the PriorityMiss deprioritization still applied, where
+// they sorted with the deferred backlog instead of as fresh work and were
+// invisible to RecheckDeferred and `queue deferred`, both being scoped
+// WHERE status = 'deferred'.
+//
+// last_error is cleared only when the row returns to 'pending'. A row restored
+// to 'failed' keeps its reason: a throttle is not the song's fault, but the
+// row stays in the failures view, and wiping the reason there would strand it
+// as an "unknown" bucket in CountFailuresByReason with its cause destroyed.
+//
+// Dequeue is the sole writer of status='processing' and always re-stamps
+// prev_status as it claims, so a stale prev_status from an earlier claim can
+// never be consumed. Any future path that sets 'processing' directly must
+// stamp prev_status too.
+//
+// An empty prev_status (a row claimed before migration 030 added the column)
+// falls back to 'pending', preserving the historical behavior.
 func (q *DBQueue) Release(ctx context.Context, id int64) error {
 	res, err := q.db.ExecContext(ctx,
 		`UPDATE work_queue
-         SET status = 'pending',
-             last_error = ''
+         SET status = CASE
+                 WHEN prev_status = '' THEN 'pending'
+                 ELSE prev_status
+             END,
+             last_error = CASE
+                 WHEN prev_status IN ('', 'pending') THEN ''
+                 ELSE last_error
+             END
          WHERE id = ?
            AND status = 'processing'`,
 		id,

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1109,6 +1109,105 @@ func TestDBQueue_ReleaseReturnsItemToPendingWithoutFailure(t *testing.T) {
 	}
 }
 
+// A deferred row claimed by the worker and then released by the throttle path
+// (every lane's breaker open) must return to 'deferred', not 'pending'. Forcing
+// it to 'pending' strands the row with the PriorityMiss (-100) deprioritization
+// still applied -- a pairing priority.go does not describe -- where it neither
+// sorts as fresh work nor is reachable by RecheckDeferred or `queue deferred`,
+// both of which are scoped WHERE status='deferred'.
+func TestDBQueue_ReleaseRestoresDeferredStatus(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	const cooldown = 7 * 24 * time.Hour
+	deferred, err := q.Defer(ctx, item.ID, cooldown, errors.New("musixmatch: no results"))
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if deferred.Priority != PriorityMiss {
+		t.Fatalf("priority after Defer = %d; want %d", deferred.Priority, PriorityMiss)
+	}
+
+	// Advance past the cooldown so the deferred row is claimable again.
+	q.now = func() time.Time { return now.Add(cooldown + time.Second) }
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue after cooldown: %v", err)
+	}
+
+	if err := q.Release(ctx, item.ID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	var status string
+	var priority int
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, priority FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &priority); err != nil {
+		t.Fatalf("query released row: %v", err)
+	}
+	if status != StatusDeferred {
+		t.Fatalf("status = %q; want %q (release must restore the pre-claim status, not force pending)", status, StatusDeferred)
+	}
+	if priority != PriorityMiss {
+		t.Fatalf("priority = %d; want %d (release must not disturb miss deprioritization)", priority, PriorityMiss)
+	}
+}
+
+// Release must not destroy the diagnostic on a row it restores to 'failed'.
+// Clearing last_error was harmless while every release forced the row to
+// 'pending' (it left the failures view anyway), but a status-preserving release
+// leaves the row in 'failed' -- with its reason wiped, it becomes an "unknown"
+// bucket in CountFailuresByReason and the operator loses the cause.
+func TestDBQueue_ReleasePreservesLastErrorOnFailedRow(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	item, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Artist", TrackName: "Title"}}, PriorityScan)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	failed, err := q.Fail(ctx, item.ID, errors.New("musixmatch: transport error"))
+	if err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+
+	// Advance past the geometric backoff so the failed row is claimable again.
+	q.now = func() time.Time { return failed.NextAttemptAt.Add(time.Second) }
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("Dequeue after backoff: %v", err)
+	}
+	if err := q.Release(ctx, item.ID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	var status, lastError string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, last_error FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &lastError); err != nil {
+		t.Fatalf("query released row: %v", err)
+	}
+	if status != StatusFailed {
+		t.Fatalf("status = %q; want %q", status, StatusFailed)
+	}
+	if lastError == "" {
+		t.Fatal("last_error was cleared on a row restored to 'failed'; the failure reason must survive a throttle release")
+	}
+}
+
 func TestDBQueue_ReleaseRequiresProcessingStatus(t *testing.T) {
 	ctx := context.Background()
 	q := NewDBQueue(openQueueTestDB(t))


### PR DESCRIPTION
## Summary

- `Release` returned every throttle-released row to `status='pending'`, discarding the status it was claimed from. A deferred row released this way kept the `PriorityMiss` (-100) deprioritization but sat in `pending` -- a pairing `priority.go` does not describe, which reserves -100 for deferred rows.
- `Dequeue` now stamps a `prev_status` column with the row's pre-claim status and `Release` restores it, making a throttle release a true no-op round-trip. Migration 030 adds the column and repairs already-stranded rows.
- `last_error` is now cleared only when the row returns to `pending`, so a row restored to `failed` keeps its reason instead of becoming an `unknown` bucket in `CountFailuresByReason`.

## Linked issue

Closes #569

## Why it mattered

Stranded rows sort with the deferred backlog rather than as fresh work, and are invisible to `RecheckDeferred` and `queue deferred` -- both scoped `WHERE status = 'deferred'` -- so the operator lever built for exactly this situation could not reach them.

The refill is silent: the worker's `OutcomeUnavailable` branch releases without emitting a log line (the breaker trip is logged once when it opens), so rows accumulate with no corresponding WARN in the window.

Measured on a live instance: **129 of 129** `pending` rows were stranded, every one with `priority=-100` and `miss_count=1`. They held a 1.28% share of a 10,102-row eligible pool under the flat `RANDOM()` tiebreak at ~60 items/hr -- an expected **~0.8 picks/hr**, so they read as permanently stuck while the deferred backlog around them drained normally.

## Design notes

Resetting `priority` to `PriorityScan` in `Release` was considered and rejected: it would promote genuine miss rows above fresh scan work on every breaker trip, defeating `PriorityMiss`.

The migration's repair predicate (`status='pending' AND priority=-100 AND miss_count>0`) does **not** distinguish stranded rows from a row an operator explicitly retried -- `Retry` resets `failed -> pending` without touching `priority` or `miss_count`. That imprecision is accepted and documented inline because it is inert: both states are dequeued by the same predicate at the same priority, so only the reporting bucket changes, and `deferred` is the honest bucket for a row that has in fact missed.

## Test plan

- [x] `TestDBQueue_ReleaseRestoresDeferredStatus` -- new; verified RED before the fix
- [x] `TestDBQueue_ReleasePreservesLastErrorOnFailedRow` -- new; verified RED before the fix
- [x] `TestMigration030AddsPrevStatusAndRepairsStrandedRows` -- new; verified RED by removing the repair, with two control rows confirming no over-match
- [x] `make gate` (build, race tests, patch coverage, codecov dry-run, golangci-lint, actionlint, govulncheck) -- exits 0
- [x] Full suite: 2,579 tests across 51 packages
- [x] Repair predicate dry-run read-only against a production database: 129 matched, 0 false positives, 0 missed
- [x] Adversarial pre-push review; its three real findings (`last_error` wipe, two falsifiable comment claims) fixed in this commit
- [ ] Reviewer follow-ups

## Follow-up worth filing separately

`Retry` leaves `priority` at -100 on a previously-missed row, so `queue retry` returns the row to the same starved lottery it came from -- the operator's retry does not meaningfully re-prioritize it. Same starvation class as this issue, out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue items released after processing now return to their previous status instead of always becoming pending.
  - Deferred items retain their deferred state and prioritization behavior.
  - Failure diagnostics are preserved when items return to a failed state.
  - Existing misclassified queue items are automatically repaired during migration.

- **Improvements**
  - Queue processing now tracks each item’s status before it is claimed, enabling more accurate release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->