### PR TITLE
fix(scanner): let an upgrade pass reach a track with extracted unsynced lyrics

### DIFF
--- a/internal/scanner/embedded_lyrics_test.go
+++ b/internal/scanner/embedded_lyrics_test.go
@@ -35,6 +35,45 @@ func TestScanLibrary_EmbeddedLyricsRespect(t *testing.T) {
 	}
 }
 
+// A track whose lyrics were extracted from tags to an unsynced .txt must still
+// be enqueued when an upgrade pass is requested, so a provider can promote it to
+// synced. Extraction produces the unsynced form only (the USLT frame), which is
+// not a terminal result -- treating it as one freezes the track permanently in a
+// worse state than a normal unsynced fetch, which upgrade does revisit.
+//
+// The ordering under test: the .txt sidecar check correctly defers to Upgrade,
+// but the embedded-lyrics block runs afterward and skips the file regardless
+// (#538).
+func TestScanLibrary_EmbeddedLyricsExtractDoesNotBlockUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "song.mp3", "Artist", "Title", "Album", "placeholder lyric text"); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	// First pass: extraction writes the unsynced sidecar and skips the fetch.
+	first, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if len(first) != 0 {
+		t.Fatalf("first pass: got %d results; want 0 (extracted, fetch skipped)", len(first))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.txt")); err != nil {
+		t.Fatalf("expected song.txt after extraction: %v", err)
+	}
+
+	// Upgrade pass: the track holds only unsynced lyrics, so it must be enqueued
+	// for a synced re-fetch.
+	upgraded, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract", Upgrade: true})
+	if err != nil {
+		t.Fatalf("upgrade scan: %v", err)
+	}
+	if len(upgraded) != 1 {
+		t.Fatalf("upgrade pass: got %d results; want 1 -- an extracted unsynced track must stay eligible for synced promotion, not be frozen at unsynced", len(upgraded))
+	}
+}
+
 func TestScanLibrary_EmbeddedLyricsExtract(t *testing.T) {
 	dir := t.TempDir()
 	if err := testutil.WriteAudioFile(dir, "song.mp3", "Artist", "Title", "Album", "la la la"); err != nil {

--- a/internal/scanner/embedded_lyrics_test.go
+++ b/internal/scanner/embedded_lyrics_test.go
@@ -74,6 +74,37 @@ func TestScanLibrary_EmbeddedLyricsExtractDoesNotBlockUpgrade(t *testing.T) {
 	}
 }
 
+// A failed sidecar write must not drop the track. The extract path promises the
+// track is still enqueued so an ordinary fetch is attempted -- silently skipping
+// it would lose the work with only a warning to show for it.
+func TestScanLibrary_EmbeddedLyricsExtractWriteFailureStillEnqueues(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a read-only directory does not block writes, so the failure cannot be injected")
+	}
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "song.mp3", "Artist", "Title", "Album", "placeholder lyric text"); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	// Read-only directory: the sidecar's temp file cannot be created, so
+	// extraction fails. t.TempDir()'s cleanup needs the bit back.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	sc := NewScanner()
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("got %d results; want 1 -- a failed sidecar write must fall through to enqueue, not silently skip the track", len(res))
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "song.txt")); statErr == nil {
+		t.Error("song.txt exists; the write was supposed to fail, so this test is not exercising the failure path")
+	}
+}
+
 func TestScanLibrary_EmbeddedLyricsExtract(t *testing.T) {
 	dir := t.TempDir()
 	if err := testutil.WriteAudioFile(dir, "song.mp3", "Artist", "Title", "Album", "la la la"); err != nil {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -513,6 +513,23 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 						}
 					} else if err := extractEmbeddedLyrics(dir, stem, unsynced); err != nil {
 						slog.Warn("failed to extract embedded lyrics; enqueuing for fetch instead", "file", file.Name(), "error", err)
+					} else if reopen.Unsynced {
+						// Extraction yielded the UNSYNCED form only, which is not a
+						// terminal result. When an upgrade/update pass asked for
+						// unsynced work to be reconsidered, the sidecar is written but
+						// the fetch must still run so a provider can promote the track
+						// to synced. Skipping here froze such tracks permanently at
+						// unsynced -- worse than an ordinary unsynced fetch, which
+						// upgrade does revisit (#538). Mirrors the txtExists case above,
+						// which already defers to reopen.Unsynced.
+						//
+						// f is deliberately NOT closed here. Unlike the skip branches,
+						// which close and continue, this one falls through to the
+						// straight-line region below that ends in a single
+						// unconditional f.Close(). Closing here would double-close, and
+						// would be a use-after-close whenever EnrichRecording is set,
+						// since probeDuration still reads from the handle first.
+						slog.Debug("extracted embedded lyrics to .txt sidecar; still enqueuing for synced upgrade", "file", file.Name())
 					} else {
 						_ = f.Close()
 						slog.Debug("extracted embedded lyrics to .txt sidecar; skipping fetch", "file", file.Name())


### PR DESCRIPTION
## Summary

- In `embedded_lyrics = "extract"` mode the scanner wrote the unsynced `.txt` sidecar from the USLT frame and then skipped the fetch **unconditionally**, freezing the track permanently at unsynced.
- The earlier `txtExists` case already defers to `reopen.Unsynced` and correctly lets an upgrade through; the embedded-lyrics block runs afterward and skipped regardless, so no `--upgrade` pass could ever promote such a track to synced.
- Gate that skip on `reopen.Unsynced`, mirroring the existing case, so `--upgrade`/`--update` still write the sidecar but continue to the fetch.

## Linked issue

Part of #538

## Why this matters in practice

Unsynced lyrics are not a terminal result. A track that got its `.txt` from an ordinary unsynced fetch *is* revisited by an upgrade pass; a track that got the identical `.txt` from tag extraction was not. That is a worse state than not extracting at all.

Production runs `embedded_lyrics = "extract"`, so any library track carrying embedded unsynced lyrics has been stuck at unsynced regardless of upgrade passes.

## Scope

Deliberately narrow, confirmed by an exhaustive mode matrix (see Test plan):

| mode | upgrade=false | upgrade=true |
|---|---|---|
| `off` / `""` | 1 result | 1 result |
| `respect` | 0 | 0 |
| `extract` | 0 | **1 (this change)** |

Single-cell delta. `respect` is left alone deliberately -- it means "do not fetch for files that already carry lyrics", which is an explicit opt-out rather than a skip that lost track of upgrade intent.

## File-handle note

The new branch deliberately does **not** close `f`. The skip branches close-and-`continue`; this one falls through to a straight-line region ending in a single unconditional `f.Close()`. Closing in the branch would double-close, and would be a use-after-close whenever `EnrichRecording` is set, since `probeDuration` reads the handle first. An earlier draft of this fix had exactly that bug; the comment records why the asymmetry is intentional.

## Test plan

- [x] `TestScanLibrary_EmbeddedLyricsExtractDoesNotBlockUpgrade` -- new; verified RED before the fix (`got 0 results; want 1`)
- [x] Non-vacuity re-confirmed independently by reverting the fix in a scratch copy: the new test fails, and **78 of 79** scanner tests still pass, which is direct evidence the change alters nothing else
- [x] File-handle correctness verified empirically, not by inspection: `probeDuration`'s error is swallowed to `dur = 0`, so a use-after-close would be silent. Captured logs on the fall-through path show the open-file signature (`EOF`), not the closed-handle one (`file already closed`), byte-identical to a plain-scan baseline
- [x] No fd leak: 5000 consecutive fall-through scans
- [x] Idempotence: `linkSidecar` is exclusive-create via `os.Link`, so an existing sidecar is never overwritten and a better `.lrc` cannot be clobbered. After 5000 upgrade scans, sidecar content and mtime unchanged (matters given library managers keying on mtime)
- [x] `make gate` -- exits 0 (build, race tests, patch coverage, codecov dry-run, golangci-lint, actionlint, govulncheck)
- [x] Adversarial pre-push review; its one in-scope finding (an imprecise comment I had written) fixed before push

## Follow-up found during review, deliberately not fixed here

A tag-extracted **synced** `.lrc` is never re-fetchable, even under `--update`. That contradicts two documented contracts: `reopenClassesFor` (`--update` "reopens every class") and `GetSongDir` ("update causes existing .lrc files to be re-queued"). Same defect class as this one, but pre-existing and out of scope -- filing separately rather than widening this diff.
