### PR TITLE
fix(scanner): re-queue a tag-extracted synced .lrc under --update (#575)

### DIFF
--- a/internal/scanner/reopen.go
+++ b/internal/scanner/reopen.go
@@ -2,24 +2,30 @@ package scanner
 
 import "github.com/sydlexius/canticle/internal/lyrics"
 
-// reopenClasses is the set of settled .txt states a scan is willing to reconsider.
-// Modeling re-check eligibility as classes (not a single bool) keeps the
-// instrumental-provenance distinction expressible: a provider marker is
+// reopenClasses is the set of settled lyric states a scan is willing to
+// reconsider. Modeling re-check eligibility as classes (not a single bool) keeps
+// the instrumental-provenance distinction expressible: a provider marker is
 // authoritative and a detector marker is provisional, and only the requested
 // classes are reopened. See #502.
+//
+// Synced covers a settled .lrc, the one class that is not a .txt state. Only a
+// full --update reopens it: --upgrade exists to promote a track toward synced,
+// so it has nothing to do for a track that is already there. See #575.
 type reopenClasses struct {
 	Unsynced                  bool
 	ProvisionalInstrumental   bool
 	AuthoritativeInstrumental bool
+	Synced                    bool
 }
 
 // reopenClassesFor derives the reopen set from the scan flags. --update is a full
 // re-fetch (reopens every class); --upgrade reopens unsynced .txt and provisional
-// (detector-written) instrumental markers, but not authoritative provider markers.
+// (detector-written) instrumental markers, but not authoritative provider markers
+// and not a settled .lrc.
 func reopenClassesFor(opts ScanOptions) reopenClasses {
 	switch {
 	case opts.Update:
-		return reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}
+		return reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true, Synced: true}
 	case opts.Upgrade:
 		return reopenClasses{Unsynced: true, ProvisionalInstrumental: true}
 	default:

--- a/internal/scanner/reopen_test.go
+++ b/internal/scanner/reopen_test.go
@@ -13,9 +13,11 @@ func TestReopenClassesFor(t *testing.T) {
 		want            reopenClasses
 	}{
 		{"neither", false, false, reopenClasses{}},
+		// --upgrade promotes a track toward synced, so it must never set Synced:
+		// there is nothing above a settled .lrc to promote it to (#575).
 		{"upgrade", false, true, reopenClasses{Unsynced: true, ProvisionalInstrumental: true}},
-		{"update", true, false, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}},
-		{"both", true, true, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true}},
+		{"update", true, false, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true, Synced: true}},
+		{"both", true, true, reopenClasses{Unsynced: true, ProvisionalInstrumental: true, AuthoritativeInstrumental: true, Synced: true}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -409,8 +409,10 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 		}
 
 		switch {
-		case lrcExists && !opts.Update:
+		case lrcExists && !reopen.Synced:
 			// Synced lyrics already present and not asked to update -- skip.
+			// Gated on the Synced class rather than opts.Update directly so this
+			// and the embedded-lyrics hasSynced skip below cannot drift apart.
 			slog.Debug("skipping file, lyrics exist", "file", file.Name())
 			continue
 		case txtExists && !lrcExists && isInstrumentalTxt(filepath.Join(dir, txtFile)):
@@ -506,6 +508,28 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 					if hasSynced {
 						if err := extractEmbeddedSyncedLyrics(dir, stem, synced); err != nil {
 							slog.Warn("failed to extract embedded synced lyrics; enqueuing for fetch instead", "file", file.Name(), "error", err)
+						} else if reopen.Synced {
+							// Extraction yielded a synced .lrc, but --update is a full
+							// re-fetch: embedded SYNCEDLYRICS is whatever previous
+							// tooling happened to write and is frequently worse than a
+							// provider result. Skipping here pinned the track to it with
+							// no supported way to refresh short of deleting the sidecar
+							// by hand (#575). The sidecar is already written -- the
+							// extraction above ran first -- so falling through costs
+							// nothing and lets a provider fetch replace it.
+							//
+							// Deliberately NOT gated on lrcExists (captured before
+							// extraction): that made the first --update pass write-and-
+							// skip while the second re-queued, so two identical passes
+							// disagreed. Mirrors the reopen.Unsynced branch below, which
+							// is likewise unconditional on an existing sidecar.
+							//
+							// f is deliberately NOT closed here, for the same reason as
+							// the reopen.Unsynced branch below: this falls through to the
+							// straight-line region that ends in a single unconditional
+							// f.Close(), and probeDuration still reads from the handle
+							// when EnrichRecording is set.
+							slog.Debug("extracted synced .lrc present; still enqueuing for update re-fetch", "file", file.Name())
 						} else {
 							_ = f.Close()
 							slog.Debug("extracted embedded synced lyrics to .lrc sidecar; skipping fetch", "file", file.Name())

--- a/internal/scanner/synced_reopen_test.go
+++ b/internal/scanner/synced_reopen_test.go
@@ -1,0 +1,181 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/testutil"
+)
+
+// extractSyncedFixture writes a FLAC carrying a valid SYNCEDLYRICS comment and
+// runs one "extract" scan over it, leaving the tag-extracted .lrc sidecar in
+// place. It returns the directory and the scanner, so a caller can rescan the
+// same tree with different reopen flags -- the real extract-then-rescan loop.
+func extractSyncedFixture(t *testing.T) (string, *Scanner) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+	if _, err := sc.ScanLibrary(context.Background(), dir,
+		ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract"}); err != nil {
+		t.Fatalf("seed extract scan: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); err != nil {
+		t.Fatalf("fixture precondition: expected extracted song.lrc: %v", err)
+	}
+	return dir, sc
+}
+
+// --update must re-queue a track whose synced .lrc came from tag extraction
+// (#575). The top-level switch already falls through for lrcExists && Update,
+// but the embedded-lyrics block then skipped unconditionally in the hasSynced
+// arm, silently defeating --update for these tracks. Embedded SYNCEDLYRICS is
+// whatever previous tooling wrote and is frequently worse than a provider
+// result, so without this the track is pinned to it with no supported refresh.
+func TestScanLibrary_SyncedExtracted_UpdateRequeues(t *testing.T) {
+	dir, sc := extractSyncedFixture(t)
+
+	res, err := sc.ScanLibrary(context.Background(), dir,
+		ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract", Update: true})
+	if err != nil {
+		t.Fatalf("update rescan: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("update rescan: got %d results; want 1 (re-queued for fetch)", len(res))
+	}
+	// The sidecar stays byte-identical: re-extraction is a no-op (linkSidecar
+	// never overwrites), and the fetch that replaces it happens downstream.
+	got, err := os.ReadFile(filepath.Join(dir, "song.lrc"))
+	if err != nil {
+		t.Fatalf("read sidecar after update rescan: %v", err)
+	}
+	if string(got) != syncedLRC {
+		t.Errorf(".lrc = %q; want unchanged %q", string(got), syncedLRC)
+	}
+}
+
+// Regression guard, not a RED test: --upgrade must still skip an extracted
+// synced .lrc. There is nothing above synced to promote it to, so upgrade has
+// no work to do here -- only --update reopens a settled synced sidecar.
+func TestScanLibrary_SyncedExtracted_UpgradeStillSkips(t *testing.T) {
+	dir, sc := extractSyncedFixture(t)
+
+	res, err := sc.ScanLibrary(context.Background(), dir,
+		ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract", Upgrade: true})
+	if err != nil {
+		t.Fatalf("upgrade rescan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("upgrade rescan: got %d results; want 0 (nothing to promote to)", len(res))
+	}
+}
+
+// Two identical --update passes over a fresh library must agree. Gating the
+// fall-through on a pre-extraction lrcExists made the first pass write the
+// sidecar and skip, and only the second pass re-queue -- so --update was
+// non-idempotent and AC "update re-queues an extracted synced .lrc" held only
+// from the second run onward. The sidecar is written either way (extraction
+// runs before the branch), so there is nothing to protect by skipping here.
+func TestScanLibrary_SyncedExtracted_UpdateIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+	opts := ScanOptions{MaxDepth: 100, EmbeddedLyrics: "extract", Update: true}
+
+	first, err := sc.ScanLibrary(context.Background(), dir, opts)
+	if err != nil {
+		t.Fatalf("first update scan: %v", err)
+	}
+	second, err := sc.ScanLibrary(context.Background(), dir, opts)
+	if err != nil {
+		t.Fatalf("second update scan: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("--update is not idempotent: pass1=%d, pass2=%d results", len(first), len(second))
+	}
+	if len(first) != 1 {
+		t.Fatalf("update over fresh extraction: got %d results; want 1 (re-queued for fetch)", len(first))
+	}
+	// The sidecar is still written on the first pass -- falling through to
+	// enqueue must not cost the extraction.
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); err != nil {
+		t.Errorf("first --update pass must still write the extracted .lrc: %v", err)
+	}
+}
+
+// Regression guard for the f.Close invariant, on the config every production
+// caller of directory-mode --update actually uses: GetSongDir hardcodes
+// EnrichRecording: true. The new fall-through deliberately does NOT close f,
+// because probeDuration still reads from the handle downstream. A premature
+// close here would surface as a zero TrackLength (or a use-after-close).
+func TestScanLibrary_SyncedExtracted_UpdateEnrichRecording(t *testing.T) {
+	dir, sc := extractSyncedFixture(t)
+
+	res, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{
+		MaxDepth: 100, EmbeddedLyrics: "extract", Update: true, EnrichRecording: true,
+	})
+	if err != nil {
+		t.Fatalf("update rescan with enrichment: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("update rescan: got %d results; want 1", len(res))
+	}
+	if res[0].Track.TrackLength == 0 {
+		t.Errorf("TrackLength = 0; want the probed duration -- the handle must still be open when probeDuration reads it")
+	}
+}
+
+// off mode is a no-op: the embedded block never runs, so the reopen gate is
+// unreachable and SYNCEDLYRICS is ignored entirely. --update still enqueues,
+// but via the ordinary fetch path and with no sidecar written.
+func TestScanLibrary_SyncedOff_UpdateUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir,
+		ScanOptions{MaxDepth: 100, EmbeddedLyrics: "off", Update: true})
+	if err != nil {
+		t.Fatalf("off update scan: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("off + update: got %d results; want 1 (ordinary fetch path)", len(res))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("off mode must never write a sidecar")
+	}
+}
+
+// respect mode is unchanged by the reopen gate: it never writes a sidecar, and
+// an --update pass still skips a track whose embedded lyrics are respected.
+func TestScanLibrary_SyncedRespect_UpdateUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "song.flac", 44100, 441000,
+		map[string]string{"SYNCEDLYRICS": syncedLRC}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc := NewScanner()
+
+	res, err := sc.ScanLibrary(context.Background(), dir,
+		ScanOptions{MaxDepth: 100, EmbeddedLyrics: "respect", Update: true})
+	if err != nil {
+		t.Fatalf("respect update scan: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("respect + update: got %d results; want 0 (skipped)", len(res))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "song.lrc")); !os.IsNotExist(err) {
+		t.Errorf("respect must not write any sidecar")
+	}
+}


### PR DESCRIPTION
## Summary

- A synced `.lrc` written by embedded-lyrics extraction was skipped on every subsequent scan, **including `--update`**. The top-level switch deliberately fell through for `lrcExists && Update`, but the embedded-lyrics block then skipped unconditionally in the `hasSynced` arm. The re-extraction it ran first is a silent no-op, since `linkSidecar` uses exclusive-create semantics and never overwrites -- so the code did nothing, then skipped the fetch anyway.
- Embedded `SYNCEDLYRICS` is whatever previous tooling happened to write and is frequently worse than a provider result, so a track was pinned to it with no supported refresh short of deleting the sidecar by hand.
- Adds a `Synced` reopen class, set only by `--update`, and routes **both** the top-level `.lrc` skip and the embedded `hasSynced` skip through it so the two sites cannot drift apart. `--upgrade` still skips (nothing above synced to promote to); plain scans and `respect`/`off` modes are unchanged.
- Same defect class as #574: a skip that lost track of reopen intent.

### Note on the fall-through condition

The fall-through is deliberately **unconditional on an existing sidecar**, mirroring the adjacent `reopen.Unsynced` branch. An earlier revision gated it on `lrcExists`, which is captured *before* extraction runs -- that made the first `--update` pass write-and-skip while the second re-queued, so two identical passes disagreed. Caught by adversarial pre-push review and fixed here, with `TestScanLibrary_SyncedExtracted_UpdateIsIdempotent` pinning it.

## Linked issue

Closes #575

## Gates (run locally via `make gate`; CI enforces them)

- [x] conflict markers, gofmt
- [x] generated web UI assets (templ + Tailwind), `updates=0`
- [x] `go build ./...`
- [x] `go test` (race + coverage) -- 2,586 tests across 51 packages
- [x] patch coverage (Codecov parity): **96.15%** (25/26 lines) vs 70% threshold
- [x] coverage floor ratchet: `internal/scanner` 76% vs 68% floor (+8%)
- [x] codecov report validation (dry-run)
- [x] golangci-lint: 0 issues
- [x] actionlint
- [x] govulncheck: no vulnerabilities

## Test plan

All five acceptance criteria from #575 are covered by tests using a FLAC fixture with a Vorbis `SYNCEDLYRICS` comment (MP3 cannot carry that key, so this path only reproduces on FLAC). Fixture lyric text is synthetic placeholder content.

- [x] `--update` re-queues a track whose synced `.lrc` came from tag extraction -- `TestScanLibrary_SyncedExtracted_UpdateRequeues`
- [x] `--update` is idempotent across two identical passes -- `TestScanLibrary_SyncedExtracted_UpdateIsIdempotent`
- [x] `--upgrade` still skips it -- `TestScanLibrary_SyncedExtracted_UpgradeStillSkips`
- [x] Plain scan still skips it -- existing `TestScanLibrary_SyncedLyricsExtract_RescanSkips`
- [x] `respect` and `off` modes unchanged -- `TestScanLibrary_SyncedRespect_UpdateUnchanged`, `TestScanLibrary_SyncedOff_UpdateUnchanged`
- [x] `f.Close()` invariant held on the fall-through path with `EnrichRecording: true` (the config `GetSongDir` hardcodes, so every directory-mode `--update` user hits it) -- `TestScanLibrary_SyncedExtracted_UpdateEnrichRecording`

**Discrimination verified:** the two behavior tests were confirmed RED against unfixed code (`got 0 results; want 1`, and `pass1=0, pass2=1`) before the fix was written. The remaining tests are labeled in-source as regression guards rather than presented as RED tests; the `--upgrade` guard was mutation-tested (adding `Synced: true` to the `opts.Upgrade` branch makes it fail), confirming it is load-bearing.

- [ ] Reviewer follow-ups

## Not covered

Verified at the **scanner** level only. How a re-queued row behaves end-to-end through the worker is not exercised here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated lyric scanning so `--update` can reprocess synchronized lyrics extracted from embedded metadata.
  * Preserved existing `.lrc` sidecars while allowing eligible tracks to be refreshed.
  * Kept `--upgrade` behavior unchanged, preventing reprocessing of settled synchronized lyrics.
  * Fixed recording duration detection during lyric updates.
  * Preserved expected behavior when embedded lyrics handling is disabled or set to respect existing files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->