### PR TITLE
chore(github): add PR templates adapted from stillwater

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,29 @@
+## Summary
+
+- What changed and why (focus on the why; 1-3 bullets).
+- Note anything reviewers should look at first.
+
+## Linked issue
+
+Closes #
+
+(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved.)
+
+## Pre-flight checklist
+
+- [ ] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
+- [ ] Code review pass complete; critical and important findings fixed before pushing.
+- [ ] Commits squashed into one clean commit before the first push.
+- [ ] Label set on `gh pr create --label ...` (`chore`, `ci`, `docker`, or `documentation`).
+- [ ] No user-visible behavior change -- if there is one, use the default PR template instead.
+
+## Test plan
+
+- [ ] `make gate` passes locally.
+- [ ] For a CI or workflow change: `actionlint` clean, Actions pinned to commit SHAs (with `# vX`),
+      `persist-credentials: false` on checkout steps, and no `paths-ignore` on a trigger that has
+      required status checks (a check that never runs stays pending forever).
+- [ ] For a tool-version bump: `make sync-tool-versions` passes (the golangci-lint pin must agree
+      across `ci.yml` and `.pre-commit-config.yaml`).
+- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
+  - [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Summary
+
+- What changed and why (focus on the why; 1-3 bullets).
+- Note any user-visible behavior change.
+- Call out anything reviewers should look at first.
+
+## Linked issue
+
+Closes #
+
+(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved. GitHub binds the keyword to the ONE number right after it -- repeat it per issue: `Closes #A, closes #B`.)
+
+## Pre-flight checklist
+
+- [ ] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
+- [ ] Code review pass complete; critical and important findings fixed before pushing.
+- [ ] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
+- [ ] Label set on `gh pr create --label ...` (no CI gate enforces this, but it keeps the tracker usable).
+- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
+- [ ] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD.
+- [ ] `make ui` re-run if any `.templ` or CSS source changed. Generated `*_templ.go` and
+      `web/static/css/output.css` are gitignored and built on demand -- do **not** commit them.
+- [ ] Migration added under `internal/db/migrations/` if this is a one-time data correction
+      (goose gives run-once and transactionality for free; do not hand-roll it in Go).
+
+## Test plan
+
+- [ ] `make gate` passes locally. It runs, in order: conflict markers, gofmt, `make ui`,
+      `go build`, `go test -race` + coverage, patch coverage (Codecov parity), coverage-floor
+      ratchet, codecov report validation, golangci-lint, actionlint, govulncheck.
+- [ ] New tests were confirmed to **fail against unfixed code** before the fix was written.
+      Tests that only ever passed are regression guards -- label them as such rather than
+      presenting them as proof the fix works.
+- [ ] Patch coverage meets the Codecov threshold (`make patch-cover`).
+- [ ] Which **surface** this change fixes is stated explicitly, and was verified by looking at
+      that surface. `/metrics` reads `provider_outcomes`; the dashboard reads `lane_attempts`.
+      Correcting one does not correct the other, and a DB-level check will not catch it.
+- [ ] Manual UAT steps (list the specific flows exercised):
+  - [ ]
+- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
+  - [ ]
+
+## Not covered
+
+What this change does **not** verify -- the layers left untested, and anything deferred to a
+follow-up issue.


### PR DESCRIPTION
## Summary

- Canticle had issue templates but no PR template, so PR bodies were hand-assembled and inconsistent (`/prep-pr` fell back to generating one each time). This adds a default PR template and a `chore` variant.
- Ported from stillwater but **reconciled against this repo, not copied**: dropped the OpenAPI and docs-label rows (neither exists here), inverted the templ row (generated `*_templ.go` and `output.css` are gitignored and built by `make ui`, never committed), softened the label row (no CI label gate here), and added canticle's own gates -- patch coverage, coverage floor, actionlint, govulncheck.
- Encodes three standing lessons from prior sessions: state which **surface** a change fixes (`/metrics` reads `provider_outcomes`, the dashboard reads `lane_attempts`), confirm new tests fail against unfixed code, and prefer a goose migration over Go for one-time data corrections.

## Linked issue

No tracking issue -- process/tooling chore. Anchor is this PR.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete; no code changes (docs-only, two new Markdown files).
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] No user-visible behavior change.

## Test plan

- [x] `make gate` passes locally (docs-only diff; full chain still run: build, race tests, patch coverage, golangci-lint, actionlint, govulncheck all green).
- [ ] For a CI or workflow change: n/a -- no workflow touched.
- [ ] For a tool-version bump: n/a.
- [ ] Reviewer follow-ups: this PR's body is written in the very template it adds -- the useful sanity check is whether that shape reads well.
