### PR TITLE
fix(deps): pin mbedtls3>=3.6.7-r0 to clear the Grype CVE batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,10 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
 # The explicit version also cache-busts the GHA BuildKit layer so the image scan
 # stops reusing a stale 8.1.1-r0 layer. Keep in sync with Dockerfile.goreleaser;
 # raise/drop the floor when the base apk index ships a newer ffmpeg by default.
-RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" su-exec tzdata && \
+# mbedtls3 floor pinned to remediate the 3.6.6-r0 CVE batch (16 low-severity
+# Alpine CVEs, fixed in 3.6.7-r0); raise/drop when the base index ships it by
+# default.
+RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" "mbedtls3>=3.6.7-r0" su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -12,7 +12,10 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
 # The explicit version also cache-busts the GHA BuildKit layer so the image scan
 # stops reusing a stale 8.1.1-r0 layer. Keep in sync with the top-level Dockerfile;
 # raise/drop the floor when the base apk index ships a newer ffmpeg by default.
-RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" su-exec tzdata && \
+# mbedtls3 floor pinned to remediate the 3.6.6-r0 CVE batch (16 low-severity
+# Alpine CVEs, fixed in 3.6.7-r0); raise/drop when the base index ships it by
+# default.
+RUN apk add --no-cache bash ca-certificates "ffmpeg>=8.1.2-r0" "mbedtls3>=3.6.7-r0" su-exec tzdata && \
     apk upgrade --no-cache && \
     { grep -q "^mxlrcgo:" /etc/group || addgroup mxlrcgo; } && \
     { id -u mxlrcgo >/dev/null 2>&1 || adduser -u 99 -G mxlrcgo -s /bin/bash -D mxlrcgo; } && \


### PR DESCRIPTION
## Summary

- Pins `mbedtls3>=3.6.7-r0` in both the dev `Dockerfile` and `build/docker/Dockerfile.goreleaser`, clearing the 16 open Grype code-scanning alerts (all `mbedtls3` 3.6.6-r0 Alpine CVEs, all severity low, all with an available fix in 3.6.7-r0).
- `mbedtls3` is a transitive dependency (the Go binary uses Go's own crypto; `mbedtls3` is pulled in by `ffmpeg`). So the fix is an image-layer floor, mirroring the existing `ffmpeg>=8.1.2-r0` pin, not a Go dependency change.
- Both Dockerfiles are updated because the release image (`Dockerfile.goreleaser`) is what actually ships; pinning only the dev image would leave the released image on 3.6.6-r0 and the CVEs would recur. The two runtime `apk add` lines are now byte-for-byte identical.
- Not dismissed: these have an upstream fix, so the correct disposition is to bump. GitHub auto-closes the 16 alerts on the next Grype scan of the rebuilt image.

## Test plan

- [x] `docker build` confirms `mbedtls3-3.6.7-r0 [installed]` in the runtime image (`apk list --installed | grep mbedtls3`).
- [x] Both `RUN apk add` lines verified structurally identical across `Dockerfile` and `Dockerfile.goreleaser`.
- [ ] The 16 code-scanning alerts (#65-#80) auto-close on the next scheduled Grype scan of the rebuilt image; verify post-merge.
