### PR TITLE
feat(dashboard): add "Up next" panel showing buffered queue work (#572)

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -354,3 +354,113 @@ func (r *Repo) FailureAnalysis(ctx context.Context) ([]FailureGroup, error) {
 	}
 	return out, nil
 }
+
+// UpNextItem is one buffered work_queue row the worker will claim next, in the
+// order it will be claimed. Priority is the raw tier value; the caller maps it
+// to a display label ("miss"/"fresh"). CreatedAt drives the "waited" column.
+type UpNextItem struct {
+	Artist string
+	Title  string
+	// Album is the row's album, empty when not recorded.
+	Album    string
+	Priority int
+	// CreatedAt is when the row entered the queue (work_queue.created_at). Zero
+	// only if the stored value is unparsable, which the schema default prevents.
+	CreatedAt time.Time
+}
+
+// UpNext returns the shuffled lookahead buffer (#571) in claim order: the rows
+// the worker will process next, ordered by batch_seq ascending, capped at limit.
+//
+// Source: work_queue rows with a non-null batch_seq. A NULL batch_seq means
+// "unbuffered" -- either the buffer was never drawn (batching disabled via
+// queue.batch_size = 0, or an idle queue) or the row was already claimed
+// (Dequeue clears batch_seq atomically at claim). The predicate mirrors the
+// batched-claim SQL exactly (status IN ('pending','failed','deferred') AND
+// next_attempt_at <= now), so this lists only rows the worker would actually
+// serve; a buffered row that has since become ineligible is skipped here just as
+// the claim would skip it. An empty result is the panel's empty-state signal.
+//
+// now is compared as an RFC3339 UTC string, matching internal/queue.formatTime;
+// the stored timestamps are lexically ordered, so a string comparison is a
+// correct time comparison (do not substitute SQLite datetime('now'), which
+// mismatches the stored 'T...Z' layout).
+func (r *Repo) UpNext(ctx context.Context, limit int) ([]UpNextItem, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	now := time.Now().UTC().Format(timeFormat)
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT artist, title, album, priority, created_at
+         FROM work_queue
+         WHERE batch_seq IS NOT NULL
+           AND status IN ('pending', 'failed', 'deferred')
+           AND next_attempt_at <= ?
+         ORDER BY batch_seq ASC
+         LIMIT ?`,
+		now, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("reports: up next: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []UpNextItem
+	for rows.Next() {
+		var (
+			it        UpNextItem
+			createdAt sql.NullString
+		)
+		if err := rows.Scan(&it.Artist, &it.Title, &it.Album, &it.Priority, &createdAt); err != nil {
+			return nil, fmt.Errorf("reports: scan up next: %w", err)
+		}
+		if createdAt.Valid && createdAt.String != "" {
+			t, err := time.Parse(timeFormat, createdAt.String)
+			if err != nil {
+				return nil, fmt.Errorf("reports: parse created_at %q: %w", createdAt.String, err)
+			}
+			it.CreatedAt = t
+		}
+		out = append(out, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reports: up next rows: %w", err)
+	}
+	return out, nil
+}
+
+// QueueEligibility partitions the not-yet-done backlog by readiness: Eligible
+// rows are claimable now, Cooldown rows are waiting out a backoff/retry delay.
+type QueueEligibility struct {
+	// Eligible counts rows the worker can claim now (status pending/failed/
+	// deferred, next_attempt_at <= now). This is the "of M eligible" header total.
+	Eligible int64
+	// Cooldown counts rows in the same statuses whose next_attempt_at is still in
+	// the future -- deferred/backoff rows not yet actionable. The empty state uses
+	// it to distinguish "nothing queued" from "everything waiting on cooldown".
+	Cooldown int64
+}
+
+// QueueEligibility returns the eligible and cooldown counts for the Up-next
+// panel header and empty state, in one query so both share a single now and
+// cannot skew against each other.
+//
+// Source: work_queue rows with status IN ('pending','failed','deferred'), split
+// on next_attempt_at <= now (see UpNext on the string-comparison contract). A
+// SUM over zero matching rows is NULL in SQLite, so each total is scanned
+// through sql.NullInt64 and defaults to 0.
+func (r *Repo) QueueEligibility(ctx context.Context) (QueueEligibility, error) {
+	now := time.Now().UTC().Format(timeFormat)
+	var eligible, cooldown sql.NullInt64
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT
+             SUM(CASE WHEN next_attempt_at <= ? THEN 1 ELSE 0 END),
+             SUM(CASE WHEN next_attempt_at >  ? THEN 1 ELSE 0 END)
+         FROM work_queue
+         WHERE status IN ('pending', 'failed', 'deferred')`,
+		now, now,
+	).Scan(&eligible, &cooldown); err != nil {
+		return QueueEligibility{}, fmt.Errorf("reports: queue eligibility: %w", err)
+	}
+	return QueueEligibility{Eligible: eligible.Int64, Cooldown: cooldown.Int64}, nil
+}

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -430,7 +430,8 @@ func (r *Repo) UpNext(ctx context.Context, limit int) ([]UpNextItem, error) {
 }
 
 // QueueEligibility partitions the not-yet-done backlog by readiness: Eligible
-// rows are claimable now, Cooldown rows are waiting out a backoff/retry delay.
+// rows are claimable now, Cooldown rows are waiting out a backoff/retry delay,
+// and Buffered is the eligible subset already stamped into the lookahead buffer.
 type QueueEligibility struct {
 	// Eligible counts rows the worker can claim now (status pending/failed/
 	// deferred, next_attempt_at <= now). This is the "of M eligible" header total.
@@ -439,28 +440,39 @@ type QueueEligibility struct {
 	// the future -- deferred/backoff rows not yet actionable. The empty state uses
 	// it to distinguish "nothing queued" from "everything waiting on cooldown".
 	Cooldown int64
+	// Buffered counts the eligible rows currently stamped into the lookahead
+	// buffer (batch_seq IS NOT NULL) -- the TRUE size of the buffer, independent
+	// of any display cap on UpNext. The header uses this so a capped UpNext page
+	// never misreports the buffered count (#572 CR).
+	Buffered int64
 }
 
-// QueueEligibility returns the eligible and cooldown counts for the Up-next
-// panel header and empty state, in one query so both share a single now and
-// cannot skew against each other.
+// QueueEligibility returns the eligible, cooldown, and buffered counts for the
+// Up-next panel header and empty state, in one query so all three share a single
+// now and cannot skew against each other.
 //
 // Source: work_queue rows with status IN ('pending','failed','deferred'), split
-// on next_attempt_at <= now (see UpNext on the string-comparison contract). A
-// SUM over zero matching rows is NULL in SQLite, so each total is scanned
-// through sql.NullInt64 and defaults to 0.
+// on next_attempt_at <= now (see UpNext on the string-comparison contract); the
+// buffered tally additionally requires batch_seq IS NOT NULL, matching UpNext's
+// predicate exactly. A SUM over zero matching rows is NULL in SQLite, so each
+// total is scanned through sql.NullInt64 and defaults to 0.
 func (r *Repo) QueueEligibility(ctx context.Context) (QueueEligibility, error) {
 	now := time.Now().UTC().Format(timeFormat)
-	var eligible, cooldown sql.NullInt64
+	var eligible, cooldown, buffered sql.NullInt64
 	if err := r.db.QueryRowContext(ctx,
 		`SELECT
              SUM(CASE WHEN next_attempt_at <= ? THEN 1 ELSE 0 END),
-             SUM(CASE WHEN next_attempt_at >  ? THEN 1 ELSE 0 END)
+             SUM(CASE WHEN next_attempt_at >  ? THEN 1 ELSE 0 END),
+             SUM(CASE WHEN batch_seq IS NOT NULL AND next_attempt_at <= ? THEN 1 ELSE 0 END)
          FROM work_queue
          WHERE status IN ('pending', 'failed', 'deferred')`,
-		now, now,
-	).Scan(&eligible, &cooldown); err != nil {
+		now, now, now,
+	).Scan(&eligible, &cooldown, &buffered); err != nil {
 		return QueueEligibility{}, fmt.Errorf("reports: queue eligibility: %w", err)
 	}
-	return QueueEligibility{Eligible: eligible.Int64, Cooldown: cooldown.Int64}, nil
+	return QueueEligibility{
+		Eligible: eligible.Int64,
+		Cooldown: cooldown.Int64,
+		Buffered: buffered.Int64,
+	}, nil
 }

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -37,6 +37,13 @@ type workItem struct {
 	instrumentalResult any // int or nil
 	detectInstrumental any // int or nil
 	outcomeType        any // string ("synced"|"unsynced"|"instrumental") or nil
+	// Buffered-panel columns (#572). These are applied as a post-insert UPDATE
+	// only when non-zero/non-empty, so existing callers keep the schema defaults
+	// (priority 0, batch_seq NULL, next_attempt_at 1970 = eligible, created_at now).
+	priority      int    // 0 => default (PriorityScan); negative => miss tier
+	batchSeq      int    // 0 => NULL (unbuffered); >0 => buffered at this seq
+	nextAttemptAt string // "" => default (eligible); else RFC3339 (future => cooldown)
+	createdAt     string // "" => default (now); else RFC3339
 }
 
 func insertWorkItem(t *testing.T, sqlDB *sql.DB, w workItem) int64 {
@@ -58,7 +65,26 @@ func insertWorkItem(t *testing.T, sqlDB *sql.DB, w workItem) int64 {
 	if err != nil {
 		t.Fatalf("last insert id: %v", err)
 	}
+	setWorkItemColumn(t, sqlDB, id, "priority", w.priority != 0, w.priority)
+	setWorkItemColumn(t, sqlDB, id, "batch_seq", w.batchSeq != 0, w.batchSeq)
+	setWorkItemColumn(t, sqlDB, id, "next_attempt_at", w.nextAttemptAt != "", w.nextAttemptAt)
+	setWorkItemColumn(t, sqlDB, id, "created_at", w.createdAt != "", w.createdAt)
 	return id
+}
+
+// setWorkItemColumn updates one work_queue column on row id when set is true.
+// It keeps the base INSERT untouched for the NOT-NULL columns (priority,
+// next_attempt_at, created_at) so unset fields fall through to their schema
+// defaults instead of a NULL that would violate the constraint.
+func setWorkItemColumn(t *testing.T, sqlDB *sql.DB, id int64, col string, set bool, val any) {
+	t.Helper()
+	if !set {
+		return
+	}
+	if _, err := sqlDB.ExecContext(context.Background(),
+		"UPDATE work_queue SET "+col+" = ? WHERE id = ?", val, id); err != nil {
+		t.Fatalf("set work_queue.%s: %v", col, err)
+	}
 }
 
 func insertLibrary(t *testing.T, sqlDB *sql.DB) int64 {
@@ -497,6 +523,12 @@ func TestQueryErrorsSurface(t *testing.T) {
 	if _, err := repo.CountInstrumental(ctx); err == nil {
 		t.Error("CountInstrumental on closed DB: want error")
 	}
+	if _, err := repo.UpNext(ctx, 5); err == nil {
+		t.Error("UpNext on closed DB: want error")
+	}
+	if _, err := repo.QueueEligibility(ctx); err == nil {
+		t.Error("QueueEligibility on closed DB: want error")
+	}
 }
 
 // TestCountInstrumental verifies CountInstrumental counts every row whose
@@ -555,4 +587,120 @@ func mustParse(t *testing.T, s string) time.Time {
 		t.Fatalf("parse time %q: %v", s, err)
 	}
 	return parsed
+}
+
+// TestUpNext verifies the buffered list is returned in batch_seq order and that
+// only eligible buffered rows appear (non-buffered, done, and future-cooldown
+// rows are excluded), matching the batched-claim predicate. Synthetic fixtures.
+func TestUpNext(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// Buffered rows stamped out of insertion order to prove ordering is by
+	// batch_seq, not id. Priorities span the miss/scan tiers.
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist 3", title: "Track Gamma", status: "pending", batchSeq: 3, priority: 0})
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist 1", title: "Track Alpha", album: "Album One", status: "failed", batchSeq: 1, priority: -100})
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist 2", title: "Track Beta", status: "deferred", batchSeq: 2, priority: 0})
+
+	// Excluded: not buffered (batch_seq NULL).
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist U", title: "Unbuffered", status: "pending"})
+	// Excluded: buffered but already done (fails the status predicate).
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist D", title: "Done", status: "done", batchSeq: 4})
+	// Excluded: buffered and pending but on cooldown (next_attempt_at in future).
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist C", title: "Cooldown", status: "deferred", batchSeq: 5, nextAttemptAt: "3000-01-01T00:00:00Z"})
+
+	got, err := repo.UpNext(ctx, 10)
+	if err != nil {
+		t.Fatalf("UpNext: %v", err)
+	}
+	wantTitles := []string{"Track Alpha", "Track Beta", "Track Gamma"}
+	if len(got) != len(wantTitles) {
+		t.Fatalf("UpNext returned %d rows, want %d: %+v", len(got), len(wantTitles), got)
+	}
+	for i, want := range wantTitles {
+		if got[i].Title != want {
+			t.Errorf("row %d: title = %q, want %q (order must be by batch_seq)", i, got[i].Title, want)
+		}
+	}
+	// Album passes through for its own column.
+	if got[0].Album != "Album One" {
+		t.Errorf("row 0 album = %q, want %q", got[0].Album, "Album One")
+	}
+	// Priority passes through raw for the handler's tier mapping.
+	if got[0].Priority != -100 {
+		t.Errorf("row 0 priority = %d, want -100 (miss tier)", got[0].Priority)
+	}
+	if got[1].Priority != 0 {
+		t.Errorf("row 1 priority = %d, want 0 (scan tier)", got[1].Priority)
+	}
+	if got[0].CreatedAt.IsZero() {
+		t.Error("row 0 CreatedAt is zero; want the schema-default timestamp parsed")
+	}
+}
+
+// TestUpNextLimit checks the limit guard and cap.
+func TestUpNextLimit(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	for i := 1; i <= 4; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "t" + string(rune('a'+i)), status: "pending", batchSeq: i})
+	}
+	if got, err := repo.UpNext(ctx, 0); err != nil || got != nil {
+		t.Errorf("UpNext(limit=0) = (%v, %v), want (nil, nil)", got, err)
+	}
+	got, err := repo.UpNext(ctx, 2)
+	if err != nil {
+		t.Fatalf("UpNext(limit=2): %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("UpNext(limit=2) returned %d rows, want 2", len(got))
+	}
+}
+
+// TestQueueEligibility checks the eligible/cooldown split and the exclusion of
+// done/processing rows, all sharing one now so the two counts cannot skew.
+func TestQueueEligibility(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// Eligible: pending, failed, deferred with a past (default) next_attempt_at.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-pending", status: "pending"})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-failed", status: "failed"})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-deferred", status: "deferred"})
+	// Cooldown: same statuses but next_attempt_at in the future.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-deferred", status: "deferred", nextAttemptAt: "3000-01-01T00:00:00Z"})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-failed", status: "failed", nextAttemptAt: "3000-01-01T00:00:00Z"})
+	// Excluded from both: done and processing are not part of the backlog.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "done", status: "done"})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "proc", status: "processing"})
+
+	got, err := repo.QueueEligibility(ctx)
+	if err != nil {
+		t.Fatalf("QueueEligibility: %v", err)
+	}
+	if got.Eligible != 3 {
+		t.Errorf("Eligible = %d, want 3", got.Eligible)
+	}
+	if got.Cooldown != 2 {
+		t.Errorf("Cooldown = %d, want 2", got.Cooldown)
+	}
+}
+
+// TestQueueEligibilityEmpty confirms the SUM-over-no-rows NULL collapses to 0.
+func TestQueueEligibilityEmpty(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	got, err := repo.QueueEligibility(ctx)
+	if err != nil {
+		t.Fatalf("QueueEligibility: %v", err)
+	}
+	if got.Eligible != 0 || got.Cooldown != 0 {
+		t.Errorf("empty queue = %+v, want {0 0}", got)
+	}
 }

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -668,11 +668,13 @@ func TestQueueEligibility(t *testing.T) {
 	repo := reports.New(sqlDB)
 
 	// Eligible: pending, failed, deferred with a past (default) next_attempt_at.
-	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-pending", status: "pending"})
-	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-failed", status: "failed"})
+	// Two of them are buffered (batch_seq set) -> Buffered counts exactly those.
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-pending", status: "pending", batchSeq: 1})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-failed", status: "failed", batchSeq: 2})
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-deferred", status: "deferred"})
-	// Cooldown: same statuses but next_attempt_at in the future.
-	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-deferred", status: "deferred", nextAttemptAt: "3000-01-01T00:00:00Z"})
+	// Cooldown: same statuses but next_attempt_at in the future. One carries a
+	// batch_seq, which must NOT count as Buffered (it is not eligible now).
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-deferred", status: "deferred", nextAttemptAt: "3000-01-01T00:00:00Z", batchSeq: 3})
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-failed", status: "failed", nextAttemptAt: "3000-01-01T00:00:00Z"})
 	// Excluded from both: done and processing are not part of the backlog.
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "done", status: "done"})
@@ -687,6 +689,11 @@ func TestQueueEligibility(t *testing.T) {
 	}
 	if got.Cooldown != 2 {
 		t.Errorf("Cooldown = %d, want 2", got.Cooldown)
+	}
+	// Buffered = the two eligible rows with a batch_seq; the buffered cooldown
+	// row is excluded because it is not eligible now.
+	if got.Buffered != 2 {
+		t.Errorf("Buffered = %d, want 2 (buffered cooldown row must not count)", got.Buffered)
 	}
 }
 

--- a/internal/web/dashboard.go
+++ b/internal/web/dashboard.go
@@ -17,6 +17,13 @@ import (
 // Kept lower than the canned report (50) to keep the page scannable.
 const dashboardRecentLimit = 20
 
+// dashboardUpNextLimit caps the "Up next" panel (#572). The lookahead buffer is
+// DB-bounded by queue.batch_size (default 10), so a cap comfortably above any
+// realistic batch size means the panel shows the whole buffer and the "N
+// buffered" header equals the rendered row count. An operator running a larger
+// batch_size sees the first N; the buffer never lists more than batch_size rows.
+const dashboardUpNextLimit = 50
+
 // handleDashboard renders the read-only observability dashboard. It is gated
 // by the same auth guard as the other UI routes and is never cached (it exposes
 // queue state and config detail). When the reports repo is not wired (no DB
@@ -81,7 +88,96 @@ func (u *UI) buildDashboardView(r *http.Request) (templates.DashboardView, error
 	}
 	view.RecentRows = buildRecentRows(recent, serverLoc)
 
+	upNext, err := u.reports.UpNext(ctx, dashboardUpNextLimit)
+	if err != nil {
+		return templates.DashboardView{}, fmt.Errorf("dashboard: up next: %w", err)
+	}
+	elig, err := u.reports.QueueEligibility(ctx)
+	if err != nil {
+		return templates.DashboardView{}, fmt.Errorf("dashboard: queue eligibility: %w", err)
+	}
+	view.UpNextRows = buildUpNextRows(upNext, time.Now())
+	view.UpNextHeader = fmt.Sprintf("%d buffered of %s eligible",
+		len(view.UpNextRows), groupThousands(elig.Eligible))
+	view.UpNextEmpty = fmt.Sprintf("Nothing buffered. %s eligible, %s waiting on cooldown.",
+		groupThousands(elig.Eligible), groupThousands(elig.Cooldown))
+
 	return view, nil
+}
+
+// buildUpNextRows shapes buffered work items into ordered panel rows (#572),
+// carrying artist/title/album as distinct columns, mapping the priority tier to
+// a label, and rendering the compact "waited" age from created_at against now.
+func buildUpNextRows(items []reports.UpNextItem, now time.Time) []templates.UpNextRow {
+	rows := make([]templates.UpNextRow, 0, len(items))
+	for i, it := range items {
+		rows = append(rows, templates.UpNextRow{
+			Position: strconv.Itoa(i + 1),
+			Artist:   it.Artist,
+			Title:    it.Title,
+			Album:    it.Album,
+			Tier:     tierLabel(it.Priority),
+			Waited:   formatWaited(it.CreatedAt, now),
+		})
+	}
+	return rows
+}
+
+// groupThousands formats n with comma thousands separators (e.g. 10102 ->
+// "10,102"), keeping the large eligible/cooldown counts readable in the panel
+// header and empty state. Negative values keep the sign.
+func groupThousands(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	neg := ""
+	if n < 0 {
+		neg, s = "-", s[1:]
+	}
+	if len(s) <= 3 {
+		return neg + s
+	}
+	// Insert a comma every three digits from the right.
+	var b []byte
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b = append(b, ',')
+		}
+		b = append(b, c)
+	}
+	return neg + string(b)
+}
+
+// tierLabel maps a raw work_queue.priority to the panel's tier label. Negative
+// priorities are the deferred benign-miss tier (queue.PriorityMiss = -100);
+// everything at or above the scan baseline (0) reads as "fresh". Kept in the
+// handler so relabeling never touches the query or template.
+func tierLabel(priority int) string {
+	if priority < 0 {
+		return "miss"
+	}
+	return "fresh"
+}
+
+// formatWaited renders how long an item has waited as one dominant unit (s, m,
+// h, d), matching the compact mock ("2m", "6d"). A zero timestamp or a
+// non-positive span renders "0s" so the column is never blank or negative.
+func formatWaited(since, now time.Time) string {
+	if since.IsZero() {
+		return "0s"
+	}
+	d := now.Sub(since)
+	switch {
+	case d < time.Minute:
+		if d < 0 {
+			d = 0
+		}
+		return strconv.Itoa(int(d/time.Second)) + "s"
+	case d < time.Hour:
+		return strconv.Itoa(int(d/time.Minute)) + "m"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d/time.Hour)) + "h"
+	default:
+		return strconv.Itoa(int(d/(24*time.Hour))) + "d"
+	}
 }
 
 // buildQueueTiles shapes a QueueSummary into the dashboard's queue stat tiles.

--- a/internal/web/dashboard.go
+++ b/internal/web/dashboard.go
@@ -97,8 +97,11 @@ func (u *UI) buildDashboardView(r *http.Request) (templates.DashboardView, error
 		return templates.DashboardView{}, fmt.Errorf("dashboard: queue eligibility: %w", err)
 	}
 	view.UpNextRows = buildUpNextRows(upNext, time.Now())
+	// Header count is the TRUE buffered total from the DB, not len(rows): the
+	// displayed list is capped at dashboardUpNextLimit, so a larger buffer
+	// (queue.batch_size > cap) must still report its real size (#572 CR).
 	view.UpNextHeader = fmt.Sprintf("%d buffered of %s eligible",
-		len(view.UpNextRows), groupThousands(elig.Eligible))
+		elig.Buffered, groupThousands(elig.Eligible))
 	view.UpNextEmpty = fmt.Sprintf("Nothing buffered. %s eligible, %s waiting on cooldown.",
 		groupThousands(elig.Eligible), groupThousands(elig.Cooldown))
 

--- a/internal/web/dashboard_upnext_test.go
+++ b/internal/web/dashboard_upnext_test.go
@@ -1,0 +1,210 @@
+package web
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/reports"
+)
+
+func TestTierLabel(t *testing.T) {
+	// PriorityMiss=-100 -> miss; PriorityScan=0 and PriorityWebhook=10 -> fresh.
+	tests := []struct {
+		priority int
+		want     string
+	}{
+		{-100, "miss"},
+		{-1, "miss"},
+		{0, "fresh"},
+		{10, "fresh"},
+	}
+	for _, tc := range tests {
+		if got := tierLabel(tc.priority); got != tc.want {
+			t.Errorf("tierLabel(%d) = %q, want %q", tc.priority, got, tc.want)
+		}
+	}
+}
+
+func TestFormatWaited(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		since time.Time
+		want  string
+	}{
+		{"zero", time.Time{}, "0s"},
+		{"future clamps to 0s", now.Add(time.Hour), "0s"},
+		{"seconds", now.Add(-30 * time.Second), "30s"},
+		{"minutes", now.Add(-2 * time.Minute), "2m"},
+		{"hours", now.Add(-5 * time.Hour), "5h"},
+		{"days", now.Add(-6 * 24 * time.Hour), "6d"},
+		{"just under a day is hours", now.Add(-23 * time.Hour), "23h"},
+	}
+	for _, tc := range tests {
+		if got := formatWaited(tc.since, now); got != tc.want {
+			t.Errorf("%s: formatWaited = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestGroupThousands(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{999, "999"},
+		{1000, "1,000"},
+		{10102, "10,102"},
+		{1234567, "1,234,567"},
+		{-15556, "-15,556"},
+	}
+	for _, tc := range tests {
+		if got := groupThousands(tc.n); got != tc.want {
+			t.Errorf("groupThousands(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestBuildUpNextRows(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	items := []reports.UpNextItem{
+		{Artist: "Test Artist 1", Title: "Track Alpha", Album: "Album One", Priority: -100, CreatedAt: now.Add(-6 * 24 * time.Hour)},
+		{Artist: "Test Artist 2", Title: "Track Beta", Priority: 0, CreatedAt: now.Add(-2 * time.Minute)},
+	}
+	rows := buildUpNextRows(items, now)
+	if len(rows) != 2 {
+		t.Fatalf("buildUpNextRows returned %d rows, want 2", len(rows))
+	}
+	if rows[0].Position != "1" || rows[1].Position != "2" {
+		t.Errorf("positions = %q, %q; want 1, 2", rows[0].Position, rows[1].Position)
+	}
+	if rows[0].Artist != "Test Artist 1" || rows[0].Title != "Track Alpha" || rows[0].Album != "Album One" {
+		t.Errorf("row 0 identity = %q/%q/%q; want Test Artist 1/Track Alpha/Album One", rows[0].Artist, rows[0].Title, rows[0].Album)
+	}
+	if rows[0].Tier != "miss" || rows[1].Tier != "fresh" {
+		t.Errorf("tiers = %q, %q; want miss, fresh", rows[0].Tier, rows[1].Tier)
+	}
+	if rows[0].Waited != "6d" || rows[1].Waited != "2m" {
+		t.Errorf("waited = %q, %q; want 6d, 2m", rows[0].Waited, rows[1].Waited)
+	}
+}
+
+// insertBuffered seeds one buffered work_queue row (batch_seq set) with synthetic
+// identity, for the Up-next panel handler test. Synthetic values only (#572 AC).
+func insertBuffered(t *testing.T, sqlDB *sql.DB, artist, title, album, status string, priority, batchSeq int) {
+	t.Helper()
+	var seq any // NULL (unbuffered) when batchSeq <= 0; the draw stamps 1..N.
+	if batchSeq > 0 {
+		seq = batchSeq
+	}
+	_, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO work_queue
+            (artist, title, artist_key, title_key, album, status, last_error,
+             priority, batch_seq)
+         VALUES (?, ?, ?, ?, ?, ?, '', ?, ?)`,
+		artist, title, artist, title, album, status, priority, seq)
+	if err != nil {
+		t.Fatalf("insert buffered work_queue: %v", err)
+	}
+}
+
+// TestHandleDashboard_UpNextPanel verifies the panel renders buffered rows in
+// batch_seq order, placed between Lyrics Sources and Recent Outcomes.
+func TestHandleDashboard_UpNextPanel(t *testing.T) {
+	sqlDB := openReportsTestDB(t)
+	// Stamped out of insertion order to prove ordering is by batch_seq.
+	insertBuffered(t, sqlDB, "Test Artist 3", "Track Gamma", "Album Three", "pending", 0, 3)
+	insertBuffered(t, sqlDB, "Test Artist 1", "Track Alpha", "Album One", "failed", -100, 1)
+	insertBuffered(t, sqlDB, "Test Artist 2", "Track Beta", "Album Two", "deferred", 0, 2)
+
+	mux := newReportsUIServer(t, sqlDB)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /dashboard status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "Up Next") {
+		t.Error("dashboard missing Up Next heading")
+	}
+	if !strings.Contains(body, "3 buffered of 3 eligible") {
+		t.Errorf("dashboard missing buffered/eligible header; body has: %s", excerptAround(body, "buffered"))
+	}
+	// Rows appear in batch_seq order: Alpha (1) < Beta (2) < Gamma (3).
+	iAlpha := strings.Index(body, "Track Alpha")
+	iBeta := strings.Index(body, "Track Beta")
+	iGamma := strings.Index(body, "Track Gamma")
+	if iAlpha < 0 || iBeta < 0 || iGamma < 0 {
+		t.Fatalf("missing a buffered track: alpha=%d beta=%d gamma=%d", iAlpha, iBeta, iGamma)
+	}
+	if iAlpha >= iBeta || iBeta >= iGamma {
+		t.Errorf("rows out of batch_seq order: alpha=%d beta=%d gamma=%d", iAlpha, iBeta, iGamma)
+	}
+	// Album renders in its own column.
+	if !strings.Contains(body, "Album One") {
+		t.Error("dashboard Up-next panel missing album value")
+	}
+	for _, h := range []string{">Artist<", ">Title<", ">Album<"} {
+		if !strings.Contains(body, h) {
+			t.Errorf("Up-next table missing distinct column header %q", h)
+		}
+	}
+	// Panel is placed between Lyrics Sources and Recent Outcomes.
+	iSources := strings.Index(body, "Lyrics Sources")
+	iUpNext := strings.Index(body, "Up Next")
+	iRecent := strings.Index(body, "Recent Outcomes")
+	if iSources >= iUpNext || iUpNext >= iRecent {
+		t.Errorf("Up Next misplaced: sources=%d upnext=%d recent=%d", iSources, iUpNext, iRecent)
+	}
+	// The miss-tier badge renders for the deferred benign-miss row.
+	if !strings.Contains(body, "mx-upnext-tier-miss") {
+		t.Error("dashboard missing miss-tier badge class")
+	}
+}
+
+// TestHandleDashboard_UpNextEmpty verifies the empty state shows counts with no
+// ordering claim when nothing is buffered.
+func TestHandleDashboard_UpNextEmpty(t *testing.T) {
+	sqlDB := openReportsTestDB(t)
+	// An unbuffered pending row: eligible, but not in the lookahead buffer.
+	insertBuffered(t, sqlDB, "Test Artist U", "Unbuffered", "Album U", "pending", 0, 0)
+
+	mux := newReportsUIServer(t, sqlDB)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Up Next") {
+		t.Error("dashboard missing Up Next heading in empty state")
+	}
+	if !strings.Contains(body, "Nothing buffered.") {
+		t.Errorf("empty state missing counts-only line; got: %s", excerptAround(body, "Up Next"))
+	}
+	// No ordered table when the buffer is empty.
+	if strings.Contains(body, `aria-label="Upcoming queue work"`) {
+		t.Error("empty state must not render the ordered table")
+	}
+}
+
+// excerptAround returns a short slice of s around the first occurrence of marker,
+// for readable test failure messages.
+func excerptAround(s, marker string) string {
+	i := strings.Index(s, marker)
+	if i < 0 {
+		return "(marker not found)"
+	}
+	start := max(i-40, 0)
+	end := min(i+80, len(s))
+	return s[start:end]
+}

--- a/internal/web/dashboard_upnext_test.go
+++ b/internal/web/dashboard_upnext_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -169,6 +170,33 @@ func TestHandleDashboard_UpNextPanel(t *testing.T) {
 	// The miss-tier badge renders for the deferred benign-miss row.
 	if !strings.Contains(body, "mx-upnext-tier-miss") {
 		t.Error("dashboard missing miss-tier badge class")
+	}
+}
+
+// TestHandleDashboard_UpNextCappedCount verifies the header reports the TRUE
+// buffered count even when the buffer exceeds the display cap
+// (dashboardUpNextLimit): the count comes from the DB, not the capped row slice
+// (#572 CR). Discriminates: a len(rows)-based header would read "50 buffered".
+func TestHandleDashboard_UpNextCappedCount(t *testing.T) {
+	sqlDB := openReportsTestDB(t)
+	total := dashboardUpNextLimit + 1 // one past the display cap
+	for i := 1; i <= total; i++ {
+		insertBuffered(t, sqlDB, "Test Artist", "Track "+strconv.Itoa(i), "Album", "pending", 0, i)
+	}
+
+	mux := newReportsUIServer(t, sqlDB)
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	want := strconv.Itoa(total) + " buffered of " + strconv.Itoa(total) + " eligible"
+	if !strings.Contains(body, want) {
+		t.Errorf("header must report true buffered count %q; got: %s", want, excerptAround(body, "buffered of"))
+	}
+	// The displayed table is still capped at the display limit.
+	if n := strings.Count(body, `class="mx-cell-mono mx-upnext-pos"`); n != dashboardUpNextLimit {
+		t.Errorf("displayed rows = %d, want %d (display cap)", n, dashboardUpNextLimit)
 	}
 }
 

--- a/web/static/css/dashboard.css
+++ b/web/static/css/dashboard.css
@@ -157,6 +157,46 @@
   height: 100%;
 }
 
+/* -- Up next panel (#572) -------------------------------------------------- */
+/* The panel reuses .mx-table / .mx-table-wrap / .mx-cell-mono from the shared
+ * stylesheet; only the tier badge and the narrow numeric columns are panel
+ * specific. All colors reference --mx-* tokens so a token swap propagates. */
+
+/* Narrow, right-aligned numeric columns keep the position and waited values
+ * compact so the Artist - Title column takes the remaining width. */
+.mx-upnext-pos,
+.mx-upnext-waited {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+}
+
+/* Tier badge: a small pill echoing the queue chart's semantic hues. "fresh"
+ * uses the blue accent (new scan/webhook work); "miss" uses the amber deferred
+ * hue muted, matching --mx-chart-deferred, so a long run of misses reads as the
+ * rate-limited backlog it is. */
+.mx-upnext-tier {
+  display: inline-block;
+  font-family: var(--mx-font-sans);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--mx-radius-sm);
+  border: 1px solid var(--mx-surface-border);
+}
+
+.mx-upnext-tier-fresh {
+  color: var(--mx-accent);
+  background: var(--mx-accent-glow);
+}
+
+.mx-upnext-tier-miss {
+  color: var(--mx-chart-deferred); /* amber: the rate-limited/deferred hue */
+  background: rgba(245, 158, 11, 0.12); /* amber-500 @ 12%; no alpha token exists */
+}
+
 /* -- Metrics footer note --------------------------------------------------- */
 .mx-dash-metrics-note {
   font-size: 0.8125rem;

--- a/web/templates/dashboard.templ
+++ b/web/templates/dashboard.templ
@@ -30,6 +30,7 @@ templ dashboardContent(view DashboardView) {
 		</div>
 		@dashQueueTiles(view.QueueTiles, view.InstrumentalCount, view.QueueChart)
 		@dashProviderTiles(view.ProviderTiles)
+		@dashUpNext(view.UpNextRows, view.UpNextHeader, view.UpNextEmpty)
 		@dashRecentOutcomes(view.RecentRows)
 		<p class="mx-dash-metrics-note">
 			Prometheus metrics:
@@ -227,6 +228,63 @@ templ dashRecentOutcomes(rows []RecentOutcomeRow) {
 			</div>
 		}
 	</section>
+}
+
+// dashUpNext renders the "Up next" panel (#572): the buffered work the worker
+// will claim next, in claim order. When the lookahead buffer is empty (an idle
+// queue, or batching disabled via queue.batch_size = 0) it shows the eligible/
+// cooldown counts only, with no ordered list and no ordering claim -- the empty
+// value carries that pre-formatted line. Reuses the mx-table styling from
+// dashRecentOutcomes so the two tables read as one system.
+templ dashUpNext(rows []UpNextRow, header, empty string) {
+	<section
+		class="mx-dash-section"
+		aria-labelledby="mx-dash-upnext-heading"
+		title="Buffered upcoming work in the order the background worker will claim it. Composed once per batch; refresh to update."
+	>
+		<h2 class="mx-dash-section-title" id="mx-dash-upnext-heading">Up Next</h2>
+		if len(rows) == 0 {
+			<p class="mx-dash-empty">{ empty }</p>
+		} else {
+			<p class="mx-dash-section-sub">{ header }</p>
+			<div class="mx-table-wrap">
+				<table class="mx-table" aria-label="Upcoming queue work">
+					<thead>
+						<tr>
+							<th class="mx-upnext-pos">#</th>
+							<th>Artist</th>
+							<th>Title</th>
+							<th>Album</th>
+							<th>Tier</th>
+							<th class="mx-upnext-waited">Waited</th>
+						</tr>
+					</thead>
+					<tbody>
+						for _, row := range rows {
+							<tr>
+								<td class="mx-cell-mono mx-upnext-pos">{ row.Position }</td>
+								<td>{ row.Artist }</td>
+								<td>{ row.Title }</td>
+								<td>{ row.Album }</td>
+								<td><span class={ dashUpNextTierClass(row.Tier) }>{ row.Tier }</span></td>
+								<td class="mx-cell-mono mx-upnext-waited">{ row.Waited }</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		}
+	</section>
+}
+
+// dashUpNextTierClass returns the badge classes for an Up-next tier label. The
+// miss tier (deferred benign-miss backlog) gets a muted variant so a long run of
+// misses is visually distinct from fresh scan/webhook work at a glance.
+func dashUpNextTierClass(tier string) string {
+	if tier == "miss" {
+		return "mx-upnext-tier mx-upnext-tier-miss"
+	}
+	return "mx-upnext-tier mx-upnext-tier-fresh"
 }
 
 // dashQueueTileTooltip returns the hover description for a queue-status tile.

--- a/web/templates/dashboard.templ
+++ b/web/templates/dashboard.templ
@@ -240,7 +240,7 @@ templ dashUpNext(rows []UpNextRow, header, empty string) {
 	<section
 		class="mx-dash-section"
 		aria-labelledby="mx-dash-upnext-heading"
-		title="Buffered upcoming work in the order the background worker will claim it. Composed once per batch; refresh to update."
+		title={ dashUpNextTitle(len(rows) == 0) }
 	>
 		<h2 class="mx-dash-section-title" id="mx-dash-upnext-heading">Up Next</h2>
 		if len(rows) == 0 {
@@ -275,6 +275,16 @@ templ dashUpNext(rows []UpNextRow, header, empty string) {
 			</div>
 		}
 	</section>
+}
+
+// dashUpNextTitle returns the section tooltip. Only the populated panel asserts
+// claim ORDER; the empty state has no ordered list, so it must not imply one
+// (#572 CR).
+func dashUpNextTitle(empty bool) string {
+	if empty {
+		return "Buffered upcoming work. Nothing is buffered right now; showing the eligible and cooldown counts. Refresh to update."
+	}
+	return "Buffered upcoming work in the order the background worker will claim it. Composed once per batch; refresh to update."
 }
 
 // dashUpNextTierClass returns the badge classes for an Up-next tier label. The

--- a/web/templates/dashboard_view.go
+++ b/web/templates/dashboard_view.go
@@ -22,8 +22,35 @@ type DashboardView struct {
 	// RecentRows holds the most recently completed tracks (newest first, capped at 20).
 	// Uses the shared RecentOutcomeRow type from reports_view.go.
 	RecentRows []RecentOutcomeRow
+	// UpNextRows holds the buffered upcoming work in worker-claim order (#572).
+	// Empty when the lookahead buffer is empty or batching is disabled, which
+	// drives the panel's counts-only empty state.
+	UpNextRows []UpNextRow
+	// UpNextHeader is the pre-formatted "N buffered of M eligible" line shown
+	// above the table when rows are present. UpNextEmpty is the counts-only line
+	// (eligible + cooldown, no ordering claim) shown when UpNextRows is empty.
+	// The template picks one by branching on len(UpNextRows); all formatting
+	// (including thousands grouping) is done in the handler.
+	UpNextHeader string
+	UpNextEmpty  string
 	// AsOf is the formatted timestamp of this render, for the "as of" annotation.
 	AsOf string
+}
+
+// UpNextRow is one buffered work item in the dashboard "Up next" panel (#572).
+// Every field is pre-formatted by the handler; the template only renders strings.
+type UpNextRow struct {
+	// Position is the 1-based rank in claim order (the buffer sequence), as a
+	// pre-formatted string.
+	Position string
+	// Artist, Title, and Album are the track identity, each in its own column.
+	Artist string
+	Title  string
+	Album  string
+	// Tier is the priority-tier label ("miss" or "fresh").
+	Tier string
+	// Waited is the compact single-unit age of the item (e.g. "2m", "6d").
+	Waited string
 }
 
 // ChartData is the label/value series for one dashboard chart (#318). The


### PR DESCRIPTION
## Summary

- Adds an "Up next" dashboard panel that surfaces the shuffled lookahead buffer (#571) between Lyrics Sources and Recent Outcomes, showing the work items in the exact order the worker will claim them (position, artist, title, album, priority tier, time waited).
- Two new read-only `reports.Repo` methods back it: `UpNext` (buffered rows ordered by `batch_seq`, filtered to the *same* eligibility predicate the batched claim uses, so the panel never lists a row the worker would skip) and `QueueEligibility` (eligible + cooldown counts in one query sharing a single `now`, feeding the header total and the empty state).
- User-visible: a new server-rendered panel. Empty state (buffer empty, or `queue.batch_size = 0`) shows eligible/cooldown counts with **no** ordering claim. No new migration -- `batch_seq` shipped in #571.
- Reviewers look first at: the `UpNext` predicate vs `dequeueBatchedClaimSQL` in `internal/queue/queue.go` (they must match), and the RFC3339-UTC string comparison for `next_attempt_at <= now`.

## Linked issue

Closes #572

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`) via `/prep-pr`.
- [x] Code review pass complete; adversarial pre-push review found no critical/important issues (mutation-verified the tests discriminate).
- [x] Single clean commit before first push.
- [x] Label set (`enhancement`).
- [ ] UAT performed for user-visible changes -- verified via the live rendered page (real handler + real templ/CSS in a browser: computed styles, WCAG-AA contrast, section order, populated + empty states) rather than a full serve-mode run. Full end-to-end serve UAT left for the maintainer.
- [ ] Screenshot attached -- live render verified at branch HEAD; screenshots shared in the working session (CLI cannot attach an image to the PR body). Fixtures/screenshots use synthetic values only.
- [x] `make ui` re-run (the gate runs `templ generate` + Tailwind); generated `*_templ.go` stays gitignored.
- [x] No migration needed -- `batch_seq` / `queue.batch_size` already landed in #571.

## Test plan

- [x] `make gate` passes locally (conflict markers, gofmt, `make ui`, build, `-race` + coverage, patch coverage, coverage-floor, codecov dry-run, golangci-lint, actionlint, govulncheck).
- [x] New tests confirmed to **fail against unfixed code**: dropping `ORDER BY batch_seq` from `UpNext` fails `TestUpNext` (rows stamped 3,1,2 must return Alpha/Beta/Gamma); the empty-state test caught a real NULL-vs-0 buffering bug during development.
- [x] Patch coverage meets threshold: 87.29% (reports 83.0%, dashboard 90.8%; threshold 70%).
- [x] Surface stated explicitly: this fixes the **dashboard page** (server-rendered), reading `reports.UpNext`/`QueueEligibility` over `work_queue`. Verified by looking at that rendered surface, not just the DB.
- [ ] Manual UAT steps (flows exercised):
  - [x] Populated panel: 4 buffered rows in `batch_seq` order, `# / Artist / Title / Album / Tier / Waited` columns, MISS/FRESH badges, "N buffered of M eligible" header.
  - [x] Empty state: heading + counts-only line, no table, no ordering claim.
  - [x] Computed styles: tier-badge contrast 8.77:1 (miss) / 5.12:1 (fresh); `--mx-*` tokens resolve.
- [ ] Reviewer follow-ups:
  - [x] `dashboardUpNextLimit = 50` caps the displayed buffer; if an operator sets `queue.batch_size > 50` the "N buffered" header understates the true buffer (documented in the handler; default batch_size is 10).

## Not covered

Full serve-mode end-to-end (a live worker draining a real buffer) was not run -- verification is at the rendered-page and handler-integration level. The complementary "currently processing" live view and its SSE/polling transport decision are tracked separately in #468 and are explicitly out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Up Next” dashboard panel showing buffered work in processing order.
  * Displays track details, priority tiers, queue position, and time waiting.
  * Added eligible and cooldown queue counts to the panel header.
  * Shows a clear empty state when no buffered work is available.
* **Style**
  * Added visual styling for priority badges and compact queue columns.
* **Tests**
  * Added coverage for ordering, filtering, formatting, queue counts, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->