### PR TITLE
fix(db): backfill album/album_artist onto pre-013 work_queue rows (#583)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -706,3 +706,121 @@ func TestMigration022LaneAttemptsUpDown(t *testing.T) {
 		t.Fatal("idx_lane_attempts_lane still present after down-migration")
 	}
 }
+
+// TestMigration032BackfillsAlbumFromScanResults drives migration 032: it
+// migrates to v31, seeds work_queue rows with empty (or set) album/album_artist
+// linked (or not) to scan_results, applies 032, and asserts the values are
+// backfilled from the linked scan_result only where the queue value is empty and
+// a non-empty source exists -- never overwriting an existing value, and album /
+// album_artist backfilling independently.
+func TestMigration032BackfillsAlbumFromScanResults(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig032.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	applyOpenPragmas(ctx, t, sqlDB)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 31); err != nil {
+		t.Fatalf("UpTo(31): %v", err)
+	}
+
+	exec := func(q string, args ...any) sql.Result {
+		t.Helper()
+		res, err := sqlDB.ExecContext(ctx, q, args...)
+		if err != nil {
+			t.Fatalf("exec: %v", err)
+		}
+		return res
+	}
+	lastID := func(res sql.Result) int64 {
+		t.Helper()
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("last insert id: %v", err)
+		}
+		return id
+	}
+
+	libID := lastID(exec(`INSERT INTO libraries (path, name) VALUES ('/music', 'lib')`))
+	seedWQ := func(key, album, albumArtist string) int64 {
+		return lastID(exec(
+			`INSERT INTO work_queue (artist, title, artist_key, title_key, album, album_artist, status, next_attempt_at)
+             VALUES (?, 'T', ?, ?, ?, ?, 'deferred', '2026-01-01T00:00:00Z')`,
+			key, key, key, album, albumArtist))
+	}
+	seedSR := func(file, album, albumArtist string) int64 {
+		return lastID(exec(
+			`INSERT INTO scan_results (library_id, file_path, album, album_artist) VALUES (?, ?, ?, ?)`,
+			libID, file, album, albumArtist))
+	}
+	link := func(wqID, srID int64) {
+		exec(`INSERT INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`, wqID, srID)
+	}
+
+	// A: empty album+album_artist, linked to a source that HAS both -> both backfilled.
+	wqA := seedWQ("a", "", "")
+	link(wqA, seedSR("/a.flac", "Album A", "AA A"))
+	// B: both already set, linked to a source with DIFFERENT values -> unchanged.
+	wqB := seedWQ("b", "Existing B", "Existing AA B")
+	link(wqB, seedSR("/b.flac", "Other B", "Other AA B"))
+	// C: empty, NO linked source -> stays empty.
+	wqC := seedWQ("c", "", "")
+	// D: empty, linked source is also EMPTY -> stays empty.
+	wqD := seedWQ("d", "", "")
+	link(wqD, seedSR("/d.flac", "", ""))
+	// E: album set but album_artist empty -> album kept, album_artist backfilled (independent).
+	wqE := seedWQ("e", "Set E", "")
+	link(wqE, seedSR("/e.flac", "Ignored E", "Backfill AA E"))
+	// F: collapsed-files fan-out -- one row linked to THREE scan_results. The
+	// lowest-id source is EMPTY, so the WHERE sr.album <> '' filter must skip it
+	// and ORDER BY sr.id LIMIT 1 must pick the lowest-id NON-empty one (F middle),
+	// not the empty first nor the higher-id third. Exercises the multi-link branch
+	// the join table exists for.
+	wqF := seedWQ("f", "", "")
+	link(wqF, seedSR("/f1.flac", "", ""))                  // lowest id, empty  -> skipped
+	link(wqF, seedSR("/f2.flac", "Album F", "AA F"))       // next id, non-empty -> chosen
+	link(wqF, seedSR("/f3.flac", "Other F", "Other AA F")) // highest id, non-empty -> not chosen
+
+	if _, err := provider.UpTo(ctx, 32); err != nil {
+		t.Fatalf("UpTo(32): %v", err)
+	}
+
+	get := func(id int64) (string, string) {
+		t.Helper()
+		var album, aa string
+		if err := sqlDB.QueryRowContext(ctx, `SELECT album, album_artist FROM work_queue WHERE id = ?`, id).Scan(&album, &aa); err != nil {
+			t.Fatalf("get %d: %v", id, err)
+		}
+		return album, aa
+	}
+
+	if album, aa := get(wqA); album != "Album A" || aa != "AA A" {
+		t.Errorf("A backfill: got %q/%q; want Album A / AA A", album, aa)
+	}
+	if album, aa := get(wqB); album != "Existing B" || aa != "Existing AA B" {
+		t.Errorf("B must not overwrite: got %q/%q; want Existing B / Existing AA B", album, aa)
+	}
+	if album, _ := get(wqC); album != "" {
+		t.Errorf("C (no link): album=%q; want empty", album)
+	}
+	if album, _ := get(wqD); album != "" {
+		t.Errorf("D (empty source): album=%q; want empty", album)
+	}
+	if album, aa := get(wqE); album != "Set E" || aa != "Backfill AA E" {
+		t.Errorf("E independent: got %q/%q; want Set E / Backfill AA E", album, aa)
+	}
+	if album, aa := get(wqF); album != "Album F" || aa != "AA F" {
+		t.Errorf("F multi-link: got %q/%q; want Album F / AA F (lowest-id non-empty source)", album, aa)
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -796,7 +796,7 @@ func TestMigration032BackfillsAlbumFromScanResults(t *testing.T) {
 		t.Fatalf("UpTo(32): %v", err)
 	}
 
-	get := func(id int64) (string, string) {
+	get := func(t *testing.T, id int64) (string, string) {
 		t.Helper()
 		var album, aa string
 		if err := sqlDB.QueryRowContext(ctx, `SELECT album, album_artist FROM work_queue WHERE id = ?`, id).Scan(&album, &aa); err != nil {
@@ -805,22 +805,25 @@ func TestMigration032BackfillsAlbumFromScanResults(t *testing.T) {
 		return album, aa
 	}
 
-	if album, aa := get(wqA); album != "Album A" || aa != "AA A" {
-		t.Errorf("A backfill: got %q/%q; want Album A / AA A", album, aa)
-	}
-	if album, aa := get(wqB); album != "Existing B" || aa != "Existing AA B" {
-		t.Errorf("B must not overwrite: got %q/%q; want Existing B / Existing AA B", album, aa)
-	}
-	if album, _ := get(wqC); album != "" {
-		t.Errorf("C (no link): album=%q; want empty", album)
-	}
-	if album, _ := get(wqD); album != "" {
-		t.Errorf("D (empty source): album=%q; want empty", album)
-	}
-	if album, aa := get(wqE); album != "Set E" || aa != "Backfill AA E" {
-		t.Errorf("E independent: got %q/%q; want Set E / Backfill AA E", album, aa)
-	}
-	if album, aa := get(wqF); album != "Album F" || aa != "AA F" {
-		t.Errorf("F multi-link: got %q/%q; want Album F / AA F (lowest-id non-empty source)", album, aa)
+	// Each case asserted in its own subtest so a failure is isolated and
+	// -run-filterable per scenario. Setup (seed + single UpTo(32)) is shared above.
+	for _, tc := range []struct {
+		name              string
+		id                int64
+		wantAlbum, wantAA string
+	}{
+		{"A_backfilled_from_linked_source", wqA, "Album A", "AA A"},
+		{"B_existing_value_not_overwritten", wqB, "Existing B", "Existing AA B"},
+		{"C_no_linked_source_stays_empty", wqC, "", ""},
+		{"D_empty_source_stays_empty", wqD, "", ""},
+		{"E_album_kept_album_artist_backfilled_independently", wqE, "Set E", "Backfill AA E"},
+		{"F_multi_link_picks_lowest_id_non_empty", wqF, "Album F", "AA F"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			album, aa := get(t, tc.id)
+			if album != tc.wantAlbum || aa != tc.wantAA {
+				t.Errorf("album/album_artist = %q/%q; want %q/%q", album, aa, tc.wantAlbum, tc.wantAA)
+			}
+		})
 	}
 }

--- a/internal/db/migrations/032_work_queue_album_backfill.sql
+++ b/internal/db/migrations/032_work_queue_album_backfill.sql
@@ -1,0 +1,77 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Backfill album and album_artist onto the pre-013 work_queue backlog (#583).
+--
+-- Migration 013 added work_queue.album / .album_artist with DEFAULT '' and left
+-- existing rows to be "backfilled on the next library scan upsert". But the
+-- periodic scan does not re-enqueue a track that is already in the queue, so the
+-- ON CONFLICT upsert (internal/queue/queue.go) never fires for those rows and
+-- their album stays ''. The value was present in the linked scan_results the
+-- whole time (the scanner writes it from the tags), so this pass copies it
+-- across. On the reference database this recovered album on ~48.8k rows and
+-- album_artist on ~42.1k; only 6 empty-album rows were genuinely album-less.
+--
+-- This matters beyond the dashboard display: the worker passes q_album from the
+-- work item to Musixmatch (internal/musixmatch/client.go), so a blank album
+-- drops the match signal migration 013 added, for ~89% of the deferred backlog.
+--
+-- WHY A MIGRATION, not startup code (#548 / #565): goose gives run-once and
+-- transactionality for free and completes inside db.Open before any goroutine
+-- exists. This is a one-time correction of historical rows -- the current
+-- enqueue path already carries album (rows created in the last 14 days have zero
+-- empty albums), so nothing ongoing needs fixing.
+--
+-- A work_queue row can link to several scan_results (collapsed files); pick the
+-- lowest-id non-empty source deterministically. The EXISTS guard keeps the
+-- correlated subquery from ever writing NULL into the NOT NULL column -- it runs
+-- the UPDATE only where a non-empty source exists.
+--
+-- Side effect: the update_work_queue_updated_at trigger (migration 012) fires on
+-- each touched row, so updated_at is rewritten to the deploy timestamp for every
+-- backfilled row. That is cosmetic (no report window-queries updated_at), but an
+-- ad-hoc "recent activity by updated_at" query will over-count these rows as
+-- freshly active for one deploy. Acceptable for a one-time correction; noted so
+-- the bump is not mistaken for real churn.
+UPDATE work_queue
+SET album = (
+    SELECT sr.album
+    FROM work_queue_scan_results wqsr
+    JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+    WHERE wqsr.work_queue_id = work_queue.id AND sr.album <> ''
+    ORDER BY sr.id
+    LIMIT 1
+)
+WHERE album = ''
+  AND EXISTS (
+    SELECT 1
+    FROM work_queue_scan_results wqsr
+    JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+    WHERE wqsr.work_queue_id = work_queue.id AND sr.album <> ''
+  );
+
+UPDATE work_queue
+SET album_artist = (
+    SELECT sr.album_artist
+    FROM work_queue_scan_results wqsr
+    JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+    WHERE wqsr.work_queue_id = work_queue.id AND sr.album_artist <> ''
+    ORDER BY sr.id
+    LIMIT 1
+)
+WHERE album_artist = ''
+  AND EXISTS (
+    SELECT 1
+    FROM work_queue_scan_results wqsr
+    JOIN scan_results sr ON sr.id = wqsr.scan_result_id
+    WHERE wqsr.work_queue_id = work_queue.id AND sr.album_artist <> ''
+  );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Irreversible by design: once album/album_artist is copied across, a row
+-- corrected here is indistinguishable from one the live enqueue populated, so a
+-- Down would have to guess which to blank. Deliberate no-op; restore from backup
+-- if this must be undone. (Matches migration 028.)
+SELECT 1;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

- Migration 032 backfills `work_queue.album` / `.album_artist` from the linked `scan_results` for rows whose queue value is empty but whose scan-result carries one. Migration 013 added the columns with `DEFAULT ''` and relied on a rescan upsert to fill them, but the periodic scan does not re-enqueue an already-queued track, so ~44k pre-013 backlog rows kept `album=''` while the value sat in `scan_results` all along.
- User-visible: the dashboard (incl. the new Up Next panel) shows the album; and the worker sends `q_album` to Musixmatch, so this restores that match signal for ~89% of the deferred backlog. On the reference DB this recovers album on ~48.8k rows and album_artist on ~42.1k; only 6 empty-album rows are genuinely album-less.
- Reviewers look first at: the two `UPDATE`s in `032_work_queue_album_backfill.sql` (EXISTS-guarded so they never write NULL into the NOT NULL column, and only touch empty values), and the multi-link determinism (`ORDER BY sr.id LIMIT 1`).

## Linked issue

Closes #583

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`) via `/prep-pr`.
- [x] Code review pass complete; adversarial review found no critical/important issues (two Minor findings fixed: `updated_at`-trigger note + multi-link test case).
- [x] Single clean commit before first push.
- [x] Label set (`bug`).
- [x] No UAT / binary run needed -- the migration runs automatically at `db.Open` on the next deploy; verified by a migration test that seeds pre-032 state and asserts the backfill.
- [x] No screenshot (no UI code changed; the panel that displays album shipped in #581).
- [x] No `make ui` needed (no templ/CSS change).
- [x] Migration added under `internal/db/migrations/` -- this is the one-time data correction, done as a goose migration per #548/#565 (run-once + transactional), not startup code.

## Test plan

- [x] `make gate` passes locally (race tests, coverage floor, golangci-lint, actionlint, govulncheck all green).
- [x] New test `TestMigration032BackfillsAlbumFromScanResults` seeds pre-032 rows and applies the migration, asserting: (A) empty -> backfilled from the linked source; (B) an existing value is not overwritten; (C) a row with no linked source stays empty; (D) an empty source is skipped; (E) album / album_artist backfill independently; (F) multi-link fan-out picks the lowest-id non-empty source. It fails against unfixed code (case A only holds because the migration ran).
- [x] Patch coverage: N/A -- the change is SQL + test, no new Go source lines (`patch-coverage.sh` reports "no Go source changes in scope").
- [x] Surface: this fixes the **serve-mode data** (`work_queue.album`); verified by the migration test against real SQLite, and the prod counts were measured directly before/after scoping.
- [ ] Manual UAT steps: none (auto-applied migration).
- [ ] Reviewer follow-ups:
  - [x] Prod-safety: the per-row subquery is index-backed (join-table PK `(work_queue_id, scan_result_id)` + `scan_results` PK), so the ~44k-row backfill is sub-second and transactional -- no container stall on deploy.

## Not covered

Does not change the ongoing enqueue path (already correct -- rows created in the last 14 days have zero empty albums). The related serve-mode fetch-parity gap (duration/ISRC not carried, causing wrong-version matches) is tracked separately in #584, and re-fetching already-mismatched `.lrc` in #585.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing album and album artist information for existing queued work items.
  * Preserved previously populated album details while filling only empty fields.
  * Applied consistent values when multiple scan results are linked to the same queued item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->