### PR TITLE
fix(queue): keep the lookahead buffer topped up on every dequeue (#587)

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -387,22 +387,24 @@ const dequeueBatchedClaimSQL = `UPDATE work_queue
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
                    miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
 
-// drawBatchSQL stamps batch_seq = 1..N on the top-N eligible unbuffered rows,
-// randomizing composition and intra-tier order once per batch while preserving
-// priority tiers (webhook rows draw first). The RANDOM() shuffle is the
-// anti-fingerprint mechanism, moved from per-claim to per-batch. ROW_NUMBER()
-// and UPDATE ... FROM are both supported by modernc.org/sqlite (proven in
-// migration 004). batch_seq IS NULL restricts the draw to fresh rows; at draw
-// time every eligible row is unbuffered, since any eligible buffered row would
-// have been claimed before the draw ran.
+// refillBufferSQL stamps batch_seq = offset + 1 .. offset + N on the next N
+// eligible unbuffered rows, randomizing composition and intra-tier order while
+// preserving priority tiers (webhook rows draw first). The RANDOM() shuffle is
+// the anti-fingerprint mechanism. The leading `?` is a batch_seq offset: refill
+// appends drawn rows AFTER the rows already buffered (offset = current max
+// batch_seq), so a rolling top-up never collides with, nor reorders, the buffer's
+// existing claim order (#587). Offset 0 is the empty-buffer case (stamps 1..N).
+// ROW_NUMBER() and UPDATE ... FROM are both supported by modernc.org/sqlite
+// (proven in migration 004). batch_seq IS NULL restricts the draw to rows not
+// already buffered.
 //
 // The subquery's `ORDER BY rn` before `LIMIT ?` is load-bearing: the window
 // ORDER BY only assigns rn, and SQLite leaves the final row order undefined
 // without a top-level ORDER BY, so LIMIT could otherwise keep an arbitrary N
 // rows rather than the top-N by priority -- dropping a high-priority (webhook)
-// row from the batch. Ordering by rn guarantees LIMIT takes ranks 1..N.
-const drawBatchSQL = `UPDATE work_queue
-         SET batch_seq = ranked.rn
+// row from the draw. Ordering by rn guarantees LIMIT takes ranks 1..N.
+const refillBufferSQL = `UPDATE work_queue
+         SET batch_seq = ranked.rn + ?
          FROM (
              SELECT id, ROW_NUMBER() OVER (ORDER BY priority DESC, RANDOM()) AS rn
              FROM work_queue
@@ -437,13 +439,45 @@ func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
 	return item, nil
 }
 
-// dequeueBatched serves the shuffled lookahead buffer: claim the lowest-batch_seq
-// eligible buffered row; if none exists, draw a fresh batch and claim again. The
-// draw (stamping batch_seq) and the claim are two statements, so they run in one
-// transaction -- the DB is single-connection, but each bare statement would
-// release it, letting a concurrent webhook Enqueue clear batch_seq between draw
-// and claim. Holding the connection across the brief draw+claim window keeps the
-// operation coherent. The claim itself stays a single atomic UPDATE ... RETURNING.
+// refillBuffer tops the lookahead buffer up to batchSize by drawing the next
+// eligible unbuffered rows and appending them AFTER the current max batch_seq. It
+// is what keeps the buffer populated between the worker's claim cycles (#587):
+// instead of draining to empty and only redrawing on the next Dequeue, the buffer
+// is refilled on every Dequeue, so the #572 panel always shows the next batchSize
+// items rather than going blank during the worker's pacer wait. Drawn rows keep
+// the RANDOM()-within-priority order (#571 anti-fingerprint) and, via the offset,
+// always sort after the rows already buffered -- so the lowest-batch_seq claim
+// order is preserved and no existing buffered row is reordered. A no-op once the
+// buffer already holds batchSize rows. Runs inside the caller's transaction.
+func (q *DBQueue) refillBuffer(ctx context.Context, tx *sql.Tx, now string) error {
+	var count, maxSeq int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(MAX(batch_seq), 0) FROM work_queue WHERE batch_seq IS NOT NULL`,
+	).Scan(&count, &maxSeq); err != nil {
+		return fmt.Errorf("queue: buffer census: %w", err)
+	}
+	limit := int64(q.batchSize) - count
+	if limit <= 0 {
+		return nil // buffer already full
+	}
+	// maxSeq is read here (not as a SQL subquery inside the UPDATE) to avoid
+	// reading batch_seq while the same statement writes it.
+	if _, err := tx.ExecContext(ctx, refillBufferSQL, maxSeq, now, limit); err != nil {
+		return fmt.Errorf("queue: refill buffer: %w", err)
+	}
+	return nil
+}
+
+// dequeueBatched serves the shuffled lookahead buffer: top the buffer up to
+// batchSize, then claim the lowest-batch_seq eligible buffered row. Topping up on
+// every Dequeue (rather than only when the buffer drains to empty) keeps the
+// buffer populated between claim cycles, so the #572 "Up next" panel shows the
+// next batchSize items instead of going blank during the worker's pacer wait
+// (#587). The refill and the claim share one transaction -- the DB is
+// single-connection, but two bare statements would release it, letting a
+// concurrent webhook Enqueue clear batch_seq between them; holding the connection
+// across the refill+claim window keeps the operation coherent (the #571 reason).
+// The claim itself stays a single atomic UPDATE ... RETURNING.
 func (q *DBQueue) dequeueBatched(ctx context.Context, now string) (WorkItem, error) {
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -451,19 +485,12 @@ func (q *DBQueue) dequeueBatched(ctx context.Context, now string) (WorkItem, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Claim the lowest-batch_seq eligible buffered row. If the buffer holds none,
-	// draw a fresh batch and claim again. A single ErrNoRows check then covers
-	// both "nothing buffered yet" (first call) and "pool genuinely empty" (after
-	// the draw found nothing), so there is one claim-error path and one commit.
+	if err := q.refillBuffer(ctx, tx, now); err != nil {
+		return WorkItem{}, err
+	}
 	item, err := scanWorkItem(tx.QueryRowContext(ctx, dequeueBatchedClaimSQL, now))
 	if errors.Is(err, sql.ErrNoRows) {
-		if _, derr := tx.ExecContext(ctx, drawBatchSQL, now, q.batchSize); derr != nil {
-			return WorkItem{}, fmt.Errorf("queue: draw batch: %w", derr)
-		}
-		item, err = scanWorkItem(tx.QueryRowContext(ctx, dequeueBatchedClaimSQL, now))
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		return WorkItem{}, sql.ErrNoRows // pool empty even after a fresh draw
+		return WorkItem{}, sql.ErrNoRows // pool genuinely empty (refill drew nothing)
 	}
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: batched claim: %w", err)

--- a/internal/queue/queue_batch_test.go
+++ b/internal/queue/queue_batch_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/models"
 )
 
@@ -198,7 +200,7 @@ func TestDBQueue_BatchDrawsAreRandomized(t *testing.T) {
 		if _, err := q.db.ExecContext(ctx, `UPDATE work_queue SET batch_seq = NULL`); err != nil {
 			t.Fatalf("clear batch_seq: %v", err)
 		}
-		if _, err := q.db.ExecContext(ctx, drawBatchSQL, "2026-04-27T12:00:00Z", 5); err != nil {
+		if _, err := q.db.ExecContext(ctx, refillBufferSQL, 0, "2026-04-27T12:00:00Z", 5); err != nil {
 			t.Fatalf("draw: %v", err)
 		}
 		return bufferedIDsBySeq(t, q)
@@ -218,6 +220,99 @@ func TestDBQueue_BatchDrawsAreRandomized(t *testing.T) {
 	}
 	if same {
 		t.Fatalf("two draws produced identical order %v; randomness not retained", a)
+	}
+}
+
+// TestDBQueue_BufferRefillsEachDequeue verifies the buffer is topped back up to
+// batch_size on every Dequeue (not only when it drains to empty), so the #572
+// "Up next" panel never goes blank while eligible work exists (#587). With a pool
+// far larger than the batch, the buffered count stays at batch_size-1 after each
+// successive Dequeue (batch_size drawn, one just claimed). Discriminates the fix:
+// the old drain-then-redraw behavior would count down 4,3,2,1,0 before redrawing.
+func TestDBQueue_BufferRefillsEachDequeue(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+	q.SetBatchSize(5)
+
+	enqueueN(t, q, 30) // pool much larger than the batch so refill always succeeds
+
+	for i := range 6 {
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue %d: %v", i, err)
+		}
+		if got := len(bufferedIDsBySeq(t, q)); got != 4 {
+			t.Fatalf("after dequeue %d: buffered = %d; want 4 (batch_size-1, rolling refill)", i, got)
+		}
+	}
+}
+
+// TestDBQueue_BatchedDequeueEmptyPool: with batching on and nothing eligible, the
+// refill draws nothing and the claim returns sql.ErrNoRows (not a silent empty
+// item).
+func TestDBQueue_BatchedDequeueEmptyPool(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetBatchSize(5)
+
+	if _, err := q.Dequeue(ctx); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Dequeue on empty batched queue: err = %v; want sql.ErrNoRows", err)
+	}
+}
+
+// TestDBQueue_RefillNoOpWhenBufferAtCapacity: when the buffered count already
+// meets (or exceeds) batch_size, the refill is a no-op. Exercised by shrinking
+// batch_size below the current buffer -- the guard must skip the draw rather than
+// pass a negative LIMIT, which SQLite treats as "no limit" and would drain the
+// whole pool into the buffer.
+func TestDBQueue_RefillNoOpWhenBufferAtCapacity(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
+	q.SetBatchSize(5)
+	enqueueN(t, q, 30)
+
+	if _, err := q.Dequeue(ctx); err != nil { // refill(5) + claim -> 4 buffered
+		t.Fatalf("prime: %v", err)
+	}
+	// Shrink below the current buffered count (4): the next refill's limit is
+	// negative, so it must no-op instead of drawing the rest of the pool.
+	q.SetBatchSize(3)
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue after shrink: %v", err)
+	}
+	if got := len(bufferedIDsBySeq(t, q)); got != 3 {
+		t.Fatalf("buffered after shrink+claim = %d; want 3 (no refill, one claimed from 4)", got)
+	}
+}
+
+// TestDBQueue_BatchedDequeueSurfacesRefillError: a failure in the buffer refill
+// must surface, not be swallowed into a silent empty claim. Seed eligible rows
+// through a writable handle, then reopen the same file read-only so BeginTx and
+// the census SELECT succeed but the refill UPDATE is rejected (query_only).
+func TestDBQueue_BatchedDequeueSurfacesRefillError(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "ro.db")
+
+	w, err := db.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("open writable: %v", err)
+	}
+	enqueueN(t, NewDBQueue(w), 5)
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writable: %v", err)
+	}
+
+	ro, err := db.OpenReadOnly(ctx, path)
+	if err != nil {
+		t.Fatalf("open read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = ro.Close() })
+	q := NewDBQueue(ro)
+	q.SetBatchSize(5)
+
+	if _, err := q.Dequeue(ctx); err == nil {
+		t.Fatal("Dequeue with a read-only DB (refill UPDATE rejected) returned nil error; want a surfaced failure")
 	}
 }
 


### PR DESCRIPTION
## Summary

- The batched dequeue drew a batch only when the buffer drained to empty, then served it down to 0 before the next `Dequeue` redrew. Between the last claim of a batch and the worker's next `Dequeue` (a full pacer wait -- minutes), the buffer sat empty, so the #572 "Up next" panel showed "Nothing buffered" while thousands of rows were eligible.
- Fix: refill on every `Dequeue`. `refillBuffer` tops the buffer back up to `batch_size` (drawing the next eligible rows and appending them after the current max `batch_seq`), then the lowest-`batch_seq` row is claimed. The buffer now holds ~`batch_size` items continuously, so the panel always shows the next batch.
- User-visible: serve mode (the primary use case) no longer flashes a blank up-next panel between the worker's claim cycles.
- Reviewers look first at: `refillBuffer` (the Go-computed `maxSeq` offset avoids a read-while-write `MAX()` subquery inside the UPDATE; the `limit <= 0` guard prevents a negative SQLite LIMIT from draining the whole pool), and that webhook preemption + the `ORDER BY rn` priority guard (#580) are unchanged.

## Linked issue

Closes #587

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`) via `/prep-pr`.
- [x] Code review pass complete; adversarial review found no critical/important/minor defects across 8 attack vectors (append-offset correctness, read-while-write avoidance, `limit<=0` guard, webhook preemption + latency bound, both new tests verified to discriminate/cover, per-dequeue cost).
- [x] Single clean commit before first push.
- [x] Label set (`bug`).
- [x] UAT: verified via queue tests against real SQLite (rolling refill, empty pool, capacity guard, refill-error surfacing); the observable prod symptom is the blank panel, which the rolling refill removes.
- [x] No UI/templ/CSS change; no migration.

## Test plan

- [x] `make gate` passes locally (race tests, patch coverage 84%, coverage floor `internal/queue` 83.5% >= 83, golangci-lint, actionlint, govulncheck).
- [x] `TestDBQueue_BufferRefillsEachDequeue` confirmed to **fail against unfixed code**: with a pool of 30 and batch 5 it asserts the buffer stays at `batch_size-1` after each of 6 dequeues; the old drain-then-redraw counts 4,3,2,1,0 and fails at the second iteration.
- [x] `TestDBQueue_RefillNoOpWhenBufferAtCapacity` (shrink `batch_size` below buffer -> refill no-ops, no negative-LIMIT drain); `TestDBQueue_BatchedDequeueEmptyPool` (empty pool -> `sql.ErrNoRows`); `TestDBQueue_BatchedDequeueSurfacesRefillError` (read-only DB makes the refill UPDATE fail after BeginTx+census succeed -> error surfaces, not swallowed).
- [x] Existing `TestDBQueue_WebhookEnqueuePreemptsBatch` and `TestDBQueue_DrawKeepsHighestPriorityUnderLimit` still pass -- webhook still claimed first, one-dequeue latency bound unchanged.
- [x] Patch coverage 84% (16/19). The 3 uncovered lines are the deepest DB-failure error-wraps (census scan, claim, commit); stopped there per the don't-chase-defensive-lines guidance.
- [ ] Reviewer follow-ups:
  - [x] Bounded non-webhook priority inversion (transparency): a higher-priority NON-webhook row arriving after the buffer is full is appended at the tail (`maxSeq+1`), so it serves after already-buffered lower-priority rows -- bounded by ~`batch_size` dequeues, and a pre-existing #571 intra-batch tradeoff, not introduced here. Webhooks still preempt via the buffer-clear.

## Not covered

Does not change the pacer/throughput or the anti-fingerprint property (still `RANDOM()`-within-priority per draw). The per-dequeue `ROW_NUMBER()` scan now runs per-dequeue instead of per-batch; at ~60 dequeues/hr over a ~10k eligible pool that is negligible, but it was not load-tested at extreme `batch_size`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batched dequeue behavior by replenishing available items consistently.
  * Preserved the established order of buffered items while adding new entries.
  * Correctly reports empty queues when no items are available.
  * Surfaces errors encountered while replenishing the queue.

* **Tests**
  * Added coverage for repeated dequeue refills, empty queues, capacity handling, and refill failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->