### PR TITLE
fix(worker): re-read ISRC and duration at fetch time (#584)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1032,6 +1032,13 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	configureWorkerAudioDetector(w, audioDetector)
 	w.SetInstrumentalDetectionDefault(cfg.InstrumentalDetector.Enabled)
 	w.SetDetectorOrdering(cfg.InstrumentalDetector.Ordering)
+	// Gate the fetch-time recording-identity refresh (#584) on the GLOBAL
+	// enrichment default, so disabling enrichment keeps serve mode at CLI parity
+	// instead of reading tags the operator opted out of. Per-library overrides are
+	// NOT resolved here -- a scan resolves them via scan.Scheduler
+	// (config.ResolveBool over EnrichOverride/lib.EnrichRecording/global), but the
+	// worker holds no library context. See Worker.enrichRecordingDefault.
+	w.SetRecordingEnrichmentDefault(cfg.Enrichment.Enabled)
 	configureWorkerGuard(w, newGuard(cfg))
 	// Wire the DB-backed provider outcome recorder so hits and misses are persisted
 	// and exposed via GET /metrics (mxlrcgo_provider_hits_total{lane},

--- a/internal/scanner/audiometadata_test.go
+++ b/internal/scanner/audiometadata_test.go
@@ -1,0 +1,95 @@
+package scanner
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/testutil"
+)
+
+// TestReadAudioMetadata_AllPresent uses a FLAC fixture because STREAMINFO gives
+// an exact computed duration (totalSamples/sampleRate) while Vorbis comments
+// carry ISRC and album, so one file exercises all three fields exactly.
+func TestReadAudioMetadata_AllPresent(t *testing.T) {
+	const sampleRate = 44100
+	const totalSamples = 44100 * 180 // exactly 180 seconds
+
+	dir := t.TempDir()
+	if err := testutil.WriteFLACFileWithComments(dir, "track.flac", sampleRate, totalSamples,
+		map[string]string{
+			"ARTIST": "Artist",
+			"TITLE":  "Title",
+			"ALBUM":  "Album",
+			"ISRC":   testISRC,
+		}); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	meta, err := ReadAudioMetadata(filepath.Join(dir, "track.flac"))
+	if err != nil {
+		t.Fatalf("ReadAudioMetadata: %v", err)
+	}
+	if meta.TrackLength != 180 {
+		t.Errorf("TrackLength = %d; want 180", meta.TrackLength)
+	}
+	if meta.ISRC != testISRC {
+		t.Errorf("ISRC = %q; want %q", meta.ISRC, testISRC)
+	}
+	if meta.AlbumName != "Album" {
+		t.Errorf("AlbumName = %q; want %q", meta.AlbumName, "Album")
+	}
+}
+
+// TestReadAudioMetadata_TagsAbsent verifies the sentinel contract: a readable
+// file missing these tags is not an error.
+func TestReadAudioMetadata_TagsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "Artist", "Title", "", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	meta, err := ReadAudioMetadata(filepath.Join(dir, "track.mp3"))
+	if err != nil {
+		t.Fatalf("ReadAudioMetadata: %v", err)
+	}
+	if meta.ISRC != "" {
+		t.Errorf("ISRC = %q; want empty", meta.ISRC)
+	}
+	if meta.AlbumName != "" {
+		t.Errorf("AlbumName = %q; want empty", meta.AlbumName)
+	}
+}
+
+// TestReadAudioMetadata_MissingFile verifies an open failure is a wrapped error,
+// so the caller can distinguish it from a genuinely untagged file.
+func TestReadAudioMetadata_MissingFile(t *testing.T) {
+	_, err := ReadAudioMetadata(filepath.Join(t.TempDir(), "nope.mp3"))
+	if err == nil {
+		t.Fatal("ReadAudioMetadata: got nil error for a missing file; want an error")
+	}
+}
+
+// TestReadAudioMetadata_UnknownDurationIsNotAnError verifies that a file whose
+// duration cannot be derived still returns its tags with TrackLength 0, rather
+// than failing the whole read.
+func TestReadAudioMetadata_UnknownDurationIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	if err := testutil.WriteAudioFileExtended(dir, "track.mp3", "Artist", "Title", "Album", "",
+		map[string]string{"TSRC": testISRC}, nil); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	meta, err := ReadAudioMetadata(filepath.Join(dir, "track.mp3"))
+	if err != nil {
+		t.Fatalf("ReadAudioMetadata: %v", err)
+	}
+	if meta.ISRC != testISRC {
+		t.Errorf("ISRC = %q; want %q", meta.ISRC, testISRC)
+	}
+	if meta.AlbumName != "Album" {
+		t.Errorf("AlbumName = %q; want %q", meta.AlbumName, "Album")
+	}
+	if meta.TrackLength < 0 {
+		t.Errorf("TrackLength = %d; want 0 or a positive duration", meta.TrackLength)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -94,7 +94,7 @@ type AudioMetadata struct {
 // error and yields the zero-value sentinel; only an open or parse failure returns
 // an error, matching ReadAudioProvenance and ReadArtistIdentity.
 func ReadAudioMetadata(path string) (AudioMetadata, error) {
-	f, oerr := os.Open(path) //nolint:gosec // G304: path is a work_queue source_path, written from a configured library root and confined via pathutil upstream
+	f, oerr := os.Open(path) //nolint:gosec // reason: G304 - path is a work_queue source_path, written from a configured library root and confined via pathutil upstream
 	if oerr != nil {
 		return AudioMetadata{}, fmt.Errorf("open %s: %w", path, oerr)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -73,6 +73,47 @@ func ReadArtistIdentity(path string) (artist, albumArtist string, err error) {
 	return extractArtist(m), extractAlbumArtist(m), nil
 }
 
+// AudioMetadata carries the recording disambiguators a provider query needs from
+// an audio file's tags. The zero values are the documented "absent" sentinels:
+// TrackLength 0 is the unknown-duration sentinel normalize.DurationBucket keys
+// on, and an empty string means the tag is absent.
+type AudioMetadata struct {
+	TrackLength int
+	ISRC        string
+	AlbumName   string
+}
+
+// ReadAudioMetadata opens the audio file at path and returns the recording
+// disambiguators a provider query needs: duration, ISRC, and album. It is the
+// seam serve mode uses to reach fetch-mode parity (#584): work_queue persists
+// neither duration nor ISRC, so the worker re-reads them from disk at fetch time
+// through exactly the readers a scan uses, which makes the two paths identical by
+// construction rather than by agreement.
+//
+// A missing tag, an unparsable duration, or an unsupported extension is not an
+// error and yields the zero-value sentinel; only an open or parse failure returns
+// an error, matching ReadAudioProvenance and ReadArtistIdentity.
+func ReadAudioMetadata(path string) (AudioMetadata, error) {
+	f, oerr := os.Open(path) //nolint:gosec // G304: path is a work_queue source_path, written from a configured library root and confined via pathutil upstream
+	if oerr != nil {
+		return AudioMetadata{}, fmt.Errorf("open %s: %w", path, oerr)
+	}
+	defer func() { _ = f.Close() }()
+	m, terr := tag.ReadFrom(f)
+	if terr != nil {
+		return AudioMetadata{}, fmt.Errorf("read metadata %s: %w", path, terr)
+	}
+	// audioduration seeks to 0 internally, so f may sit at any offset after
+	// tag.ReadFrom; no rewind is needed here. A parse failure degrades to the
+	// unknown-duration sentinel exactly as scanDir does.
+	dur, derr := audioDuration(f, strings.ToLower(filepath.Ext(path)))
+	if derr != nil {
+		slog.Debug("duration parse failed; using 0", "file", path, "error", derr)
+		dur = 0
+	}
+	return AudioMetadata{TrackLength: dur, ISRC: extractISRC(m), AlbumName: m.Album()}, nil
+}
+
 // audioFileTypeForExt returns the audioduration type constant for a lower-case
 // audio file extension. Extensions not recognized return (0, false); callers
 // degrade to TrackLength=0 (the "unknown duration" sentinel).

--- a/internal/worker/metadata_refresh_test.go
+++ b/internal/worker/metadata_refresh_test.go
@@ -1,0 +1,203 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/normalize"
+	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// fakeMetadataReader stands in for scanner.ReadAudioMetadata so worker tests
+// exercise the fetch-time refresh without binary audio fixtures.
+type fakeMetadataReader struct {
+	meta  scanner.AudioMetadata
+	err   error
+	calls int
+	paths []string
+}
+
+func (r *fakeMetadataReader) read(path string) (scanner.AudioMetadata, error) {
+	r.calls++
+	r.paths = append(r.paths, path)
+	if r.err != nil {
+		return scanner.AudioMetadata{}, r.err
+	}
+	return r.meta, nil
+}
+
+// queuedItem builds a work item shaped like the queue path: album and
+// album_artist survive the round trip through work_queue, duration and ISRC do
+// not (#584).
+func queuedItem(sourcePath string) queue.WorkItem {
+	return queue.WorkItem{
+		ID: 1,
+		Inputs: models.Inputs{
+			Track: models.Track{
+				ArtistName: "Artist",
+				TrackName:  "Title",
+				AlbumName:  "Backfilled Album",
+			},
+			Outdir:     "/out",
+			Filename:   "track.lrc",
+			SourcePath: sourcePath,
+		},
+	}
+}
+
+func refreshFetcher() *fakeFetcher {
+	return &fakeFetcher{song: models.Song{Lyrics: models.Lyrics{LyricsBody: "fresh lyrics"}}}
+}
+
+func newRefreshWorker(t *testing.T, q *fakeQueue, c *fakeCache, f *fakeFetcher, r *fakeMetadataReader) *Worker {
+	t.Helper()
+	w := New(q, c, f, &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+	return w
+}
+
+// TestRefresh_SendsDurationAndISRCToProvider is the core parity assertion: the
+// track handed to the provider carries the on-disk duration and ISRC even though
+// work_queue stored neither.
+func TestRefresh_SendsDurationAndISRCToProvider(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/track.flac")}}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180, ISRC: "USAB11800001", AlbumName: "Tag Album"}}
+
+	w := newRefreshWorker(t, q, &fakeCache{}, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(f.tracks) != 1 {
+		t.Fatalf("provider called %d times; want 1", len(f.tracks))
+	}
+	got := f.tracks[0]
+	if got.TrackLength != 180 {
+		t.Errorf("TrackLength = %d; want 180 (q_duration would be omitted)", got.TrackLength)
+	}
+	if got.ISRC != "USAB11800001" {
+		t.Errorf("ISRC = %q; want USAB11800001 (track_isrc would be omitted)", got.ISRC)
+	}
+	if len(r.paths) != 1 || r.paths[0] != "/library/track.flac" {
+		t.Errorf("read paths = %v; want [/library/track.flac]", r.paths)
+	}
+}
+
+// TestRefresh_CacheBucketsAgree verifies the refresh happens at the single
+// mutation point, so the lookup and store keys are the same non-zero bucket.
+func TestRefresh_CacheBucketsAgree(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/track.flac")}}
+	c := &fakeCache{}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180}}
+
+	w := newRefreshWorker(t, q, c, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	want := normalize.DurationBucket(180)
+	if want == 0 {
+		t.Fatal("test setup error: expected a non-zero bucket for 180 seconds")
+	}
+	if len(c.lookupBuckets) != 1 || c.lookupBuckets[0] != want {
+		t.Errorf("lookup buckets = %v; want [%d]", c.lookupBuckets, want)
+	}
+	if len(c.stores) != 1 || c.stores[0].bucket != want {
+		t.Errorf("store buckets = %+v; want one entry with bucket %d", c.stores, want)
+	}
+}
+
+// TestRefresh_DoesNotClobberAlbumWithEmptyTag locks in the fresh-when-present
+// rule: a file with no album tag must not clear the album migration 032
+// backfilled onto the row, because q_album is sent unconditionally.
+func TestRefresh_DoesNotClobberAlbumWithEmptyTag(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/track.flac")}}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180}} // no album tag
+
+	w := newRefreshWorker(t, q, &fakeCache{}, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(f.tracks) != 1 {
+		t.Fatalf("provider called %d times; want 1", len(f.tracks))
+	}
+	if got := f.tracks[0].AlbumName; got != "Backfilled Album" {
+		t.Errorf("AlbumName = %q; want %q", got, "Backfilled Album")
+	}
+}
+
+// TestRefresh_ReadErrorIsNonFatal verifies a metadata read failure degrades to
+// the enqueue-time identity instead of failing or deferring the item; a vanished
+// file is prune's business, not the fetch path's.
+func TestRefresh_ReadErrorIsNonFatal(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/gone.flac")}}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{err: errors.New("open: no such file")}
+
+	w := newRefreshWorker(t, q, &fakeCache{}, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(f.tracks) != 1 {
+		t.Fatalf("provider called %d times; want 1 (the item must still be attempted)", len(f.tracks))
+	}
+	if got := f.tracks[0].TrackLength; got != 0 {
+		t.Errorf("TrackLength = %d; want 0 (the enqueue-time value)", got)
+	}
+	if len(q.failed) != 0 {
+		t.Errorf("failed = %v; want none (a metadata read failure must not fail the item)", q.failed)
+	}
+}
+
+// TestRefresh_SkippedWhenSourcePathEmpty verifies no read is attempted when there
+// is no file to read.
+func TestRefresh_SkippedWhenSourcePathEmpty(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("")}}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180}}
+
+	w := newRefreshWorker(t, q, &fakeCache{}, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if r.calls != 0 {
+		t.Errorf("reader called %d times; want 0", r.calls)
+	}
+}
+
+// TestRefresh_SkippedWhenEnrichmentDisabled verifies the operator's global
+// enrichment opt-out suppresses the fetch-time read entirely, keeping serve mode
+// at CLI parity in that configuration rather than exceeding it.
+func TestRefresh_SkippedWhenEnrichmentDisabled(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/track.flac")}}
+	f := refreshFetcher()
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180}}
+
+	w := New(q, &fakeCache{}, f, &fakeWriter{})
+	w.SetMetadataReader(r.read)
+	w.SetRecordingEnrichmentDefault(false)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if r.calls != 0 {
+		t.Errorf("reader called %d times; want 0 when enrichment is disabled", r.calls)
+	}
+	if len(f.tracks) != 1 {
+		t.Fatalf("provider called %d times; want 1", len(f.tracks))
+	}
+	if got := f.tracks[0].TrackLength; got != 0 {
+		t.Errorf("TrackLength = %d; want 0", got)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sydlexius/canticle/internal/orchestrator"
 	"github.com/sydlexius/canticle/internal/providers"
 	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/scanner"
 	"github.com/sydlexius/canticle/internal/verification"
 )
 
@@ -100,6 +101,13 @@ const defaultCircuitBackoffBase = 60 * time.Second
 // valid earlier this session, may now have expired.
 const escalationThreshold = 5
 
+// MetadataReader re-reads the recording disambiguators (duration, ISRC, album)
+// from an audio file at fetch time. It defaults to scanner.ReadAudioMetadata and
+// is injectable so worker tests exercise the refresh without binary audio
+// fixtures, following the seam precedent of realign's readProv and
+// identityrepair's IdentityReader.
+type MetadataReader func(path string) (scanner.AudioMetadata, error)
+
 // Worker consumes queued lyrics work one item at a time. The scan_results
 // writeback for successful completions is handled atomically inside
 // queue.DBQueue.Complete, so the worker has no separate ledger dependency.
@@ -112,6 +120,19 @@ const escalationThreshold = 5
 type Worker struct {
 	queue Queue
 	cache Cache
+	// readMetadata re-reads recording disambiguators from the item's source file
+	// at fetch time. work_queue persists neither duration nor ISRC (#584), so
+	// without this the provider query degrades to artist plus title and Musixmatch
+	// answers with its default recording, which writes a live or remastered cut's
+	// lyrics onto a studio track. Defaults to scanner.ReadAudioMetadata.
+	readMetadata MetadataReader
+	// enrichRecordingDefault mirrors config.Enrichment.Enabled. When false the
+	// operator has opted out of reading ISRC and duration, and a scan leaves them
+	// empty, so the fetch-time refresh is skipped too and serve mode sends exactly
+	// what the CLI would. Global default only: the worker holds no library context,
+	// so per-library enrichment overrides are not resolved here. Set via
+	// SetRecordingEnrichmentDefault.
+	enrichRecordingDefault bool
 	// orch dispatches the lyrics lookup across one or more provider lanes. With a
 	// single Musixmatch lane (the only deployment today) it is a behavior-
 	// preserving pass-through of the prior single-fetch path. The lane owns the
@@ -275,15 +296,20 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		lanes:                 []*orchestrator.Lane{lane},
 		writer:                writer,
 		verifyBelowConfidence: 0.85,
-		baseBackoff:           backoff.DefaultBase,
-		maxBackoff:            backoff.DefaultMax,
-		sleep:                 sleepCtx,
-		now:                   now,
-		circuit:               cb,
-		circuitBackoffBase:    defaultCircuitBackoffBase,
-		circuitOpenDuration:   defaultCircuitOpenDuration,
-		missBackoffBase:       backoff.DefaultMissBase,
-		missBackoffCap:        backoff.DefaultMissCap,
+		// Default to the scanner reader with enrichment on, matching
+		// config.Enrichment.Enabled's own default, so a caller that never calls the
+		// setters still gets fetch-mode parity rather than a silently disabled fix.
+		readMetadata:           scanner.ReadAudioMetadata,
+		enrichRecordingDefault: true,
+		baseBackoff:            backoff.DefaultBase,
+		maxBackoff:             backoff.DefaultMax,
+		sleep:                  sleepCtx,
+		now:                    now,
+		circuit:                cb,
+		circuitBackoffBase:     defaultCircuitBackoffBase,
+		circuitOpenDuration:    defaultCircuitOpenDuration,
+		missBackoffBase:        backoff.DefaultMissBase,
+		missBackoffCap:         backoff.DefaultMissCap,
 		// maxMissAttempts defaults to 0 (no cap). Non-serve callers (tests, ad-hoc
 		// CLI runs) get indefinite deferral; the config layer sets the cap via
 		// SetMaxMissAttempts using [api].max_miss_attempts (default 15).
@@ -567,6 +593,23 @@ func (w *Worker) SetInstrumentalDetectionDefault(enabled bool) {
 	w.detectInstrumentalDefault = enabled
 }
 
+// SetRecordingEnrichmentDefault sets whether the fetch-time recording-identity
+// refresh runs. It mirrors config.Enrichment.Enabled. Per-library overrides are
+// not resolved here; see the enrichRecordingDefault field comment.
+func (w *Worker) SetRecordingEnrichmentDefault(enabled bool) {
+	w.enrichRecordingDefault = enabled
+}
+
+// SetMetadataReader overrides the fetch-time metadata reader. Production uses the
+// scanner.ReadAudioMetadata default set in New; tests inject a fake. A nil reader
+// is ignored so the default can never be cleared into a no-op refresh.
+func (w *Worker) SetMetadataReader(r MetadataReader) {
+	if r == nil {
+		return
+	}
+	w.readMetadata = r
+}
+
 // SetDetectorOrdering selects whether the detector lane goes first ("front") or
 // last (any other value, e.g. "demoted") among the dispatch lanes, then
 // rebuilds the orchestrator. A nil audioDetector makes this a no-op at build
@@ -807,6 +850,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	// cache keys always agree. Confidence still scores against the original tag.
 	resolvedTrack := item.Inputs.Track
 	resolvedTrack.ArtistName = normalize.ResolveArtist(item.Inputs.Track.AlbumArtist, item.Inputs.Track.ArtistName)
+	// Restore the recording identity work_queue does not persist (duration, ISRC)
+	// before anything reads resolvedTrack, so the cache lookup, the provider query,
+	// and the cache store all see the same values. Any later position would break
+	// the read/write key agreement the comment above promises.
+	resolvedTrack = w.refreshRecordingIdentity(item, resolvedTrack)
 
 	// A configured providers generation that no longer matches the stamp the item
 	// was enqueued under means a cached result (if any) predates the current
@@ -1072,6 +1120,47 @@ func (w *Worker) detectorPathFor(item queue.WorkItem) string {
 		return ""
 	}
 	return item.Inputs.SourcePath
+}
+
+// refreshRecordingIdentity returns track with its recording disambiguators
+// re-read from the item's source file. work_queue stores neither duration nor
+// ISRC, so a queue-path track always arrives with TrackLength 0 and ISRC "";
+// re-reading restores fetch-mode parity (#584) with no schema change, and stays
+// correct if the file was retagged after enqueue.
+//
+// Fresh-when-present: a field is replaced only when the read produced a value, so
+// a file whose album tag is absent cannot clear the album that migration 032
+// backfilled onto the row (q_album is sent unconditionally). SpotifyID is never
+// tag-derived and is left alone.
+//
+// Every non-success path returns track unchanged and is non-fatal: a metadata
+// read must never fail or defer an item, because a vanished file is prune's
+// business, not the fetch path's. A read error logs at Warn (loud-skip, mirroring
+// detectorPathFor); a disabled enrichment switch and an absent source path are
+// expected states and log nothing.
+func (w *Worker) refreshRecordingIdentity(item queue.WorkItem, track models.Track) models.Track {
+	if !w.enrichRecordingDefault || w.readMetadata == nil {
+		return track
+	}
+	if strings.TrimSpace(item.Inputs.SourcePath) == "" {
+		return track
+	}
+	meta, err := w.readMetadata(item.Inputs.SourcePath)
+	if err != nil {
+		slog.Warn("fetch-time metadata refresh failed; querying with enqueue-time identity",
+			"id", item.ID, "artist", track.ArtistName, "track", track.TrackName, "error", err)
+		return track
+	}
+	if meta.TrackLength > 0 {
+		track.TrackLength = meta.TrackLength
+	}
+	if meta.ISRC != "" {
+		track.ISRC = meta.ISRC
+	}
+	if meta.AlbumName != "" {
+		track.AlbumName = meta.AlbumName
+	}
+	return track
 }
 
 // stampDetectorInstrumental records a detector-sourced instrumental settle from

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -220,6 +220,7 @@ func (q *fakeQueue) removeFromProcessing(id int64) {
 type cacheStore struct {
 	artist string
 	title  string
+	bucket int
 	lyrics string
 }
 
@@ -227,9 +228,13 @@ type fakeCache struct {
 	hit    string
 	err    error
 	stores []cacheStore
+	// lookupBuckets records the duration bucket each Lookup was keyed on, so a
+	// test can assert the read and write keys agree (#584).
+	lookupBuckets []int
 }
 
-func (c *fakeCache) Lookup(_ context.Context, _ string, _ string, _ int) (string, error) {
+func (c *fakeCache) Lookup(_ context.Context, _ string, _ string, bucket int) (string, error) {
+	c.lookupBuckets = append(c.lookupBuckets, bucket)
 	if c.err != nil {
 		return "", c.err
 	}
@@ -239,8 +244,8 @@ func (c *fakeCache) Lookup(_ context.Context, _ string, _ string, _ int) (string
 	return c.hit, nil
 }
 
-func (c *fakeCache) Store(_ context.Context, artist, title string, _ int, lyrics string) error {
-	c.stores = append(c.stores, cacheStore{artist: artist, title: title, lyrics: lyrics})
+func (c *fakeCache) Store(_ context.Context, artist, title string, bucket int, lyrics string) error {
+	c.stores = append(c.stores, cacheStore{artist: artist, title: title, bucket: bucket, lyrics: lyrics})
 	return nil
 }
 
@@ -248,10 +253,14 @@ type fakeFetcher struct {
 	song  models.Song
 	err   error
 	calls int
+	// tracks records each track handed to the provider, so a test can assert the
+	// recording disambiguators actually reached the query (#584).
+	tracks []models.Track
 }
 
-func (f *fakeFetcher) FindLyrics(context.Context, models.Track) (models.Song, error) {
+func (f *fakeFetcher) FindLyrics(_ context.Context, t models.Track) (models.Song, error) {
 	f.calls++
+	f.tracks = append(f.tracks, t)
 	if f.err != nil {
 		return models.Song{}, f.err
 	}


### PR DESCRIPTION
## Summary

- Serve mode queried Musixmatch with artist + title only, because `work_queue` persists no `track_length` or `isrc` column. The client was already wired to send `q_duration` and `track_isrc` when the track carries them (`client.go:388,392`), so the values simply never arrived on the queue path. Musixmatch therefore answered with its default (most-popular) recording, which writes a live/extended/remaster cut's lyrics and timing onto a studio track.
- The worker now re-reads those disambiguators from the item's `source_path` at fetch time (Option A), reaching CLI parity by construction: it is the identical tag/duration read path a scan uses. No schema change, no migration, no backfill, and it fixes existing rows as well as new ones.
- The refresh is gated on the existing `enrichment.enabled` switch, so an operator who disabled recording enrichment keeps CLI parity rather than exceeding it.
- **Measured on a real library (2,000 files sampled from 83,666, zero read errors): duration coverage is 100%, ISRC coverage is 41.7%.** So every serve-mode fetch goes from zero disambiguators to at least one, and roughly two in five also gain the exact recording identifier. Note this inverts the issue's emphasis: ISRC is the strongest signal per track, but duration is the one that carries this fix in practice.
- **Reviewers look here first:** the call-site position (`worker.go`, immediately after `ResolveArtist`) is load-bearing -- it is the single mutation point that keeps the cache read key, the provider query, and the cache write key in agreement. Also read the cache-behavior note under "Not covered": already-cached tracks keep their old result via the existing bucket-0 fallback, so this fix lands on cache misses.

## Linked issue

Closes #584

Unblocks #585 (re-fetch mis-disambiguated `.lrc` already on disk). Sibling of #583 (album), which remains the display/recall fix.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [ ] Commits squashed into one clean commit before the first push (two commits today: scanner reader, then worker wiring).
- [ ] Label set on `gh pr create --label ...` (suggest `bug`).
- [~] UAT: input-side verified against the real library (see Test plan); end-to-end provider run not performed.
- [x] Screenshot: not applicable, no web-UI change.
- [x] `make ui`: not applicable, no `.templ` or CSS change.
- [x] Migration: not applicable and deliberately avoided -- Option A exists precisely so no migration or backfill is needed.

## Test plan

- [x] `make gate` passes locally. Coverage rose rather than fell: `internal/scanner` 68% -> 76% (+8%), `internal/worker` 83% -> 86% (+3%), every package at or above floor.
- [x] `make test-shuffle` (`go test -race -shuffle=on`) exits 0 with zero failures.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Task 1's four scanner tests failed with `undefined: ReadAudioMetadata`; Task 2's six worker tests failed with `SetMetadataReader undefined`. The worker tests cannot pass vacuously: a queue-path item carries `TrackLength = 0` and `ISRC = ""` by construction, so the assertions are only satisfiable if the refresh actually ran.
- [x] Which **surface** this change fixes: the **outbound Musixmatch query parameters** (`q_duration`, `track_isrc`, `q_album`) and the **`lyrics_cache` key**. It is not a UI or `/metrics` change; neither the dashboard nor `provider_outcomes` is touched. Verified by asserting on the track handed to the provider stub and on the duration bucket passed to both cache Lookup and Store, not by a DB-level check.
- [x] **Input-side UAT against the real library.** A throwaway read-only probe calling the shipped `scanner.ReadAudioMetadata` sampled 2,000 files across all four library roots (83,666 audio files found), reporting aggregate counts only:

  | Root | Files | Duration | ISRC | Album |
  |---|---|---|---|---|
  | Music | 68,716 | 100% | 49.2% | 100% |
  | Classical | 6,710 | 100% | 50.2% | 100% |
  | VGM | 6,338 | 100% | 24.4% | 100% |
  | Kids_Music | 1,902 | 100% | 43.0% | 100% |
  | **Total** | **83,666** | **100%** | **41.7%** | **100%** |

  Zero read errors. Duration is the built-in positive control: it comes from the same successful open and parse as ISRC, so 100% duration coverage proves the reader worked and the 58% ISRC absence is a real property of the library rather than a parse failure. At n=2,000 the 95% interval on 41.7% is about ±2.2%.

- [ ] End-to-end UAT: **not performed.** Would require running the branch binary against a scratch DB and a temp copy of tracks whose Musixmatch default is a non-studio version, then confirming the written `.lrc` matches the studio cut.
- [ ] Reviewer follow-ups:
  - [ ] The `AudioMetadata` struct return deviates from the siblings' positional multi-return (`ReadAudioProvenance` returns five values). Chosen so #585 can add `RecordingMBID` without touching call sites; say if package uniformity is preferred.
  - [ ] `SetMetadataReader` ignores a nil reader rather than clearing the default, so the refresh cannot be silently turned into a no-op. Confirm that is the preferred failure posture.

## Not covered

**Cache behavior: no strand, no re-fetch wave.** `lyrics_cache` is keyed `UNIQUE(artist, title, duration_bucket)` (migration 014), where `duration_bucket = floor(seconds/5)` and `0` is the unknown-duration sentinel. Serve mode previously supplied `TrackLength = 0` on every item, so its existing entries all live at bucket 0. Supplying a real duration moves lookups to a different bucket -- but `CacheRepo.Lookup` (`internal/cache/cache.go:39-79`) already falls back to the bucket-0 sentinel row on an exact-bucket miss, precisely so pre-existing entries keep serving without a re-fetch wave or migration. So legacy entries stay reachable, hit rate does not collapse, and no extra provider load is introduced. `worker.go:988` gates the cache Store on `!cacheHit`, so a fallback hit does not duplicate the row at the new bucket.

The real limitation is the other side of that fallback: **a track that already has a bucket-0 cache entry is served from cache and never issues the improved query**, so it keeps its possibly mis-disambiguated lyrics. That is not a regression (before this change the same track hit bucket 0 by exact match), but it does mean the fix takes effect on cache *misses*. That is the population that matters here -- the deferred backlog consists of prior misses with nothing cached -- and re-examining already-settled tracks is exactly #585's job.

Reviewers: an earlier draft of this PR claimed the opposite (that legacy entries would be stranded and the hit rate would collapse). That was wrong, caught by the adversarial pre-push review, and is corrected above.

**Enrichment gate is global-only.** `enrichment.enabled` is also resolvable per library (`scan/scheduler.go:122` resolves override, then library, then global). The worker holds no library context, so honoring the per-library value would mean plumbing the library repository into the worker purely to gate a tag read. A library that disables enrichment while the global default is on will still be refreshed. Deliberate scope boundary, not an oversight.

**About 58% of the library carries no ISRC** (24.4% coverage in VGM, where much of the material was never issued commercially and so never had an ISRC assigned). Those tracks are disambiguated by duration and album alone. That is still strictly better than today's artist-plus-title query, but it is not the exact-identifier match, so some version ambiguity will remain there and #585 should not assume otherwise.

**Not verified by this change:**
- No end-to-end test against the real Musixmatch API; the provider is stubbed. The input side is measured (see Test plan), but whether a correct `track_isrc` actually changes Musixmatch's chosen recording is asserted only from the API's documented behavior and the CLI's existing results.
- `RecordingMBID` is still not sent; the client has no MBID parameter. Realign/provenance only.
- The mis-disambiguated `.lrc` files already written to disk are untouched. That is #585.
- No measurement of the added per-fetch file open. Argued as negligible against a serial, network-bound loop paced at roughly 60 items/hour that already opens the same file for detection, rather than benchmarked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording metadata is refreshed from audio files before provider searches and caching.
  * Duration, ISRC, and album information now improve track identification when available.
  * Metadata enrichment can be enabled or disabled through configuration.

* **Bug Fixes**
  * Missing or unreadable metadata no longer prevents provider searches.
  * Existing album information is preserved when audio tags are empty.
  * Unknown track duration is handled gracefully.

* **Tests**
  * Added coverage for metadata extraction, enrichment behavior, caching consistency, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->