### PR TITLE
feat(musixmatch): bootstrap and renew the API token automatically (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Renamed an audio file and left its `.lrc`/`.txt` behind? `canticle realign` re-a
 
 In **serve mode**, a Musixmatch API token is optional: on first run canticle obtains one automatically and stores it encrypted at rest, reusing it on every later start, so there is nothing to set up. The one-shot `fetch` CLI keeps no state, so it cannot store a token and still needs one supplied explicitly.
 
-To supply your own instead, use the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). A token you supply always takes precedence and is never overwritten. If automatic setup is unavailable, you can obtain one by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
+To supply your own instead, prefer `canticle secrets set musixmatch_token`, which reads the value from stdin and stores it encrypted at rest, keeping it out of shell history and process listings. The `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, and a `.env`/config file remain supported, in that order of precedence (CLI > env > file). A token you supply always takes precedence and is never overwritten. If automatic setup is unavailable, you can obtain one by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
 
 ## Encrypted secrets
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Renamed an audio file and left its `.lrc`/`.txt` behind? `canticle realign` re-a
 
 ## Token
 
-A Musixmatch API token is required. Supply it via the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). To get a token, follow steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
+In **serve mode**, a Musixmatch API token is optional: on first run canticle obtains one automatically and stores it encrypted at rest, reusing it on every later start, so there is nothing to set up. The one-shot `fetch` CLI keeps no state, so it cannot store a token and still needs one supplied explicitly.
+
+To supply your own instead, use the `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, or a `.env`/config file, in that order of precedence (CLI > env > file). A token you supply always takes precedence and is never overwritten. If automatic setup is unavailable, you can obtain one by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
 
 ## Encrypted secrets
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,7 +22,9 @@ A Musixmatch API token is required. Supply it using any of the following methods
    MUSIXMATCH_TOKEN=YOUR_TOKEN
    ```
 
-To obtain a token, follow steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work).
+In serve mode a token is optional: when none is configured, canticle obtains one automatically on first run and persists it in the encrypted secret store, reusing it on later starts. A token you configure here always takes precedence and is never overwritten by that automatic path. The one-shot `fetch` CLI is stateless and has no secret store, so it cannot persist a token and still requires one.
+
+If automatic setup is unavailable, obtain a token by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work).
 
 ## General precedence
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,7 +6,7 @@ A fully commented `config.example.toml` ships in the repository root; copy it an
 
 ## Token precedence
 
-A Musixmatch API token is required. Supply it using any of the following methods, listed in order of precedence (highest first):
+A Musixmatch API token is required for the one-shot `fetch` CLI, and optional in serve mode (which provisions and stores one itself). When you do supply one, these are the sources in order of precedence (highest first):
 
 1. **`--token` CLI flag** - highest priority.
    ```sh
@@ -54,7 +54,7 @@ The table below is the complete env-var surface; the watcher and verification se
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `MUSIXMATCH_TOKEN` | (required) | Musixmatch API token. `MXLRC_API_TOKEN` is accepted as a lower-precedence alias. |
+| `MUSIXMATCH_TOKEN` | (auto-provisioned in serve mode; required for `fetch`) | Musixmatch API token. `MXLRC_API_TOKEN` is accepted as a lower-precedence alias. |
 | `MXLRC_WEBHOOK_API_KEY` | (none) | Comma-separated webhook API key(s) accepted by the server. Generate with `canticle keys create --scope webhook`. |
 | `MXLRC_SERVER_ADDR` | `127.0.0.1:3876` | HTTP listen address for `serve`. Docker images default this to `0.0.0.0:50705`. |
 | `MXLRC_WEB_UI_ENABLED` | `false` | Enable the browser UI on the serve listener. Env override of `web_ui_enabled` (precedence: env > file). Restart to apply. |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,9 +12,17 @@ Every path needs a Musixmatch token first.
 
 ## Get a Musixmatch token
 
-A Musixmatch API token is required. Without one, every fetch returns a `401` and no lyrics are written. The token is a long opaque string (it is not your Musixmatch account password).
+In **serve mode**, a Musixmatch API token is optional. On first run canticle requests one automatically and stores it in its encrypted secret store, then reuses that stored token on every later start. For most installs there is nothing to do here.
 
-To obtain a token, follow steps 1 to 5 of the [Spicetify FAQ](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). In our words: install the Spicetify lyrics setup it describes, open your browser developer tools on the network tab while lyrics load, find the Musixmatch request, and copy the `usertoken` value out of its query string. That copied string is your token.
+The one-shot `fetch` CLI keeps no state and has no secret store, so it cannot save a token for reuse. It still needs one supplied explicitly, via `--token`, `MUSIXMATCH_TOKEN`, or a config file.
+
+The token is a long opaque string (it is not your Musixmatch account password).
+
+You may still want to supply your own, for example if you already have one or you are running somewhere the automatic request is refused. A token you supply always takes precedence and is never overwritten.
+
+### Obtaining a token by hand (optional)
+
+If you need to provision one yourself, follow steps 1 to 5 of the [Spicetify FAQ](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). In our words: install the Spicetify lyrics setup it describes, open your browser developer tools on the network tab while lyrics load, find the Musixmatch request, and copy the `usertoken` value out of its query string. That copied string is your token.
 
 The quickest way to provision it for a shell session:
 
@@ -160,7 +168,7 @@ See the [User Guide](USER_GUIDE.md#inspection-commands) for the full inspection 
 
 ## Troubleshooting
 
-- **`401` / token rejected.** The token is missing, wrong, or expired. Re-check the [precedence](#get-a-musixmatch-token): a `--token` flag or a stale environment variable can silently override the one you think you are using. Confirm with `--token` explicitly, then re-provision a fresh token from the Spicetify FAQ.
+- **`401` is usually throttling, not a dead token.** A bare `401` most often means the request was throttled, not that the credential expired. This is measured, not assumed: a token that was working began returning `401` after a few closely spaced requests, then worked normally again later. So the first thing to try is slowing down (raise `MXLRC_API_COOLDOWN`), not re-provisioning. A genuinely finished credential is reported differently, and canticle handles that case itself by obtaining a replacement and retrying. If `401`s persist across a long quiet period, then re-check the [precedence](#get-a-musixmatch-token): a `--token` flag or a stale environment variable can silently override the token you think you are using.
 - **Rate limiting / circuit breaker.** When Musixmatch signals throttling, the worker opens a circuit breaker and pauses dequeuing globally to back off. If you hit this often, raise the request cooldown with `MXLRC_API_COOLDOWN` (seconds between requests). See [Configuration](CONFIGURATION.md#environment-variables) for the cooldown and circuit-breaker variables.
 - **Benign miss / `deferred`.** A track Musixmatch has no lyrics for yet lands in `queue deferred`, not `queue failed`. This is not a failure; the row waits out a cooldown and re-checks itself later.
 - **Unraid `/mnt/user` watcher caveat.** The optional filesystem watcher relies on inotify events, which Unraid `/mnt/user` (FUSE/shfs) mounts often do not deliver into the container. Keep the periodic scan as the source of truth there; do not set the scan interval to `0`. Note the watcher switch is `MXLRCGO_WATCH_ENABLED` (the `MXLRCGO_` prefix, not `MXLRC_`).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -8,7 +8,7 @@ Canticle fetches synced lyrics from [Musixmatch](https://www.musixmatch.com/) an
 - **Have a music library on disk?** Point the tool at a folder and it writes a lyric file next to each track. See [Directory mode](#directory-mode).
 - **Use Lidarr, or run containers?** Run it as a long-lived service that accepts Lidarr webhooks and scans your libraries on a schedule. See [Daemon / serve](#daemon-serve). If you do not know what Lidarr is, you probably do not need it.
 
-Every path needs a Musixmatch token first.
+Serve mode obtains a Musixmatch token on its own; the one-shot `fetch` CLI needs one supplied.
 
 ## Get a Musixmatch token
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -909,6 +909,11 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		return 1
 	}
 
+	// operatorSupplied records whether a token arrived from CLI/env/TOML, before
+	// the lower tiers can substitute one. It gates both auto-minting and renewal:
+	// an operator credential is never overwritten (#554).
+	operatorSupplied := strings.TrimSpace(token) != ""
+
 	// DB is the lowest-precedence source for both secrets: consulted only when the
 	// higher tiers (CLI/env/TOML) are empty, and a DB-sourced value is never
 	// auto-persisted back.
@@ -918,6 +923,23 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		slog.Error("failed to resolve musixmatch token", "error", err)
 		return 1
 	}
+	// Lowest tier of all: with every other source empty, mint a token and persist
+	// it so the deployment is zero-config (#554). A stored or operator-supplied
+	// token short-circuits this, which is what keeps a restart from re-minting --
+	// the mint endpoint is rate limited, so a re-minting restart loop would lock
+	// itself out.
+	tokenMinterImpl := musixmatch.NewTokenMinter(nil)
+	token, _ = bootstrapToken(ctx, token, tokenFromDB, store, tokenMinterImpl)
+
+	// tokenRenewer is installed only when no operator credential is in play. It
+	// fires solely on the API's explicit hint=renew signal, never on a bare 401
+	// (observed behavior attributes those to throttling, and renewing on them
+	// would burn rate-limited mints during the exact window they are refused).
+	var tokenRenewer musixmatch.TokenRenewer
+	if !operatorSupplied && store != nil {
+		tokenRenewer = &persistingRenewer{minter: tokenMinterImpl, store: store}
+	}
+
 	webhookKeys, webhookFromDB, err := resolveWebhookKeysWithStore(ctx, cfg.Server.WebhookAPIKeys, store)
 	if err != nil {
 		_ = sqlDB.Close()
@@ -953,6 +975,17 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// the worker/scheduler never start (the queue is left untouched rather than
 	// churned into permanent miss retirements).
 	fetcher, selErr := selectedProvider(cfg, token, newFetcher)
+	// Attach the renewer to the concrete Musixmatch client when one was built. The
+	// assertion is deliberately best-effort: petitlyrics and the degraded no-op
+	// provider have no token to renew, so a failed assertion is the expected
+	// no-token path, not an error.
+	if tokenRenewer != nil {
+		if mc, ok := fetcher.(interface {
+			SetTokenRenewer(musixmatch.TokenRenewer)
+		}); ok {
+			mc.SetTokenRenewer(tokenRenewer)
+		}
+	}
 	fetcher, musixmatchInactive, lyricsDisabled, err := resolveServeProvider(fetcher, selErr)
 	if err != nil {
 		_ = sqlDB.Close()

--- a/internal/commands/token_bootstrap.go
+++ b/internal/commands/token_bootstrap.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/sydlexius/canticle/internal/musixmatch"
+	"github.com/sydlexius/canticle/internal/secrets"
+)
+
+// tokenMinter is the seam for obtaining a fresh Musixmatch token.
+// musixmatch.TokenMinter satisfies it in production; tests inject a fake.
+type tokenMinter interface {
+	Mint(ctx context.Context) (string, error)
+}
+
+// persistingRenewer mints a replacement token on the explicit hint=renew signal
+// and persists it, so the replacement survives a restart exactly as a
+// bootstrapped token does.
+//
+// It is installed ONLY when no operator-supplied token is in play. An operator
+// token is never overwritten (AC4), and a deployment that supplies its own
+// credential should fail loudly rather than silently swap in a minted one.
+type persistingRenewer struct {
+	minter tokenMinter
+	store  secrets.Store
+}
+
+// Renew mints a replacement and persists it. A persist failure is logged at
+// ERROR but the token is still returned: the current run recovers, and the log
+// says the replacement will not survive a restart.
+func (r *persistingRenewer) Renew(ctx context.Context) (string, error) {
+	tok, err := r.minter.Mint(ctx)
+	if err != nil {
+		return "", err
+	}
+	if err := r.store.Set(ctx, secrets.NameMusixmatchToken, tok); err != nil {
+		slog.Error("renewed the musixmatch token but could not persist it; the next start will use the old one",
+			"error", err)
+	}
+	return tok, nil
+}
+
+// bootstrapToken is the LOWEST-precedence token source (#554): it mints a token
+// only when every higher tier came up empty, then persists it so the existing
+// secret-store tier serves it on the next start.
+//
+// Precedence and safety rules, in order:
+//
+//   - An operator-supplied token (CLI / env / TOML) is returned untouched and is
+//     NEVER overwritten, matching resolveTokenWithStore's contract.
+//   - A token already read from the secret store is returned untouched. This is
+//     what makes a restart never re-mint, which matters because the token
+//     endpoint rate-limits: #554 measured three rapid mints from one egress all
+//     refused. A re-minting restart loop would lock itself out.
+//   - A refused mint degrades to no token rather than retrying. Serve mode
+//     already handles an absent token by disabling lyrics while keeping the web
+//     UI up (#385), so degrading is strictly better than spinning.
+//
+// A persist failure is logged at ERROR but the freshly minted token is still
+// returned: the current run works, and the loud log surfaces that the next start
+// will have to mint again.
+func bootstrapToken(ctx context.Context, higher string, fromDB bool, store secrets.Store, minter tokenMinter) (token string, minted bool) {
+	if strings.TrimSpace(higher) != "" {
+		return higher, false
+	}
+	if fromDB {
+		return higher, false
+	}
+	if store == nil || minter == nil {
+		return higher, false
+	}
+
+	tok, err := minter.Mint(ctx)
+	if err != nil {
+		if errors.Is(err, musixmatch.ErrTokenMintRefused) {
+			slog.Warn("musixmatch token bootstrap refused (rate limited); continuing without a token",
+				"hint", "supply MUSIXMATCH_TOKEN or retry later; do not restart in a loop")
+			return higher, false
+		}
+		slog.Warn("musixmatch token bootstrap failed; continuing without a token", "error", err)
+		return higher, false
+	}
+
+	if err := store.Set(ctx, secrets.NameMusixmatchToken, tok); err != nil {
+		slog.Error("minted a musixmatch token but could not persist it; the next start will mint again",
+			"error", err)
+		return tok, true
+	}
+	slog.Info("bootstrapped a musixmatch token and persisted it to the encrypted secret store")
+	return tok, true
+}

--- a/internal/commands/token_bootstrap_test.go
+++ b/internal/commands/token_bootstrap_test.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/musixmatch"
+	"github.com/sydlexius/canticle/internal/secrets"
+)
+
+type fakeMinter struct {
+	token string
+	err   error
+	calls int
+}
+
+func (f *fakeMinter) Mint(context.Context) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.token, nil
+}
+
+// failingStore is a secrets.Store whose Set always fails, to exercise the
+// persist-failure path without a broken database.
+type failingStore struct {
+	secrets.Store
+}
+
+func (failingStore) Set(context.Context, string, string) error {
+	return errors.New("disk full")
+}
+
+// TestBootstrapToken_OperatorTokenIsNeverOverwritten pins AC4: a supplied token
+// short-circuits before minting, and nothing is persisted.
+func TestBootstrapToken_OperatorTokenIsNeverOverwritten(t *testing.T) {
+	store := secrets.NewMemoryStore()
+	m := &fakeMinter{token: "minted"}
+
+	got, minted := bootstrapToken(context.Background(), "operator-token", false, store, m)
+
+	if got != "operator-token" {
+		t.Errorf("token = %q; want the operator token", got)
+	}
+	if minted {
+		t.Error("minted = true; want false")
+	}
+	if m.calls != 0 {
+		t.Errorf("minter called %d times; want 0", m.calls)
+	}
+	if _, ok, _ := store.Get(context.Background(), secrets.NameMusixmatchToken); ok {
+		t.Error("a token was persisted; an operator-supplied token must never be written")
+	}
+}
+
+// TestBootstrapToken_StoredTokenIsNotReminted pins AC2, the constraint that
+// keeps a restart loop from locking itself out of the mint endpoint.
+func TestBootstrapToken_StoredTokenIsNotReminted(t *testing.T) {
+	m := &fakeMinter{token: "minted"}
+
+	got, minted := bootstrapToken(context.Background(), "stored-token", true, secrets.NewMemoryStore(), m)
+
+	if got != "stored-token" {
+		t.Errorf("token = %q; want the stored token", got)
+	}
+	if minted {
+		t.Error("minted = true; want false")
+	}
+	if m.calls != 0 {
+		t.Errorf("minter called %d times; want 0 (a restart must never re-mint)", m.calls)
+	}
+}
+
+// TestBootstrapToken_MintsAndPersists pins AC1.
+func TestBootstrapToken_MintsAndPersists(t *testing.T) {
+	store := secrets.NewMemoryStore()
+	m := &fakeMinter{token: "fresh-token"}
+
+	got, minted := bootstrapToken(context.Background(), "", false, store, m)
+
+	if got != "fresh-token" {
+		t.Errorf("token = %q; want the minted token", got)
+	}
+	if !minted {
+		t.Error("minted = false; want true")
+	}
+	if m.calls != 1 {
+		t.Errorf("minter called %d times; want 1", m.calls)
+	}
+	v, ok, err := store.Get(context.Background(), secrets.NameMusixmatchToken)
+	if err != nil || !ok {
+		t.Fatalf("token not persisted (ok=%v err=%v)", ok, err)
+	}
+	if v != "fresh-token" {
+		t.Errorf("persisted %q; want the minted token", v)
+	}
+}
+
+// TestBootstrapToken_RefusedMintDegrades verifies a rate-limited mint yields no
+// token and no retry, rather than spinning against the endpoint.
+func TestBootstrapToken_RefusedMintDegrades(t *testing.T) {
+	store := secrets.NewMemoryStore()
+	m := &fakeMinter{err: musixmatch.ErrTokenMintRefused}
+
+	got, minted := bootstrapToken(context.Background(), "", false, store, m)
+
+	if got != "" {
+		t.Errorf("token = %q; want empty", got)
+	}
+	if minted {
+		t.Error("minted = true; want false")
+	}
+	if m.calls != 1 {
+		t.Errorf("minter called %d times; want exactly 1 (no retry loop)", m.calls)
+	}
+	if _, ok, _ := store.Get(context.Background(), secrets.NameMusixmatchToken); ok {
+		t.Error("something was persisted after a refused mint")
+	}
+}
+
+func TestBootstrapToken_MintErrorDegrades(t *testing.T) {
+	m := &fakeMinter{err: errors.New("network unreachable")}
+
+	got, minted := bootstrapToken(context.Background(), "", false, secrets.NewMemoryStore(), m)
+
+	if got != "" || minted {
+		t.Errorf("got (%q, %v); want (\"\", false)", got, minted)
+	}
+}
+
+// TestBootstrapToken_PersistFailureStillReturnsToken keeps the current run
+// working when the store cannot be written; the ERROR log carries the warning
+// that the next start will mint again.
+func TestBootstrapToken_PersistFailureStillReturnsToken(t *testing.T) {
+	m := &fakeMinter{token: "fresh-token"}
+
+	got, minted := bootstrapToken(context.Background(), "", false, failingStore{secrets.NewMemoryStore()}, m)
+
+	if got != "fresh-token" {
+		t.Errorf("token = %q; want the minted token despite the persist failure", got)
+	}
+	if !minted {
+		t.Error("minted = false; want true")
+	}
+}
+
+func TestBootstrapToken_NilStoreOrMinterIsANoOp(t *testing.T) {
+	if got, minted := bootstrapToken(context.Background(), "", false, nil, &fakeMinter{token: "x"}); got != "" || minted {
+		t.Errorf("nil store: got (%q, %v); want (\"\", false)", got, minted)
+	}
+	if got, minted := bootstrapToken(context.Background(), "", false, secrets.NewMemoryStore(), nil); got != "" || minted {
+		t.Errorf("nil minter: got (%q, %v); want (\"\", false)", got, minted)
+	}
+}

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -155,6 +155,11 @@ type Client struct {
 	tokenMu sync.RWMutex
 	// renewedToken, when non-empty, supersedes Token after a successful renewal.
 	renewedToken string
+	// renewMu single-flights the renewal path so concurrent hint=renew signals
+	// produce ONE mint rather than one per goroutine. It is held across the mint
+	// call, so it is deliberately NOT tokenMu (which must stay uncontended for
+	// per-request token reads).
+	renewMu sync.Mutex
 	// renewer, when non-nil, mints a replacement token on the hint=renew signal.
 	// Nil disables renewal entirely, which is the behavior for every caller that
 	// supplies its own operator token.
@@ -433,13 +438,30 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	if renewer == nil {
 		return song, err
 	}
+
+	// Single-flight the renewal. FindLyrics may be called concurrently, and the
+	// mint endpoint is rate limited (three rapid mints from one egress were
+	// measured to all return 401), so N goroutines seeing hint=renew together must
+	// produce ONE mint, not N. Without this the feature triggers the exact lockout
+	// it exists to avoid.
+	staleToken := c.currentToken()
+	c.renewMu.Lock()
+	if c.currentToken() != staleToken {
+		// Another goroutine renewed while this one waited. Use its token rather
+		// than minting a second time.
+		c.renewMu.Unlock()
+		slog.Debug("musixmatch token was renewed concurrently; retrying with the existing replacement")
+		return c.findLyricsOnce(ctx, track)
+	}
 	tok, rerr := renewer.Renew(ctx)
 	if rerr != nil {
+		c.renewMu.Unlock()
 		slog.Warn("musixmatch signaled token renewal but minting a replacement failed",
 			"error", rerr)
 		return song, err
 	}
 	c.installRenewedToken(tok)
+	c.renewMu.Unlock()
 	slog.Info("musixmatch signaled token renewal; installed a freshly minted token and retrying once")
 	return c.findLyricsOnce(ctx, track)
 }

--- a/internal/musixmatch/client.go
+++ b/internal/musixmatch/client.go
@@ -134,10 +134,31 @@ func IsBenignMiss(err error) bool {
 	return errors.Is(err, ErrNotFound) || errors.Is(err, ErrNoLyrics)
 }
 
+// TokenRenewer supplies a replacement token when the API explicitly signals that
+// the current one is finished. It is deliberately narrow: the ONLY trigger is the
+// body-level hint=renew signal (see ErrTokenRenewalRequired), never a bare HTTP
+// 401, which observed behavior says is usually an egress/token throttle rather
+// than a dead credential (#554).
+type TokenRenewer interface {
+	Renew(ctx context.Context) (string, error)
+}
+
 // Client communicates with the Musixmatch desktop API.
 type Client struct {
+	// Token is the initial token. Read it through currentToken(), which also sees
+	// a token installed later by a renewal.
 	Token      string
 	httpClient *http.Client
+
+	// tokenMu guards the renewed token. It is separate from mu (the pacer lock) so
+	// a token read can never nest inside the pacing critical section.
+	tokenMu sync.RWMutex
+	// renewedToken, when non-empty, supersedes Token after a successful renewal.
+	renewedToken string
+	// renewer, when non-nil, mints a replacement token on the hint=renew signal.
+	// Nil disables renewal entirely, which is the behavior for every caller that
+	// supplies its own operator token.
+	renewer TokenRenewer
 
 	// pacer fields -- zero value means no pacing (minInterval == 0).
 	mu          sync.Mutex
@@ -159,6 +180,39 @@ type Client struct {
 	// occurred, since there is nothing to decay from and no meaningful elapsed
 	// window to measure.
 	lastLevelChange time.Time
+}
+
+// SetTokenRenewer installs the renewer consulted when the API signals
+// hint=renew. A nil renewer leaves renewal disabled.
+func (c *Client) SetTokenRenewer(r TokenRenewer) {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+	c.renewer = r
+}
+
+// currentToken returns the token to send: the renewed one when a renewal has
+// succeeded, otherwise the token supplied at construction.
+func (c *Client) currentToken() string {
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
+	if c.renewedToken != "" {
+		return c.renewedToken
+	}
+	return c.Token
+}
+
+// installRenewedToken records a freshly minted token for subsequent requests.
+func (c *Client) installRenewedToken(tok string) {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+	c.renewedToken = tok
+}
+
+// tokenRenewer returns the configured renewer, or nil.
+func (c *Client) tokenRenewer() TokenRenewer {
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
+	return c.renewer
 }
 
 // NewClient creates a new Musixmatch API client.
@@ -358,7 +412,40 @@ func (c *Client) Name() string {
 }
 
 // FindLyrics looks up lyrics for the given track from the Musixmatch API.
+//
+// When the API answers with the explicit hint=renew signal and a renewer is
+// installed, it mints a replacement token, installs it, and retries the request
+// EXACTLY ONCE (#554). The retry is deliberately bounded: a renewal that fails,
+// is refused, or is followed by a second renewal signal returns the error rather
+// than looping, because the mint endpoint is itself rate-limited and a retry loop
+// would lock the deployment out of it entirely.
+//
+// A bare HTTP 401 never triggers renewal. errors.Is(err, ErrTokenRenewalRequired)
+// matches only the body-level hint=renew case; the bare 401 path returns
+// ErrUnauthorized, which observed behavior attributes to throttling rather than a
+// dead credential.
 func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
+	song, err := c.findLyricsOnce(ctx, track)
+	if err == nil || !errors.Is(err, ErrTokenRenewalRequired) {
+		return song, err
+	}
+	renewer := c.tokenRenewer()
+	if renewer == nil {
+		return song, err
+	}
+	tok, rerr := renewer.Renew(ctx)
+	if rerr != nil {
+		slog.Warn("musixmatch signaled token renewal but minting a replacement failed",
+			"error", rerr)
+		return song, err
+	}
+	c.installRenewedToken(tok)
+	slog.Info("musixmatch signaled token renewal; installed a freshly minted token and retrying once")
+	return c.findLyricsOnce(ctx, track)
+}
+
+// findLyricsOnce performs a single lookup with the currently installed token.
+func (c *Client) findLyricsOnce(ctx context.Context, track models.Track) (models.Song, error) {
 	if err := c.pace(ctx); err != nil {
 		return models.Song{}, err
 	}
@@ -372,7 +459,7 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 		"namespace":         {"lyrics_richsynched"},
 		"subtitle_format":   {"mxm"},
 		"app_id":            {"web-desktop-app-v1.0"},
-		"usertoken":         {c.Token},
+		"usertoken":         {c.currentToken()},
 		"q_album":           {track.AlbumName},
 		"q_artist":          {track.ArtistName},
 		"q_artists":         {track.ArtistName},

--- a/internal/musixmatch/renew_test.go
+++ b/internal/musixmatch/renew_test.go
@@ -1,0 +1,171 @@
+package musixmatch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// renewSignalBody is the body-level hint=renew response: HTTP 200 at the
+// transport layer, with the renewal flag inside message.header.
+const renewSignalBody = `{"message":{"header":{"status_code":401,"hint":"renew"}}}`
+
+// missBody is a well-formed macro response reporting no matching track. The
+// retry assertions only need the second response to be CONSUMED and classified,
+// so a benign miss is a cleaner fixture than a synthetic lyrics payload.
+const missBody = `{"message":{"header":{"status_code":200},"body":{"macro_calls":{` +
+	`"matcher.track.get":{"message":{"header":{"status_code":404}}}` +
+	`}}}}`
+
+func respond(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+type stubRenewer struct {
+	token string
+	err   error
+	calls int
+}
+
+func (s *stubRenewer) Renew(context.Context) (string, error) {
+	s.calls++
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.token, nil
+}
+
+// clientWithResponses returns a client whose transport replays the given bodies
+// in order, and records the usertoken sent on each request.
+func clientWithResponses(t *testing.T, bodies ...string) (*Client, *[]string) {
+	t.Helper()
+	var sentTokens []string
+	i := 0
+	c := NewClient("original-token")
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sentTokens = append(sentTokens, req.URL.Query().Get("usertoken"))
+		body := bodies[len(bodies)-1]
+		if i < len(bodies) {
+			body = bodies[i]
+		}
+		i++
+		return respond(http.StatusOK, body), nil
+	})}
+	return c, &sentTokens
+}
+
+// TestFindLyrics_RenewsOnHintRenew is AC3: the explicit signal mints a
+// replacement, installs it, and retries once with the NEW token.
+func TestFindLyrics_RenewsOnHintRenew(t *testing.T) {
+	c, sent := clientWithResponses(t, renewSignalBody, missBody)
+	r := &stubRenewer{token: "renewed-token"}
+	c.SetTokenRenewer(r)
+
+	// The retry's outcome is a benign miss; what matters is that the SECOND
+	// response was consumed, proving the retry actually happened, and that it
+	// carried the renewed token.
+	_, err := c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound from the retried request", err)
+	}
+	if r.calls != 1 {
+		t.Errorf("renewer called %d times; want 1", r.calls)
+	}
+	if len(*sent) != 2 {
+		t.Fatalf("requests = %d; want 2 (original + one retry)", len(*sent))
+	}
+	if (*sent)[0] != "original-token" {
+		t.Errorf("first request token = %q; want original-token", (*sent)[0])
+	}
+	if (*sent)[1] != "renewed-token" {
+		t.Errorf("retry token = %q; want renewed-token", (*sent)[1])
+	}
+}
+
+// TestFindLyrics_BareUnauthorizedDoesNotRenew is the load-bearing safety
+// property. Observed behavior attributes bare 401s to throttling, and the mint
+// endpoint is itself rate limited, so renewing on them would burn mints during
+// exactly the window when they are most likely to be refused.
+func TestFindLyrics_BareUnauthorizedDoesNotRenew(t *testing.T) {
+	var sentTokens []string
+	c := NewClient("original-token")
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sentTokens = append(sentTokens, req.URL.Query().Get("usertoken"))
+		return respond(http.StatusUnauthorized, `{}`), nil
+	})}
+	r := &stubRenewer{token: "renewed-token"}
+	c.SetTokenRenewer(r)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized", err)
+	}
+	if r.calls != 0 {
+		t.Errorf("renewer called %d times; want 0 on a bare 401", r.calls)
+	}
+	if len(sentTokens) != 1 {
+		t.Errorf("requests = %d; want 1 (no retry)", len(sentTokens))
+	}
+}
+
+// TestFindLyrics_RenewalFailureReturnsOriginalError verifies a refused mint does
+// not loop and surfaces the renewal error to the caller.
+func TestFindLyrics_RenewalFailureReturnsOriginalError(t *testing.T) {
+	c, sent := clientWithResponses(t, renewSignalBody)
+	r := &stubRenewer{err: ErrTokenMintRefused}
+	c.SetTokenRenewer(r)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+	if !errors.Is(err, ErrTokenRenewalRequired) {
+		t.Fatalf("err = %v; want ErrTokenRenewalRequired", err)
+	}
+	if r.calls != 1 {
+		t.Errorf("renewer called %d times; want exactly 1 (no retry loop)", r.calls)
+	}
+	if len(*sent) != 1 {
+		t.Errorf("requests = %d; want 1", len(*sent))
+	}
+}
+
+// TestFindLyrics_RetriesAtMostOnce verifies a second renewal signal on the retry
+// does not recurse: the mint endpoint is rate limited, so an unbounded
+// renew-retry loop would lock the deployment out of it.
+func TestFindLyrics_RetriesAtMostOnce(t *testing.T) {
+	c, sent := clientWithResponses(t, renewSignalBody, renewSignalBody)
+	r := &stubRenewer{token: "renewed-token"}
+	c.SetTokenRenewer(r)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+	if !errors.Is(err, ErrTokenRenewalRequired) {
+		t.Fatalf("err = %v; want ErrTokenRenewalRequired", err)
+	}
+	if r.calls != 1 {
+		t.Errorf("renewer called %d times; want exactly 1", r.calls)
+	}
+	if len(*sent) != 2 {
+		t.Errorf("requests = %d; want exactly 2", len(*sent))
+	}
+}
+
+// TestFindLyrics_NoRenewerLeavesBehaviorUnchanged covers every caller that
+// supplies its own operator token: renewal stays off.
+func TestFindLyrics_NoRenewerLeavesBehaviorUnchanged(t *testing.T) {
+	c, sent := clientWithResponses(t, renewSignalBody)
+
+	_, err := c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+	if !errors.Is(err, ErrTokenRenewalRequired) {
+		t.Fatalf("err = %v; want ErrTokenRenewalRequired", err)
+	}
+	if len(*sent) != 1 {
+		t.Errorf("requests = %d; want 1 (no retry without a renewer)", len(*sent))
+	}
+}

--- a/internal/musixmatch/renew_test.go
+++ b/internal/musixmatch/renew_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/models"
 )
@@ -154,6 +156,71 @@ func TestFindLyrics_RetriesAtMostOnce(t *testing.T) {
 	if len(*sent) != 2 {
 		t.Errorf("requests = %d; want exactly 2", len(*sent))
 	}
+}
+
+// TestFindLyrics_ConcurrentRenewalMintsOnce is the single-flight guard. The mint
+// endpoint is rate limited (three rapid mints from one egress were measured to
+// all return 401), so concurrent hint=renew signals must produce ONE mint. Without
+// serialization this feature triggers the exact lockout it exists to prevent.
+func TestFindLyrics_ConcurrentRenewalMintsOnce(t *testing.T) {
+	const goroutines = 8
+
+	var mu sync.Mutex
+	seenTokens := map[string]int{}
+
+	c := NewClient("original-token")
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		tok := req.URL.Query().Get("usertoken")
+		mu.Lock()
+		seenTokens[tok]++
+		mu.Unlock()
+		// The original token always draws the renewal signal; the renewed one
+		// resolves to a benign miss, ending the retry.
+		if tok == "original-token" {
+			return respond(http.StatusOK, renewSignalBody), nil
+		}
+		return respond(http.StatusOK, missBody), nil
+	})}
+
+	// A renewer that blocks briefly, widening the window in which a second
+	// goroutine could mint concurrently if the path were not serialized.
+	r := &slowRenewer{token: "renewed-token", delay: 20 * time.Millisecond}
+	c.SetTokenRenewer(r)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.FindLyrics(context.Background(), models.Track{ArtistName: "A", TrackName: "T"})
+		}()
+	}
+	wg.Wait()
+
+	if got := r.Calls(); got != 1 {
+		t.Errorf("mints = %d; want exactly 1 across %d concurrent renewals", got, goroutines)
+	}
+}
+
+type slowRenewer struct {
+	token string
+	delay time.Duration
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *slowRenewer) Renew(context.Context) (string, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	time.Sleep(s.delay)
+	return s.token, nil
+}
+
+func (s *slowRenewer) Calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
 }
 
 // TestFindLyrics_NoRenewerLeavesBehaviorUnchanged covers every caller that

--- a/internal/musixmatch/token.go
+++ b/internal/musixmatch/token.go
@@ -1,0 +1,106 @@
+package musixmatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/valyala/fastjson"
+)
+
+// tokenURL is the unauthenticated endpoint that issues a desktop-app user token.
+// It is the same host the lyrics endpoint uses, on the token.get path.
+const tokenURL = "https://apic-desktop.musixmatch.com/ws/1.1/token.get" //nolint:gosec // reason: G101 - this is the public endpoint URL, not a credential; the name matches the API path
+
+// desktopAppID identifies the client to the API. It matches the app_id the
+// lyrics request already sends, so a minted token is issued for the same client
+// identity that will later use it.
+const desktopAppID = "web-desktop-app-v1.0"
+
+// maxTokenBodyBytes caps the token response read. The body is a single small
+// JSON object; anything larger is a wrong endpoint or an error page.
+const maxTokenBodyBytes = 64 << 10
+
+// ErrTokenMintRefused reports that the token endpoint declined to issue a token,
+// which in practice means rate limiting: #554 measured three rapid successive
+// mints from one egress all returning 401.
+//
+// Callers MUST treat this as "back off and keep whatever token you already
+// have", never as a reason to retry immediately. A restart loop that re-mints
+// would lock itself out of the bootstrap endpoint entirely.
+var ErrTokenMintRefused = errors.New("musixmatch: token mint refused (rate limited)")
+
+// TokenMinter obtains a Musixmatch user token from the unauthenticated
+// token.get endpoint, so canticle can bootstrap itself with no operator-supplied
+// credential (#554).
+//
+// A minted token MUST be persisted by the caller. Minting on every start would
+// trip the endpoint's rate limit and leave the deployment with no token at all.
+type TokenMinter struct {
+	httpClient *http.Client
+	// baseURL is overridden in tests; production always uses tokenURL.
+	baseURL string
+}
+
+// NewTokenMinter returns a minter using httpClient, or a client with a sane
+// timeout when httpClient is nil.
+func NewTokenMinter(httpClient *http.Client) *TokenMinter {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &TokenMinter{httpClient: httpClient, baseURL: tokenURL}
+}
+
+// Mint requests a fresh user token.
+//
+// It returns ErrTokenMintRefused when the endpoint answers with status_code 401
+// (rate limited). Every other failure -- transport, malformed body, or a 200
+// carrying no token -- returns a plain error, because persisting an empty or
+// unparsable value would be worse than having no token at all.
+func (m *TokenMinter) Mint(ctx context.Context) (string, error) {
+	u, err := url.Parse(m.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("musixmatch: parse token URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("app_id", desktopAppID)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("musixmatch: build token request: %w", err)
+	}
+	resp, err := m.httpClient.Do(req) //nolint:gosec // reason: G704 - the URL is a package constant (tokenURL), overridden only by tests
+	if err != nil {
+		return "", fmt.Errorf("musixmatch: token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("musixmatch: token endpoint HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenBodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("musixmatch: read token response: %w", err)
+	}
+
+	var p fastjson.Parser
+	v, err := p.ParseBytes(body)
+	if err != nil {
+		return "", fmt.Errorf("musixmatch: parse token response: %w", err)
+	}
+	if code := v.GetInt("message", "header", "status_code"); code == http.StatusUnauthorized {
+		return "", ErrTokenMintRefused
+	} else if code != http.StatusOK {
+		return "", fmt.Errorf("musixmatch: token endpoint status_code %d", code)
+	}
+	token := string(v.GetStringBytes("message", "body", "user_token"))
+	if token == "" {
+		return "", errors.New("musixmatch: token response carried no user_token")
+	}
+	return token, nil
+}

--- a/internal/musixmatch/token_test.go
+++ b/internal/musixmatch/token_test.go
@@ -1,0 +1,92 @@
+package musixmatch
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMintToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("app_id"); got != desktopAppID {
+			t.Errorf("app_id = %q; want %q", got, desktopAppID)
+		}
+		_, _ = w.Write([]byte(`{"message":{"header":{"status_code":200},"body":{"user_token":"tok-abcdefghijklmnopqrstuvwxyz"}}}`))
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinter(srv.Client())
+	m.baseURL = srv.URL
+
+	tok, err := m.Mint(context.Background())
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if tok != "tok-abcdefghijklmnopqrstuvwxyz" {
+		t.Errorf("token = %q; want the minted value", tok)
+	}
+}
+
+// TestMintToken_RateLimited pins the constraint #554 measured: three rapid mints
+// from one egress all return 401. That must surface as a distinct sentinel so the
+// caller can back off rather than spin, which would lock itself out entirely.
+func TestMintToken_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"message":{"header":{"status_code":401}}}`))
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinter(srv.Client())
+	m.baseURL = srv.URL
+
+	_, err := m.Mint(context.Background())
+	if !errors.Is(err, ErrTokenMintRefused) {
+		t.Fatalf("err = %v; want ErrTokenMintRefused", err)
+	}
+}
+
+// TestMintToken_EmptyTokenIsAnError guards against persisting a useless value:
+// a 200 with no user_token must fail rather than store an empty secret.
+func TestMintToken_EmptyTokenIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"message":{"header":{"status_code":200},"body":{"user_token":""}}}`))
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinter(srv.Client())
+	m.baseURL = srv.URL
+
+	if _, err := m.Mint(context.Background()); err == nil {
+		t.Fatal("Mint: got nil error for an empty user_token; want an error")
+	}
+}
+
+func TestMintToken_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinter(srv.Client())
+	m.baseURL = srv.URL
+
+	if _, err := m.Mint(context.Background()); err == nil {
+		t.Fatal("Mint: got nil error for a malformed body; want an error")
+	}
+}
+
+func TestMintToken_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	m := NewTokenMinter(srv.Client())
+	m.baseURL = srv.URL
+
+	if _, err := m.Mint(context.Background()); err == nil {
+		t.Fatal("Mint: got nil error for HTTP 500; want an error")
+	}
+}

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -86,9 +86,9 @@ templ musixmatchBanner() {
 		<div class="mx-banner-body">
 			<p class="mx-banner-title">Musixmatch lyric fetching is disabled</p>
 			<p class="mx-banner-text">
-				No Musixmatch API token is available, so Musixmatch is disabled. canticle normally obtains
-				one automatically on first run, so this usually means that request was declined; it retries on a
-				later start. In
+				No Musixmatch API token is available, so Musixmatch is disabled. canticle normally provisions
+				one automatically on first run; that did not complete here, and it will be retried on a later
+				start. In
 				<a class="mx-banner-link" href="/settings">Settings</a> you can add a token (then restart) to enable it,
 				or switch the provider to PetitLyrics, which needs no token and handles CJK lyrics well.
 				To obtain a Musixmatch token by hand, see the

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -86,10 +86,12 @@ templ musixmatchBanner() {
 		<div class="mx-banner-body">
 			<p class="mx-banner-title">Musixmatch lyric fetching is disabled</p>
 			<p class="mx-banner-text">
-				No Musixmatch API token is configured, so Musixmatch is disabled. In
+				No Musixmatch API token is available, so Musixmatch is disabled. canticle normally obtains
+				one automatically on first run, so this usually means that request was declined; it retries on a
+				later start. In
 				<a class="mx-banner-link" href="/settings">Settings</a> you can add a token (then restart) to enable it,
 				or switch the provider to PetitLyrics, which needs no token and handles CJK lyrics well.
-				To obtain a Musixmatch token, see the
+				To obtain a Musixmatch token by hand, see the
 				<a class="mx-banner-link" href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work" target="_blank" rel="noopener noreferrer">Spicetify FAQ</a>.
 			</p>
 		</div>


### PR DESCRIPTION
## Summary

- **Serve mode is now zero-config for lyrics fetching.** With no token supplied by any tier, canticle mints one from the unauthenticated `token.get` endpoint, persists it to the encrypted secret store, and reuses it on every later start. This removes the Spicetify-plus-devtools walkthrough from the primary onboarding path, which #554 calls "the single largest barrier to first-run success".
- **Renewal fires only on the API's explicit `hint=renew` signal**, and retries exactly once. A bare HTTP 401 never renews.
- **An operator-supplied token still wins and is never overwritten**, and no renewer is installed when one is present.
- **Reviewers look here first:** the bare-401 exclusion (below) is the load-bearing safety property, and the scope boundaries are deliberate rather than unfinished.

## Linked issue

Closes #554

Follow-up filed as #592 (a one-shot CLI command to mint a token for stateless `fetch` users).

## What the evidence changed about this issue

#554's motivation is an outage attributed to a dead token. Measurements taken while implementing this do not support that framing, and the PR is scoped accordingly:

- **`hint=renew` has never fired in production.** Across the entire container log retention, the renewal signal appears **0** times; every 401 canticle has logged is the bare kind.
- **A known-good token 401s from pacing alone.** An interleaved probe (prod worker stopped, so no concurrent traffic) sent a fixed simple query and real library-derived queries in the same window: **SYNTH 6/8 401s, REAL 7/8 401s**. Both arms failed alike, with the first pair succeeding and everything after degrading. That refutes query params as the trigger and points at request pacing.

So the feature's real value is **onboarding, not outage recovery**. The renewal path is correct client behavior for an expired credential, but it is speculative resilience: it has never been observed to trigger, and this PR does not claim otherwise.

## Deliberate scope boundaries

**No token rotation.** #554 already scoped it out, and the evidence strengthens that. There is no signal that distinguishes a dead token from a throttled one: `hint=renew` is the only unambiguous indicator and it has never fired, while sustained bare 401s have a documented false positive in this project's own history (a fresh token worked while the stored one failed, and the resulting "token was rejected" verdict was later recorded as contradicted). Rotating on that inference would also fire during exactly the window when a mint is most likely to be refused, since `token.get` is itself rate limited and the quota appears to be per-egress.

**Serve mode only.** `runFetch` opens no database and has no secret store, so it cannot persist a minted token. Minting per invocation was rejected: a stateless command cannot tell it is being run in a loop, and #554 measured three rapid mints from one egress all returning 401. Because the quota is per-egress, a scripted `fetch` loop could exhaust it and break serve mode's bootstrap too. The docs now say plainly that `fetch` still requires a supplied token; #592 covers a safe CLI path.

**A restart never re-mints.** `bootstrapToken` short-circuits when the token came from the store, which is what keeps a crash loop from locking the deployment out of the mint endpoint. There is a test asserting the minter is called zero times in that case.

## Test plan

- [x] `make gate` passes locally: conflict markers, gofmt, `make ui`, build, race tests, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, govulncheck.
- [x] Patch coverage **76.06%** against the 70% threshold. `internal/musixmatch` 90% -> 91%, `internal/commands` 68% -> 73%, both above floor.
- [x] New tests were confirmed to **fail against unfixed code** before the implementation existed (`undefined: NewTokenMinter`, `undefined: ErrTokenMintRefused`, `SetTokenRenewer undefined`).
- [x] **The bare-401 exclusion has a dedicated test.** `TestFindLyrics_BareUnauthorizedDoesNotRenew` asserts the renewer is called zero times on an HTTP 401 and that no retry is issued. This is the property that prevents a mint storm during a throttle window.
- [x] Renewal is bounded: `TestFindLyrics_RetriesAtMostOnce` proves a second renewal signal on the retry does not recurse.
- [x] Precedence is pinned: `TestBootstrapToken_OperatorTokenIsNeverOverwritten` asserts nothing is persisted and the minter is never called when a token is supplied.
- [x] Which **surface** this changes: serve-mode startup token resolution, the outbound `usertoken` parameter, and the setup banner copy. No queue, cache, or scan behavior is touched.
- [ ] Manual UAT: **not performed.** See below.

## Not covered

**The mint path has never touched the live endpoint.** Every test uses `httptest` fakes and a stubbed transport. #554 records the real endpoint working when measured on 2026-07-19, but this implementation has not been exercised against it, and doing so costs a mint against an endpoint known to refuse rapid attempts.

Proposed UAT, which validates mint, persist, reuse, and a live query in one pass for the cost of a single mint:

1. Empty config dir, no `MUSIXMATCH_TOKEN` / `MXLRC_API_TOKEN`, fresh database.
2. Start `serve`; expect the log line about bootstrapping and persisting a token.
3. Confirm a real fetch settles.
4. Restart; expect "token sourced from encrypted secret store" and **no** second mint. That step is the one that matters, since it is the lockout guard.

**Token longevity is still unverified**, exactly as #554 notes. Whether anonymously minted tokens are shorter-lived than app-harvested ones is unknown, and the docs deliberately promise nothing about it.

**No change to pacing.** If sustained 401s really are token- or egress-scoped throttling, the lever is the pacer and circuit breaker, not credential acquisition. Nothing here alters that behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Serve mode can automatically obtain and securely store a Musixmatch token on first run.
  * Automatically renews tokens when Musixmatch requests require it, with a limited retry.
  * User-provided tokens remain unchanged and take precedence.

* **Bug Fixes**
  * Improved handling of token throttling, renewal failures, and unavailable tokens.
  * Updated in-app messaging to clarify token status and retry behavior.

* **Documentation**
  * Clarified token requirements for serve mode versus one-shot fetch commands, configuration options, precedence, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->