### PR TITLE
docs: tell agents to query the memory MCP, it will not come to them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 > **On resume / handoff, read the gitignored `SESSION-STATE.md` at the repo root FIRST.** It is the running orchestration checkpoint (current main SHA, in-flight PRs/worktrees, ordered NEXT ACTIONS, standing directives). Transient session state lives there, never in this file or the auto-memory.
 
+## Memory MCP: query it, it will not come to you
+
+Durable, hard-won lessons for this repo live in the `memory-canticle` MCP server (repo tier) and
+`memory-global` (user tier). That store is PULL-only: it returns nothing unless you call
+`search_nodes`. An interactive session gets an index of its contents at startup, but **spawned
+subagents do not**, so an agent that never queries never sees any of it. If you dispatch a subagent
+into one of the areas below, either query first and put the answer in its brief, or tell it to query.
+
+QUERY BEFORE, not after, each of these:
+
+- **Releases** - notes formatting, and reading a red Release workflow correctly.
+- **Unraid / prod ops** - compose stack paths, picking up a new image, long detached jobs, egress.
+- **Debugging a "stuck" or idle-looking pipeline** - queue timestamps, log levels, throttling.
+  There is a standing "do not re-test this" result here; check before re-running an experiment.
+- **Review / merge mechanics** - what the merge oracle actually counts, and thread resolution.
+- Any "why is it done this way here" question where a prior decision or a refuted hypothesis exists.
+
+Natural phrasing works: word order, plurals, hyphens, and camelCase names are all handled. Prefer one
+broad query over guessing the stored wording. A miss costs one call; a silently-missed constraint has
+already cost real work here more than once.
+
+Detail lives in the auto-memory `.md` files, which remain canonical; the MCP holds a one-line hook
+plus a `Detail: <file>.md` pointer. Do not copy a fact back into the auto-memory index - one
+canonical home per fact.
+
 ## Project Overview
 
 `canticle` (module `github.com/sydlexius/canticle`, matching the repo after the transfer from the doxazo-net org to the sydlexius personal account; the `cmd/mxlrcgo-svc` directory, config paths, and systemd unit names retain the historical `mxlrcgo-svc` string) is a Go tool for fetching synced lyrics. It has two faces: a one-shot `fetch` CLI that writes `.lrc` / `.txt` files, and a stateful `serve` mode -- an HTTP server with a durable SQLite work queue, a background worker, a library scan scheduler (+ optional filesystem watcher), multi-provider orchestration, encrypted-at-rest secrets, and a browser-authenticated web UI. Global state is eliminated; the API token is externalized; config is TOML.


### PR DESCRIPTION
## Summary

- The `memory-canticle` / `memory-global` MCP stores are PULL-only: they return nothing unless something calls `search_nodes`. An interactive session gets an index of their contents at startup, but **spawned subagents do not**, so an agent that never queries never sees any of the repo's durable lessons.
- `CLAUDE.md` is the only channel that reaches a subagent, so this names the query triggers there: releases, Unraid/prod ops, pipeline debugging, and review/merge mechanics.
- Documentation only. No code, no behavior change.

## Linked issue

No tracked issue. This is the remaining artifact of a memory-layout change (the auto-memory index was slimmed and reference lessons moved into the MCP); the pointer had to live somewhere a subagent would actually read.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; doc-truth lens applied (see below).
- [x] Commits squashed into one clean commit before the first push (single commit throughout).
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- N/A, no user-visible behavior.
- [ ] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [ ] `make ui` re-run if any `.templ` or CSS source changed -- N/A, none changed.
- [ ] Migration added -- N/A, no data correction.

## Test plan

- [x] `make gate` passes locally: conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov report validation, golangci-lint, actionlint, govulncheck.
- [ ] New tests confirmed to fail against unfixed code -- N/A, no tests (documentation change).
- [x] Patch coverage: reported "no Go source changes in scope", so the gate self-skipped rather than passing vacuously.
- [x] Which **surface** this change fixes: the text a spawned subagent receives in its context. Verified on that surface rather than inferred -- during this session a subagent dispatched onto issue #568 confirmed the gap by needing repo facts hand-carried into its brief, because the startup index hook does not fire for subagents.
- [x] Manual verification of each factual claim in the added text:
  - [x] The store is pull-only and `search_nodes` is the accessor -- confirmed by querying it.
  - [x] All four named entities exist (`CanticleReleaseOps`, `CanticleUnraidAndProdOps`, `CanticleDebuggingTraps`, `CanticleBuildAndReviewMechanics`).
  - [x] Detail remains canonical in the auto-memory `.md` files; the MCP holds a one-line hook plus a `Detail:` pointer.
- [ ] Reviewer follow-ups:
  - [ ] Whether the four listed trigger areas are the right ones, or whether the list should stay shorter to avoid becoming boilerplate that gets skimmed.

## Not covered

This documents the gap; it does not close it. Telling a subagent to query does not guarantee one will, and nothing enforces it. For anything load-bearing the fact still belongs in the dispatch brief rather than trusted to the agent looking it up -- the added text says so explicitly, but that remains a convention, not a mechanism.

No change to what the MCP contains, to the auto-memory files, or to any retrieval behavior.
