### PR TITLE
refactor(scanner): extract a shared open+tag-read helper

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -34,6 +34,43 @@ func IsAudioFile(name string) bool {
 	return slices.Contains(supportedFileTypes, strings.ToLower(filepath.Ext(name)))
 }
 
+// openAndReadTags opens the audio file at path and reads its tag metadata. It is
+// the single implementation of the open/read/error-wrap contract the three
+// exported single-file readers below share, so they cannot drift as that contract
+// evolves.
+//
+// The contract: only an open or parse failure returns an error, and each is
+// wrapped with the path. A missing TAG is never an error here -- that is the
+// caller's business, and each reader turns an absent tag into its own documented
+// zero-value sentinel.
+//
+// On success the caller owns the returned *os.File and MUST close it. The handle
+// is returned rather than closed here because ReadAudioMetadata needs the same
+// handle for audioDuration (which seeks to 0 internally, so the offset left by
+// tag.ReadFrom does not matter). On error the file is already closed and the
+// returned handle is nil, so a caller that checks the error first can never leak
+// it.
+func openAndReadTags(path string) (tag.Metadata, *os.File, error) {
+	// reason: G304 - path is never attacker-supplied at any of the three call
+	// sites, and the invariant differs per caller: ReadAudioProvenance takes a
+	// configured library root + scanned filename confined via pathutil upstream;
+	// ReadArtistIdentity takes a scan_results file_path written from a configured
+	// library root; ReadAudioMetadata takes a work_queue source_path, likewise
+	// written from a configured library root and confined via pathutil upstream.
+	f, oerr := os.Open(path) //nolint:gosec // reason: see the G304 note above -- all three callers supply a path derived from a configured library root
+	if oerr != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", path, oerr)
+	}
+	m, terr := tag.ReadFrom(f)
+	if terr != nil {
+		// Close here rather than leaving it to the caller: on the error return the
+		// handle is nil, so the caller has nothing left to defer a close on.
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("read metadata %s: %w", path, terr)
+	}
+	return m, f, nil
+}
+
 // ReadAudioProvenance reads the ISRC and MusicBrainz recording MBID embedded in
 // the audio file at path, plus its artist/title tags, for a single file outside
 // the full-library scan loop. It wraps the same extractISRC/extractRecordingMBID
@@ -41,15 +78,11 @@ func IsAudioFile(name string) bool {
 // identity signals a scan would. A missing tag yields an empty string, not an
 // error; only an open/parse failure returns an error.
 func ReadAudioProvenance(path string) (isrc, mbid, artist, title string, err error) {
-	f, oerr := os.Open(path) //nolint:gosec // G304: path is derived from a configured library root + scanned filename, confined via pathutil upstream by the caller
-	if oerr != nil {
-		return "", "", "", "", fmt.Errorf("open %s: %w", path, oerr)
+	m, f, rerr := openAndReadTags(path)
+	if rerr != nil {
+		return "", "", "", "", rerr
 	}
 	defer func() { _ = f.Close() }()
-	m, terr := tag.ReadFrom(f)
-	if terr != nil {
-		return "", "", "", "", fmt.Errorf("read metadata %s: %w", path, terr)
-	}
 	return extractISRC(m), extractRecordingMBID(m), extractArtist(m), m.Title(), nil
 }
 
@@ -61,15 +94,11 @@ func ReadAudioProvenance(path string) (isrc, mbid, artist, title string, err err
 // open or parse failure returns a non-empty error so the caller can skip the
 // row rather than mistake a read failure for a genuinely empty artist.
 func ReadArtistIdentity(path string) (artist, albumArtist string, err error) {
-	f, oerr := os.Open(path) //nolint:gosec // G304: path originates from a scan_results row whose file_path was written from a configured library root
-	if oerr != nil {
-		return "", "", fmt.Errorf("open %s: %w", path, oerr)
+	m, f, rerr := openAndReadTags(path)
+	if rerr != nil {
+		return "", "", rerr
 	}
 	defer func() { _ = f.Close() }()
-	m, terr := tag.ReadFrom(f)
-	if terr != nil {
-		return "", "", fmt.Errorf("read metadata %s: %w", path, terr)
-	}
 	return extractArtist(m), extractAlbumArtist(m), nil
 }
 
@@ -94,15 +123,11 @@ type AudioMetadata struct {
 // error and yields the zero-value sentinel; only an open or parse failure returns
 // an error, matching ReadAudioProvenance and ReadArtistIdentity.
 func ReadAudioMetadata(path string) (AudioMetadata, error) {
-	f, oerr := os.Open(path) //nolint:gosec // reason: G304 - path is a work_queue source_path, written from a configured library root and confined via pathutil upstream
-	if oerr != nil {
-		return AudioMetadata{}, fmt.Errorf("open %s: %w", path, oerr)
+	m, f, rerr := openAndReadTags(path)
+	if rerr != nil {
+		return AudioMetadata{}, rerr
 	}
 	defer func() { _ = f.Close() }()
-	m, terr := tag.ReadFrom(f)
-	if terr != nil {
-		return AudioMetadata{}, fmt.Errorf("read metadata %s: %w", path, terr)
-	}
 	// audioduration seeks to 0 internally, so f may sit at any offset after
 	// tag.ReadFrom; no rewind is needed here. A parse failure degrades to the
 	// unknown-duration sentinel exactly as scanDir does.


### PR DESCRIPTION
## Summary

- `ReadAudioProvenance`, `ReadArtistIdentity` and `ReadAudioMetadata` each opened the file, called `tag.ReadFrom` once, and wrapped the same two errors. `openAndReadTags` is now the single implementation of that contract, so the three readers cannot drift as it evolves.
- No behavior change. Signatures, error contracts and zero-value sentinels are identical; the existing scanner, realign and identityrepair tests pass **unmodified** (120 tests).
- Reviewers should look first at the error path and at the single `gosec` nolint (both called out below).

## Linked issue

Closes #590

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (single commit throughout).
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- N/A, no user-visible behavior change.
- [ ] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [ ] `make ui` re-run if any `.templ` or CSS source changed -- N/A, none changed.
- [ ] Migration added -- N/A, no data correction.

## Two things worth reviewer attention

**1. The error path is where a naive extraction leaks.** Previously each reader installed `defer f.Close()` *before* calling `tag.ReadFrom`, so a parse failure still closed the handle. The helper cannot rely on the caller's defer, because on the error return the caller has no handle to defer on. So the helper closes the file itself on the parse-failure path and returns a nil handle, and each caller installs its `defer` only *after* the error check. The result is exactly one close on both paths -- no leak, no double close.

**2. Consolidating the open leaves one `gosec` nolint, not three.** G304 fires on the `os.Open` call site, so there is now a single site. AC3 asked that per-reader reasons stay specific to each reader's path provenance, which is not literally satisfiable once the open is shared -- the ACs conflict with AC1 and with the issue's own implementer note that the helper must return the open `*os.File`. Rather than collapse to a generic justification, the single reason **enumerates all three** provenances (library root + scanned filename, `scan_results.file_path`, `work_queue.source_path`), so the invariant each caller actually relies on is still named. Say the word if you would rather keep three `os.Open` sites to preserve three nolints; that trade is real but buys less sharing.

## Test plan

- [x] `make gate` passes locally: conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov report validation, golangci-lint, actionlint, govulncheck.
- [x] `go test ./internal/scanner/... ./internal/realign/... ./internal/identityrepair/...` -- 120 pass.
- [ ] New tests confirmed to fail against unfixed code -- **N/A, and deliberately so.** This is a pure refactor with no behavior change, so there is no defect for a new test to discriminate against. The load-bearing evidence is the opposite: the *existing* tests pass **with no modification**, which is what demonstrates the contracts were preserved. No new tests were added; adding tests that only ever passed would be regression-guard padding, not proof.
- [x] `internal/scanner` coverage rose 68% -> 76% against its floor, purely from the shared helper concentrating previously-duplicated lines. No test changes contributed to that.
- [x] Which **surface** this change fixes: none -- it is internal to `internal/scanner`. The three exported readers are the surface, and their signatures and error strings are unchanged, which is precisely what the unmodified tests verify. No `/metrics` or dashboard involvement.
- [ ] Manual UAT steps:
  - [ ] N/A -- no user-visible behavior change to exercise.
- [ ] Reviewer follow-ups:
  - [ ] The single-vs-three nolint trade described above.

## Not covered

The refactor does not change, and therefore does not verify, anything about the *callers* of these three readers (`realign`, `identityrepair`, `worker`); it relies on their existing tests, which pass unchanged.

The helper returns the open handle so `ReadAudioMetadata` can reuse it for `audioDuration`. `audioduration` seeks to 0 internally, so the offset `tag.ReadFrom` leaves does not matter -- that was already true before this change and is unchanged by it, but it is an assumption inherited rather than newly tested here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading audio tags and metadata.
  * File-reading errors now provide clearer context, including the affected audio file.
  * Ensured resources are cleaned up correctly when metadata cannot be read.
  * Preserved existing behavior for missing tags, invalid durations, and other unavailable metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->