### PR TITLE
chore(release): declare release-notes section grouping

### DIFF
--- a/.claude/release.toml
+++ b/.claude/release.toml
@@ -8,5 +8,31 @@ pre_checks = [
   "golangci-lint run",
 ]
 
+# Section grouping for generated release notes. Maps a merged PR's GitHub label
+# to the heading it lands under, matching the headings the last several releases
+# actually used. Without this, grouping is re-decided by judgment every release.
+#
+# PRECEDENCE: a PR commonly carries several of these (a bug fix labeled `go`, or
+# an `enhancement` also labeled `priority: high`). The change-kind labels win over
+# the catch-all buckets -- prefer `enhancement`/`bug` over `documentation`/`chore`/
+# `go`/`docker` when a PR carries both. Priority labels are deliberately absent:
+# they describe urgency, not the kind of change, so they never select a section.
+#
+# This governs GROUPING only. The surrounding structure -- the `### Highlights`
+# prose for a minor release, and the Docker-pull / full-changelog footer -- is not
+# expressible here; follow the previous release (`gh release view <prev-tag>`).
+[release_notes]
+default_group = "Maintenance"
+
+[release_notes.group_labels]
+enhancement = "New"
+bug = "Bug fixes"
+dependencies = "Security & dependencies"
+ci = "Security & dependencies"
+documentation = "Maintenance"
+chore = "Maintenance"
+go = "Maintenance"
+docker = "Maintenance"
+
 [release]
 tag_prefix = "v"


### PR DESCRIPTION
## Summary

- The release workflow reads `release_notes.group_labels` to map a merged PR's GitHub label to the section heading it lands under. That section was absent from `.claude/release.toml`, so section grouping was re-decided by judgment on every release instead of being deterministic.
- The mapping encodes the headings the last several releases actually used, so this documents existing practice rather than changing it.
- Config only. No code, no behavior change, and the file is not read by the built binary.

## Linked issue

No tracked issue. Surfaced while cutting v1.25.0: the release skill expects a `[release_notes]` section and the config did not have one.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push (single commit throughout).
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- N/A, no user-visible behavior.
- [ ] Screenshot attached for any web-UI change -- N/A.
- [ ] `make ui` re-run -- N/A, no `.templ` or CSS change.
- [ ] Migration added -- N/A.

## Two deliberate omissions, so they are not read as oversights

**`[versioning]` stays absent.** GoReleaser stamps the version from the git tag into `internal/version` via ldflags; there is no checked-in version file to bump. The existing comment at the top of the file already records this. Adding a `[versioning]` section would invent a file that does not exist.

**Priority labels are excluded from the mapping.** `priority: high` / `medium` / `low` describe urgency, not the kind of change, so they must never select a section. Only change-kind labels map to headings.

## Known limitation, stated plainly

This governs **grouping only**. The surrounding structure that the recent releases actually use -- the `### Highlights` prose block for a minor release, and the Docker-pull / full-changelog footer -- has no representation in this schema and cannot be expressed here. Those remain convention, carried by the house style and by reading the previous release. So this closes part of the gap between the tooling and practice, not all of it.

The schema also does not define **precedence** when a PR carries several mapped labels (a bug fix also labeled `go`, an `enhancement` also labeled `priority: high`). A comment in the file states the intended rule -- change-kind labels beat the catch-all buckets -- but nothing enforces it, so a multi-label PR still depends on the person cutting the release following that comment.

## Test plan

- [x] `make gate` passes locally: conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov report validation, golangci-lint, actionlint, govulncheck.
- [x] The file parses as valid TOML and produces the expected structure, verified with `python3 -c "import tomllib; tomllib.load(...)"` rather than by inspection -- a malformed table here would surface only at the next release.
- [ ] New tests confirmed to fail against unfixed code -- N/A, declarative config with no code path to test.
- [x] Which **surface** this affects: the release-notes generation step of the release workflow. Nothing in the shipped binary reads this file.
- [ ] Manual UAT steps:
  - [ ] N/A. The mapping is exercised the next time release notes are generated; it was derived by reading the headings v1.24.0 and v1.24.1 actually used.
- [ ] Reviewer follow-ups:
  - [ ] Whether `go` and `docker` belong under "Maintenance" or deserve their own headings once enough PRs carry them.

## Not covered

The mapping is asserted against recent release history, not validated by tooling -- nothing checks that a label in this file still exists in the repo's label set, so a renamed or deleted label would silently fall through to `default_group`.
