### PR TITLE
docs: stop instructing users to extract a Musixmatch token by hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Renamed an audio file and left its `.lrc`/`.txt` behind? `canticle realign` re-a
 
 In **serve mode**, a Musixmatch API token is optional: on first run canticle obtains one automatically and stores it encrypted at rest, reusing it on every later start, so there is nothing to set up. The one-shot `fetch` CLI keeps no state, so it cannot store a token and still needs one supplied explicitly.
 
-To supply your own instead, prefer `canticle secrets set musixmatch_token`, which reads the value from stdin and stores it encrypted at rest, keeping it out of shell history and process listings. The `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, and a `.env`/config file remain supported, in that order of precedence (CLI > env > file). A token you supply always takes precedence and is never overwritten. If automatic setup is unavailable, you can obtain one by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
+To supply your own instead, prefer `canticle secrets set musixmatch_token`, which reads the value from stdin and stores it encrypted at rest, keeping it out of shell history and process listings. The `--token` CLI flag, the `MUSIXMATCH_TOKEN` environment variable, and a `.env`/config file remain supported, in that order of precedence (CLI > env > file). A token you supply always takes precedence and is never overwritten. See [Configuration](https://sydlexius.github.io/canticle/CONFIGURATION/) for the full env-var and TOML surface.
 
 ## Encrypted secrets
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,8 +24,6 @@ A Musixmatch API token is required for the one-shot `fetch` CLI, and optional in
 
 In serve mode a token is optional: when none is configured, canticle obtains one automatically on first run and persists it in the encrypted secret store, reusing it on later starts. A token you configure here always takes precedence and is never overwritten by that automatic path. The one-shot `fetch` CLI is stateless and has no secret store, so it cannot persist a token and still requires one.
 
-If automatic setup is unavailable, obtain a token by hand with steps 1 to 5 from the [Spicetify guide](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work).
-
 ## General precedence
 
 For all settings, precedence is **CLI flag > environment variable > config file > built-in default**.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -20,9 +20,7 @@ The token is a long opaque string (it is not your Musixmatch account password).
 
 You may still want to supply your own, for example if you already have one or you are running somewhere the automatic request is refused. A token you supply always takes precedence and is never overwritten.
 
-### Obtaining a token by hand (optional)
-
-If you need to provision one yourself, follow steps 1 to 5 of the [Spicetify FAQ](https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work). In our words: install the Spicetify lyrics setup it describes, open your browser developer tools on the network tab while lyrics load, find the Musixmatch request, and copy the `usertoken` value out of its query string. That copied string is your token.
+### Supplying a token you already have
 
 The quickest way to provision it for a shell session:
 

--- a/internal/web/banner_ui_test.go
+++ b/internal/web/banner_ui_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/sydlexius/canticle/internal/config"
 )
 
-// spicetifyFAQURL is the documented source for obtaining a Musixmatch token; the
-// banner must link to it (#385).
+// spicetifyFAQURL was once linked from the banner as a way to obtain a Musixmatch
+// token by hand (#385). It is now asserted ABSENT: serve mode provisions a token
+// automatically and retries on a later start, so the banner's actionable remedies
+// are Settings and the tokenless provider. Walking an operator through extracting
+// a credential out of another application's traffic is not guidance canticle
+// ships, and this constant is retained purely so the assertion below keeps the
+// link from being reintroduced.
 const spicetifyFAQURL = "https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work"
 
 // renderShell mounts a (public, no-auth) UI and fetches the Reports workspace
@@ -38,11 +43,10 @@ func TestMusixmatchInactiveBannerRendersWhenInactive(t *testing.T) {
 	if !strings.Contains(body, `href="/settings"`) {
 		t.Fatal("banner must link to /settings to add the token")
 	}
-	if !strings.Contains(body, spicetifyFAQURL) {
-		t.Fatalf("banner must link to the Spicetify FAQ (%s)", spicetifyFAQURL)
-	}
-	if !strings.Contains(body, `rel="noopener noreferrer"`) {
-		t.Fatal("the external FAQ link must carry rel=\"noopener noreferrer\"")
+	// The banner must NOT teach the operator to obtain a token by hand. This is the
+	// inverse of the original #385 assertion and exists to stop the link coming back.
+	if strings.Contains(body, spicetifyFAQURL) {
+		t.Fatalf("banner must not link to a manual token-extraction guide (%s)", spicetifyFAQURL)
 	}
 	if !strings.Contains(body, "Musixmatch") {
 		t.Fatal("banner copy must mention Musixmatch")

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -73,9 +73,14 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 // with Musixmatch inactive because no token was configured (#385). It states
 // Musixmatch is disabled (without claiming all fetching is off, since a tokenless
 // provider may be covering), links to Settings to add a token or switch to a
-// tokenless provider (PetitLyrics, which also handles CJK lyrics well), and links
-// to the Spicetify FAQ for obtaining a token (new tab, noopener/noreferrer). The
+// tokenless provider (PetitLyrics, which also handles CJK lyrics well). The
 // copy notes a restart is needed because the token is read at startup.
+//
+// It deliberately does NOT tell the operator how to obtain a token by hand.
+// Serve mode provisions one automatically and retries on a later start, so the
+// two remedies named here are the actionable ones; walking a user through
+// extracting a credential out of another application's traffic is not guidance
+// canticle ships.
 templ musixmatchBanner() {
 	<div class="mx-banner" role="status">
 		<svg class="mx-banner-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -91,8 +96,6 @@ templ musixmatchBanner() {
 				start. In
 				<a class="mx-banner-link" href="/settings">Settings</a> you can add a token (then restart) to enable it,
 				or switch the provider to PetitLyrics, which needs no token and handles CJK lyrics well.
-				To obtain a Musixmatch token by hand, see the
-				<a class="mx-banner-link" href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work" target="_blank" rel="noopener noreferrer">Spicetify FAQ</a>.
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- Serve mode provisions a Musixmatch token automatically and retries on a later start (#554), so the "obtain one by hand" guidance is obsolete. It is also not guidance canticle should ship: it walked the reader through pulling a credential out of another application's traffic.
- Removed from four surfaces: `README.md`, `docs/CONFIGURATION.md`, `docs/GETTING_STARTED.md`, and the in-app "Musixmatch disabled" banner.
- Reviewers should look first at the test inversion, described below -- it is the part that would have silently defeated a docs-only cleanup.

## Linked issue

No tracked issue; raised directly while preparing the v1.25.0 release.

## The part worth reviewing

**A test was pinning the link into the UI.** `internal/web/banner_ui_test.go` asserted the Spicetify link was **present** in the rendered banner. So a cleanup that only touched Markdown would have left the link live in the running product with every doc looking clean, and the suite still green. The assertion is inverted into a guard against reintroduction.

**That guard was verified to discriminate, not just to pass.** The link was temporarily re-added to `layout.templ`, `make ui` re-rendered, and the test was confirmed to FAIL with `banner must not link to a manual token-extraction guide`. The template was then restored and the suite re-run green. A test that has only ever passed would not have been evidence of anything.

**`GETTING_STARTED.md` was the worst surface** and the reason this is more than a link removal. The other two merely linked out; that page restated the procedure in canticle's own words -- install the third-party setup, open developer tools on the network tab, find the request, copy the `usertoken` out of its query string. Deleted. The section now covers only how to supply a token you already have, which is still genuinely needed by the stateless `fetch` CLI.

**Deliberately retained:** the Credits link to Spicetify Lyrics Plus in `README.md`. That is attribution to prior art, not instructions -- different in kind, and removing it would be uncredited borrowing.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push (single commit throughout).
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- see "Not covered"; the banner change was verified by rendering it in a test, not by running the binary with a tokenless config.
- [ ] Screenshot attached for any web-UI change -- not attached; the banner renders only in the tokenless startup state, and the rendered-HTML assertion covers the change.
- [x] `make ui` re-run -- `layout.templ` changed. Generated `*_templ.go` and `output.css` are gitignored and were not committed.
- [ ] Migration added -- N/A.

## Test plan

- [x] `make gate` passes: conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov report validation, golangci-lint, actionlint, govulncheck.
- [x] `go test ./internal/web/ -run TestMusixmatchInactiveBanner` -- 2 pass against the freshly generated template.
- [x] New assertion confirmed to **fail against unfixed code**: link re-added, `make ui`, test failed on the expected message; template restored, tests pass. This is the load-bearing evidence, not the green run.
- [x] Which **surface** this change fixes: two distinct ones, and both were checked. The docs surface (three Markdown files, verified by grep for remaining references) and the **rendered UI** surface (verified by asserting against the actual rendered HTML, since the docs and the banner are independent and fixing one does not fix the other).
- [ ] Manual UAT steps:
  - [ ] Not performed -- reproducing it means starting serve with no token and no secret store, which the rendered-HTML test covers more precisely.
- [ ] Reviewer follow-ups:
  - [ ] Whether the banner should say anything at all in place of the removed sentence, or whether "add a token in Settings, or use the tokenless provider" is sufficient. It currently says nothing extra.

## Not covered

The banner was verified by rendering it through the real template in a test, **not** by running the binary against a tokenless configuration, so the startup path that decides `musixmatchInactive` is unchanged and unretested here.

Archived planning documents under the numbered phase directories still mention the old guidance. They are historical records of past work, not user instructions, and were left alone deliberately.

A stale claim was noticed but **not** fixed here to keep the diff scoped: the package doc in `web/templates/layout.templ` says generated `*_templ.go` files are "committed and CI-verified", while they are in fact gitignored and rebuilt on demand (per `CLAUDE.md` and `git ls-files`). Worth a separate follow-up.
