### PR TITLE
fix(petitlyrics): drop the unsynced fallback retry

### DIFF
--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -13,8 +13,8 @@
 // (issue #495), and even fully repaired the web surface exposes no timestamps
 // and no ISRC or duration, so it could not serve synced lyrics at all.
 //
-// Request cost is one call when the word-synced tier has the track, and two when
-// it does not (the client then retries at the unsynced tier). The scrape needed
+// Request cost is exactly one call per lookup, hit or miss: the API returns
+// whatever tier the track has, so a single request settles it. The scrape needed
 // three calls plus two large HTML pages in every case. The API also requires no
 // cookies, session, or CSRF token, and returns ISRC, duration, and word-level
 // timings, none of which the web surface exposes.
@@ -28,7 +28,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -139,12 +138,10 @@ func ctxSleep(ctx context.Context, d time.Duration) bool {
 // from the service: comfortably slower than anything plausibly enforced, and
 // deliberately not tuned by probing the service until it refuses.
 //
-// Note the interval is enforced per REQUEST, not per lookup, which is what makes
-// it safe for the two-request miss path: a track the provider does not have
-// costs a word-sync call plus an unsynced retry, and both are paced. Because
-// petitlyrics is a fallback lane that only sees what the primary provider
-// missed, that two-request path is the common case, not the exception -- so the
-// floor is set against it rather than against the cheaper hit path.
+// The interval is enforced per REQUEST, which is now the same as per lookup:
+// every lookup costs exactly one call. That matters for a fallback lane, whose
+// traffic is mostly misses (90 of 120 in a measured sample) -- misses are paced
+// identically to hits and cost no more.
 const MinAllowedInterval = 10 * time.Second
 
 // DefaultMinInterval is the recommended pacing interval: 30s, or 120 tracks/hr.
@@ -264,34 +261,21 @@ type apiSong struct {
 	LyricsData string `xml:"lyricsData"`
 }
 
-// FindLyrics looks up lyrics for the given track.
+// FindLyrics looks up lyrics for the given track in a single request.
 //
-// It requests the word-synced tier first: word-sync is a superset of line-sync
-// (a line's cue is its first word's start time), and its payload is plain XML
-// whereas the line-sync tier is an encrypted binary blob this client cannot yet
-// decode. When the word-sync request yields nothing usable, it retries at the
-// unsynced tier so a track with only plain lyrics still produces a result.
+// It always asks for the word-synced tier, and that one request is the whole
+// flow: the API returns whatever tier the track actually has, not only the tier
+// requested. Measured over 107 hits, the response tier matched the track's
+// advertised availableLyricsType with no exceptions -- a tier-3 request returns
+// an unsynced payload for an unsynced-only track, and a line-sync payload for a
+// line-sync-only one.
+//
+// So a tier-3 miss is a genuine miss. An earlier version retried at the unsynced
+// tier on a miss, which could never rescue anything and simply doubled outbound
+// volume on the miss path -- the dominant path for a fallback lane that only
+// sees what the primary provider missed (90 of 120 lookups in a measured sample).
 func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Song, error) {
-	song, err := c.lookup(ctx, track, tierWordSync)
-	if err == nil {
-		return song, nil
-	}
-	// A word-sync miss is not a track miss: fall back to plain lyrics. Transport
-	// and policy failures (401/403/429, context cancellation) are returned as-is
-	// so the circuit breaker sees them.
-	if !isTierMiss(err) {
-		return models.Song{}, err
-	}
-	slog.Debug("petitlyrics: word-sync tier unavailable, retrying unsynced",
-		"track", track.TrackName, "reason", err)
-	return c.lookup(ctx, track, tierUnsynced)
-}
-
-// isTierMiss reports whether err means "this tier had nothing" rather than "the
-// request failed", which decides whether falling back to another tier is worth a
-// second request.
-func isTierMiss(err error) bool {
-	return errors.Is(err, ErrNotFound) || errors.Is(err, ErrUnsupportedTier)
+	return c.lookup(ctx, track, tierWordSync)
 }
 
 // lookup performs one API request at the given tier and decodes the result.

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -231,33 +231,43 @@ func TestFindLyrics_CuesAreNormalized(t *testing.T) {
 	}
 }
 
-func TestFindLyrics_UnsyncedFallback(t *testing.T) {
-	// Word-sync returns nothing; the client should retry at the unsynced tier
-	// rather than reporting the track as a miss.
-	var calls int
-	c, fs := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
-		calls++
-		name := "type1_unsynced.xml"
-		if calls == 1 {
-			name = "empty.xml"
-		}
-		body, _ := os.ReadFile(filepath.Join("testdata", name))
-		_, _ = w.Write(body)
-	})
+// TestFindLyrics_UnsyncedFromSingleRequest pins the property that makes the tier
+// fallback unnecessary: a track whose only tier is unsynced still yields its
+// lyrics from ONE word-sync request, because the API returns whatever tier the
+// track actually has rather than only the tier asked for.
+func TestFindLyrics_UnsyncedFromSingleRequest(t *testing.T) {
+	c, fs := newTestClient(t, serveFixture(t, "type1_unsynced.xml"))
 
 	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
 	if err != nil {
-		t.Fatalf("FindLyrics should fall back to unsynced: %v", err)
+		t.Fatalf("FindLyrics: %v", err)
 	}
 	if song.Lyrics.LyricsBody == "" {
-		t.Error("fallback should produce plain lyrics")
+		t.Error("an unsynced-only track should still produce plain lyrics")
 	}
 	reqs := fs.snapshot()
-	if len(reqs) != 2 {
-		t.Fatalf("want 2 requests (word-sync then unsynced), got %d", len(reqs))
+	if len(reqs) != 1 {
+		t.Fatalf("want 1 request, got %d", len(reqs))
 	}
-	if reqs[0].form["lyricsType"] != "3" || reqs[1].form["lyricsType"] != "1" {
-		t.Errorf("tier order wrong: %q then %q", reqs[0].form["lyricsType"], reqs[1].form["lyricsType"])
+	if reqs[0].form["lyricsType"] != "3" {
+		t.Errorf("the single request should ask for word-sync, got %q", reqs[0].form["lyricsType"])
+	}
+}
+
+// TestFindLyrics_MissCostsOneRequest is the regression guard for #608. The
+// removed fallback retried at the unsynced tier on a miss, which could never
+// rescue anything (a tier-3 miss is a genuine miss) and doubled outbound volume
+// on the miss path -- the dominant path for a fallback lane. Assert on the wire,
+// not the return value: the defect was request count, not correctness.
+func TestFindLyrics_MissCostsOneRequest(t *testing.T) {
+	c, fs := newTestClient(t, serveFixture(t, "empty.xml"))
+
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Nothing"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+	if n := len(fs.snapshot()); n != 1 {
+		t.Errorf("a miss must cost exactly one request, got %d", n)
 	}
 }
 
@@ -270,8 +280,8 @@ func TestFindLyrics_LineSyncIsUnsupported(t *testing.T) {
 	if err == nil {
 		t.Fatal("an encrypted line-sync payload must not be reported as success")
 	}
-	// After the word-sync attempt yields an unsupported tier, the fallback also
-	// serves the same binary payload, so the final error is still the tier error.
+	// The single request returns the track's actual tier, so a line-sync-only
+	// track surfaces the typed tier error directly -- no retry involved.
 	if !errors.Is(err, ErrUnsupportedTier) {
 		t.Errorf("want ErrUnsupportedTier, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Removes a retry that could never succeed.** The client asked for the word-synced tier and, on a miss, retried at the unsynced tier. Measured over **107 hits**, a `lyricsType=3` request returns whatever tier the track actually has — matching `availableLyricsType` with **no exceptions** (`1`→unsynced 29, `2`→line-sync 24, `3`→word-sync 54). An unsynced-only track already comes back from the tier-3 request, so a tier-3 miss is a genuine miss and the retry always returned empty too.
- **The cost landed where it hurt most.** petitlyrics is a fallback lane: it only sees what the primary provider missed, so misses dominate. In a measured sample of real fallback traffic, **90 of 120 lookups were misses** — every one paying two requests instead of one. Every lookup now costs exactly one request, hit or miss.
- **No behaviour change for callers.** Same results for word-synced, unsynced, and line-sync-only tracks; only the wasted second request is gone.

**Look at first:** `FindLyrics` in `client.go` — it collapses to a single `lookup` call. The original assumption (that a tier-3 request only returns tier-3 material) is the thing the measurement refuted.

## Linked issue

Closes #608

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — N/A, the lane is disabled in config; behaviour verified by tests against recorded API shapes.
- [x] Screenshot attached for any web-UI change — N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A, no data correction.

## Test plan

- [x] `make gate` passes locally (race tests, coverage floor, golangci-lint, actionlint, govulncheck).
- [x] New tests were confirmed to **fail against unfixed code**. Verified by mutation, not assertion: reintroducing the fallback retry into `FindLyrics` **fails the suite**. `TestFindLyrics_MissCostsOneRequest` asserts on the observed request count rather than the return value, because the defect was request volume, not correctness.
- [x] Patch coverage meets the threshold. Package coverage 95% against an 86% floor; floor deliberately not bumped.
- [x] Which **surface** this change fixes: `internal/petitlyrics` outbound request volume only. No queue, DB, or write-path surface is touched.
- [x] Manual UAT steps:
  - [x] The tier-behaviour claim was established from live measurement (240 real lookups across two samples), not inferred from the code.
- [ ] Reviewer follow-ups:
  - [ ] **Two doc comments were also corrected** — the package doc and the `MinAllowedInterval` rationale both still described the two-request miss path. Worth confirming no other comment reasons from the old flow.
  - [ ] `TestFindLyrics_UnsyncedFromSingleRequest` replaces the old fallback test. It pins the *reason* the retry is unnecessary rather than just deleting coverage.

## Not covered

- **`availableLyricsType` is now load-bearing for this reasoning but is not asserted in code.** The client still derives the tier from the payload bytes (correctly — that stays the safer discriminator). If the provider ever changed the field's meaning, this PR's rationale would silently stop holding while the code kept working. A mismatch assertion was considered and deliberately left out to keep the change a pure removal.
- **The 107-hit measurement is one library's traffic plus one curated mainstream sample.** The tier-correspondence was exceptionless in that data, but it is observed behaviour of an undocumented API, not a contract.
- **`lyricsType 2` remains undecodable** (encrypted LSY binary) — unchanged here, tracked in #602.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Lyrics lookups now make a single request, reducing unnecessary retries.
  * Tracks available only as unsynced lyrics continue to return plain lyrics when supported.
  * Missing or unsupported lyric tiers now return their result directly without fallback attempts.

* **Bug Fixes**
  * Improved request pacing and lookup behavior consistency.
  * Added safeguards to prevent duplicate requests for failed lyric searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->