### PR TITLE
feat(orchestrator): rank word-synced results above line-synced

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -31,6 +31,25 @@ type Synced struct {
 	Lines []Lines
 }
 
+// WordTiming is one word's timing within a synced line, carrying the word-level
+// granularity that line cues cannot express. Providers that expose per-word
+// timings (currently petitlyrics' word-synced tier) populate these alongside
+// Song.Subtitles; providers that do not leave the slice empty.
+//
+// This is what lets the orchestrator rank a word-synced result above a merely
+// line-synced one: the cues look identical either way, so the timings are the
+// only signal that the richer tier was served.
+type WordTiming struct {
+	// Line is the zero-based index of the owning cue in Song.Subtitles.Lines.
+	Line int
+	// Text is the word as the provider supplied it.
+	Text string
+	// StartMS and EndMS are milliseconds from the start of the track. Both are
+	// clamped to be non-negative by the producing provider.
+	StartMS int
+	EndMS   int
+}
+
 // Lines represents a single synced lyrics line with text and timestamp.
 type Lines struct {
 	Text string `json:"text,omitempty"`
@@ -58,6 +77,16 @@ type Song struct {
 	// Subtitles. Zero value (empty Lines) means absent. Not interleaved by
 	// default; reserved for a future romanization output flag.
 	RomanizationSubtitles Synced
+	// WordTimings carries per-word timings parallel to Subtitles, when the
+	// provider served a word-synced result. Empty means the result is at most
+	// line-synced. Each entry's Line indexes into Subtitles.Lines.
+	//
+	// Coverage is NOT uniform in practice: a provider may return word timings for
+	// most lines and a single shared timestamp for others (measured: median 100%
+	// of words distinctly timed, worst case 51%). Consumers that need genuine
+	// per-word detail must inspect the timings rather than assume every line has
+	// them. Transient: not persisted, not serialized.
+	WordTimings []WordTiming `json:"-"`
 	// WinningLane is the provider lane name that returned this song. It is set by
 	// the orchestrator for both suitable results and best-available fallbacks.
 	// Empty on cache hits and zero-value songs. Used by the worker write-path to

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -44,8 +44,10 @@ type WordTiming struct {
 	Line int
 	// Text is the word as the provider supplied it.
 	Text string
-	// StartMS and EndMS are milliseconds from the start of the track. Both are
-	// clamped to be non-negative by the producing provider.
+	// StartMS and EndMS are milliseconds from the start of the track.
+	// Producers MUST clamp both to be non-negative; this is a requirement on
+	// providers, not a guarantee the type enforces, so a consumer hardening
+	// against a future provider should not assume it.
 	StartMS int
 	EndMS   int
 }
@@ -82,10 +84,16 @@ type Song struct {
 	// line-synced. Each entry's Line indexes into Subtitles.Lines.
 	//
 	// Coverage is NOT uniform in practice: a provider may return word timings for
-	// most lines and a single shared timestamp for others (measured: median 100%
-	// of words distinctly timed, worst case 51%). Consumers that need genuine
-	// per-word detail must inspect the timings rather than assume every line has
-	// them. Transient: not persisted, not serialized.
+	// most lines and a single shared timestamp for others. Measured across 54
+	// word-synced tracks (2026-07-21), the median had 100% of words distinctly
+	// timed and the worst 51%. Consumers that need genuine per-word detail must
+	// inspect the timings rather than assume every line has them.
+	//
+	// Transient: not persisted, not serialized. Note the consequence for caching
+	// -- the worker stores songs as JSON, so a cache HIT returns a song with no
+	// timings and QualityOf classifies it as merely line-synced. Harmless while
+	// nothing consumes them; a constraint on the Enhanced-LRC writer (#480),
+	// which will only see word data on a cache miss.
 	WordTimings []WordTiming `json:"-"`
 	// WinningLane is the provider lane name that returned this song. It is set by
 	// the orchestrator for both suitable results and best-available fallbacks.

--- a/internal/orchestrator/parallel_test.go
+++ b/internal/orchestrator/parallel_test.go
@@ -109,6 +109,62 @@ func TestParallelFastSyncedWinsImmediately(t *testing.T) {
 	}
 }
 
+// TestParallelWordSyncedCommitsImmediately covers the word-sync tier through
+// findParallel, which the rest of the #603 tests miss.
+//
+// The commit branch tests `QualityOf(res.song) >= QualitySynced`. A `==`
+// comparison there still passes every other test in the suite, yet it would stop
+// a word-synced result from short-circuiting the race: it would fall into the
+// "suitable but unsynced" branch, be HELD, arm the upgrade window, and become
+// preemptible by a later line-synced result. That is the exact quality inversion
+// #603 exists to prevent, in the dispatch mode where lanes actually race.
+//
+// Asserting on elapsed time is what makes the test bite: a held result waits for
+// the race window, so "committed immediately" and "was held" are distinguishable.
+func TestParallelWordSyncedCommitsImmediately(t *testing.T) {
+	fast := &delayProvider{name: "petitlyrics", song: wordSyncedSong()}
+	slow := &delayProvider{name: "musixmatch", song: syncedSong(), delay: 300 * time.Millisecond}
+	o, _ := New("parallel", delayLane(fast), delayLane(slow))
+	o.SetRaceWait(5 * time.Second)
+
+	start := time.Now()
+	song, err := o.FindLyrics(context.Background(), models.Track{}, "")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualityWordSynced {
+		t.Fatalf("quality = %v; want word-synced", QualityOf(song))
+	}
+	if song.WinningLane != "petitlyrics" {
+		t.Fatalf("winning lane = %q; the word-synced lane must win", song.WinningLane)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("returned in %v; a word-synced result must commit immediately, not be held for the race window", elapsed)
+	}
+}
+
+// TestParallelWordSyncedNotPreemptedByLineSynced: even when a line-synced lane
+// reports FIRST, the word-synced result must not lose. The first suitable synced
+// result commits, so this asserts the ranking holds in the losing arrival order.
+func TestParallelWordSyncedNotPreemptedByLineSynced(t *testing.T) {
+	word := &delayProvider{name: "petitlyrics", song: wordSyncedSong()}
+	line := &delayProvider{name: "musixmatch", song: syncedSong(), delay: 200 * time.Millisecond}
+	o, _ := New("parallel", delayLane(word), delayLane(line))
+	o.SetRaceWait(2 * time.Second)
+
+	song, err := o.FindLyrics(context.Background(), models.Track{}, "")
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if QualityOf(song) != QualityWordSynced {
+		t.Fatalf("quality = %v; want word-synced to survive", QualityOf(song))
+	}
+	if len(song.WordTimings) == 0 {
+		t.Error("the committed song must retain its word timings")
+	}
+}
+
 func TestParallelSingleUnsyncedCommitsImmediately(t *testing.T) {
 	// A held unsynced result with no other lane in flight cannot be upgraded, so it
 	// must commit immediately rather than burn the full race window.

--- a/internal/orchestrator/suitability.go
+++ b/internal/orchestrator/suitability.go
@@ -39,10 +39,10 @@ const (
 //
 // That is a ranking rule, NOT a terminal-state rule. Whether a result is good
 // enough to stop improving needs a higher bar, because coverage is uneven in
-// practice (measured: median 100% of words distinctly timed, worst case 51%).
-// Marking a half-timed result terminal would permanently exclude it from
-// upgrade. That threshold belongs to the upgrade-eligibility policy (#553),
-// which owns terminal-ness; this function only orders results.
+// practice -- see the measurement cited on models.Song.WordTimings. Marking a
+// half-timed result terminal would permanently exclude it from upgrade. That
+// threshold belongs to the upgrade-eligibility policy (#553), which owns
+// terminal-ness; this function only orders results.
 func QualityOf(song models.Song) Quality {
 	switch {
 	case len(song.Subtitles.Lines) > 0 && len(song.WordTimings) > 0:

--- a/internal/orchestrator/suitability.go
+++ b/internal/orchestrator/suitability.go
@@ -17,16 +17,36 @@ const (
 	QualityInstrumental
 	// QualityUnsynced means the result carries an unsynced lyric body.
 	QualityUnsynced
-	// QualitySynced means the result carries time-synced subtitle lines.
+	// QualitySynced means the result carries line-level time-synced subtitles.
 	QualitySynced
+	// QualityWordSynced means the result carries per-word timings in addition to
+	// line cues. It ranks above QualitySynced because it is strictly more
+	// information: the line cues are still present, plus word-level detail the
+	// Enhanced-LRC (A2) writer can use.
+	QualityWordSynced
 )
 
 // QualityOf classifies a song's lyric quality. The precedence mirrors the LRC
 // writer's content selection (synced lines, then an unsynced body, then an
 // instrumental marker), so the orchestrator's ranking agrees with what the
 // writer will actually emit.
+//
+// Word-sync is recognized by the presence of WordTimings alongside line cues.
+// ANY word timings promote the result, deliberately: for RANKING purposes a
+// partially word-timed result is still strictly better than a line-only one --
+// the line cues are unchanged and the word detail is a bonus, so preferring it
+// can never make output worse.
+//
+// That is a ranking rule, NOT a terminal-state rule. Whether a result is good
+// enough to stop improving needs a higher bar, because coverage is uneven in
+// practice (measured: median 100% of words distinctly timed, worst case 51%).
+// Marking a half-timed result terminal would permanently exclude it from
+// upgrade. That threshold belongs to the upgrade-eligibility policy (#553),
+// which owns terminal-ness; this function only orders results.
 func QualityOf(song models.Song) Quality {
 	switch {
+	case len(song.Subtitles.Lines) > 0 && len(song.WordTimings) > 0:
+		return QualityWordSynced
 	case len(song.Subtitles.Lines) > 0:
 		return QualitySynced
 	case song.Lyrics.LyricsBody != "":

--- a/internal/orchestrator/suitability_test.go
+++ b/internal/orchestrator/suitability_test.go
@@ -58,9 +58,10 @@ func TestQualityOf(t *testing.T) {
 }
 
 func TestQualityOrdering(t *testing.T) {
-	if QualitySynced <= QualityUnsynced || QualityUnsynced <= QualityInstrumental || QualityInstrumental <= QualityNone {
-		t.Fatalf("quality ordering broken: synced=%d unsynced=%d instrumental=%d none=%d",
-			QualitySynced, QualityUnsynced, QualityInstrumental, QualityNone)
+	if QualityWordSynced <= QualitySynced || QualitySynced <= QualityUnsynced ||
+		QualityUnsynced <= QualityInstrumental || QualityInstrumental <= QualityNone {
+		t.Fatalf("quality ordering broken: wordsynced=%d synced=%d unsynced=%d instrumental=%d none=%d",
+			QualityWordSynced, QualitySynced, QualityUnsynced, QualityInstrumental, QualityNone)
 	}
 }
 

--- a/internal/orchestrator/wordsync_quality_test.go
+++ b/internal/orchestrator/wordsync_quality_test.go
@@ -42,17 +42,42 @@ func TestQualityOf_WordTimingsWithoutCuesIsNotWordSynced(t *testing.T) {
 }
 
 // TestQualityOf_PartialWordCoverageStillRanksAbove pins the deliberate ranking
-// rule: ANY word timings promote the result. Coverage is uneven in practice
-// (measured: median 100% of words distinctly timed, worst case 51%), but a
-// partially timed result still carries every line cue a line-synced one would,
-// so preferring it can never produce worse output.
+// rule at its BOUNDARY: ANY word timings promote the result, even when most
+// lines carry none.
+//
+// The fixture must have a genuinely untimed line for this to test anything. An
+// earlier version reused syncedSong() -- which has exactly ONE cue -- plus one
+// timing, i.e. 100% coverage, so it was indistinguishable from the full-coverage
+// case and would have passed under any "promote if len(WordTimings) > 0"
+// implementation. Here 1 of 4 cues is timed: unambiguously partial.
+//
+// Rationale for promoting anyway: a partially timed result still carries every
+// line cue a line-synced one would, so preferring it can never produce worse
+// output. Coverage is uneven in the wild -- across 54 word-synced tracks
+// measured 2026-07-21, the median had 100% of words distinctly timed and the
+// worst 51%.
 //
 // This is a RANKING rule only. The higher bar for terminal-ness -- where marking
 // a half-timed result "done" would permanently exclude it from upgrade -- is
 // #553's call, not QualityOf's.
 func TestQualityOf_PartialWordCoverageStillRanksAbove(t *testing.T) {
-	partial := syncedSong()
-	partial.WordTimings = []models.WordTiming{{Line: 0, Text: "la", StartMS: 1000, EndMS: 1200}}
+	partial := models.Song{Subtitles: models.Synced{Lines: []models.Lines{
+		{Text: "one", Time: models.Time{Total: 1}},
+		{Text: "two", Time: models.Time{Total: 2}},
+		{Text: "three", Time: models.Time{Total: 3}},
+		{Text: "four", Time: models.Time{Total: 4}},
+	}}}
+	// Only the first of four cues carries word timings.
+	partial.WordTimings = []models.WordTiming{{Line: 0, Text: "one", StartMS: 1000, EndMS: 1200}}
+
+	timedLines := map[int]bool{}
+	for _, w := range partial.WordTimings {
+		timedLines[w.Line] = true
+	}
+	if len(timedLines) >= len(partial.Subtitles.Lines) {
+		t.Fatalf("fixture is not partial: %d of %d cues timed", len(timedLines), len(partial.Subtitles.Lines))
+	}
+
 	if got := QualityOf(partial); got != QualityWordSynced {
 		t.Errorf("partial word coverage should still rank as word-synced, got %d", got)
 	}

--- a/internal/orchestrator/wordsync_quality_test.go
+++ b/internal/orchestrator/wordsync_quality_test.go
@@ -1,0 +1,104 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// wordSyncedSong is syncedSong plus per-word timings -- the only difference the
+// orchestrator can see between the two tiers, since the line cues are identical.
+func wordSyncedSong() models.Song {
+	s := syncedSong()
+	s.WordTimings = []models.WordTiming{
+		{Line: 0, Text: "la", StartMS: 1000, EndMS: 1200},
+		{Line: 0, Text: "la", StartMS: 1200, EndMS: 1400},
+	}
+	return s
+}
+
+func TestQualityOf_WordSyncedOutranksSynced(t *testing.T) {
+	ws, ls := QualityOf(wordSyncedSong()), QualityOf(syncedSong())
+	if ws != QualityWordSynced {
+		t.Errorf("word-synced song classified as %d, want %d", ws, QualityWordSynced)
+	}
+	if ls != QualitySynced {
+		t.Errorf("line-synced song classified as %d, want %d", ls, QualitySynced)
+	}
+	if ws <= ls {
+		t.Errorf("word-sync must outrank line-sync: %d vs %d", ws, ls)
+	}
+}
+
+// TestQualityOf_WordTimingsWithoutCuesIsNotWordSynced: timings index into
+// Subtitles.Lines, so they are meaningless without cues and must not promote a
+// song on their own.
+func TestQualityOf_WordTimingsWithoutCuesIsNotWordSynced(t *testing.T) {
+	orphan := unsyncedSong()
+	orphan.WordTimings = []models.WordTiming{{Line: 0, Text: "la", StartMS: 0, EndMS: 100}}
+	if got := QualityOf(orphan); got != QualityUnsynced {
+		t.Errorf("orphan word timings should not promote past unsynced, got %d", got)
+	}
+}
+
+// TestQualityOf_PartialWordCoverageStillRanksAbove pins the deliberate ranking
+// rule: ANY word timings promote the result. Coverage is uneven in practice
+// (measured: median 100% of words distinctly timed, worst case 51%), but a
+// partially timed result still carries every line cue a line-synced one would,
+// so preferring it can never produce worse output.
+//
+// This is a RANKING rule only. The higher bar for terminal-ness -- where marking
+// a half-timed result "done" would permanently exclude it from upgrade -- is
+// #553's call, not QualityOf's.
+func TestQualityOf_PartialWordCoverageStillRanksAbove(t *testing.T) {
+	partial := syncedSong()
+	partial.WordTimings = []models.WordTiming{{Line: 0, Text: "la", StartMS: 1000, EndMS: 1200}}
+	if got := QualityOf(partial); got != QualityWordSynced {
+		t.Errorf("partial word coverage should still rank as word-synced, got %d", got)
+	}
+}
+
+// TestIsSuitable_UnchangedByWordSync guards the scope boundary of #603: this
+// change reorders results, it does not change when a lane short-circuits.
+func TestIsSuitable_UnchangedByWordSync(t *testing.T) {
+	cases := []struct {
+		name string
+		song models.Song
+		want bool
+	}{
+		{"word-synced is suitable", wordSyncedSong(), true},
+		{"line-synced is suitable", syncedSong(), true},
+		{"unsynced is suitable", unsyncedSong(), true},
+		{"provider instrumental is not suitable alone", instrumentalSong(), false},
+		{"empty is not suitable", models.Song{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSuitable(tc.song, nil); got != tc.want {
+				t.Errorf("IsSuitable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRetain_PrefersWordSynced exercises the actual consumer: the
+// best-available fallback path must prefer a word-synced result over a
+// line-synced one regardless of which lane reported first.
+func TestRetain_PrefersWordSynced(t *testing.T) {
+	t.Run("word-sync arrives second", func(t *testing.T) {
+		var r dispatchResult
+		r.retain(syncedSong(), "line-lane")
+		r.retain(wordSyncedSong(), "word-lane")
+		if r.bestLane != "word-lane" {
+			t.Errorf("best lane = %q, want word-lane", r.bestLane)
+		}
+	})
+	t.Run("word-sync arrives first and is not displaced", func(t *testing.T) {
+		var r dispatchResult
+		r.retain(wordSyncedSong(), "word-lane")
+		r.retain(syncedSong(), "line-lane")
+		if r.bestLane != "word-lane" {
+			t.Errorf("best lane = %q, want word-lane", r.bestLane)
+		}
+	})
+}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -318,13 +318,27 @@ func (c *Client) lookup(ctx context.Context, track models.Track, tier int) (mode
 
 	switch classifyPayload(raw) {
 	case tierWordSync:
-		cues, _, err := decodeWordSync(raw)
+		cues, timings, err := decodeWordSync(raw)
 		if err != nil {
 			return models.Song{}, err
 		}
 		// Run the shared normalizer so this lane holds the same one-cue-per-line
 		// model as every other write path (#470).
-		song.Subtitles = lrcnormalize.Expand(models.Synced{Lines: cues})
+		expanded := lrcnormalize.Expand(models.Synced{Lines: cues})
+		song.Subtitles = expanded
+		// Word timings index into the cue slice, so they are only safe to attach
+		// when normalization left that slice untouched. Expand splits a cue whose
+		// TEXT carries an embedded timestamp, which shifts every later index; the
+		// timings would then point at the wrong cue. decodeWordSync already sorts,
+		// so a well-formed payload is unchanged here and the timings survive --
+		// but a payload with stray in-text stamps drops to line-sync quality
+		// rather than shipping misaligned word data.
+		if len(expanded.Lines) == len(cues) {
+			song.WordTimings = timings
+		} else {
+			slog.Debug("petitlyrics: cue normalization changed the line set; dropping word timings",
+				"before", len(cues), "after", len(expanded.Lines))
+		}
 		return song, nil
 
 	case tierLineSync:

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -326,18 +326,27 @@ func (c *Client) lookup(ctx context.Context, track models.Track, tier int) (mode
 		// model as every other write path (#470).
 		expanded := lrcnormalize.Expand(models.Synced{Lines: cues})
 		song.Subtitles = expanded
-		// Word timings index into the cue slice, so they are only safe to attach
-		// when normalization left that slice untouched. Expand splits a cue whose
-		// TEXT carries an embedded timestamp, which shifts every later index; the
-		// timings would then point at the wrong cue. decodeWordSync already sorts,
-		// so a well-formed payload is unchanged here and the timings survive --
-		// but a payload with stray in-text stamps drops to line-sync quality
-		// rather than shipping misaligned word data.
+		// Word timings are positional indices into the cue slice, so they are only
+		// safe to attach when no cue was SPLIT. Expand splits a cue whose TEXT
+		// carries an embedded timestamp, which shifts every later index and would
+		// leave the timings pointing at the wrong words.
+		//
+		// The length comparison detects a split, which is not the same as proving
+		// the order is unchanged: Expand ends in a sort, so in general it can
+		// reorder at constant length. That cannot happen HERE because
+		// decodeWordSync sorts by first-word start time before assigning indices
+		// and msToTime is monotone, making Expand's stable sort a no-op on this
+		// path -- an invariant defended by
+		// TestDecodeWordSync_OrderingIsStableThroughExpand. If that sort is ever
+		// removed, this check stops being sufficient.
 		if len(expanded.Lines) == len(cues) {
 			song.WordTimings = timings
 		} else {
-			slog.Debug("petitlyrics: cue normalization changed the line set; dropping word timings",
-				"before", len(cues), "after", len(expanded.Lines))
+			// Info, not Debug: this silently demotes a result a full quality tier,
+			// and it should be rare. If it ever becomes common that signals a
+			// payload-shape change worth noticing in production.
+			slog.Info("petitlyrics: cue normalization split a line; dropping word timings",
+				"track", track.TrackName, "before", len(cues), "after", len(expanded.Lines))
 		}
 		return song, nil
 

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -155,6 +155,56 @@ func TestFindLyrics_WordSyncProducesCues(t *testing.T) {
 	}
 }
 
+// TestFindLyrics_AttachesWordTimings pins that the decoded per-word timings
+// actually reach models.Song. They were decoded and discarded before #603; the
+// orchestrator now needs them to rank a word-synced result above a line-synced
+// one, and #480's A2 writer will consume them.
+func TestFindLyrics_AttachesWordTimings(t *testing.T) {
+	c, _ := newTestClient(t, serveFixture(t, "type3_wordsync.xml"))
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.WordTimings) == 0 {
+		t.Fatal("word-synced result must carry word timings")
+	}
+	// Every timing must index a real cue, or downstream grouping is corrupt.
+	for i, w := range song.WordTimings {
+		if w.Line < 0 || w.Line >= len(song.Subtitles.Lines) {
+			t.Fatalf("timing %d indexes line %d, outside 0..%d",
+				i, w.Line, len(song.Subtitles.Lines)-1)
+		}
+	}
+}
+
+// TestFindLyrics_DropsTimingsWhenNormalizationShiftsCues covers the alignment
+// guard. Word timings are positional indices into the cue slice, so if
+// lrcnormalize.Expand splits a cue (it does that for a cue whose TEXT carries an
+// embedded timestamp) every later index shifts and the timings would point at
+// the wrong words. The client must drop them rather than ship misaligned data --
+// the result degrades to line-sync quality, which is correct but lesser.
+func TestFindLyrics_DropsTimingsWhenNormalizationShiftsCues(t *testing.T) {
+	inner := `<wsy><line><linestring>[00:09.00]Lorem ipsum</linestring>` +
+		`<word><starttime>3000</starttime><endtime>4000</endtime><wordstring>Lorem</wordstring></word>` +
+		`</line></wsy>`
+	body := `<response><songs><song><lyricsId>1</lyricsId><title>Lorem Ipsum</title>` +
+		`<lyricsData>` + base64.StdEncoding.EncodeToString([]byte(inner)) +
+		`</lyricsData></song></songs></response>`
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) != 2 {
+		t.Fatalf("expected the embedded stamp to expand to 2 cues, got %d", len(song.Subtitles.Lines))
+	}
+	if len(song.WordTimings) != 0 {
+		t.Errorf("timings must be dropped when normalization changes the cue set, got %d", len(song.WordTimings))
+	}
+}
+
 // TestFindLyrics_MultiCandidateIntegration exercises the whole path end to end
 // on real XML -- parse envelope, score candidates, decode payload -- rather than
 // unit-testing selectCandidate against hand-built structs. The fixture holds two

--- a/internal/petitlyrics/decode.go
+++ b/internal/petitlyrics/decode.go
@@ -18,18 +18,11 @@ const (
 	tierWordSync = 3 // base64 <wsy> XML with per-word timings
 )
 
-// WordTiming is one word's timing within a synced line. Emitted alongside the
-// line-level cues so the Enhanced-LRC (A2) writer (#480) has word granularity
-// without re-parsing the payload.
-type WordTiming struct {
-	// Line is the zero-based index of the owning line in the returned cues.
-	Line int
-	// Text is the word as it appears in the payload.
-	Text string
-	// StartMS and EndMS are milliseconds from the start of the track.
-	StartMS int
-	EndMS   int
-}
+// WordTiming is the shared models type, aliased here so this package's decoder
+// signature stays readable. It lives in models because the orchestrator needs it
+// to rank a word-synced result above a line-synced one, and because the
+// Enhanced-LRC (A2) writer (#480) will consume it from models.Song.
+type WordTiming = models.WordTiming
 
 // wsyDoc mirrors the <wsy> word-sync payload. Element names are taken from
 // observed responses: <wsy> holds <line> elements, each with a <linestring>


### PR DESCRIPTION
## Summary

- **Adds `QualityWordSynced` above `QualitySynced`.** Before this, a word-synced result and a line-synced one scored identically, so *lane order* decided which won rather than quality. That was fine while nothing produced word timings; the petitlyrics API rewrite (#495) changed it.
- **Stops discarding the word timings.** `decodeWordSync` already produced them and the client threw them away. They now travel on `models.Song.WordTimings` — the carrier the orchestrator needs, since line cues are byte-identical across the two tiers and the timings are the *only* signal that the richer tier was served.
- **No change to when a lane short-circuits.** `IsSuitable`'s threshold is deliberately untouched; this reorders results, it does not change dispatch.

**Look at first:** the ranking rule in `QualityOf`, and the alignment guard in `client.go`'s word-sync branch.

## Linked issue

Closes #603

## Design decisions worth reviewing

**Any word timings promote the result.** Coverage is uneven in practice — measured across 54 word-synced tracks, the median had 100% of words distinctly timed but the worst case only 51%. A partially timed result still carries every line cue a line-synced one would, so preferring it can never produce worse output. This is a **ranking** rule only; the higher bar for *terminal-ness* (where marking a half-timed result "done" would permanently exclude it from upgrade) belongs to #553.

**Timings are dropped when normalization shifts the cue set.** `WordTiming.Line` is a positional index into `Subtitles.Lines`. `lrcnormalize.Expand` splits a cue whose *text* carries an embedded timestamp, which shifts every later index and would leave the timings pointing at the wrong words. The client detects the length change and drops them, degrading to line-sync quality rather than shipping misaligned word data.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete.
- [x] Single commit before first push.
- [x] Label set.
- [x] UAT — N/A, lane disabled in config; behaviour covered by tests against recorded API shapes.
- [x] Screenshot — N/A, no web-UI change.
- [x] `make ui` — N/A.
- [x] Migration — N/A. `WordTimings` is transient (`json:"-"`), never persisted.

## Test plan

- [x] `make gate` passes (race, coverage floor, golangci-lint, actionlint, govulncheck). orchestrator 95%, petitlyrics 95%.
- [x] New tests confirmed to **fail against unfixed code**, verified by mutation rather than assertion. Three meaningful mutants, all killed:
      `QualityOf` never returning `QualityWordSynced`; the client discarding timings again (pre-#603 behaviour); the client attaching timings despite a cue-set shift.
      A fourth mutant (reordering the enum) broke the build, so it is **not** counted as evidence — a compile failure fails everything.
- [x] Both existing `Quality` consumers verified compatible: `parallel.go` uses `>= QualitySynced` and `retain` uses `> bestQuality`, so the new tier slots in without changes. `TestRetain_PrefersWordSynced` exercises the real consumer in both arrival orders.
- [x] Which **surface**: orchestrator ranking + the petitlyrics lane's output. No queue, DB, or write-path surface.
- [ ] Reviewer follow-ups:
  - [ ] **The alignment guard is new logic no issue asked for.** It prevents a real corruption (misaligned word data) but is my own addition — worth a look at whether dropping the timings is the right degradation versus repairing the indices.
  - [ ] `petitlyrics.WordTiming` is now a type alias for `models.WordTiming` to keep one definition. Check the alias reads clearly at the decoder's signature.

## Not covered

- **The A2 writer does not exist yet**, so nothing consumes `WordTimings` for output. This PR makes word-sync *rank* correctly and preserves the data; #480 makes it reach files. Until then the practical effect is provider selection only.
- **Terminal-state semantics are untouched.** A word-synced result is not treated as "done" — that is #553's call, and this PR deliberately does not pre-empt it.
- **Partial-coverage threshold is not implemented.** The ranking rule ignores coverage entirely by design; if #553 decides terminal-ness needs, say, 80% distinctly-timed words, that predicate is still to be written.
- **`lyricsType 2` remains undecodable** (#602), so line-sync-only tracks still fall back to plain text and cannot benefit from this ranking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added word-level lyric timing support.
  * Word-timed lyrics are now ranked above line-timed synced lyrics, including partial word coverage when cues are available.

* **Bug Fixes**
  * Word-timing data is preserved only when it remains correctly aligned after lyric normalization; otherwise it’s safely discarded.
  * Improved selection so the best word-timed synced result wins when available.

* **Tests**
  * Added/updated coverage for word timing attachment, ranking, suitability behavior, and parallel selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->