### PR TITLE
fix(worker): keep detector breaker state across an orchestrator rebuild

### DIFF
--- a/internal/worker/detect_instrumental_test.go
+++ b/internal/worker/detect_instrumental_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sydlexius/canticle/internal/circuit"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/musixmatch"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -114,5 +115,54 @@ func TestDetectInstrumental_WantedButNoClassifierLoudSkips(t *testing.T) {
 	logged := buf.String()
 	if !strings.Contains(logged, "level=ERROR") || !strings.Contains(logged, "no classifier") {
 		t.Errorf("expected an ERROR loud-skip log mentioning the missing classifier; got: %q", logged)
+	}
+}
+
+// TestDetectorBreakerStateSurvivesRebuild verifies that a rebuild of the
+// orchestrator preserves the detector breaker's accumulated state (#531).
+//
+// Before the fix, rebuildOrchestrator constructed a brand-new circuit.Breaker
+// for the detector lane on every call, so any trip count and open-until deadline
+// were silently discarded. That was latent while every rebuild-triggering setter
+// ran only at startup, but it would let a runtime rebuild (e.g. a settings save
+// that re-wires the worker) reset a tripped detector breaker and immediately
+// hammer a sidecar that is known to be unreachable.
+//
+// The assertion is on the breaker's OBSERVABLE state rather than on pointer
+// identity: reusing the instance and transferring its state are both valid
+// fixes, and the invariant that matters is that a tripped detector stays
+// tripped across a rebuild.
+func TestDetectorBreakerStateSurvivesRebuild(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.EnableAudioDetector(&fakeDetector{})
+	w.SetDetectorOrdering("front")
+
+	lane := w.detectorLane
+	if lane == nil {
+		t.Fatal("detector lane not installed; cannot exercise the rebuild invariant")
+	}
+
+	// Trip the detector breaker so there is state worth preserving.
+	lane.Breaker().Trip()
+	trips := lane.Breaker().Trips()
+	if trips == 0 {
+		t.Fatal("breaker reports 0 trips after Trip(); test cannot discriminate")
+	}
+	if got := lane.Breaker().Allow(); got != circuit.StateOpen {
+		t.Fatalf("breaker state after Trip() = %v; want StateOpen", got)
+	}
+
+	// Any rebuild-triggering setter will do; ordering is the cheapest.
+	w.SetDetectorOrdering("demoted")
+
+	rebuilt := w.detectorLane
+	if rebuilt == nil {
+		t.Fatal("detector lane missing after rebuild")
+	}
+	if got := rebuilt.Breaker().Trips(); got != trips {
+		t.Errorf("trips after rebuild = %d; want %d (breaker state was discarded)", got, trips)
+	}
+	if got := rebuilt.Breaker().Allow(); got != circuit.StateOpen {
+		t.Errorf("breaker state after rebuild = %v; want StateOpen (a tripped detector must stay tripped)", got)
 	}
 }

--- a/internal/worker/detect_instrumental_test.go
+++ b/internal/worker/detect_instrumental_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/circuit"
 	"github.com/sydlexius/canticle/internal/models"
@@ -164,5 +165,36 @@ func TestDetectorBreakerStateSurvivesRebuild(t *testing.T) {
 	}
 	if got := rebuilt.Breaker().Allow(); got != circuit.StateOpen {
 		t.Errorf("breaker state after rebuild = %v; want StateOpen (a tripped detector must stay tripped)", got)
+	}
+}
+
+// TestCircuitSettersReachDetectorBreaker verifies the circuit-config setters fan
+// out to the detector breaker (#531).
+//
+// This became load-bearing only once the breaker started surviving rebuilds.
+// Previously each rebuild constructed a fresh breaker from the worker's current
+// config, so a setter that skipped it was invisible. A long-lived breaker would
+// instead keep whatever window it was born with, forever.
+func TestCircuitSettersReachDetectorBreaker(t *testing.T) {
+	w := New(&fakeQueue{}, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	w.EnableAudioDetector(&fakeDetector{})
+	w.SetDetectorOrdering("front")
+	if w.detectorBreaker == nil {
+		t.Fatal("detector breaker not created; cannot exercise the fan-out")
+	}
+
+	// A frozen clock proves the setter reached the breaker: the breaker's
+	// open-until deadline is computed from ITS clock, so if setClock skipped it
+	// the deadline would be built from the real wall clock instead.
+	frozen := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	w.setClock(func() time.Time { return frozen })
+	w.SetCircuitOpenDuration(90 * time.Minute)
+	w.SetCircuitBackoff(90*time.Minute, 90*time.Minute)
+
+	w.detectorBreaker.Trip()
+	got := w.detectorBreaker.OpenUntil()
+	want := frozen.Add(90 * time.Minute)
+	if !got.Equal(want) {
+		t.Errorf("detector breaker OpenUntil = %v; want %v (a circuit setter did not reach it)", got, want)
 	}
 }

--- a/internal/worker/detect_instrumental_test.go
+++ b/internal/worker/detect_instrumental_test.go
@@ -188,8 +188,13 @@ func TestCircuitSettersReachDetectorBreaker(t *testing.T) {
 	// the deadline would be built from the real wall clock instead.
 	frozen := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
 	w.setClock(func() time.Time { return frozen })
+	// Order matters: SetCircuitBackoff runs FIRST with a distinct (smaller) cap,
+	// so SetCircuitOpenDuration is the only call that can raise the window to
+	// 90m. Setting them the other way round -- or with the same cap -- lets
+	// SetCircuitBackoff reapply the expected value and masks a missing
+	// SetCircuitOpenDuration fan-out entirely.
+	w.SetCircuitBackoff(90*time.Minute, 30*time.Minute)
 	w.SetCircuitOpenDuration(90 * time.Minute)
-	w.SetCircuitBackoff(90*time.Minute, 90*time.Minute)
 
 	w.detectorBreaker.Trip()
 	got := w.detectorBreaker.OpenUntil()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -233,6 +233,13 @@ type Worker struct {
 	// NOT part of w.lanes, which tracks provider lanes exclusively and which the
 	// circuit-config setters fan out across.
 	detectorLane *orchestrator.Lane
+	// detectorBreaker is the detector lane's circuit breaker, held on the worker
+	// so it OUTLIVES any single rebuildOrchestrator call (#531). The lane itself
+	// is rebuilt freely; its breaker must not be, or a tripped detector would be
+	// silently reopened. It is deliberately separate from w.lanes, which the
+	// circuit-config setters fan out across -- the detector's breaker is
+	// independent, so tripping it never pauses a provider lane and vice versa.
+	detectorBreaker *circuit.Breaker
 }
 
 // errIdle marks a RunOnce outcome that unwinds the run loop without recording a
@@ -349,8 +356,29 @@ func (w *Worker) rebuildOrchestrator() error {
 			slog.Warn("worker: instrumental detection is INACTIVE under parallel provider dispatch; the detector lane is not installed. Set providers.mode=ordered to enable it (see #528)", "mode", w.mode)
 			w.detectorLane = nil
 		} else {
-			cb := circuit.New(w.circuitBackoffBase, w.circuitOpenDuration)
-			cb.SetClock(w.now)
+			// REUSE the existing detector breaker across rebuilds (#531).
+			// Constructing a fresh one here discarded the accumulated trip count
+			// and open-until deadline, so a rebuild silently un-tripped a
+			// detector that had just been shut off for being unreachable -- the
+			// sidecar would be hammered again immediately instead of staying
+			// open for its backoff window. Reconfiguring in place mirrors how
+			// the circuit setters fan out across the provider lanes rather than
+			// replacing their breakers.
+			//
+			// This was latent while every rebuild-triggering setter ran only at
+			// startup (where there is no state worth keeping); it becomes live
+			// the moment anything rebuilds at runtime, e.g. a settings save that
+			// re-wires the worker.
+			cb := w.detectorBreaker
+			if cb == nil {
+				cb = circuit.New(w.circuitBackoffBase, w.circuitOpenDuration)
+				cb.SetClock(w.now)
+				w.detectorBreaker = cb
+			}
+			// No reconfiguration here: SetCircuitBackoff, SetCircuitOpenDuration
+			// and setClock now fan out to w.detectorBreaker directly, so a
+			// surviving breaker is already current. Re-applying config on every
+			// rebuild would be a second, order-dependent path to the same state.
 			// Share the primary provider lane's pacer so a detector settle credits
 			// the same ratchet-down counter the musixmatch client's OnThrottle
 			// ratchets up (#550) -- this is a decay CREDIT only; the detector lane
@@ -426,6 +454,13 @@ func (w *Worker) SetCircuitOpenDuration(d time.Duration) {
 	w.circuitOpenDuration = d
 	for _, l := range w.lanes {
 		l.Breaker().SetOpenDuration(d)
+	}
+	// The detector breaker is not in w.lanes (it is independent by design), but
+	// it now OUTLIVES rebuilds (#531), so it must be reconfigured here too. Before
+	// the breaker persisted, a rebuild recreated it with current config and hid
+	// this gap; a long-lived breaker would otherwise keep a stale window forever.
+	if w.detectorBreaker != nil {
+		w.detectorBreaker.SetOpenDuration(d)
 	}
 }
 
@@ -504,6 +539,9 @@ func (w *Worker) SetCircuitBackoff(base, cap time.Duration) {
 	for _, l := range w.lanes {
 		l.Breaker().SetBackoff(w.circuitBackoffBase, w.circuitOpenDuration)
 	}
+	if w.detectorBreaker != nil { // see SetCircuitOpenDuration (#531)
+		w.detectorBreaker.SetBackoff(w.circuitBackoffBase, w.circuitOpenDuration)
+	}
 }
 
 // SetMaxMissAttempts overrides the miss-attempt cap. When miss_count exceeds
@@ -523,6 +561,9 @@ func (w *Worker) setClock(now func() time.Time) {
 	w.now = now
 	for _, l := range w.lanes {
 		l.Breaker().SetClock(now)
+	}
+	if w.detectorBreaker != nil { // see SetCircuitOpenDuration (#531)
+		w.detectorBreaker.SetClock(now)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `rebuildOrchestrator` constructed a fresh `circuit.Breaker` for the detector lane on every call, discarding its trip count and open-until deadline. Latent today (every rebuild-triggering setter runs only at startup), but a runtime rebuild -- e.g. a settings save that re-wires the worker -- would silently un-trip a detector that had just been shut off for being unreachable, hammering the sidecar again instead of letting its backoff window run.
- The breaker now lives on the `Worker` so it outlives any single rebuild. The lane is still rebuilt freely; only its breaker persists.
- **A consequence worth reviewing:** because the breaker now survives, the circuit-config setters have to reach it. `SetCircuitBackoff`, `SetCircuitOpenDuration` and `setClock` fan out to it alongside the provider lanes. Previously each rebuild recreated the breaker from current config, which masked the fact that these setters skip anything outside `w.lanes` -- a long-lived breaker would otherwise keep whatever window it was born with, forever. The rebuild path deliberately does **not** re-apply config, which would be a second, order-dependent path to the same state.

## Linked issue

Closes #531

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete.
- [ ] Commits squashed -- kept as two: the fix, then the coverage tests added after the gate flagged patch coverage. The split shows why the second test exists.
- [ ] Label set -- no label in the repo vocabulary fits cleanly; the issue itself carries the classification.
- [ ] UAT -- N/A. The bug is latent by construction: no shipped code path rebuilds the orchestrator at runtime, so there is no user-visible behavior to exercise. See "Not covered".
- [ ] Screenshot -- N/A, no web-UI change.
- [ ] `make ui` -- N/A, no `.templ` or CSS source changed.
- [ ] Migration -- N/A, no data correction.

## Test plan

- [x] `make gate` passes: conflict markers, gofmt, build, `go test -race` + coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, govulncheck.
- [x] **New tests confirmed to fail against unfixed code.** `TestDetectorBreakerStateSurvivesRebuild` failed on both assertions before the fix (`trips after rebuild = 0; want 1`, and the open state discarded).
- [x] **Both tests mutation-tested.** Reverting the persistence (`cb := w.detectorBreaker` -> a nil breaker) makes the first test fail; removing the `setClock` fan-out makes the second fail, with the real wall clock visibly leaking into the deadline. Neither is a test that only ever passes.
- [x] Patch coverage 100% (28/28), up from 67.9% -- the gate correctly blocked the first push, and the uncovered lines were exactly the three new setter fan-outs, so the added test covers real behavior rather than padding.
- [x] Surface stated explicitly: this is worker **in-memory lane wiring**. No database, no HTTP surface, no on-disk artifact is involved, so nothing here can be verified by a DB query.

- [ ] Reviewer follow-ups:
  - [ ] The test asserts **observable breaker state** (trip count, open state, open-until deadline) rather than pointer identity, so reusing the instance and transferring its state both satisfy it. Worth confirming that is the invariant you want pinned.
  - [ ] `SetCircuitBackoff`/`SetCircuitOpenDuration`/`setClock` now have two fan-out targets (`w.lanes` and the detector breaker). If a third independent breaker is ever added, that pattern needs generalizing rather than a third copy.

## Not covered

**This does not prove the latent bug is now unreachable in production** -- it proves the breaker survives a rebuild. The rebuild-triggering setters are still startup-only, so the fix has no runtime effect today; its value is entirely in the future path the issue describes (a settings save that re-wires the worker).

The detector lane's interaction with `providers.mode=parallel` is untouched: the lane is still not installed at all under parallel dispatch, so under that mode there is no breaker to preserve. That gap is #528, not this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-detector reliability by preserving circuit-breaker state when the worker rebuilds its processing lanes.
  * Ensured detector circuit settings remain synchronized with the worker’s configured duration, backoff, and clock settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->