### PR TITLE
feat(queue): record completion provenance on the work_queue row

### DIFF
--- a/internal/db/migrations/033_work_queue_completion_provenance.sql
+++ b/internal/db/migrations/033_work_queue_completion_provenance.sql
@@ -1,0 +1,66 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-track completion provenance (#620): the identifiers and writer version a
+-- completed row was settled with. These are the same values the synced .lrc tag
+-- block already emits (internal/lyrics/writer.go, the [isrc:]/[mbid:]/[fetched:]
+-- /[ve:] tags), persisted on the row so they survive for outcomes that write no
+-- tag block at all.
+--
+-- WHY THIS IS THE ONLY HOME FOR THEM. An unsynced .txt is plain lyric text that
+-- players render verbatim, so a header block would show up as the first lines of
+-- the lyrics; the maintainer ruled that provenance must never appear in unsynced
+-- lyric files, and .txt on disk stays byte-identical. The file therefore cannot
+-- carry this, and a 2022-written .txt is byte-indistinguishable from one written
+-- today. Recording it on the row is what makes an unsynced settle judgeable by
+-- the upgrade ladder (#553), which otherwise knows a row settled unsynced
+-- (outcome_type, migration 024) but not from which identifiers or which version
+-- -- so it has no basis to decide whether re-fetching would do better.
+--
+-- Before this, ISRC/MBID were recoverable only by joining the lyrics_cache JSON
+-- blob (internal/commands/provenance.go buildProvenanceRecord), and fetch time
+-- was approximated by completed_at.
+--
+-- SCOPE LIMIT, stated so it is not mistaken for a repair: this narrows the
+-- ongoing blindness, it does not recover history. Backfill is out of scope and
+-- largely impossible. The ~10k unsynced sidecars carrying a 2026-03 mtime
+-- predate the database entirely (work_queue and scan_results both start
+-- 2026-06-07), so they have no rows for a column to be added to, and no schema
+-- change reaches backward. The filesystem remains the only witness for that
+-- cohort and mtime its only discriminator (#617). This column helps the
+-- June-and-later population only.
+--
+-- NULL is the correct initial state for every existing row and is not
+-- backfillable: legacy rows completed before this column existed, and the
+-- cache-hit path never sets FetchedAt or WinningLane at all (models.Song carries
+-- both as `json:"-"`, so a decoded cache hit leaves them zero). NULL therefore
+-- means "not recorded", never "absent from the provider result".
+--
+-- THREE live completion paths legitimately leave NULLs, so do not read a NULL as
+-- a defect:
+--   1. Guard rejection completes the row having written NOTHING (wrong-language
+--      lyrics, terminal policy), so it stamps no provenance and no outcome_type.
+--      The pair (outcome_type NULL, provenance NULL) is that path's signature.
+--   2. A cache hit records identifiers but no fetched_at -- the fetch that
+--      produced those lyrics happened on an earlier dispatch.
+--   3. A detector-instrumental settle records writer_version only: it resolves
+--      no identifiers, and it returns before the fetched_at assignment.
+-- Use provider_lane / outcome_type / instrumental_result to tell these apart;
+-- the provenance columns alone do not discriminate them.
+--
+-- These columns are write-only bookkeeping, deliberately kept out of the
+-- RETURNING list, scanWorkItem, List, and WorkItem (the batch_seq precedent in
+-- migration 031): nothing in the processing path reads them, so no consumer is
+-- coupled to them and no backfill is needed.
+ALTER TABLE work_queue ADD COLUMN isrc TEXT;
+ALTER TABLE work_queue ADD COLUMN mbid TEXT;
+ALTER TABLE work_queue ADD COLUMN fetched_at DATETIME;
+ALTER TABLE work_queue ADD COLUMN writer_version TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN isrc;
+ALTER TABLE work_queue DROP COLUMN mbid;
+ALTER TABLE work_queue DROP COLUMN fetched_at;
+ALTER TABLE work_queue DROP COLUMN writer_version;
+-- +goose StatementEnd

--- a/internal/lyrics/writer_test.go
+++ b/internal/lyrics/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/models"
 )
@@ -165,6 +166,59 @@ func TestWriteLRC_Unsynced(t *testing.T) {
 	lrcFn := Slugify("Test Artist - Lyric Track") + ".lrc"
 	if _, err := os.Stat(filepath.Join(tmpDir, lrcFn)); err == nil {
 		t.Fatal("expected no .lrc file for unsynced lyrics, but one was created")
+	}
+}
+
+// TestWriteLRC_UnsyncedIsExactlyTheLyricBody pins the maintainer's decision from
+// #620: provenance must NEVER appear in an unsynced lyric file. An unsynced .txt
+// is plain lyric text that players render verbatim, so any header block would
+// show up as the first lines of the displayed lyrics.
+//
+// This asserts the EXACT bytes rather than substrings, because that is the only
+// form that catches the regression this guards against. Every other unsynced
+// test here checks "contains the lyrics" and would keep passing if a
+// [by:canticle]/[isrc:]/[ve:] block were prepended -- exactly the change this
+// decision forbids. Completion provenance lives on the work_queue row instead
+// (queue.SetCompletionProvenance); if you are here because you want a file to
+// carry provenance, that is the mechanism, and this test is not the obstacle to
+// route around.
+func TestWriteLRC_UnsyncedIsExactlyTheLyricBody(t *testing.T) {
+	w := NewLRCWriter()
+	tmpDir := t.TempDir()
+
+	body := "First line\nSecond line"
+	// Every field that feeds the synced .lrc tag block is populated, so if the
+	// unsynced branch ever started emitting tags there would be real values to
+	// emit and the byte comparison would fail loudly.
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:    "Test Artist",
+			TrackName:     "Lyric Track",
+			AlbumName:     "Test Album",
+			TrackLength:   215,
+			ISRC:          "USABC1234567",
+			RecordingMBID: "8f3471b5-7e6a-4d3f-9c21-0a1b2c3d4e5f",
+		},
+		Lyrics:      models.Lyrics{LyricsBody: body},
+		WinningLane: "musixmatch",
+		FetchedAt:   time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	}
+
+	if err := w.WriteLRC(song, "", tmpDir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	fp := filepath.Join(tmpDir, Slugify("Test Artist - Lyric Track")+".txt")
+	data, err := os.ReadFile(fp) //nolint:gosec // test path constructed from known test data
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+
+	// The body verbatim, with no trailing newline added: this is the writer's
+	// current byte-exact output, captured so any change to it is deliberate.
+	want := body
+	if string(data) != want {
+		t.Errorf("unsynced .txt bytes changed.\n got: %q\nwant: %q\n\nAn unsynced .txt must be the lyric body and nothing else (#620).", string(data), want)
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1514,6 +1514,80 @@ func (q *DBQueue) SetOutcomeType(ctx context.Context, id int64, outcomeType stri
 	return nil
 }
 
+// CompletionProvenance carries the identifiers and writer version a work_queue
+// row was settled with (#620). Every field is optional: an empty string or zero
+// time leaves the corresponding column NULL, which means "not recorded" and
+// never "absent from the provider result". The cache-hit path in particular
+// records no FetchedAt, because models.Song carries it as `json:"-"` and a
+// decoded cache hit leaves it zero.
+type CompletionProvenance struct {
+	// ISRC is the recording's ISRC from the resolved provider result.
+	ISRC string
+	// MBID is the MusicBrainz recording ID from the resolved provider result.
+	MBID string
+	// FetchedAt is when the provider round-trip completed. Zero on a cache hit.
+	FetchedAt time.Time
+	// WriterVersion is the app version that produced the output
+	// (internal/version.Version), matching the .lrc [ve:] tag.
+	WriterVersion string
+}
+
+// IsZero reports whether the provenance carries nothing worth writing, letting
+// the caller skip the UPDATE entirely rather than stamping four NULLs over four
+// NULLs and firing the updated_at trigger for no reason.
+func (p CompletionProvenance) IsZero() bool {
+	return p.ISRC == "" && p.MBID == "" && p.FetchedAt.IsZero() && p.WriterVersion == ""
+}
+
+// SetCompletionProvenance stamps the identifiers and writer version onto a
+// work_queue row in a single UPDATE, so an outcome that writes no tag block --
+// an unsynced .txt above all, which by maintainer decision stays byte-identical
+// plain lyric text -- still records what it was settled with (#620). Together
+// with outcome_type (migration 024) this lets the upgrade ladder (#553) judge
+// whether re-fetching a settled row would do better, which knowing only that it
+// settled unsynced does not support.
+//
+// Advisory bookkeeping, so it mirrors SetOutcomeType rather than the detector
+// stamps: call before Complete while the row is still in 'processing', and treat
+// a failure as non-fatal. Nothing in the processing path reads these columns.
+// Each empty field is written as NULL ("not recorded"); a wholly empty
+// provenance is a no-op.
+func (q *DBQueue) SetCompletionProvenance(ctx context.Context, id int64, prov CompletionProvenance) error {
+	if prov.IsZero() {
+		return nil
+	}
+	var fetchedAt any
+	if !prov.FetchedAt.IsZero() {
+		fetchedAt = formatTime(prov.FetchedAt)
+	}
+	_, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET isrc = ?,
+             mbid = ?,
+             fetched_at = ?,
+             writer_version = ?
+         WHERE id = ?`,
+		nullIfEmpty(prov.ISRC),
+		nullIfEmpty(prov.MBID),
+		fetchedAt,
+		nullIfEmpty(prov.WriterVersion),
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: set completion provenance for id %d: %w", id, err)
+	}
+	return nil
+}
+
+// nullIfEmpty maps an empty string to a SQL NULL so an unrecorded provenance
+// field is distinguishable from one the provider genuinely returned as empty.
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
 // ProviderHits returns a map from lane name to cumulative hit count. Lanes that
 // have never recorded a hit are omitted.
 func (q *DBQueue) ProviderHits(ctx context.Context) (map[string]int64, error) {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3482,6 +3482,100 @@ func TestDBQueue_SetOutcomeType(t *testing.T) {
 	}
 }
 
+// TestDBQueue_SetCompletionProvenance verifies the identifiers and writer
+// version persist on a work_queue row through a real SQLite DB (#620), and that
+// an unset field lands as SQL NULL rather than an empty string -- the
+// distinction between "not recorded" and "the provider returned nothing" is the
+// whole point of the column.
+func TestDBQueue_SetCompletionProvenance(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) }
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+
+	readRow := func() (isrc, mbid, fetchedAt, writerVersion *string) {
+		t.Helper()
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT isrc, mbid, fetched_at, writer_version FROM work_queue WHERE id = ?`, item.ID,
+		).Scan(&isrc, &mbid, &fetchedAt, &writerVersion); err != nil {
+			t.Fatalf("read provenance columns: %v", err)
+		}
+		return isrc, mbid, fetchedAt, writerVersion
+	}
+
+	// Fresh row: every provenance column is NULL until stamped.
+	if isrc, mbid, fetchedAt, ver := readRow(); isrc != nil || mbid != nil || fetchedAt != nil || ver != nil {
+		t.Fatalf("initial provenance = (%v, %v, %v, %v); want all NULL", isrc, mbid, fetchedAt, ver)
+	}
+
+	// A wholly empty provenance is a no-op: it must not stamp four NULLs over
+	// four NULLs (and fire the updated_at trigger) for nothing.
+	var beforeUpdatedAt string
+	if err := q.db.QueryRowContext(ctx, `SELECT updated_at FROM work_queue WHERE id = ?`, item.ID).Scan(&beforeUpdatedAt); err != nil {
+		t.Fatalf("read updated_at: %v", err)
+	}
+	if err := q.SetCompletionProvenance(ctx, item.ID, CompletionProvenance{}); err != nil {
+		t.Fatalf("SetCompletionProvenance empty: %v", err)
+	}
+	var afterUpdatedAt string
+	if err := q.db.QueryRowContext(ctx, `SELECT updated_at FROM work_queue WHERE id = ?`, item.ID).Scan(&afterUpdatedAt); err != nil {
+		t.Fatalf("read updated_at after empty stamp: %v", err)
+	}
+	if afterUpdatedAt != beforeUpdatedAt {
+		t.Errorf("empty provenance bumped updated_at (%q -> %q); it must be a no-op, not four NULLs over four NULLs", beforeUpdatedAt, afterUpdatedAt)
+	}
+
+	fetched := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	prov := CompletionProvenance{
+		ISRC:          "USABC1234567",
+		MBID:          "8f3471b5-7e6a-4d3f-9c21-0a1b2c3d4e5f",
+		FetchedAt:     fetched,
+		WriterVersion: "v1.26.0",
+	}
+	if err := q.SetCompletionProvenance(ctx, item.ID, prov); err != nil {
+		t.Fatalf("SetCompletionProvenance: %v", err)
+	}
+	isrc, mbid, fetchedAt, ver := readRow()
+	if isrc == nil || *isrc != prov.ISRC {
+		t.Errorf("isrc = %v; want %q", isrc, prov.ISRC)
+	}
+	if mbid == nil || *mbid != prov.MBID {
+		t.Errorf("mbid = %v; want %q", mbid, prov.MBID)
+	}
+	if ver == nil || *ver != prov.WriterVersion {
+		t.Errorf("writer_version = %v; want %q", ver, prov.WriterVersion)
+	}
+	if fetchedAt == nil || *fetchedAt != formatTime(fetched) {
+		t.Errorf("fetched_at = %v; want %q", fetchedAt, formatTime(fetched))
+	}
+
+	// A partial provenance (the cache-hit shape: identifiers but no fetch time)
+	// must leave fetched_at NULL rather than writing a zero timestamp, which
+	// would read as "fetched in year 1".
+	if err := q.SetCompletionProvenance(ctx, item.ID, CompletionProvenance{
+		ISRC:          "USABC1234567",
+		WriterVersion: "v1.26.0",
+	}); err != nil {
+		t.Fatalf("SetCompletionProvenance partial: %v", err)
+	}
+	if _, mbid, fetchedAt, _ := readRow(); fetchedAt != nil || mbid != nil {
+		t.Errorf("partial stamp: fetched_at = %v, mbid = %v; want both NULL", fetchedAt, mbid)
+	}
+
+	// A missing id is a benign no-op (no error), matching the sibling stamps.
+	if err := q.SetCompletionProvenance(ctx, 999999, prov); err != nil {
+		t.Errorf("SetCompletionProvenance on missing id: want nil error, got %v", err)
+	}
+}
+
 // TestDBQueue_RecheckClosedDB verifies the recheck methods return a wrapped
 // error (rather than panicking) when the underlying handle is closed.
 func TestDBQueue_RecheckClosedDB(t *testing.T) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sydlexius/canticle/internal/queue"
 	"github.com/sydlexius/canticle/internal/scanner"
 	"github.com/sydlexius/canticle/internal/verification"
+	"github.com/sydlexius/canticle/internal/version"
 )
 
 // Queue provides durable worker queue operations.
@@ -54,6 +55,11 @@ type Queue interface {
 	// for per-track provenance. Call at completion time before Complete so the row
 	// permanently records which provider served it. An empty lane is a no-op.
 	SetProviderLane(ctx context.Context, id int64, lane string) error
+	// SetCompletionProvenance stamps the identifiers and writer version the row was
+	// settled with, so an outcome that writes no tag block -- an unsynced .txt above
+	// all -- still records what produced it (#620). Call before Complete while the
+	// row is still in processing status; a wholly empty provenance is a no-op.
+	SetCompletionProvenance(ctx context.Context, id int64, prov queue.CompletionProvenance) error
 }
 
 // ProviderRecorder records per-lane provider outcome counters. A nil
@@ -763,6 +769,37 @@ func outcomeTypeFromSong(song models.Song) string {
 	}
 }
 
+// provenanceFromSong reads the completion provenance off the same Song the
+// writer consumes, so the row records exactly what the synced .lrc tag block
+// would have emitted -- no parallel derivation (#620). The values are read, not
+// recomputed: ISRC/MBID come from the resolved provider result, FetchedAt is the
+// single fetch timestamp the worker stamps for all output paths, and the writer
+// version is the same version.Version the [ve:] tag carries.
+//
+// A cache hit legitimately yields a zero FetchedAt: models.Song carries it as
+// `json:"-"`, so it never round-trips through the cache. That leaves the column
+// NULL, meaning "not recorded" -- the honest answer, since the fetch that
+// produced those lyrics happened on an earlier dispatch.
+func provenanceFromSong(song models.Song) queue.CompletionProvenance {
+	return queue.CompletionProvenance{
+		ISRC:          song.Track.ISRC,
+		MBID:          song.Track.RecordingMBID,
+		FetchedAt:     song.FetchedAt,
+		WriterVersion: version.Version,
+	}
+}
+
+// stampCompletionProvenance records the completion provenance best-effort. It is
+// advisory bookkeeping that nothing in the processing path reads, so a failure
+// is logged and the settle proceeds -- deliberately unlike the detector stamps,
+// where a stamp failure defers the row. Losing a provenance write must never
+// cost an otherwise-good result.
+func (w *Worker) stampCompletionProvenance(ctxNoCancel context.Context, id int64, song models.Song) {
+	if err := w.queue.SetCompletionProvenance(ctxNoCancel, id, provenanceFromSong(song)); err != nil {
+		slog.Warn("worker: stamp completion provenance failed; continuing", "id", id, "error", err)
+	}
+}
+
 // Run processes ready work items until the queue is empty or the context ends.
 func (w *Worker) Run(ctx context.Context) error {
 	return w.run(ctx, nil)
@@ -1093,6 +1130,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			slog.Warn("worker: stamp outcome type failed; continuing", "id", item.ID, "error", stampErr)
 		}
 	}
+	// Record what the row was settled WITH, alongside outcome_type's what was
+	// settled TO (#620). This is the only home for it on an unsynced settle: the
+	// .txt is plain lyric text and carries no tag block, so without this the row
+	// is indistinguishable from one written by the 2022 code.
+	w.stampCompletionProvenance(ctxNoCancel, item.ID, song)
 	if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
 		cause := fmt.Errorf("worker: complete item %d: %w", item.ID, err)
 		w.consecutiveFailures++
@@ -1281,6 +1323,20 @@ func (w *Worker) completeDetectorInstrumental(ctx context.Context, item queue.Wo
 		w.consecutiveFailures = 0
 		return nil
 	}
+	// Provenance is advisory and stamped OUTSIDE stampDetectorInstrumental, whose
+	// stamps are deliberately required: a failed provenance write must not defer a
+	// settle whose marker is already on disk and whose verdict is already
+	// recorded.
+	//
+	// This path records the WRITER VERSION ONLY. A detector settle resolves no
+	// identifiers (there is no provider result), and it never carries a fetch
+	// time: song.FetchedAt is assigned inside the !cacheHit block further down
+	// runOne, which this branch has already returned before reaching. So
+	// fetched_at stays NULL here, and a detector row is indistinguishable from a
+	// cache hit on that column alone -- use provider_lane / instrumental_result
+	// to tell them apart. The detector's own timing lives in completed_at and the
+	// detector telemetry, so nothing is lost by not inventing one here.
+	w.stampCompletionProvenance(ctxNoCancel, item.ID, song)
 	if completeErr := w.queue.Complete(ctxNoCancel, item.ID); completeErr != nil {
 		cause := fmt.Errorf("worker: complete instrumental item %d: %w", item.ID, completeErr)
 		w.consecutiveFailures++

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sydlexius/canticle/internal/orchestrator"
 	"github.com/sydlexius/canticle/internal/queue"
 	"github.com/sydlexius/canticle/internal/verification"
+	"github.com/sydlexius/canticle/internal/version"
 )
 
 // logRecord captures one emitted log line's level, message, and attrs for
@@ -105,6 +106,9 @@ type fakeQueue struct {
 	deferred           []int64
 	retired            []int64
 	outcomeTypes       map[int64]string
+	provenance         map[int64]queue.CompletionProvenance
+	provenanceErr      error
+	onComplete         func(id int64)
 	failCauses         []error
 	deferCauses        []error
 	deferDurations     []time.Duration
@@ -129,6 +133,9 @@ func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
 }
 
 func (q *fakeQueue) Complete(_ context.Context, id int64) error {
+	if q.onComplete != nil {
+		q.onComplete(id)
+	}
 	if q.completeErr != nil {
 		return q.completeErr
 	}
@@ -198,6 +205,17 @@ func (q *fakeQueue) SetOutcomeType(_ context.Context, id int64, outcomeType stri
 		q.outcomeTypes = make(map[int64]string)
 	}
 	q.outcomeTypes[id] = outcomeType
+	return nil
+}
+
+func (q *fakeQueue) SetCompletionProvenance(_ context.Context, id int64, prov queue.CompletionProvenance) error {
+	if q.provenanceErr != nil {
+		return q.provenanceErr
+	}
+	if q.provenance == nil {
+		q.provenance = make(map[int64]queue.CompletionProvenance)
+	}
+	q.provenance[id] = prov
 	return nil
 }
 
@@ -2673,6 +2691,170 @@ func TestRunOnceDetectorInstrumentalStampsOutcomeType(t *testing.T) {
 	}
 	if got := q.outcomeTypes[9]; got != "instrumental" {
 		t.Fatalf("outcome_type for id 9 = %q; want \"instrumental\"", got)
+	}
+}
+
+// TestRunOnceDetectorInstrumentalStampsProvenance covers the SECOND production
+// call site (#620). Without it, deleting the stamp from the detector path leaves
+// the whole suite green -- every other provenance test drives the normal write
+// path only.
+//
+// It also pins what that path can and cannot record: a detector settle resolves
+// no identifiers and never reaches the FetchedAt assignment (that lives in the
+// !cacheHit block, which this branch returns before), so writer_version is the
+// only field it carries. Asserting the zero FetchedAt keeps the code comment
+// honest -- an earlier version of it claimed a fetch time was recorded here.
+func TestRunOnceDetectorInstrumentalStampsProvenance(t *testing.T) {
+	track := models.Track{ArtistName: "Composer", TrackName: "Silent Piece"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 10,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "silent.lrc",
+			SourcePath: "/music/silent.flac",
+		},
+	}}}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNotFound}
+	det := &fakeDetector{instrumental: true}
+
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 10 {
+		t.Fatalf("completed = %v; want [10] (precondition for this test)", q.completed)
+	}
+	prov, ok := q.provenance[10]
+	if !ok {
+		t.Fatal("no completion provenance stamped on the detector-instrumental path")
+	}
+	if prov.WriterVersion != version.Version {
+		t.Errorf("WriterVersion = %q; want %q", prov.WriterVersion, version.Version)
+	}
+	if !prov.FetchedAt.IsZero() {
+		t.Errorf("FetchedAt = %v; want zero -- the detector path never reaches the FetchedAt assignment", prov.FetchedAt)
+	}
+	if prov.ISRC != "" || prov.MBID != "" {
+		t.Errorf("identifiers = (%q, %q); want both empty -- a detector settle resolves none", prov.ISRC, prov.MBID)
+	}
+}
+
+// TestRunOnceStampsCompletionProvenanceOnUnsynced is the core of #620: an
+// unsynced settle writes a plain .txt with no tag block, so the queue row is the
+// ONLY place the identifiers survive. Without this stamp a row settled by the
+// 2022 code and one settled today are indistinguishable.
+func TestRunOnceStampsCompletionProvenanceOnUnsynced(t *testing.T) {
+	track := models.Track{
+		ArtistName:    "Artist",
+		TrackName:     "Title",
+		ISRC:          "USABC1234567",
+		RecordingMBID: "8f3471b5-7e6a-4d3f-9c21-0a1b2c3d4e5f",
+	}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID:     11,
+		Inputs: models.Inputs{Track: track},
+	}}}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "plain unsynced text"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if got := q.outcomeTypes[11]; got != "unsynced" {
+		t.Fatalf("outcome_type = %q; want \"unsynced\" (precondition for this test)", got)
+	}
+	prov, ok := q.provenance[11]
+	if !ok {
+		t.Fatal("no completion provenance stamped for id 11")
+	}
+	if prov.ISRC != track.ISRC {
+		t.Errorf("ISRC = %q; want %q", prov.ISRC, track.ISRC)
+	}
+	if prov.MBID != track.RecordingMBID {
+		t.Errorf("MBID = %q; want %q", prov.MBID, track.RecordingMBID)
+	}
+	if prov.WriterVersion != version.Version {
+		t.Errorf("WriterVersion = %q; want %q", prov.WriterVersion, version.Version)
+	}
+	// A fresh (non-cache) fetch must record when the round-trip happened; a zero
+	// value here would make every row look like a cache hit.
+	if prov.FetchedAt.IsZero() {
+		t.Error("FetchedAt is zero on a fresh fetch; want the stamped fetch time")
+	}
+}
+
+// TestRunOnceStampsProvenanceBeforeComplete pins the ordering. The stamp keys on
+// the row while it is still 'processing'; if it ran after Complete the UPDATE
+// would still match by id today, but the invariant every other Set* stamp
+// documents would be silently broken.
+func TestRunOnceStampsProvenanceBeforeComplete(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title", ISRC: "USABC1234567"}
+	q := &fakeQueue{items: []queue.WorkItem{{ID: 12, Inputs: models.Inputs{Track: track}}}}
+	q.onComplete = func(id int64) {
+		if _, stamped := q.provenance[id]; !stamped {
+			t.Errorf("Complete(%d) ran before the provenance stamp", id)
+		}
+	}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "plain unsynced text"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.completed) != 1 {
+		t.Fatalf("completed = %v; want one row", q.completed)
+	}
+}
+
+// TestRunOnceProvenanceStampFailureIsNonFatal asserts the stamp is advisory:
+// provenance is bookkeeping nothing in the processing path reads, so losing the
+// write must never cost an otherwise-good settle. This is deliberately UNLIKE
+// the detector stamps, where a failure defers the row.
+func TestRunOnceProvenanceStampFailureIsNonFatal(t *testing.T) {
+	track := models.Track{ArtistName: "Artist", TrackName: "Title"}
+	q := &fakeQueue{
+		items:         []queue.WorkItem{{ID: 13, Inputs: models.Inputs{Track: track}}},
+		provenanceErr: errors.New("boom"),
+	}
+	fetcher := &fakeFetcher{song: models.Song{
+		Track:  track,
+		Lyrics: models.Lyrics{LyricsBody: "plain unsynced text"},
+	}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce returned an error on a failed advisory stamp: %v", err)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 13 {
+		t.Fatalf("completed = %v; want [13] despite the stamp failure", q.completed)
+	}
+	if len(q.failed) != 0 || len(q.deferred) != 0 {
+		t.Fatalf("row was failed/deferred by an advisory stamp failure: failed=%v deferred=%v", q.failed, q.deferred)
+	}
+}
+
+// TestProvenanceFromSongCacheHitLeavesFetchedAtZero documents the honest gap: a
+// cache hit never sets FetchedAt (models.Song carries it as `json:"-"`, so it
+// does not round-trip), leaving the column NULL. NULL means "not recorded", not
+// "fetched at the zero time" -- the fetch that produced those lyrics happened on
+// an earlier dispatch.
+func TestProvenanceFromSongCacheHitLeavesFetchedAtZero(t *testing.T) {
+	prov := provenanceFromSong(models.Song{
+		Track:  models.Track{ArtistName: "Artist", TrackName: "Title", ISRC: "USABC1234567"},
+		Lyrics: models.Lyrics{LyricsBody: "cached text"},
+	})
+	if !prov.FetchedAt.IsZero() {
+		t.Errorf("FetchedAt = %v; want zero for a song carrying no fetch time", prov.FetchedAt)
+	}
+	if prov.ISRC != "USABC1234567" {
+		t.Errorf("ISRC = %q; want the identifier to survive a cache hit", prov.ISRC)
 	}
 }
 


### PR DESCRIPTION
## Summary

- An unsynced `.txt` is plain lyric text players render verbatim, so by the maintainer's decision on #620 provenance must never be written into the file. That leaves a 2022-written `.txt` and a today-written one byte-indistinguishable, with no basis for the upgrade ladder (#553) to judge whether re-fetching would do better. Record it on the `work_queue` row instead: `SetCompletionProvenance` stamps `isrc`, `mbid`, `fetched_at`, and `writer_version` pre-`Complete`, following the existing `SetProviderLane` / `SetOutcomeType` pattern.
- **No user-visible behavior change.** Lyrics files on disk are byte-identical, and a byte-comparison test pins that. The new columns are write-only bookkeeping that nothing in the processing path reads.
- **Look at the scope narrowing first.** The issue's revised proposal asked for two more things that measurement showed were already solved or actively undesirable; see below.

### Scope narrowed against production, and the issue updated to match

Measured before building and posted to the issue (comment 5058338706):

`outcome_type` (migration 024, #379) already records what was written and is populated -- 12,576 synced / 6,310 instrumental / 2,559 unsynced `done` rows. The NULL block splits at the 024 boundary: 10,591 legacy rows and 331 ongoing, which are the guard-rejection path that completes without writing and is correctly NULL.

So the AC's "post-June unsynced population is findable by a SQL predicate" is satisfied today by `WHERE status = 'done' AND outcome_type = 'unsynced'`, and the AC's "correct `output_paths`" is deliberately **not** implemented: #379 hit that same bug and chose to stop *reading* the field rather than fix it. Correcting it now would add a second source of truth, across five write sites, for a fact `outcome_type` already holds authoritatively. The field is left alone.

What remained -- and what this PR builds -- is the identifier provenance, which genuinely did not exist anywhere on the row.

### Three completion paths legitimately leave NULLs

Documented in the migration so a NULL is not later read as a defect: guard rejection writes nothing at all; a cache hit records identifiers but no fetch time (the fetch happened on an earlier dispatch); and a detector-instrumental settle records `writer_version` only, because it returns before the `FetchedAt` assignment. Use `provider_lane` / `outcome_type` / `instrumental_result` to discriminate them.

## Linked issue

Closes #620

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; all findings fixed before pushing. An adversarial pre-push review found three real defects, all fixed in this diff: a code comment that claimed the detector path records a fetch time it never records, that same call site having no test at all (deleting its stamp left the whole suite green), and an undocumented guard-rejection NULL. A fourth, minor, was a captured-but-never-asserted `updated_at` value.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **N/A**, there is no user-visible change. The write path is exercised by the race test suite against real SQLite; no binary run would show anything a test does not.
- [ ] Screenshot -- **N/A**, no web-UI change.
- [ ] `make ui` -- **N/A**, no `.templ` or CSS source changed.
- [x] Migration added under `internal/db/migrations/` (033). Schema addition, not a data correction; no backfill (see "Not covered").

## Test plan

- [x] `make gate` passes locally, including race tests, the coverage-floor ratchet, golangci-lint, actionlint, and govulncheck.
- [x] New tests were confirmed to fail against unfixed code. Nine mutations were applied and the result recorded for each, rather than trusting a green run:

  | Mutation | Caught by |
  |---|---|
  | Stamp call removed, normal path | `TestRunOnceStampsCompletionProvenanceOnUnsynced`, `...BeforeComplete` |
  | Stamp call removed, detector path | `TestRunOnceDetectorInstrumentalStampsProvenance` |
  | Identifiers dropped from the built provenance | `...OnUnsynced`, `...CacheHitLeavesFetchedAtZero` |
  | Fetch time dropped | `...OnUnsynced` |
  | Advisory stamp made fatal | `TestRunOnceProvenanceStampFailureIsNonFatal` |
  | `nullIfEmpty` NULL semantics removed | `TestDBQueue_SetCompletionProvenance` |
  | Migration column dropped | `TestDBQueue_SetCompletionProvenance` |
  | Unsynced branch emits the tag block | `TestWriteLRC_UnsyncedIsExactlyTheLyricBody` |
  | Detector path stamps a zero `Song` | **Not caught -- equivalent mutant, see below** |

  The last one is reported rather than hidden: on the detector path `provenanceFromSong(models.Song{})` and `provenanceFromSong(song)` produce identical output, because that path resolves no identifiers and carries no fetch time, leaving `WriterVersion` (a package constant, not a song field) as the only populated value. No test can detect a mutation with no behavioral difference. The new detector test asserts exactly the three properties that make it equivalent.

- [x] Patch coverage 93.18% (41/44 lines), against the 70% `codecov.yml` target.
- [x] Which surface this fixes, stated and verified: this changes **the `work_queue` row only**. It does not touch `/metrics` (`provider_outcomes`), the dashboard (`lane_attempts`), reports, or any lyrics file. The byte-identity test verifies the file surface is unchanged by asserting exact `.txt` bytes -- the existing unsynced tests assert substrings and would all keep passing if a header block were prepended, which is the precise regression the maintainer's decision forbids.
- [ ] Manual UAT steps: none -- see the N/A note above.
- [ ] Reviewer follow-ups:
  - [ ] The advisory-vs-required split is the main judgment call. The stamp logs and continues on failure, deliberately unlike the detector stamps which defer the row. Reasoning: losing bookkeeping that nothing reads must not cost an otherwise-good settle. Worth a second opinion if you disagree.
  - [ ] `IsZero()` is effectively dead on the real call paths, since `version.Version` is never empty (it defaults to `"dev"`). It is kept as a correct guard for direct API callers. Say if you would rather it went.

## Not covered

- **Backfill, deliberately.** No existing row gains provenance. The ~10k unsynced sidecars carrying a 2026-03 mtime predate the database entirely (`work_queue` and `scan_results` both start 2026-06-07), so they have no rows for a column to be added to and no schema change reaches them. The filesystem remains the only witness for that cohort and mtime its only discriminator (#617). This narrows the ongoing blindness; it does not recover history.
- **`output_paths` is left stale**, per the reasoning above. It remains an enqueue-time prediction that always says `.lrc`. Nothing reads it for classification anymore.
- **No consumer yet.** These columns are written and never read. The upgrade ladder (#553) is the intended consumer and is not built here, so nothing yet proves the recorded values are *sufficient* for it -- only that they are recorded.
- **One measurement discrepancy, recorded on the issue rather than resolved.** The maintainer's filesystem estimate puts ~5,600 unsynced files in the June-and-later population, but only 2,559 rows carry `outcome_type = 'unsynced'`. Part of the gap is the 06-07 to 06-24 window before migration 024 shipped; it is not established that this accounts for all of it. So the row count should not yet be treated as a complete census.
- **`fetched_at` accepts absurd timestamps** (year 999999, negative years) without validation. Confirmed harmless during review because nothing reads the column, but it is not defended against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completion records now retain track identifiers, fetch timing, and the writer version used to produce results.
  * Provenance is recorded for synced, unsynced, cached, and instrumental outcomes.
* **Bug Fixes**
  * Unsynced lyric files now contain exactly the lyric text, without an added metadata header.
  * Provenance recording failures no longer prevent successful task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->