### PR TITLE
feat(reconcile): stamp telemetry when a re-check confirms an instrumental

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -3325,6 +3325,7 @@ func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd)
 		checked, confirmed, disagreed    int
 		sidecarsDeleted, rowsReset       int
 		skippedNoSource, skippedNoMarker int
+		telemetryStamped                 int
 		errCount                         int
 	)
 
@@ -3358,6 +3359,54 @@ func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd)
 		checked++
 		if res.Instrumental {
 			confirmed++
+			// The verdict stands, but this run may be the only thing that ever
+			// re-derives its evidence. A row decided before migration 025 carries
+			// instrumental_result=1 with NULL telemetry, and the re-decision paths
+			// that read those scores skip it by construction, so it is never
+			// revisited (#557). Stamping the fresh scores here is what lets that
+			// population drain instead of staying permanently invisible.
+			//
+			// A row already carrying telemetry is not this population, and the
+			// stamp's own guard excludes it -- so only a row that would really be
+			// stamped is previewed or counted.
+			if !args.Yes {
+				// Dry run must preview exactly what apply does: this counter is part
+				// of the summary line the operator verifies against, so it counts the
+				// same rows in both modes and only the WRITE is gated. The predicate
+				// is the stamp's own, so the two can never disagree.
+				needs, nerr := workQueue.NeedsInstrumentalTelemetry(ctx, item.ID)
+				if nerr != nil {
+					slog.Warn("reconcile: telemetry preview check failed", "id", item.ID, "error", nerr)
+				} else if needs {
+					_, _ = fmt.Fprintf(out, "  would stamp telemetry: id=%d\n", item.ID)
+					telemetryStamped++
+				}
+			} else {
+				tel := queue.InstrumentalTelemetry{
+					MusicSum:        res.Confidence,
+					VocalPeak:       res.VocalConfidence,
+					SpeechMean:      res.SpeechConfidence,
+					VocalClass:      res.WinningVocalClass,
+					DetectorVersion: res.Version,
+				}
+				stamped, serr := workQueue.StampInstrumentalTelemetry(ctx, item.ID, tel)
+				switch {
+				case serr != nil:
+					// Advisory: the verdict is unchanged and the next reconcile can
+					// stamp it again, so this must not abort the run. Deliberately NOT
+					// counted into errCount -- that counter drives the exit code and
+					// otherwise means "a detection or mutation failed", which a lost
+					// backfill write is not.
+					slog.Warn("reconcile: stamp telemetry failed; verdict unchanged, run continues", "id", item.ID, "error", serr)
+				case !stamped:
+					// The row was re-claimed or re-decided between the detection and the
+					// stamp, or already carried telemetry. Nothing to attach evidence
+					// to -- benign, and exactly what the guard exists to produce.
+					slog.Info("reconcile: telemetry not stamped; row no longer a completed unscored instrumental", "id", item.ID)
+				default:
+					telemetryStamped++
+				}
+			}
 			continue
 		}
 		disagreed++
@@ -3421,8 +3470,8 @@ func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd)
 		}
 	}
 
-	_, _ = fmt.Fprintf(out, "reconcile done: checked=%d confirmed=%d disagreed=%d markers-deleted=%d rows-reset=%d skipped(no-source=%d,no-marker=%d) errors=%d\n",
-		checked, confirmed, disagreed, sidecarsDeleted, rowsReset, skippedNoSource, skippedNoMarker, errCount)
+	_, _ = fmt.Fprintf(out, "reconcile done: checked=%d confirmed=%d(telemetry-stamped=%d) disagreed=%d markers-deleted=%d rows-reset=%d skipped(no-source=%d,no-marker=%d) errors=%d\n",
+		checked, confirmed, telemetryStamped, disagreed, sidecarsDeleted, rowsReset, skippedNoSource, skippedNoMarker, errCount)
 	if args.Yes && rowsReset > 0 {
 		_, _ = fmt.Fprintf(out, "backup of cleared rows written to %s\n", backupPath)
 	}

--- a/internal/commands/reconcile_test.go
+++ b/internal/commands/reconcile_test.go
@@ -269,6 +269,128 @@ func TestRunScanReconcile_ConfirmedAllMode(t *testing.T) {
 	}
 }
 
+// TestRunScanReconcile_StampsTelemetryOnConfirm covers #557: a row decided
+// before migration 025 carries instrumental_result=1 with NULL telemetry, and
+// every re-decision path is arithmetic over those scores, so it is skipped by
+// construction and never revisited. Reconcile re-runs live detection against
+// exactly these rows, so its confirm branch is the one place the missing
+// evidence can be recovered -- it previously just counted them and moved on.
+//
+// Without this test the wiring is unguarded: deleting the stamp call leaves
+// every other reconcile test green.
+func TestRunScanReconcile_StampsTelemetryOnConfirm(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	srcPath := filepath.Join(outdir, "song.flac")
+	_ = os.WriteFile(srcPath, []byte("audio"), 0o600)
+	_ = os.WriteFile(filepath.Join(outdir, "song.txt"), []byte(lyrics.InstrumentalMarker+"\n"), 0o600)
+
+	// Classifier confirms instrumental, so the run takes the confirm branch. Each
+	// of the three scores is a DISTINCT non-zero value (music 0.95, speech 0.03,
+	// vocal peak 0.01) so every telemetry field is independently constrained --
+	// with a zero or shared value, wiring one field from another's source would
+	// satisfy the assertions anyway. Speech stays under the 0.2 gate so the
+	// instrumental verdict still holds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"mean":{"Music":0.95,"Speech":0.03},"max":{"Music":1.0,"Singing":0.01}}`))
+	}))
+	defer srv.Close()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+	id := seedInstrumentalRow(t, ctx, dbPath, models.Inputs{
+		Track:       models.Track{ArtistName: "A", TrackName: "Song"},
+		SourcePath:  srcPath,
+		OutputPaths: []models.OutputPath{{Outdir: outdir, Filename: "song.flac"}},
+	}, "current")
+
+	// Reduce the row to the pre-025 shape the issue describes: the verdict
+	// persisted, the evidence behind it not.
+	clearTelemetry(t, ctx, dbPath, id)
+
+	// DRY RUN FIRST. The command's contract is that --yes changes only whether the
+	// write happens, never which rows are reported, so the dry run must report the
+	// same telemetry-stamped count the apply does -- and must write nothing.
+	var dry bytes.Buffer
+	if code := runScanReconcile(ctx, &dry, ScanReconcileCmd{ConfigPath: cfgPath, All: true}); code != 0 {
+		t.Fatalf("dry-run exit=%d out=%s", code, dry.String())
+	}
+	if !strings.Contains(dry.String(), "telemetry-stamped=1") {
+		t.Errorf("dry run must PREVIEW the stamp it would make; want telemetry-stamped=1, got: %s", dry.String())
+	}
+	if m, _, _, _ := readTelemetry(t, ctx, dbPath, id); m != nil {
+		t.Errorf("dry run wrote telemetry (music_sum=%v); it must write nothing", *m)
+	}
+
+	var buf bytes.Buffer
+	if code := runScanReconcile(ctx, &buf, ScanReconcileCmd{ConfigPath: cfgPath, All: true, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "telemetry-stamped=1") {
+		t.Errorf("want telemetry-stamped=1 in the summary; got: %s", buf.String())
+	}
+
+	music, vocal, speech, dv := readTelemetry(t, ctx, dbPath, id)
+	if music == nil || vocal == nil || speech == nil {
+		t.Fatalf("telemetry still NULL after confirm: music=%v vocal=%v speech=%v", music, vocal, speech)
+	}
+	// The scores must be the ones this detection produced, not placeholders:
+	// the classifier above reports mean Music 0.95 and max Singing 0.01.
+	if *music != 0.95 {
+		t.Errorf("music_sum = %v; want 0.95 (the live detection's score)", *music)
+	}
+	if *vocal != 0.01 {
+		t.Errorf("vocal_peak = %v; want 0.01 (the live detection's score)", *vocal)
+	}
+	// Asserted exactly, and distinct from the other two, so a field wired from the
+	// wrong source on the Result cannot pass.
+	if *speech != 0.03 {
+		t.Errorf("speech_mean = %v; want 0.03 (the live detection's score)", *speech)
+	}
+	if dv == "" {
+		t.Error("detector_version is empty; a stamped row must record which detector confirmed it")
+	}
+}
+
+// clearTelemetry reduces a row to the pre-migration-025 shape: an instrumental
+// verdict with no evidence behind it.
+func clearTelemetry(t *testing.T, ctx context.Context, dbPath string, id int64) {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET music_sum = NULL, vocal_peak = NULL, speech_mean = NULL,
+             vocal_class = NULL, detector_version = NULL WHERE id = ?`, id); err != nil {
+		t.Fatalf("clear telemetry: %v", err)
+	}
+}
+
+func readTelemetry(t *testing.T, ctx context.Context, dbPath string, id int64) (music, vocal, speech *float64, dv string) {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	var dvNull *string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT music_sum, vocal_peak, speech_mean, detector_version FROM work_queue WHERE id = ?`, id,
+	).Scan(&music, &vocal, &speech, &dvNull); err != nil {
+		t.Fatalf("read telemetry: %v", err)
+	}
+	if dvNull != nil {
+		dv = *dvNull
+	}
+	return music, vocal, speech, dv
+}
+
 // TestRunScanReconcile_SkipsNoSourceAndNoMarker: a row with no source path is
 // skipped before detection; a disagreeing row with no on-disk marker is left
 // untouched (never reset on the basis of a missing marker).

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -695,6 +695,81 @@ func (q *DBQueue) StampUnclassifiedMiss(ctx context.Context, id int64, tel Instr
 	return n > 0, nil
 }
 
+// StampInstrumentalTelemetry records the evidence behind an instrumental verdict
+// the row already carries, without changing the verdict itself (#557).
+//
+// It exists for rows decided before migration 025 added the telemetry columns:
+// the verdict was persisted and the scores behind it were not, so every
+// re-decision path skips them by construction (all of them are arithmetic over
+// stored scores). `scan reconcile` re-runs live detection against exactly these
+// rows but its confirm branch only counted them, so a confirmed row kept its
+// NULL columns and the blind-spot population never drained. This is the write
+// that lets it reach zero.
+//
+// The guard mirrors ListInstrumental's selector exactly -- `instrumental_result
+// = 1 AND status = 'done'` -- and the status term is the load-bearing half. The
+// worker stamps instrumental_result = 1 just BEFORE Complete, so a row can carry
+// the verdict while still 'processing'. Detection takes seconds to minutes, and
+// in that window a worker can re-claim the row and begin writing its own live
+// telemetry; a verdict-only guard would match and clobber those fresh scores
+// with this run's stale ones. Re-confirming the AUDIO says nothing about who
+// owns the ROW, so the verdict alone is not sufficient to write.
+//
+// `music_sum IS NULL` confines the write to the population this exists for.
+// These rows are defined by having no evidence, so a row that already has scores
+// is not this issue's business and its telemetry is left alone -- without it, an
+// --all run would re-stamp every confirmed row on every pass.
+//
+// Any of those failing reports stamped=false and writes nothing, which is benign.
+//
+// NeedsInstrumentalTelemetry is the read-only form of the same predicate, so a
+// dry run can preview exactly this write without performing it.
+func (q *DBQueue) StampInstrumentalTelemetry(ctx context.Context, id int64, tel InstrumentalTelemetry) (bool, error) {
+	res, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET music_sum = ?,
+             vocal_peak = ?,
+             speech_mean = ?,
+             vocal_class = ?,
+             detector_version = ?
+         WHERE id = ?
+           AND instrumental_result = 1
+           AND status = 'done'
+           AND music_sum IS NULL`,
+		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion, id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("queue: stamp instrumental telemetry: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("queue: stamp instrumental telemetry rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// NeedsInstrumentalTelemetry reports whether a row is one StampInstrumentalTelemetry
+// would write to, using the same predicate. It exists so a dry run previews exactly
+// the set an apply mutates: reconcile's contract is that --yes changes only whether
+// the write happens, never which rows are reported, and a counter that disagreed
+// between the two modes would quietly break that.
+//
+// Read-only. A missing row reports false.
+func (q *DBQueue) NeedsInstrumentalTelemetry(ctx context.Context, id int64) (bool, error) {
+	var n int
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM work_queue
+         WHERE id = ?
+           AND instrumental_result = 1
+           AND status = 'done'
+           AND music_sum IS NULL`,
+		id,
+	).Scan(&n); err != nil {
+		return false, fmt.Errorf("queue: needs instrumental telemetry for id %d: %w", id, err)
+	}
+	return n > 0, nil
+}
+
 // Release returns a processing item to the pool it was claimed from, without
 // recording a failure. Used when the worker dequeued the item but cannot
 // process it for a reason that should not count against the row's retry budget

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -695,6 +695,17 @@ func (q *DBQueue) StampUnclassifiedMiss(ctx context.Context, id int64, tel Instr
 	return n > 0, nil
 }
 
+// instrumentalTelemetryGuard is the row predicate shared by
+// StampInstrumentalTelemetry and NeedsInstrumentalTelemetry. It is one constant
+// rather than two hand-copied strings because the dry-run contract depends on
+// the write and its preview selecting the same rows: previewing one set and
+// applying another is the failure that contract exists to prevent, and sharing
+// the predicate makes that divergence unrepresentable instead of merely tested
+// for.
+//
+// Every term is load-bearing; see StampInstrumentalTelemetry for why.
+const instrumentalTelemetryGuard = `instrumental_result = 1 AND status = 'done' AND music_sum IS NULL`
+
 // StampInstrumentalTelemetry records the evidence behind an instrumental verdict
 // the row already carries, without changing the verdict itself (#557).
 //
@@ -732,10 +743,7 @@ func (q *DBQueue) StampInstrumentalTelemetry(ctx context.Context, id int64, tel 
              speech_mean = ?,
              vocal_class = ?,
              detector_version = ?
-         WHERE id = ?
-           AND instrumental_result = 1
-           AND status = 'done'
-           AND music_sum IS NULL`,
+         WHERE id = ? AND `+instrumentalTelemetryGuard,
 		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion, id,
 	)
 	if err != nil {
@@ -758,11 +766,7 @@ func (q *DBQueue) StampInstrumentalTelemetry(ctx context.Context, id int64, tel 
 func (q *DBQueue) NeedsInstrumentalTelemetry(ctx context.Context, id int64) (bool, error) {
 	var n int
 	if err := q.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM work_queue
-         WHERE id = ?
-           AND instrumental_result = 1
-           AND status = 'done'
-           AND music_sum IS NULL`,
+		`SELECT COUNT(*) FROM work_queue WHERE id = ? AND `+instrumentalTelemetryGuard,
 		id,
 	).Scan(&n); err != nil {
 		return false, fmt.Errorf("queue: needs instrumental telemetry for id %d: %w", id, err)

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -34,6 +34,246 @@ func seedDeferredRow(t *testing.T, q *DBQueue, artist, title, sourcePath string)
 	return item.ID
 }
 
+// TestStampInstrumentalTelemetry covers the #557 write: a row that already
+// carries an instrumental verdict but no evidence gains its scores without the
+// verdict changing. These rows were decided before migration 025 added the
+// telemetry columns, and every re-decision path is arithmetic over those scores,
+// so until this write exists they are skipped by construction forever.
+func TestStampInstrumentalTelemetry(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+
+	// Reproduce the pre-025 shape: verdict persisted, telemetry NULL.
+	if _, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result = 1, status = 'done' WHERE id = ?`, id); err != nil {
+		t.Fatalf("seed pre-telemetry row: %v", err)
+	}
+	var music, vocal, speech *float64
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT music_sum, vocal_peak, speech_mean FROM work_queue WHERE id = ?`, id,
+	).Scan(&music, &vocal, &speech); err != nil {
+		t.Fatalf("read initial telemetry: %v", err)
+	}
+	if music != nil || vocal != nil || speech != nil {
+		t.Fatalf("precondition: telemetry should start NULL, got (%v,%v,%v)", music, vocal, speech)
+	}
+
+	// A SECOND unscored instrumental row, never passed to the stamp. It must come
+	// back untouched: without it, a WHERE clause that matched every row (or the
+	// wrong row) would satisfy every other assertion here.
+	otherID := seedDeferredRow(t, q, "Other", "Other Title", "/music/b.flac")
+	if _, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result = 1, status = 'done' WHERE id = ?`, otherID); err != nil {
+		t.Fatalf("seed second row: %v", err)
+	}
+
+	tel := InstrumentalTelemetry{MusicSum: 0.91, VocalPeak: 0.02, SpeechMean: 0.003, VocalClass: "Singing", DetectorVersion: "1.26.0"}
+	stamped, err := q.StampInstrumentalTelemetry(ctx, id, tel)
+	if err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	if !stamped {
+		t.Fatal("stamped = false; want true for a row still carrying the verdict")
+	}
+
+	var result int
+	var status, vocalClass, dv string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT instrumental_result, status, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
+         FROM work_queue WHERE id = ?`, id,
+	).Scan(&result, &status, &music, &vocal, &speech, &vocalClass, &dv); err != nil {
+		t.Fatalf("read stamped telemetry: %v", err)
+	}
+	// The verdict must be untouched: this write attaches evidence, it never
+	// re-decides. A stamp that flipped the verdict would silently rewrite history.
+	if result != 1 {
+		t.Errorf("instrumental_result = %d; want 1 (unchanged)", result)
+	}
+	// Nor may it move the row's status: re-queuing a completed instrumental as a
+	// side effect of a backfill would be invisible in the summary.
+	if status != "done" {
+		t.Errorf("status = %q; want \"done\" (unchanged)", status)
+	}
+	if music == nil || *music != tel.MusicSum {
+		t.Errorf("music_sum = %v; want %v", music, tel.MusicSum)
+	}
+	if vocal == nil || *vocal != tel.VocalPeak {
+		t.Errorf("vocal_peak = %v; want %v", vocal, tel.VocalPeak)
+	}
+	// Asserted exactly, not merely non-nil: a distinct value per field is what
+	// catches one telemetry field being wired from another's source.
+	if speech == nil || *speech != tel.SpeechMean {
+		t.Errorf("speech_mean = %v; want %v", speech, tel.SpeechMean)
+	}
+	if vocalClass != tel.VocalClass || dv != tel.DetectorVersion {
+		t.Errorf("vocal_class/detector_version = (%q,%q); want (%q,%q)", vocalClass, dv, tel.VocalClass, tel.DetectorVersion)
+	}
+
+	var otherMusic *float64
+	if err := q.db.QueryRowContext(ctx, `SELECT music_sum FROM work_queue WHERE id = ?`, otherID).Scan(&otherMusic); err != nil {
+		t.Fatalf("read second row: %v", err)
+	}
+	if otherMusic != nil {
+		t.Errorf("second row's music_sum = %v; want NULL -- the stamp must touch only the id it was given", *otherMusic)
+	}
+}
+
+// TestNeedsInstrumentalTelemetryMirrorsTheStamp is the anti-drift test. The dry
+// run's honesty depends on this predicate selecting exactly the rows the stamp
+// writes, and the two are separate SQL strings that can drift apart silently --
+// so each case asserts BOTH answers agree, rather than checking the predicate
+// alone. A divergence here means the operator is previewing one set and applying
+// another, which is the failure the dry-run contract exists to prevent.
+func TestNeedsInstrumentalTelemetryMirrorsTheStamp(t *testing.T) {
+	ctx := context.Background()
+	tel := InstrumentalTelemetry{MusicSum: 0.91, VocalPeak: 0.02, SpeechMean: 0.003, DetectorVersion: "1.26.0"}
+
+	cases := []struct {
+		name  string
+		setup string // applied to the seeded row
+		want  bool
+	}{
+		{"unscored done instrumental", `instrumental_result = 1, status = 'done'`, true},
+		{"already scored", `instrumental_result = 1, status = 'done', music_sum = 0.5`, false},
+		{"still processing", `instrumental_result = 1, status = 'processing'`, false},
+		{"not instrumental", `instrumental_result = 0, status = 'done'`, false},
+		{"no verdict", `instrumental_result = NULL, status = 'done'`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewDBQueue(openQueueTestDB(t))
+			id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+			if _, err := q.db.ExecContext(ctx,
+				fmt.Sprintf(`UPDATE work_queue SET %s WHERE id = ?`, tc.setup), id); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			needs, err := q.NeedsInstrumentalTelemetry(ctx, id)
+			if err != nil {
+				t.Fatalf("needs: %v", err)
+			}
+			if needs != tc.want {
+				t.Errorf("NeedsInstrumentalTelemetry = %v; want %v", needs, tc.want)
+			}
+			// The stamp must reach the same verdict, or the dry run previews a
+			// different set than the apply writes.
+			stamped, err := q.StampInstrumentalTelemetry(ctx, id, tel)
+			if err != nil {
+				t.Fatalf("stamp: %v", err)
+			}
+			if stamped != needs {
+				t.Errorf("predicate and stamp disagree: needs=%v stamped=%v -- the dry run would mispreview this row", needs, stamped)
+			}
+		})
+	}
+
+	// A missing row is previewable as "no", never an error.
+	q := NewDBQueue(openQueueTestDB(t))
+	needs, err := q.NeedsInstrumentalTelemetry(ctx, 999999)
+	if err != nil || needs {
+		t.Errorf("missing id: got (needs=%v, err=%v); want (false, nil)", needs, err)
+	}
+}
+
+// TestStampInstrumentalTelemetrySkipsScoredAndProcessing pins the two guard terms
+// that are not about the verdict itself.
+//
+// status='done' mirrors ListInstrumental's own selector, which excludes
+// 'processing' because the worker stamps instrumental_result=1 just BEFORE
+// Complete -- so a row can carry the verdict while a worker is mid-write, and a
+// verdict-only guard would clobber that worker's fresh scores with this run's.
+//
+// music_sum IS NULL confines the write to the population this exists for: a row
+// that already has evidence is not #557's business.
+func TestStampInstrumentalTelemetrySkipsScoredAndProcessing(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	tel := InstrumentalTelemetry{MusicSum: 0.91, VocalPeak: 0.02, SpeechMean: 0.003, DetectorVersion: "1.26.0"}
+
+	t.Run("already scored", func(t *testing.T) {
+		id := seedDeferredRow(t, q, "Artist", "Scored", "/music/scored.flac")
+		if _, err := q.db.ExecContext(ctx,
+			`UPDATE work_queue SET instrumental_result = 1, status = 'done', music_sum = 0.5 WHERE id = ?`, id); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		stamped, err := q.StampInstrumentalTelemetry(ctx, id, tel)
+		if err != nil {
+			t.Fatalf("stamp: %v", err)
+		}
+		if stamped {
+			t.Error("stamped = true on a row that already carries telemetry; the backfill must not overwrite it")
+		}
+		var music float64
+		if err := q.db.QueryRowContext(ctx, `SELECT music_sum FROM work_queue WHERE id = ?`, id).Scan(&music); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if music != 0.5 {
+			t.Errorf("music_sum = %v; want the original 0.5 preserved", music)
+		}
+	})
+
+	t.Run("still processing", func(t *testing.T) {
+		id := seedDeferredRow(t, q, "Artist", "InFlight", "/music/inflight.flac")
+		// The worker's shape mid-write: verdict stamped, row not yet completed.
+		if _, err := q.db.ExecContext(ctx,
+			`UPDATE work_queue SET instrumental_result = 1, status = 'processing' WHERE id = ?`, id); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		stamped, err := q.StampInstrumentalTelemetry(ctx, id, tel)
+		if err != nil {
+			t.Fatalf("stamp: %v", err)
+		}
+		if stamped {
+			t.Error("stamped = true on a 'processing' row; that is the mid-write window ListInstrumental excludes")
+		}
+		var music *float64
+		if err := q.db.QueryRowContext(ctx, `SELECT music_sum FROM work_queue WHERE id = ?`, id).Scan(&music); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if music != nil {
+			t.Errorf("music_sum = %v; want NULL -- a worker's in-flight row must not be written", *music)
+		}
+	})
+}
+
+// TestStampInstrumentalTelemetryGuardsOnVerdict pins the guard. If the verdict
+// changed or was cleared underneath the run -- a concurrent reconcile or a
+// worker re-decision -- there is nothing to attach evidence to, and stamping
+// anyway would describe a verdict that no longer exists.
+func TestStampInstrumentalTelemetryGuardsOnVerdict(t *testing.T) {
+	q := NewDBQueue(openQueueTestDB(t))
+	ctx := context.Background()
+	id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
+
+	// instrumental_result = 0: the detector looked and said NOT instrumental.
+	if _, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue SET instrumental_result = 0 WHERE id = ?`, id); err != nil {
+		t.Fatalf("seed non-instrumental row: %v", err)
+	}
+	stamped, err := q.StampInstrumentalTelemetry(ctx, id,
+		InstrumentalTelemetry{MusicSum: 0.91, VocalPeak: 0.02, SpeechMean: 0.003, DetectorVersion: "1.26.0"})
+	if err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	if stamped {
+		t.Error("stamped = true on a row whose verdict is not instrumental; the guard must reject it")
+	}
+	var music *float64
+	if err := q.db.QueryRowContext(ctx, `SELECT music_sum FROM work_queue WHERE id = ?`, id).Scan(&music); err != nil {
+		t.Fatalf("read telemetry: %v", err)
+	}
+	if music != nil {
+		t.Errorf("music_sum = %v; want NULL -- nothing should have been written", *music)
+	}
+
+	// A missing id is a benign no-op, matching the sibling stamps.
+	if stamped, err := q.StampInstrumentalTelemetry(ctx, 999999,
+		InstrumentalTelemetry{MusicSum: 0.5, DetectorVersion: "1.26.0"}); err != nil || stamped {
+		t.Errorf("missing id: got (stamped=%v, err=%v); want (false, nil)", stamped, err)
+	}
+}
+
 func TestListVocalGateRejections(t *testing.T) {
 	q := NewDBQueue(openQueueTestDB(t))
 	ctx := context.Background()

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -129,23 +130,29 @@ func TestNeedsInstrumentalTelemetryMirrorsTheStamp(t *testing.T) {
 	ctx := context.Background()
 	tel := InstrumentalTelemetry{MusicSum: 0.91, VocalPeak: 0.02, SpeechMean: 0.003, DetectorVersion: "1.26.0"}
 
+	// Bound as parameters rather than interpolated into the statement: the values
+	// are literals here, but the fmt.Sprintf form matches the SAST injection
+	// signature and would recur as gate noise on every run.
 	cases := []struct {
-		name  string
-		setup string // applied to the seeded row
-		want  bool
+		name               string
+		instrumentalResult sql.NullInt64
+		status             string
+		musicSum           sql.NullFloat64
+		want               bool
 	}{
-		{"unscored done instrumental", `instrumental_result = 1, status = 'done'`, true},
-		{"already scored", `instrumental_result = 1, status = 'done', music_sum = 0.5`, false},
-		{"still processing", `instrumental_result = 1, status = 'processing'`, false},
-		{"not instrumental", `instrumental_result = 0, status = 'done'`, false},
-		{"no verdict", `instrumental_result = NULL, status = 'done'`, false},
+		{"unscored done instrumental", sql.NullInt64{Int64: 1, Valid: true}, "done", sql.NullFloat64{}, true},
+		{"already scored", sql.NullInt64{Int64: 1, Valid: true}, "done", sql.NullFloat64{Float64: 0.5, Valid: true}, false},
+		{"still processing", sql.NullInt64{Int64: 1, Valid: true}, "processing", sql.NullFloat64{}, false},
+		{"not instrumental", sql.NullInt64{Int64: 0, Valid: true}, "done", sql.NullFloat64{}, false},
+		{"no verdict", sql.NullInt64{}, "done", sql.NullFloat64{}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			q := NewDBQueue(openQueueTestDB(t))
 			id := seedDeferredRow(t, q, "Artist", "Title", "/music/a.flac")
 			if _, err := q.db.ExecContext(ctx,
-				fmt.Sprintf(`UPDATE work_queue SET %s WHERE id = ?`, tc.setup), id); err != nil {
+				`UPDATE work_queue SET instrumental_result = ?, status = ?, music_sum = ? WHERE id = ?`,
+				tc.instrumentalResult, tc.status, tc.musicSum, id); err != nil {
 				t.Fatalf("seed: %v", err)
 			}
 


### PR DESCRIPTION
## Summary

- 869 `work_queue` rows carry `instrumental_result = 1` with NULL `music_sum` / `vocal_peak` / `speech_mean`. They were decided before migration 025 added those columns, so the verdict was persisted and the evidence behind it was not, and the re-decision paths that read those scores skip them by construction. `scan reconcile` is the one path that re-runs live detection against exactly this population, but its confirm branch only incremented a counter -- so a confirmed row kept its NULL columns and the count could never reach zero. It now stamps the fresh scores.
- **No behavior change for any row that already has telemetry.** The write is confined to the unscored population by `music_sum IS NULL`, so an `--all` run does not re-stamp every confirmed row.
- **Look at the guard first.** It mirrors `ListInstrumental`'s selector exactly (`instrumental_result = 1 AND status = 'done'`), and the status term is load-bearing rather than defensive -- see below.

### Why the status term is not optional

The worker stamps `instrumental_result = 1` just *before* `Complete`, so a row can carry the verdict while still `processing`. `ListInstrumental` documents excluding that window in its own comment (`internal/queue/queue.go:1861-1863`). Detection takes seconds to minutes, and in that window a worker can re-claim the row and begin writing its own live telemetry -- a verdict-only guard would match and clobber those fresh scores with this run's stale ones.

An earlier revision of this branch had exactly that bug, justified in its commit message by "the caller has just re-confirmed that verdict with a live detection." That reasoning was wrong: re-confirming the **audio** says nothing about who owns the **row**. Caught in the pre-push review; both mutations that prove the guard now hold are listed below.

### Dry-run parity

`--yes` changes only whether the write happens, never which rows are reported. The preview goes through `NeedsInstrumentalTelemetry`, the read-only form of the stamp's own predicate, and a dedicated test asserts the two agree on every row shape -- a divergence would mean previewing one set and applying another.

## Linked issue

Closes #557

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; all findings fixed before pushing. An adversarial review found five: the guard's missing status term, a dry run that reported `telemetry-stamped=0` where an apply reported N, a stamp failure incrementing `errCount` (which drives the exit code) despite being documented as advisory, a comment claiming the stamp was "not gated on `--yes`" directly above the line gating it on `--yes`, and an overstated claim about `instrumentalbackfill`.
- [x] Commits squashed into one before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed -- **deferred, and it is the substance of this issue.** See "Not covered".
- [ ] Screenshot -- **N/A**, no web-UI change.
- [ ] `make ui` -- **N/A**, no `.templ` or CSS source changed.
- [ ] Migration -- **N/A**, no schema change; this fills in columns migration 025 already added.

## Test plan

- [x] `make gate` passes locally: race tests, coverage floors, golangci-lint, actionlint, govulncheck.
- [x] New tests confirmed to fail against unfixed code. Six mutations were applied and the outcome recorded for each:

  | Mutation | Caught by |
  |---|---|
  | Drop `status = 'done'` from the guard | `...SkipsScoredAndProcessing/still_processing` |
  | Drop `music_sum IS NULL` from the guard | `...SkipsScoredAndProcessing/already_scored` |
  | `WHERE` matches every row (wrong-row write) | `TestStampInstrumentalTelemetry` (second, untouched row) |
  | Collateral `status = 'pending'` write | `TestStampInstrumentalTelemetry` (status assertion) |
  | Stamp call stubbed out | `TestRunScanReconcile_StampsTelemetryOnConfirm` |
  | `SpeechMean` wired from the wrong `Result` field | same, after the fixture fix below |
  | Preview predicate drifts from the stamp | `TestNeedsInstrumentalTelemetryMirrorsTheStamp` |

  Three of these survived an earlier version of the suite. The `SpeechMean` one is worth calling out: the stub classifier returned no speech class, so `SpeechConfidence` was pinned at 0 and the field was unconstrained -- a zero-valued fixture cannot catch a mis-wired field. The fixture now uses three distinct non-zero scores (music 0.95, speech 0.03, vocal peak 0.01).

- [x] Patch coverage **77.38%** against the 70% target.

  Worth recording, since it nearly shipped wrong: measuring with `-coverpkg` scoped to the two touched packages read **89.74%**, while the gate's whole-repo `go test ./...` read **66.67%** and correctly blocked the push. The narrow run counts only what those two test binaries executed and flatters the result. The gap was a genuinely untested `NeedsInstrumentalTelemetry` (0.0%), not a measurement artifact -- an untested predicate whose entire job is to mirror another query is exactly what drifts silently. Fixing it properly, rather than re-running until a number passed, is what moved the honest figure to 77.38%.

- [x] Which surface this changes, stated and verified: the `work_queue` row's telemetry columns only. No lyrics file is written, read, or deleted on this path; no provider request is made; the verdict itself is never modified (asserted).
- [ ] Manual UAT steps -- see "Not covered".
- [ ] Reviewer follow-ups:
  - [ ] The stamp is advisory (logged, run continues, deliberately outside `errCount`). If you would rather a lost backfill write fail the run, that is a one-line change and a reasonable different call.

## Not covered

- **The remediation itself has not been run.** This PR makes the drain *possible*; it does not drain anything. Running it is the issue's actual acceptance criterion and is deliberately a separate, operator-gated step: `scan reconcile` re-runs live detection at roughly 5.5s per row, so ~869 rows is on the order of 1.5 hours competing with the worker for the detector. The issue's runbook (tmux, verify by query rather than exit code) applies unchanged.
- **Verification must be by query, not by this tool's summary.** The `telemetry-stamped` counter is a convenience; the acceptance test is the count of NULL-telemetry instrumental rows reaching zero.
- **The 869 figure will keep moving.** The issue says 1,042 and calls it stable; it is 869 as of 2026-07-23. The mechanism is unaffected, but do not treat either number as fixed.
- **No claim about correctness of the verdicts themselves.** This attaches evidence to verdicts that already stand. Whether any of them are *wrong* is #557's stated motivation (roughly 50 tracks may be mislabeled under the old gate) and is only answerable after a re-scan, by the disagreement count -- which this PR does not change.
- **Rows whose verdict changes underneath a run are skipped, by design**, and are logged rather than counted. If a large number appear in practice, that is a signal worth investigating, not a defect in this write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reconciliation now restores missing instrumental telemetry for confirmed instrumental results.
  - Dry-run mode previews which records would receive telemetry.
  - Final reconciliation summaries report the number of telemetry records updated.

- **Bug Fixes**
  - Prevented telemetry updates for ineligible, already-scored, in-progress, or non-instrumental records.
  - Reconciliation continues safely if an individual telemetry update fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->