### PR TITLE
feat(timing): persist per-row timing outcome and log overruns (#440)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Every package with a one-line purpose. `cmd/mxlrcgo-svc/main.go` is the entry po
 - `db` -- pure-Go SQLite (`modernc.org/sqlite`) open/migrate (goose), WAL, foreign keys, busy-retry, and a read-only open path; migrations in `internal/db/migrations/`.
 - `cache` -- lyrics cache repository (`CacheRepo`) over SQLite.
 - `scanfail` -- `Store` recording files that consistently fail metadata read, so the scanner skips them until mtime/size changes; satisfies `scanner.MetadataFailureStore`.
-- `queue` -- the in-memory `InputsQueue` (fetch mode) and the durable SQLite `DBQueue` (serve/worker mode) with priority tiers and randomized within-tier dequeue.
+- `queue` -- the in-memory `InputsQueue` (fetch mode) and the durable SQLite `DBQueue` (serve/worker mode) with priority tiers and randomized within-tier dequeue. Completion stamps (`SetOutcomeType`, `SetCompletionProvenance`, `SetTimingOutcome`) are written before `Complete` while the row is still `processing`; each is non-fatal, since the output is already on disk by then.
 - `library` -- library-root CRUD repository (`Add`/`List`/`Get`/`GetByName`/`Update`/`Remove`).
 - `scan` -- library scanning: `Enqueuer`, the `scan_results` `Repo`, and the periodic scheduler that enqueues missing lyrics.
 - `worker` -- durable-queue `Worker` that drains work items through the providers/orchestrator and cache.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -827,3 +827,86 @@ func TestMigration032BackfillsAlbumFromScanResults(t *testing.T) {
 		})
 	}
 }
+
+// TestMigration034TimingOutcomeUpDown drives migration 034 directly: it migrates
+// to v33, seeds a pre-034 row, applies 034, and asserts the four timing columns
+// exist and read NULL on the pre-existing row -- NULL means "not evaluated", and
+// nothing backfills it, because the verdict depends on an audio duration no
+// completed row ever stored. Then it down-migrates and asserts the columns are
+// removed (#440).
+func TestMigration034TimingOutcomeUpDown(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig034.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	applyOpenPragmas(ctx, t, sqlDB)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 33); err != nil {
+		t.Fatalf("UpTo(33): %v", err)
+	}
+
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO work_queue (artist, title, artist_key, title_key, status, priority, next_attempt_at)
+         VALUES ('A', 'T', 'a', 't', 'done', 0, '2026-01-01T00:00:00Z')`,
+	); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	if _, err := provider.UpTo(ctx, 34); err != nil {
+		t.Fatalf("UpTo(34): %v", err)
+	}
+
+	// Every timing column reads NULL on a row that completed before the column
+	// existed. NULL is "not evaluated", never "compliant".
+	var outcome sql.NullString
+	var magnitude, ratio sql.NullFloat64
+	var evaluatedAt sql.NullString
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT timing_outcome, overrun_magnitude, overrun_ratio, evaluated_at
+           FROM work_queue WHERE artist_key = 'a'`).Scan(&outcome, &magnitude, &ratio, &evaluatedAt); err != nil {
+		t.Fatalf("query timing columns: %v", err)
+	}
+	if outcome.Valid || magnitude.Valid || ratio.Valid || evaluatedAt.Valid {
+		t.Errorf("pre-existing row has non-NULL timing columns (%v/%v/%v/%v); want all NULL",
+			outcome, magnitude, ratio, evaluatedAt)
+	}
+
+	// A negative magnitude round-trips: a lyric ending before the audio does is
+	// the common case, so the column must be signed, not an unsigned error size.
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE work_queue SET timing_outcome = 'ok', overrun_magnitude = -42.5, overrun_ratio = 0.9
+           WHERE artist_key = 'a'`); err != nil {
+		t.Fatalf("update timing columns: %v", err)
+	}
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT overrun_magnitude FROM work_queue WHERE artist_key = 'a'`).Scan(&magnitude); err != nil {
+		t.Fatalf("re-query magnitude: %v", err)
+	}
+	if !magnitude.Valid || magnitude.Float64 != -42.5 {
+		t.Errorf("overrun_magnitude = %v; want -42.5", magnitude)
+	}
+
+	// Down-migration removes every column.
+	if _, err := provider.DownTo(ctx, 33); err != nil {
+		t.Fatalf("DownTo(33): %v", err)
+	}
+	for _, col := range []string{"timing_outcome", "overrun_magnitude", "overrun_ratio", "evaluated_at"} {
+		var name string
+		err := sqlDB.QueryRowContext(ctx,
+			`SELECT name FROM pragma_table_info('work_queue') WHERE name = ?`, col).Scan(&name)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("%s column still present after down-migration (err=%v, name=%q); want removed", col, err, name)
+		}
+	}
+}

--- a/internal/db/migrations/034_work_queue_timing_outcome.sql
+++ b/internal/db/migrations/034_work_queue_timing_outcome.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-track timing outcome (#440): how a completed row's synced lyric compared
+-- against the audio duration, plus the magnitude of any overrun. Rejections and
+-- demotions move or discard user files, so the reason must be observable rather
+-- than silent; this row-level record is that surface, and it doubles as the
+-- watermark the ongoing sweep (#443) uses to stay incremental and as the review
+-- queue (WHERE timing_outcome = 'mis_synced').
+--
+-- VOCABULARY. timing_outcome stores the internal/timing TimingOutcome constants
+-- VERBATIM -- 'ok', 'mis_synced', 'categorical', 'unknown_duration' -- and no
+-- other value. Those are the predicate's own strings (#438), so the column and
+-- the code that fills it share one vocabulary with no translation layer. A
+-- second, parallel spelling was considered and rejected: any mapping between two
+-- enums for the same axis is where drift starts, and a stale mapping would
+-- silently mislabel the review queue.
+--
+-- Deliberately NO CHECK constraint, matching every other additive column here.
+-- SQLite would require a table rebuild to add one later, and the vocabulary is
+-- already enforced at the single write site.
+--
+-- THIS COLUMN RECORDS, IT DOES NOT ENFORCE. Writing 'mis_synced' here changes
+-- nothing about what lands on disk: this migration ships the observability half
+-- of the epic, and the accept-time guard that acts on the verdict is #439. Until
+-- that lands, a mis_synced row still has its .lrc written exactly as before.
+-- Reading this column as "these were rejected" is wrong until #439 ships.
+--
+-- NULL SEMANTICS. NULL means NOT EVALUATED, never "compliant". Every row that
+-- completed before this migration is NULL and is not backfillable -- the verdict
+-- depends on the audio duration at fetch time, which no completed row stored.
+-- Three live paths also leave it NULL by design, so do not read a NULL as a
+-- defect:
+--   1. Any non-synced settle (unsynced .txt, instrumental). There is no line
+--      timing to evaluate, so no verdict exists.
+--   2. Guard rejection, which completes having written nothing at all.
+--   3. A row whose duration was unknown records 'unknown_duration' rather than
+--      NULL -- that is a real verdict (fail open, deliberately distinguishable
+--      from never-evaluated).
+--
+-- overrun_magnitude is (max lyric timestamp - duration) in seconds and is
+-- NEGATIVE for the common case of a lyric ending before the audio does; it is
+-- not an error magnitude. overrun_ratio is (max timestamp / duration). Both are
+-- NULL whenever timing_outcome is NULL or 'unknown_duration', since no
+-- comparison was made. The max timestamp is the corrected one (decorative and
+-- [tag:] lines filtered), so these numbers are only comparable against the
+-- thresholds internal/timing calibrated on the same basis.
+ALTER TABLE work_queue ADD COLUMN timing_outcome TEXT;
+ALTER TABLE work_queue ADD COLUMN overrun_magnitude REAL;
+ALTER TABLE work_queue ADD COLUMN overrun_ratio REAL;
+ALTER TABLE work_queue ADD COLUMN evaluated_at DATETIME;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN timing_outcome;
+ALTER TABLE work_queue DROP COLUMN overrun_magnitude;
+ALTER TABLE work_queue DROP COLUMN overrun_ratio;
+ALTER TABLE work_queue DROP COLUMN evaluated_at;
+-- +goose StatementEnd

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1593,6 +1593,73 @@ func (q *DBQueue) SetOutcomeType(ctx context.Context, id int64, outcomeType stri
 	return nil
 }
 
+// TimingRecord carries a row's timing verdict and, when one was actually
+// computed, its magnitude (#440).
+//
+// Measured is what separates "no comparison was made" from a real measurement of
+// zero. A lyric ending exactly at the audio end is a legitimate 0.0 overrun, so
+// writing 0 for the unknown-duration case would be indistinguishable from that
+// and would quietly corrupt any aggregate over the column. When Measured is
+// false both magnitude columns are stored NULL regardless of the struct's
+// numeric fields.
+type TimingRecord struct {
+	// Outcome is an internal/timing TimingOutcome value, stored verbatim:
+	// "ok", "mis_synced", "categorical", or "unknown_duration".
+	Outcome string
+	// Magnitude is (corrected max timestamp - duration) in seconds. Negative for
+	// the common case of a lyric ending before the audio does; it is a signed
+	// offset, not an error size. Ignored unless Measured.
+	Magnitude float64
+	// Ratio is (corrected max timestamp / duration). Ignored unless Measured.
+	Ratio float64
+	// Measured reports whether a comparison against a known duration happened.
+	// False for the unknown-duration verdict.
+	Measured bool
+	// EvaluatedAt is when the verdict was reached. Recorded even when the
+	// verdict is unmeasured, so the sweep watermark advances either way.
+	EvaluatedAt time.Time
+}
+
+// SetTimingOutcome records how a row's synced lyric compared against the audio
+// duration (#440). The worker calls this before Complete while the row is still
+// in 'processing'; the UPDATE keys on id alone (no status guard, matching
+// SetOutcomeType/SetInstrumentalResult), and is a no-op for a missing id, which
+// is benign.
+//
+// This RECORDS a verdict, it does not act on one: nothing here changes what is
+// written to disk. The guard that rejects or demotes on this verdict is #439.
+func (q *DBQueue) SetTimingOutcome(ctx context.Context, id int64, rec TimingRecord) error {
+	if rec.Outcome == "" {
+		return nil
+	}
+	var magnitude, ratio any
+	if rec.Measured {
+		magnitude = rec.Magnitude
+		ratio = rec.Ratio
+	}
+	var evaluatedAt any
+	if !rec.EvaluatedAt.IsZero() {
+		evaluatedAt = formatTime(rec.EvaluatedAt)
+	}
+	_, err := q.db.ExecContext(ctx,
+		`UPDATE work_queue
+         SET timing_outcome = ?,
+             overrun_magnitude = ?,
+             overrun_ratio = ?,
+             evaluated_at = ?
+         WHERE id = ?`,
+		rec.Outcome,
+		magnitude,
+		ratio,
+		evaluatedAt,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: set timing outcome for id %d: %w", id, err)
+	}
+	return nil
+}
+
 // CompletionProvenance carries the identifiers and writer version a work_queue
 // row was settled with (#620). Every field is optional: an empty string or zero
 // time leaves the corresponding column NULL, which means "not recorded" and

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4535,3 +4535,108 @@ func TestDBQueue_ListVocalGateConfirmationsRespectsLimit(t *testing.T) {
 		t.Errorf("limited list = %d rows; want 2", len(limited))
 	}
 }
+
+// TestDBQueue_SetTimingOutcome verifies the timing verdict and its magnitude
+// persist on a work_queue row through a real SQLite DB (#440), and that the
+// no-comparison cases land as SQL NULL rather than 0. NULL vs 0 is load-bearing
+// here: 0 is a legitimate overrun (a lyric ending exactly at the audio end),
+// so writing 0 for "no comparison was made" would be indistinguishable from a
+// real measurement.
+func TestDBQueue_SetTimingOutcome(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	q.now = func() time.Time { return time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) }
+
+	newRow := func(title string) int64 {
+		t.Helper()
+		if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: title}}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+		item, err := q.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("Dequeue: %v", err)
+		}
+		return item.ID
+	}
+
+	read := func(id int64) (outcome *string, mag, ratio *float64, evaluated *string) {
+		t.Helper()
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT timing_outcome, overrun_magnitude, overrun_ratio, evaluated_at
+			   FROM work_queue WHERE id = ?`, id).Scan(&outcome, &mag, &ratio, &evaluated); err != nil {
+			t.Fatalf("read timing columns: %v", err)
+		}
+		return
+	}
+
+	id := newRow("T1")
+
+	// Fresh row: every timing column is NULL until stamped.
+	if outcome, mag, ratio, evaluated := read(id); outcome != nil || mag != nil || ratio != nil || evaluated != nil {
+		t.Fatalf("initial timing columns = %v/%v/%v/%v; want all NULL", outcome, mag, ratio, evaluated)
+	}
+
+	// A measured verdict persists all four values.
+	when := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	if err := q.SetTimingOutcome(ctx, id, TimingRecord{
+		Outcome:     "mis_synced",
+		Magnitude:   12.5,
+		Ratio:       1.25,
+		Measured:    true,
+		EvaluatedAt: when,
+	}); err != nil {
+		t.Fatalf("SetTimingOutcome: %v", err)
+	}
+	outcome, mag, ratio, evaluated := read(id)
+	if outcome == nil || *outcome != "mis_synced" {
+		t.Errorf("timing_outcome = %v; want mis_synced", outcome)
+	}
+	if mag == nil || *mag != 12.5 {
+		t.Errorf("overrun_magnitude = %v; want 12.5", mag)
+	}
+	if ratio == nil || *ratio != 1.25 {
+		t.Errorf("overrun_ratio = %v; want 1.25", ratio)
+	}
+	if evaluated == nil {
+		t.Error("evaluated_at = NULL; want a timestamp")
+	}
+
+	// An UNMEASURED verdict (unknown duration) records the outcome but leaves
+	// the magnitudes NULL: no comparison was made, and 0 would read as one.
+	id2 := newRow("T2")
+	if err := q.SetTimingOutcome(ctx, id2, TimingRecord{
+		Outcome:     "unknown_duration",
+		Measured:    false,
+		EvaluatedAt: when,
+	}); err != nil {
+		t.Fatalf("SetTimingOutcome unmeasured: %v", err)
+	}
+	outcome2, mag2, ratio2, evaluated2 := read(id2)
+	if outcome2 == nil || *outcome2 != "unknown_duration" {
+		t.Errorf("timing_outcome = %v; want unknown_duration", outcome2)
+	}
+	if mag2 != nil || ratio2 != nil {
+		t.Errorf("magnitudes = %v/%v; want NULL when no comparison was made", mag2, ratio2)
+	}
+	if evaluated2 == nil {
+		t.Error("evaluated_at = NULL; want a timestamp even when unmeasured")
+	}
+
+	// A negative magnitude (lyric ends before the audio) round-trips intact --
+	// it is the common case, not an error.
+	id3 := newRow("T3")
+	if err := q.SetTimingOutcome(ctx, id3, TimingRecord{
+		Outcome: "ok", Magnitude: -42.5, Ratio: 0.9, Measured: true, EvaluatedAt: when,
+	}); err != nil {
+		t.Fatalf("SetTimingOutcome negative: %v", err)
+	}
+	if _, mag3, _, _ := read(id3); mag3 == nil || *mag3 != -42.5 {
+		t.Errorf("overrun_magnitude = %v; want -42.5", mag3)
+	}
+
+	// A missing id is a benign no-op (no error), matching the sibling stamps.
+	if err := q.SetTimingOutcome(ctx, 999999, TimingRecord{Outcome: "ok", Measured: true, EvaluatedAt: when}); err != nil {
+		t.Errorf("SetTimingOutcome on missing id: want nil error, got %v", err)
+	}
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -52,14 +52,24 @@ const (
 	CategoricalRatio = 1.5
 )
 
-// Magnitude carries the metrics companions to a TimingOutcome. It is zero for
-// the UnknownDuration and no-timing-evidence cases, where no comparison was made.
+// Magnitude carries the metrics companions to a TimingOutcome. It is the zero
+// value whenever no comparison was made -- both the UnknownDuration case and the
+// Ok-with-no-timing-evidence case (empty or all-decorative lines) -- and
+// Measured is the explicit signal for that. Callers persisting these numbers
+// MUST gate on Measured: a real measurement of 0 is a lyric ending exactly at
+// the audio end, which is a distinct fact from "nothing was compared", and the
+// two outcomes both surface as OverrunSeconds 0 without this flag.
 type Magnitude struct {
 	// OverrunSeconds is correctedMax - duration. Negative for a lyric that ends
-	// before the audio does (e.g. a long instrumental outro).
+	// before the audio does (e.g. a long instrumental outro). Meaningful only
+	// when Measured.
 	OverrunSeconds float64
-	// Ratio is correctedMax / duration.
+	// Ratio is correctedMax / duration. Meaningful only when Measured.
 	Ratio float64
+	// Measured reports whether a real comparison against a known duration and a
+	// text-bearing lyric happened. False for both no-evidence cases, where the
+	// other two fields are zero and carry no information.
+	Measured bool
 }
 
 // Evaluate classifies song's synced lines against durationSeconds, returning the
@@ -87,7 +97,7 @@ func Evaluate(song models.Song, durationSeconds int) (TimingOutcome, Magnitude) 
 		return Ok, Magnitude{}
 	}
 	duration := float64(durationSeconds)
-	mag := Magnitude{OverrunSeconds: maxTS - duration, Ratio: maxTS / duration}
+	mag := Magnitude{OverrunSeconds: maxTS - duration, Ratio: maxTS / duration, Measured: true}
 
 	switch {
 	case mag.OverrunSeconds <= Tolerance:

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -421,6 +421,42 @@ func TestEvaluate_ShortAudioToleranceFloor(t *testing.T) {
 	}
 }
 
+// TestEvaluate_MeasuredFlag pins the distinction that keeps a persisted 0 from
+// being confused with "no comparison made". A real Ok is Measured; both
+// no-evidence cases (unknown duration, all-decorative lyric) are not, even
+// though all three can surface OverrunSeconds 0.
+func TestEvaluate_MeasuredFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		song         models.Song
+		duration     int
+		wantOutcome  TimingOutcome
+		wantMeasured bool
+	}{
+		{"real ok", song(line(50, "a")), 100, Ok, true},
+		{"real overrun", song(line(120, "a")), 100, MisSynced, true},
+		{"unknown duration", song(line(50, "a")), 0, UnknownDuration, false},
+		{"all-decorative synced lyric", song(line(400, "♪"), line(500, "[ar:x]")), 100, Ok, false},
+		{"empty subtitles", song(), 100, Ok, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome, mag := Evaluate(tt.song, tt.duration)
+			if outcome != tt.wantOutcome {
+				t.Errorf("outcome = %q, want %q", outcome, tt.wantOutcome)
+			}
+			if mag.Measured != tt.wantMeasured {
+				t.Errorf("Measured = %v, want %v", mag.Measured, tt.wantMeasured)
+			}
+			// When unmeasured, the numeric fields must be the zero value: a
+			// consumer that ignores Measured would otherwise persist them.
+			if !mag.Measured && (mag.OverrunSeconds != 0 || mag.Ratio != 0) {
+				t.Errorf("unmeasured magnitude carries data: %+v", mag)
+			}
+		})
+	}
+}
+
 func TestThresholdsMatchCalibration(t *testing.T) {
 	// Pinned by the 28.7k-corpus recalibration on issue #438. Changing either
 	// value invalidates that calibration.

--- a/internal/worker/metadata_refresh_test.go
+++ b/internal/worker/metadata_refresh_test.go
@@ -201,3 +201,47 @@ func TestRefresh_SkippedWhenEnrichmentDisabled(t *testing.T) {
 		t.Errorf("TrackLength = %d; want 0", got)
 	}
 }
+
+// TestRefresh_TimingOutcomeUsesFileDurationNotProviderLength pins the call site
+// that stamps the timing verdict (#440). The unit tests call the helper with a
+// hand-passed duration, so nothing there catches a regression that feeds the
+// provider's catalog length instead of the audio file's -- the exact I2 bug.
+// This drives the full RunOnce path: the metadata reader supplies a 180s file
+// duration onto resolvedTrack, while the provider returns a song whose own
+// Track.TrackLength is a much larger 600s and whose last cue at 300s overruns
+// the FILE but sits comfortably inside the provider length. The verdict must be
+// categorical (300 vs 180), proving the file duration reached the stamp; against
+// the provider length it would read ok and this test fails.
+func TestRefresh_TimingOutcomeUsesFileDurationNotProviderLength(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{queuedItem("/library/track.flac")}}
+	f := &fakeFetcher{song: models.Song{
+		Track: models.Track{TrackLength: 600}, // provider catalog length
+		Subtitles: models.Synced{Lines: []models.Lines{
+			{Text: "a", Time: models.Time{Total: 10}},
+			{Text: "b", Time: models.Time{Total: 300}}, // overruns 180, fits 600
+		}},
+	}}
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 180}} // file duration
+
+	w := newRefreshWorker(t, q, &fakeCache{}, f, r)
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	rec, ok := q.timingOutcomes[1]
+	if !ok {
+		t.Fatal("no timing outcome stamped")
+	}
+	if rec.Outcome != "categorical" {
+		t.Errorf("timing_outcome = %q; want categorical (300s cue vs 180s file). "+
+			"ok would mean the provider's 600s length was used instead of the file duration", rec.Outcome)
+	}
+	if !rec.Measured {
+		t.Errorf("Measured = false; want true (a real comparison against the 180s file happened)")
+	}
+	// magnitude is 300 - 180 = 120 against the file; against the provider it
+	// would be negative.
+	if rec.Magnitude != 120 {
+		t.Errorf("overrun magnitude = %v; want 120 (300s - 180s file duration)", rec.Magnitude)
+	}
+}

--- a/internal/worker/timing_outcome_test.go
+++ b/internal/worker/timing_outcome_test.go
@@ -1,0 +1,222 @@
+package worker
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/timing"
+)
+
+func tLine(sec float64, text string) models.Lines {
+	return models.Lines{Text: text, Time: models.Time{Total: sec}}
+}
+
+// syncedSong deliberately leaves Track.TrackLength ZERO: the duration reaches
+// the predicate as a separate argument (the audio-file value, not the provider
+// value the song carries), so a test that relied on the song's own length would
+// silently pass against the wrong source. Track length here would be a trap.
+func syncedSong(lines ...models.Lines) models.Song {
+	return models.Song{
+		Track:     models.Track{ArtistName: "A", TrackName: "T"},
+		Subtitles: models.Synced{Lines: lines},
+	}
+}
+
+var testNow = time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+
+// errStamp stands in for a bookkeeping write failure.
+var errStamp = errors.New("stamp failed")
+
+func TestTimingRecordFromSong(t *testing.T) {
+	tests := []struct {
+		name         string
+		song         models.Song
+		duration     int
+		wantOutcome  string
+		wantMeasured bool
+	}{
+		{
+			name:         "compliant synced lyric",
+			song:         syncedSong(tLine(10, "a"), tLine(150, "b")),
+			duration:     200,
+			wantOutcome:  string(timing.Ok),
+			wantMeasured: true,
+		},
+		{
+			name:         "overrun past tolerance",
+			song:         syncedSong(tLine(10, "a"), tLine(120, "b")),
+			duration:     100,
+			wantOutcome:  string(timing.MisSynced),
+			wantMeasured: true,
+		},
+		{
+			name:         "far past the end",
+			song:         syncedSong(tLine(400, "a")),
+			duration:     100,
+			wantOutcome:  string(timing.Categorical),
+			wantMeasured: true,
+		},
+		{
+			// TrackLength 0 is the real state whenever recording enrichment is
+			// off or the file's tags are unreadable. It must fail open AND be
+			// distinguishable from a measured verdict.
+			name:         "unknown duration fails open and is unmeasured",
+			song:         syncedSong(tLine(400, "a")),
+			duration:     0,
+			wantOutcome:  string(timing.UnknownDuration),
+			wantMeasured: false,
+		},
+		{
+			// A synced result (len > 0, so a .lrc is written) whose only lines
+			// are decorative: Evaluate returns Ok with no comparison. This must
+			// persist as UNMEASURED, or a fake 0 magnitude lands in the column.
+			name:         "all-decorative synced lyric is unmeasured",
+			song:         syncedSong(tLine(400, "♪"), tLine(500, "[ar:x]")),
+			duration:     100,
+			wantOutcome:  string(timing.Ok),
+			wantMeasured: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := timingRecordFromSong(tt.song, tt.duration, testNow)
+			if rec.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", rec.Outcome, tt.wantOutcome)
+			}
+			if rec.Measured != tt.wantMeasured {
+				t.Errorf("Measured = %v, want %v", rec.Measured, tt.wantMeasured)
+			}
+			// An unmeasured record must carry no magnitude: a downstream stamp
+			// that ignored Measured would otherwise persist a fake 0.
+			if !rec.Measured && (rec.Magnitude != 0 || rec.Ratio != 0) {
+				t.Errorf("unmeasured record carries magnitude: %+v", rec)
+			}
+			if !rec.EvaluatedAt.Equal(testNow) {
+				t.Errorf("EvaluatedAt = %v, want %v", rec.EvaluatedAt, testNow)
+			}
+		})
+	}
+}
+
+// TestTimingRecordFromSong_NonSyncedLeavesNoVerdict: an unsynced or instrumental
+// settle carries no line timing, so there is nothing to judge. That is distinct
+// from a verdict of "fine" and must leave the columns NULL.
+func TestTimingRecordFromSong_NonSyncedLeavesNoVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		song models.Song
+	}{
+		{"unsynced", models.Song{Lyrics: models.Lyrics{LyricsBody: "some words"}}},
+		{"instrumental", models.Song{Track: models.Track{Instrumental: 1}}},
+		{"empty", models.Song{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := timingRecordFromSong(tc.song, 100, testNow); rec != (queue.TimingRecord{}) {
+				t.Errorf("record = %+v, want zero value (no line timing to judge)", rec)
+			}
+		})
+	}
+}
+
+// TestTimingRecordFromSong_DelegatesToTimingPackage is the anti-duplication
+// guard, and the reason #438 landed first. A trailing decorative marker past the
+// audio end is the ~31% false-positive case: any reimplementation here that
+// keyed on the raw last cue would report an overrun. Delegation is what makes
+// this Ok, so this test fails the moment the logic is forked.
+func TestTimingRecordFromSong_DelegatesToTimingPackage(t *testing.T) {
+	// Last sung line at 90s inside a 100s track; only the decorative glyph at
+	// 160s sits past the end.
+	song := syncedSong(tLine(10, "a"), tLine(90, "b"), tLine(160, "♪"))
+	rec := timingRecordFromSong(song, 100, testNow)
+	if rec.Outcome != string(timing.Ok) {
+		t.Errorf("Outcome = %q, want ok (a trailing decorative marker is not an overrun)", rec.Outcome)
+	}
+	if rec.Magnitude > 0 {
+		t.Errorf("Magnitude = %v, want <= 0 (max must ignore the decorative line)", rec.Magnitude)
+	}
+}
+
+// TestStampTimingOutcome_PersistsVerdict covers the wiring: the verdict reaches
+// the queue, and a non-synced settle writes nothing at all.
+func TestStampTimingOutcome_PersistsVerdict(t *testing.T) {
+	q := &fakeQueue{}
+	w := &Worker{queue: q, now: func() time.Time { return testNow }}
+	item := queue.WorkItem{ID: 7, Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}
+
+	w.stampTimingOutcome(t.Context(), item, syncedSong(tLine(120, "a")), 100)
+	rec, ok := q.timingOutcomes[7]
+	if !ok {
+		t.Fatal("no timing outcome stamped")
+	}
+	if rec.Outcome != string(timing.MisSynced) {
+		t.Errorf("Outcome = %q, want mis_synced", rec.Outcome)
+	}
+	if rec.Magnitude != 20 {
+		t.Errorf("Magnitude = %v, want 20", rec.Magnitude)
+	}
+
+	// A non-synced settle stamps nothing: no row should be touched.
+	q2 := &fakeQueue{}
+	w2 := &Worker{queue: q2, now: func() time.Time { return testNow }}
+	w2.stampTimingOutcome(t.Context(), queue.WorkItem{ID: 8},
+		models.Song{Lyrics: models.Lyrics{LyricsBody: "words"}}, 100)
+	if len(q2.timingOutcomes) != 0 {
+		t.Errorf("stamped %d outcomes for a non-synced settle, want 0", len(q2.timingOutcomes))
+	}
+}
+
+// TestStampTimingOutcome_StampFailureIsNonFatal: the output is already on disk
+// by this point, so a bookkeeping write must never fail the item.
+func TestStampTimingOutcome_StampFailureIsNonFatal(t *testing.T) {
+	q := &fakeQueue{timingOutcomeErr: errStamp}
+	w := &Worker{queue: q, now: func() time.Time { return testNow }}
+	// Must not panic and must return normally.
+	w.stampTimingOutcome(t.Context(), queue.WorkItem{ID: 9}, syncedSong(tLine(120, "a")), 100)
+}
+
+// TestStampTimingOutcome_LogsOnlyNonCompliant pins the "log overruns" half of
+// the change: a non-compliant result emits exactly one warn carrying the outcome
+// and magnitude, and a compliant or unmeasured result emits none. Without this,
+// dropping the warn leaves the suite green.
+func TestStampTimingOutcome_LogsOnlyNonCompliant(t *testing.T) {
+	tests := []struct {
+		name     string
+		song     models.Song
+		duration int
+		wantLog  bool
+	}{
+		{"overrun logs", syncedSong(tLine(120, "a")), 100, true},
+		{"categorical logs", syncedSong(tLine(400, "a")), 100, true},
+		{"compliant is silent", syncedSong(tLine(50, "a")), 100, false},
+		{"unknown duration is silent", syncedSong(tLine(400, "a")), 0, false},
+		{"non-synced is silent", models.Song{Lyrics: models.Lyrics{LyricsBody: "w"}}, 100, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			defer slog.SetDefault(prev)
+
+			q := &fakeQueue{}
+			w := &Worker{queue: q, now: func() time.Time { return testNow }}
+			w.stampTimingOutcome(t.Context(), queue.WorkItem{ID: 1,
+				Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}, tt.song, tt.duration)
+
+			logged := strings.Contains(buf.String(), "timing overruns the audio")
+			if logged != tt.wantLog {
+				t.Errorf("overrun logged = %v, want %v (log: %q)", logged, tt.wantLog, buf.String())
+			}
+			if tt.wantLog && !strings.Contains(buf.String(), "outcome=") {
+				t.Errorf("overrun log missing the outcome field: %q", buf.String())
+			}
+		})
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sydlexius/canticle/internal/providers"
 	"github.com/sydlexius/canticle/internal/queue"
 	"github.com/sydlexius/canticle/internal/scanner"
+	"github.com/sydlexius/canticle/internal/timing"
 	"github.com/sydlexius/canticle/internal/verification"
 	"github.com/sydlexius/canticle/internal/version"
 )
@@ -60,6 +61,12 @@ type Queue interface {
 	// all -- still records what produced it (#620). Call before Complete while the
 	// row is still in processing status; a wholly empty provenance is a no-op.
 	SetCompletionProvenance(ctx context.Context, id int64, prov queue.CompletionProvenance) error
+	// SetTimingOutcome records how the row's synced lyric compared against the
+	// audio duration (#440), for observability and as the sweep watermark. Call
+	// before Complete while the row is still in processing status; an empty
+	// outcome is a no-op. It records a verdict only -- it never changes what was
+	// written (that guard is #439).
+	SetTimingOutcome(ctx context.Context, id int64, rec queue.TimingRecord) error
 }
 
 // ProviderRecorder records per-lane provider outcome counters. A nil
@@ -769,6 +776,47 @@ func outcomeTypeFromSong(song models.Song) string {
 	}
 }
 
+// timingRecordFromSong derives the row's timing verdict by DELEGATING to
+// internal/timing -- it deliberately owns no comparison logic of its own (#440).
+//
+// This is the whole point of #438 landing first. The naive derivation (take the
+// last cue's timestamp and compare it to the duration) falsely flags ~31% of the
+// overrunning tail: those are perfectly-synced lyrics whose only past-duration
+// timestamp is a decorative marker. timing.Evaluate applies the corrected max,
+// and the calibrated thresholds are valid ONLY against that. A second
+// implementation here would drift from the one the guard (#439) and the sweep
+// (#443) consume, which is exactly the divergence the shared package exists to
+// prevent.
+//
+// Only a synced result carries line timing, so every other outcome returns a
+// zero record and leaves the columns NULL: there is no verdict to record, which
+// is distinct from a verdict of "fine".
+//
+// durationSeconds must be the AUDIO-FILE duration, not song.Track.TrackLength.
+// On the fetch path song.Track is overwritten wholesale from the provider
+// payload, so its length is the provider's own catalog value -- the same length
+// the lyric was timed against, which makes the comparison near-circular and
+// biases every verdict toward ok. The worker holds the file's duration on the
+// resolvedTrack that refreshRecordingIdentity re-read from the tags; that is the
+// ground truth timing.Evaluate documents it needs.
+func timingRecordFromSong(song models.Song, durationSeconds int, now time.Time) queue.TimingRecord {
+	if len(song.Subtitles.Lines) == 0 {
+		return queue.TimingRecord{}
+	}
+	outcome, mag := timing.Evaluate(song, durationSeconds)
+	return queue.TimingRecord{
+		Outcome:   string(outcome),
+		Magnitude: mag.OverrunSeconds,
+		Ratio:     mag.Ratio,
+		// mag.Measured, not "outcome != UnknownDuration": Evaluate has TWO
+		// no-comparison cases -- unknown duration AND an all-decorative lyric
+		// that returns Ok with a zero magnitude. Both must persist as NULL, or a
+		// fake measured 0 corrupts any aggregate over the column.
+		Measured:    mag.Measured,
+		EvaluatedAt: now,
+	}
+}
+
 // provenanceFromSong reads the completion provenance off the same Song the
 // writer consumes, so the row records exactly what the synced .lrc tag block
 // would have emitted -- no parallel derivation (#620). The values are read, not
@@ -798,6 +846,42 @@ func (w *Worker) stampCompletionProvenance(ctxNoCancel context.Context, id int64
 	if err := w.queue.SetCompletionProvenance(ctxNoCancel, id, provenanceFromSong(song)); err != nil {
 		slog.Warn("worker: stamp completion provenance failed; continuing", "id", id, "error", err)
 	}
+}
+
+// stampTimingOutcome records the row's timing verdict and, for a non-compliant
+// one, emits the structured event (#440). Rejections and demotions eventually
+// move or discard user files, so the reason must be visible rather than silent;
+// this is that surface until the metrics counters land.
+//
+// Non-fatal like the sibling stamps: a bookkeeping write must never fail an item
+// whose output is already on disk.
+func (w *Worker) stampTimingOutcome(ctxNoCancel context.Context, item queue.WorkItem, song models.Song, durationSeconds int) {
+	rec := timingRecordFromSong(song, durationSeconds, w.now())
+	if rec.Outcome == "" {
+		// Not a synced result: no line timing exists to judge.
+		return
+	}
+	if err := w.queue.SetTimingOutcome(ctxNoCancel, item.ID, rec); err != nil {
+		slog.Warn("worker: stamp timing outcome failed; continuing", "id", item.ID, "error", err)
+	}
+	if rec.Outcome == string(timing.Ok) || rec.Outcome == string(timing.UnknownDuration) {
+		// Compliant, or not judgeable. Neither is an event worth a Warn: the
+		// unknown-duration case is a routine fail-open, not an anomaly.
+		return
+	}
+	// Artist and track name identify the row for an operator reading their own
+	// logs, matching every sibling warn here. They stay in the log line only and
+	// are never routed to a metric label or any shared surface.
+	slog.Warn("worker: synced lyric timing overruns the audio",
+		"id", item.ID,
+		"outcome", rec.Outcome,
+		"overrun_seconds", rec.Magnitude,
+		"ratio", rec.Ratio,
+		"lane", song.WinningLane,
+		"duration_seconds", durationSeconds,
+		"artist", item.Inputs.Track.ArtistName,
+		"track", item.Inputs.Track.TrackName,
+	)
 }
 
 // Run processes ready work items until the queue is empty or the context ends.
@@ -1135,6 +1219,10 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	// .txt is plain lyric text and carries no tag block, so without this the row
 	// is indistinguishable from one written by the 2022 code.
 	w.stampCompletionProvenance(ctxNoCancel, item.ID, song)
+	// Record how the synced timing compared against the audio duration (#440).
+	// OBSERVABILITY ONLY at this point: the .lrc above is already written, and
+	// nothing here changes that. The guard that acts on the verdict is #439.
+	w.stampTimingOutcome(ctxNoCancel, item, song, resolvedTrack.TrackLength)
 	if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
 		cause := fmt.Errorf("worker: complete item %d: %w", item.ID, err)
 		w.consecutiveFailures++

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -108,6 +108,8 @@ type fakeQueue struct {
 	outcomeTypes       map[int64]string
 	provenance         map[int64]queue.CompletionProvenance
 	provenanceErr      error
+	timingOutcomes     map[int64]queue.TimingRecord
+	timingOutcomeErr   error
 	onComplete         func(id int64)
 	failCauses         []error
 	deferCauses        []error
@@ -216,6 +218,17 @@ func (q *fakeQueue) SetCompletionProvenance(_ context.Context, id int64, prov qu
 		q.provenance = make(map[int64]queue.CompletionProvenance)
 	}
 	q.provenance[id] = prov
+	return nil
+}
+
+func (q *fakeQueue) SetTimingOutcome(_ context.Context, id int64, rec queue.TimingRecord) error {
+	if q.timingOutcomeErr != nil {
+		return q.timingOutcomeErr
+	}
+	if q.timingOutcomes == nil {
+		q.timingOutcomes = make(map[int64]queue.TimingRecord)
+	}
+	q.timingOutcomes[id] = rec
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Records a per-row timing verdict on completed `work_queue` rows -- how a synced lyric's timestamps compared against the audio duration -- as the observability half of the timing epic (#437). The verdict doubles as the sweep watermark (#443) and a review queue (`WHERE timing_outcome = 'mis_synced'`).
- **RECORDS ONLY.** Nothing here changes what lands on disk; the `.lrc` is written exactly as before. The guard that rejects or demotes on the verdict is #439. Reading this column as "these were rejected" is wrong until #439 ships.
- The worker **delegates** classification to `internal/timing` (#438) rather than reimplementing it. That is load-bearing: the naive last-cue derivation falsely flags ~31% of the overrunning tail (trailing decorative markers), and a fork would drift from what the guard and sweep consume. A test pins the delegation.

## Linked issue

Closes #440

(Follow-up filed as #629 for the deferred `/metrics` counters + review-queue report -- scoped out to keep this reviewable.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite). -- N/A: no user-visible behavior change; a serve-mode worker writes a new DB column and a log line, exercised by tests. The verdict has no effect on output until #439.
- [ ] Screenshot attached for any web-UI change. -- N/A, no web-UI change.
- [ ] `make ui` re-run if any `.templ` or CSS source changed. -- N/A.
- [x] Migration added under `internal/db/migrations/` -- migration 034 (additive nullable columns, reversible; up/down proven by `TestMigration034TimingOutcomeUpDown`).

## Test plan

- [x] `make gate` passes locally (race tests, coverage floor, golangci-lint 0 issues, actionlint, govulncheck).
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Every fix below was reverted by mutation and the named test confirmed to fail:
  - migration reversibility -> `TestMigration034TimingOutcomeUpDown`
  - NULL-vs-0 at the queue layer (unmeasured -> NULL magnitude) -> `TestDBQueue_SetTimingOutcome`
  - delegation to `internal/timing` (not reimplemented) -> `TestTimingRecordFromSong_DelegatesToTimingPackage`
  - the overrun `slog.Warn` fires only for non-compliant results -> `TestStampTimingOutcome_LogsOnlyNonCompliant`
  - **audio-file duration, not provider length** (I2, end-to-end) -> `TestRefresh_TimingOutcomeUsesFileDurationNotProviderLength`
  - **all-decorative synced lyric persists unmeasured** (C1) -> `TestTimingRecordFromSong` / `TestEvaluate_MeasuredFlag`
- [x] Patch coverage meets the Codecov threshold: **92.00% (69/75 lines)** against 70%.
- [x] Which **surface** this change fixes is stated explicitly: the `work_queue` row (a new DB column) and the worker log. No metrics or web surface yet -- that is #629.
- [ ] Manual UAT steps: N/A until the verdict has a visible effect (#639/#629).
- [ ] Reviewer follow-ups (a second pair of eyes welcome on):
  - [ ] The verdict is compared against `resolvedTrack.TrackLength` (the audio file's duration, re-read from tags by `refreshRecordingIdentity`), not `song.Track.TrackLength` (the provider's catalog length, which `song.Track` is overwritten with on the fetch path). The first review round found the provider-length version and it was fixed; worth confirming the audio-file source is right and that `unknown_duration` (TrackLength 0, enrichment off / unreadable tags) is the intended fail-open.
  - [ ] Vocabulary: the column stores the `internal/timing` constants verbatim (`ok` / `mis_synced` / `categorical` / `unknown_duration`), not the issue's original `compliant` / `demoted` / `quarantined`. This was a deliberate choice to avoid a translation layer; `demoted` / `quarantined` become #439's to write.

## Not covered

- **No consumer acts on the verdict.** This is the data + log layer; the guard (#439), the sweep (#443), and the metrics/report surface (#629) consume it later. End-to-end effect on user files is out of scope here by design.
- **NULL rows are not backfillable.** Every row completed before migration 034 is NULL, and the verdict depends on an audio duration no completed row stored. The migration comment states this; it is a stated limit, not a gap.
- **Adversarial review ran two rounds** (find + fix-scoped verify). One CRITICAL (NULL-vs-0) and two IMPORTANT (provider-vs-file duration, untested log) were found and fixed; a MINOR test-gap the fix round surfaced (call site unguarded) was closed with the end-to-end test above. No findings survived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lyric timing verdicts and overrun metrics to completed work items.
  * Timing results now distinguish measured comparisons from cases without sufficient duration data.
  * Added operator-visible warnings for non-compliant timing outcomes.
  * Timing records are saved before work is marked complete, without interrupting completion if recording fails.

* **Documentation**
  * Documented timing outcome recording and its non-fatal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->