### PR TITLE
ci(yamnet): publish the sidecar image, gate it, document the contract

### DIFF
--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # dorny/paths-filter's documented least-privilege scope for PR change detection
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -1,0 +1,182 @@
+name: YAMNet Sidecar
+
+# Builds and publishes the YAMNet instrumental-detection sidecar image
+# (deploy/yamnet-detector/) to GHCR so deployments pull a versioned artifact
+# instead of building from a hand-copied local directory (#498).
+#
+# The image is amd64-only: the linux/amd64 TensorFlow wheel requires AVX, so
+# there is no arm64 leg (unlike the app image). This is also why a published
+# image matters -- contributors on Apple Silicon cannot build the sidecar at all.
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect Sidecar Changes
+    runs-on: ubuntu-latest
+    # On a tag the output short-circuits to 'true' and the paths-filter step is
+    # skipped entirely -- a release must publish the version-tagged sidecar
+    # regardless of what the tag commit touched, and paths-filter on a fresh tag
+    # ref (no reliable "before" SHA) is exactly the run we must not depend on.
+    # So the release publish never rides through paths-filter (finding #498-1).
+    outputs:
+      sidecar: ${{ github.ref_type == 'tag' || steps.filter.outputs.sidecar == 'true' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        if: github.ref_type != 'tag'
+        with:
+          filters: |
+            sidecar:
+              - 'deploy/yamnet-detector/**'
+              - '.github/workflows/yamnet.yml'
+
+  build:
+    name: Build & Smoke Test
+    runs-on: ubuntu-latest # amd64: the TF wheel needs AVX (no arm64/self-hosted)
+    needs: [changes]
+    # Build when the sidecar changed, or always on a tag (encoded in the
+    # `changes.sidecar` output above, so the tag path does not touch paths-filter).
+    if: needs.changes.outputs.sidecar == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Build once, load into the local daemon for the smoke test. The publish
+      # step below reuses the same GHA layer cache, so this is not a double build.
+      - name: Build sidecar image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: deploy/yamnet-detector
+          file: deploy/yamnet-detector/Dockerfile
+          push: false
+          load: true
+          tags: canticle-yamnet:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      # The sidecar's health contract: GET /health -> {"status":"ok","classes":N}
+      # with N = the full YAMNet class map (521). A drifted or broken model bake
+      # changes the class count, so asserting it catches the whole class of
+      # "sidecar starts but is wrong" failures the Go suite cannot see.
+      - name: Smoke test (/health)
+        run: |
+          set -euo pipefail
+          docker run -d --name yamnet-smoke -p 8080:8080 canticle-yamnet:smoke
+          # Poll up to ~60s for the model to load and the server to bind.
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health >/tmp/health.json 2>/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          echo "health response:"; cat /tmp/health.json; echo
+          status=$(jq -r '.status' /tmp/health.json)
+          classes=$(jq -r '.classes' /tmp/health.json)
+          test "$status" = "ok" || { echo "expected status=ok, got $status" >&2; exit 1; }
+          test "$classes" = "521" || { echo "expected classes=521, got $classes" >&2; exit 1; }
+          echo "smoke test passed: status=$status classes=$classes"
+        # Always dump logs on failure so a broken start is diagnosable in CI.
+      - name: Sidecar logs on failure
+        if: failure()
+        run: docker logs yamnet-smoke || true
+
+      - name: Stop sidecar
+        if: always()
+        run: docker rm -f yamnet-smoke || true
+
+      # The /classify shape test (test_app.py) stubs the model, so it needs no
+      # download and runs in seconds -- it belongs in CI (its former "not in CI"
+      # docstring is corrected in this PR). Run it INSIDE the built image so it
+      # validates against the exact hash-pinned requirements.txt the sidecar
+      # ships, rather than a drift-prone hand-assembled dep list on the runner.
+      # `import app` pulls tensorflow/soundfile at module load, so the image's
+      # own environment is the only faithful place to run it. test_app.py is not
+      # COPYed into the image, so it is bind-mounted read-only for this run.
+      - name: Run sidecar shape test (inside the image)
+        run: |
+          set -euo pipefail
+          # --user root: the image drops to appuser (uid 1000), but installing
+          # pytest into system site-packages for this throwaway run needs root.
+          docker run --rm --user root \
+            -v "$PWD/deploy/yamnet-detector/test_app.py:/app/test_app.py:ro" \
+            --entrypoint sh canticle-yamnet:smoke -c \
+            'pip install --no-cache-dir --quiet pytest httpx && pytest test_app.py -q'
+
+  publish:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    needs: [build]
+    # Never publish from a PR or a fork; only push-to-main and release tags.
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ghcr.io/<owner>/<repo>-yamnet, tracking the repository like the app image
+      # (nightly.yml / release.yml use ghcr.io/${{ github.repository }}). On main:
+      # dev + nightly + dated. On a vX.Y.Z tag: the semver tags, mirroring the app.
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}-yamnet
+          # latest=false: a version-pinned sidecar should not have `latest` drift
+          # under it on each release (deployments pin X.Y.Z to match Canticle).
+          flavor: latest=false
+          tags: |
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}},enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: deploy/yamnet-detector
+          file: deploy/yamnet-detector/Dockerfile
+          push: true
+          platforms: linux/amd64 # AVX-dependent TF wheel; no arm64 leg
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/deploy/yamnet-detector/README.md
+++ b/deploy/yamnet-detector/README.md
@@ -29,11 +29,48 @@ with `tf.saved_model.load` -- `tensorflow-hub` is deliberately not a dependency
 
 - `GET /health` returns `{"status": "ok", "classes": <N>}`.
 
-## Build & deploy
+## Deployment contract: pull the published image
+
+**A deployment consumes this sidecar by pulling the published image, not by
+building from a hand-copied directory.** CI builds `deploy/yamnet-detector/` and
+publishes it to GHCR on every merge to `main` that changes the sidecar, and on
+each release tag (see `.github/workflows/yamnet.yml`, issue #498):
+
+```
+ghcr.io/sydlexius/canticle-yamnet:<tag>
+```
+
+Tags mirror the app image: `nightly` / `dev` (and a dated `nightly-YYYYMMDD`) on
+`main`, plus the semver tags (`X.Y.Z`, `X.Y`) on a release. The image is
+**amd64-only** -- the `linux/amd64` TensorFlow wheel requires AVX, so there is no
+arm64 build and the sidecar cannot run on Apple Silicon (even under emulation the
+TF import aborts). Pull a version tag that matches your Canticle version so their
+`detector_version` provenance lines up (the recorded `detector_version` is the
+Canticle app version -- see the Dockerfile).
+
+Point compose at the published image:
+
+```yaml
+services:
+  yamnet:
+    image: ghcr.io/sydlexius/canticle-yamnet:1.26.0 # match your Canticle version
+```
+
+> **Unsupported: a hand-copied `build.context`.** Do not deploy by copying these
+> files onto a host and pointing `build.context` at that directory. Nothing syncs
+> such a copy to git, nothing validates it, and a merged fix (including a security
+> fix) can sit unshipped while a rebuild faithfully reproduces the stale image and
+> reports success -- the exact failure that motivated #498 (discovered shipping
+> the CVE-2026-59890 fix in #491). Pull the published tag instead.
+
+## Build locally (development only)
 
 ```bash
-docker build -t canticle-yamnet:local .
+docker build -t canticle-yamnet:local deploy/yamnet-detector
 ```
+
+This is for local iteration on the sidecar itself; deployments pull the published
+image above. (Requires an amd64 builder -- see the AVX note.)
 
 ### Resource limits (cap this container)
 
@@ -73,4 +110,7 @@ pip install pytest
 pytest test_app.py -q
 ```
 
-This is a maintainer smoke test; the Go test suite is the CI gate.
+CI also runs this shape test and a live `/health` smoke check on every change to
+`deploy/yamnet-detector/**` (see `.github/workflows/yamnet.yml`), so a change that
+breaks the sidecar's build or its `/classify` contract fails CI rather than only
+surfacing as "instrumental detection stopped working" in production.

--- a/deploy/yamnet-detector/test_app.py
+++ b/deploy/yamnet-detector/test_app.py
@@ -4,7 +4,8 @@ Stubs the YAMNet model so the test needs no model download. TestClient is used
 WITHOUT a `with` block so the lifespan (which would load the real model) never
 runs, and the stubbed _state is what the handler reads.
 
-Run locally (not in CI; the Go suite is the gate):
+Runs in CI inside the built image (.github/workflows/yamnet.yml, #498) and
+locally:
     pip install -r requirements.txt pytest
     pytest test_app.py -q
 """


### PR DESCRIPTION
## Summary

- The YAMNet instrumental-detection sidecar (`deploy/yamnet-detector/`) had no CI build and no published image: a merged change reached a deployment only by hand-copying files onto the host, so a merged fix (including the CVE-2026-59890 fix in #491) could sit unshipped while a compose rebuild faithfully reproduced the stale image and reported success.
- Adds `.github/workflows/yamnet.yml`: **publishes** `ghcr.io/sydlexius/canticle-yamnet` on merge-to-main (that changes the sidecar) and on release tags (amd64-only -- the linux/amd64 TF wheel needs AVX, so no arm64 leg); **gates** every change to `deploy/yamnet-detector/**` with a build + live `/health` smoke check (asserts 200 + the full 521-class map) and runs the `/classify` shape test inside the built image.
- Documents the deployment contract in the sidecar README (pull the published tag; a hand-copied `build.context` is explicitly unsupported) and corrects `test_app.py`'s stale "not in CI" docstring.
- Reviewers: the release-tag path deliberately short-circuits the paths-filter (`changes.sidecar` output is `true` on a tag, and the filter step is skipped) so a release publish never depends on a paths-filter run against a fresh tag ref.

## Linked issue

Closes #498

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), via `/prep-pr`.
- [x] Code review pass complete; the one important finding (release-tag publish coupled to paths-filter) fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- N/A here; the amd64 AVX-dependent image cannot be built on the Apple Silicon dev machine (that is the very problem #498 fixes), so the build/smoke/publish get their real green from CI on this PR.
- [ ] Screenshot -- N/A (no web-UI change).
- [ ] `make ui` -- N/A (no `.templ`/CSS change).
- [ ] Migration -- N/A (no schema/data change).

## Test plan

- [x] `make gate` passes locally (conflict markers, gofmt, `make ui`, build, `go test -race` + coverage, patch coverage, coverage-floor, codecov validation, golangci-lint, **actionlint**, govulncheck). No Go changes, so the Go-specific gates self-skipped; actionlint validated the new workflow.
- [ ] New-tests-fail-first -- N/A (no new Go tests; the sidecar shape test is pre-existing, now wired into CI).
- [x] Patch coverage -- N/A (no Go source changes in scope; `patch-coverage` reported nothing to measure).
- [x] Surface stated: this changes the **CI/delivery** surface (image build + publish), not the detector's runtime behavior. Verified by tracing the workflow gating matrix (PR / main / tag / fork) in review.
- [ ] Manual UAT steps:
  - [ ] The build/smoke/publish jobs run for the first time on this PR (build+smoke on the PR; publish only after merge/tag).
- [ ] Reviewer follow-ups:
  - [ ] Confirm the amd64 sidecar image builds and `/health` returns 521 on the CI runner (cannot be reproduced on Apple Silicon).

## Not covered

- The image is **not** built or smoke-tested locally (Apple Silicon cannot build the amd64 AVX-dependent TF image) -- CI is the first place that runs. If the sidecar Dockerfile has a build-time regression, it surfaces on this PR's `build` job, not before.
- No change to the sidecar's runtime behavior, the Go detector client, or the `/classify` contract -- purely build, publish, gate, and docs.
- A rare CI-runner-contention flake is possible in the pre-existing concurrency-timing shape test; left as-is (a targeted follow-up if it ever fires) rather than weakened here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI validation for the YAMNet instrumental-detection service, including health and response-shape checks.
  * Published AMD64 container images automatically for main-branch updates and releases.
  * Added versioned container image tagging and caching for faster builds.

* **Documentation**
  * Updated deployment guidance to use published container images.
  * Documented AMD64-only support, tag usage, local development builds, and CI testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->