### PR TITLE
fix(detector): release, not defer, when the sidecar is still booting (#567)

### DIFF
--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -17,9 +17,16 @@ import (
 	"errors"
 )
 
-// ErrClassifierUnavailable is returned when the classifier HTTP endpoint
-// cannot be reached or returns a non-2xx status.
+// ErrClassifierUnavailable is returned when the classifier HTTP endpoint is
+// reachable but returns a non-2xx status.
 var ErrClassifierUnavailable = errors.New("detector: classifier unavailable")
+
+// ErrClassifierNotReady is returned when the classifier endpoint cannot be
+// dialed at all (connection refused / no route) -- the transport never
+// completed. It is split from ErrClassifierUnavailable (a reachable endpoint
+// returning a non-2xx status) so callers can treat a sidecar that is still
+// booting differently from one that is genuinely broken (issue #567).
+var ErrClassifierNotReady = errors.New("detector: classifier not ready")
 
 // ErrInvalidResponse is returned when the classifier returns a response that
 // cannot be decoded as a class-probability map.

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -182,6 +182,65 @@ func TestNewHTTPDetectorClampsSampleDuration(t *testing.T) {
 	}
 }
 
+// TestHTTPDetectorDialErrorIsNotReady verifies that a transport-level failure
+// (the classifier endpoint cannot be dialed at all) surfaces as
+// ErrClassifierNotReady, distinct from ErrClassifierUnavailable, so a
+// still-booting sidecar is not treated as a genuine outage (#567).
+func TestHTTPDetectorDialErrorIsNotReady(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	// Create then immediately close a server so its URL refuses connections.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	d, err := NewHTTPDetector(Config{ClassifierURL: url, SampleDurationSeconds: 30, MinConfidence: 0.90, InstrumentalClasses: []string{"Music"}, VocalClasses: []string{"Singing"}, VocalMaxConfidence: 0.05, FFmpegPath: ffmpegPath})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, derr := d.Detect(context.Background(), audioPath)
+	if !errors.Is(derr, ErrClassifierNotReady) {
+		t.Fatalf("dial error: got %v; want ErrClassifierNotReady", derr)
+	}
+	if errors.Is(derr, ErrClassifierUnavailable) {
+		t.Fatalf("dial error must NOT also match ErrClassifierUnavailable: %v", derr)
+	}
+}
+
+// TestHTTPDetectorNon2xxIsUnavailableNotNotReady guards the split: a reachable
+// endpoint returning a non-2xx status stays ErrClassifierUnavailable and must
+// NOT be misclassified as the not-ready (dial-failure) case (#567).
+func TestHTTPDetectorNon2xxIsUnavailableNotNotReady(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	ffmpegPath := fakeFFmpeg(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, SampleDurationSeconds: 30, MinConfidence: 0.90, InstrumentalClasses: []string{"Music"}, VocalClasses: []string{"Singing"}, VocalMaxConfidence: 0.05, FFmpegPath: ffmpegPath})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, derr := d.Detect(context.Background(), audioPath)
+	if !errors.Is(derr, ErrClassifierUnavailable) {
+		t.Fatalf("500 response: got %v; want ErrClassifierUnavailable", derr)
+	}
+	if errors.Is(derr, ErrClassifierNotReady) {
+		t.Fatalf("500 response must NOT match ErrClassifierNotReady: %v", derr)
+	}
+}
+
 func TestNewHTTPDetectorErrorsWhenFFmpegMissing(t *testing.T) {
 	_, err := NewHTTPDetector(Config{ClassifierURL: "http://classifier:8080", SampleDurationSeconds: 30, MinConfidence: 0.90, FFmpegPath: filepath.Join(t.TempDir(), "missing-ffmpeg")})
 	if err == nil {

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -559,7 +559,10 @@ func (d *HTTPDetector) classify(ctx context.Context, samplePath string) (_ class
 
 	res, err := d.httpClient.Do(req)
 	if err != nil {
-		return classifyResponse{}, fmt.Errorf("%w: %w", ErrClassifierUnavailable, err)
+		// A transport-level failure (connection refused / no route): the sidecar
+		// is not reachable at all. Distinct from a reachable-but-non-2xx response
+		// below, so a boot-time race is not treated as a genuine outage (#567).
+		return classifyResponse{}, fmt.Errorf("%w: %w", ErrClassifierNotReady, err)
 	}
 	defer func() {
 		if closeErr := res.Body.Close(); closeErr != nil && retErr == nil {

--- a/internal/orchestrator/detector_lane.go
+++ b/internal/orchestrator/detector_lane.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/sydlexius/canticle/internal/circuit"
 	"github.com/sydlexius/canticle/internal/detector"
@@ -13,6 +14,14 @@ import (
 
 // detectorLaneName is the lane name a detector-backed lane reports.
 const detectorLaneName = "detector"
+
+// notReadyBound caps how many consecutive "not ready" (dial-refused, never
+// reached) results a detector lane emits before escalating to a genuine outage.
+// A sidecar that is merely booting comes up within a few work cycles; one that
+// has never been reachable is misconfigured or dead, and must trip the breaker
+// so the lane stops re-spending a rate-limited provider call every cycle (#567).
+// This is an attempt count, not a wall-clock sleep (which the issue forbids).
+const notReadyBound = 5
 
 // NewDetectorLane builds an orchestrator lane over the audio detector and its
 // dedicated breaker. The resolve func runs the 3-gate over the work item's audio
@@ -29,6 +38,13 @@ const detectorLaneName = "detector"
 // detector-owned one -- the detector has no throttle concept of its own; it is
 // only ever crediting recovery of the provider's adaptive interval.
 func NewDetectorLane(d detector.Detector, breaker *circuit.Breaker, pacer providers.AdaptivePacer) *Lane {
+	// everReached records whether the lane has ever completed a detector call
+	// since this process booted; notReadyStreak counts consecutive dial failures
+	// while it has not. Together they distinguish a boot race (release, no trip)
+	// from a die-after-up or dead-from-boot sidecar (outage, trip) -- see #567.
+	// These are lane-global across work items, captured in the resolve closure.
+	var everReached atomic.Bool
+	var notReadyStreak atomic.Uint32
 	return &Lane{
 		name:        detectorLaneName,
 		breaker:     breaker,
@@ -61,11 +77,25 @@ func NewDetectorLane(d detector.Detector, breaker *circuit.Breaker, pacer provid
 			}
 			res, err := d.Detect(ctx, sourcePath)
 			if err != nil {
+				// A dial-level failure (sidecar unreachable) is a startup race ONLY
+				// until the lane has reached the sidecar once since boot, and only
+				// for the first notReadyBound attempts. Beyond that -- or after any
+				// prior success -- an unreachable sidecar is a genuine outage that
+				// must trip the breaker (#567). Any non-dial detector error (a
+				// non-2xx status, an ffmpeg sampling failure) is always an outage.
+				//
 				// Join rather than %v so BOTH the sentinel and the detector's own
-				// cause stay matchable with errors.Is: the classifier keys on
-				// ErrLaneOutage, while callers and logs need the underlying failure.
+				// cause stay matchable with errors.Is: the classifier keys on the
+				// sentinel, while callers and logs need the underlying failure.
+				if errors.Is(err, detector.ErrClassifierNotReady) &&
+					!everReached.Load() && notReadyStreak.Load() < notReadyBound {
+					notReadyStreak.Add(1)
+					return models.Song{}, fmt.Errorf("detector not ready: %w", errors.Join(ErrLaneNotReady, err))
+				}
 				return models.Song{}, fmt.Errorf("detector request failed: %w", errors.Join(ErrLaneOutage, err))
 			}
+			everReached.Store(true)
+			notReadyStreak.Store(0)
 			if !res.Instrumental {
 				return models.Song{}, ErrLaneBenignMiss
 			}

--- a/internal/orchestrator/detector_lane_test.go
+++ b/internal/orchestrator/detector_lane_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -155,6 +156,136 @@ func TestDetectorLane_NilPacerIsSafe(t *testing.T) {
 
 	if _, err := lane.FindLyrics(context.Background(), models.Track{TrackName: "x"}, "/music/x.flac"); err != nil {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+// scriptedDetector returns a scripted sequence of (result, error) pairs, one
+// per Detect call, so a test can drive a success-then-failure or repeated
+// failure sequence through the lane's ever-reached gate (#567).
+type scriptedDetector struct {
+	steps []scriptStep
+	i     int
+}
+
+type scriptStep struct {
+	res detector.Result
+	err error
+}
+
+func (s *scriptedDetector) Detect(_ context.Context, _ string) (detector.Result, error) {
+	step := s.steps[s.i]
+	if s.i < len(s.steps)-1 {
+		s.i++
+	}
+	return step.res, step.err
+}
+
+// notReadyErr mimics the detector's dial-failure wrap: the classifier could not
+// be reached at all.
+func notReadyErr() error {
+	return fmt.Errorf("detector classify: %w: dial tcp: connect: connection refused", detector.ErrClassifierNotReady)
+}
+
+// TestDetectorLane_FirstDialErrorIsNotReady: before the lane has ever reached
+// the sidecar, a dial failure is a startup race (ErrLaneNotReady), not an
+// outage, and does not trip the breaker.
+func TestDetectorLane_FirstDialErrorIsNotReady(t *testing.T) {
+	d := &scriptedDetector{steps: []scriptStep{{err: notReadyErr()}}}
+	br := circuit.New(time.Minute, time.Hour)
+	lane := NewDetectorLane(d, br, nil)
+
+	_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
+	if !errors.Is(err, ErrLaneNotReady) {
+		t.Fatalf("first dial error: got %v, want ErrLaneNotReady", err)
+	}
+	if errors.Is(err, ErrLaneOutage) {
+		t.Fatalf("a boot-race must not be an outage: %v", err)
+	}
+	if br.Trips() != 0 {
+		t.Fatalf("not-ready must not trip the breaker, got %d trips", br.Trips())
+	}
+}
+
+// TestDetectorLane_DialErrorAfterSuccessIsOutage: once the lane has reached the
+// sidecar, a later dial failure means the sidecar was up and then died - a
+// genuine outage.
+func TestDetectorLane_DialErrorAfterSuccessIsOutage(t *testing.T) {
+	d := &scriptedDetector{steps: []scriptStep{
+		{res: detector.Result{Instrumental: false, Version: "1.5.0"}}, // reaches sidecar
+		{err: notReadyErr()}, // now it died
+	}}
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
+
+	_, _ = lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")    // success
+	_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac") // died
+	if !errors.Is(err, ErrLaneOutage) {
+		t.Fatalf("dial error after a success: got %v, want ErrLaneOutage", err)
+	}
+	if errors.Is(err, ErrLaneNotReady) {
+		t.Fatalf("a post-success failure must not be not-ready: %v", err)
+	}
+}
+
+// TestDetectorLane_DeadFromBootEscalatesAfterBound: a sidecar never reachable
+// since boot is not a boot race - after notReadyBound not-ready results the lane
+// escalates to a genuine outage so the breaker trips and the lane stops
+// re-spending a provider call every cycle.
+func TestDetectorLane_DeadFromBootEscalatesAfterBound(t *testing.T) {
+	steps := make([]scriptStep, notReadyBound+1)
+	for i := range steps {
+		steps[i] = scriptStep{err: notReadyErr()}
+	}
+	d := &scriptedDetector{steps: steps}
+	lane := NewDetectorLane(d, circuit.New(time.Minute, time.Hour), nil)
+
+	for i := range notReadyBound {
+		_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
+		if !errors.Is(err, ErrLaneNotReady) {
+			t.Fatalf("call %d: got %v, want ErrLaneNotReady", i+1, err)
+		}
+	}
+	_, err := lane.FindLyrics(context.Background(), models.Track{}, "/music/x.flac")
+	if !errors.Is(err, ErrLaneOutage) {
+		t.Fatalf("after %d not-readies: got %v, want ErrLaneOutage", notReadyBound, err)
+	}
+}
+
+// TestDetectorClassifier_NotReadyDoesNotTrip: a not-ready (startup race) error
+// must leave the breaker CLOSED, so the next work cycle re-attempts the lane
+// once the sidecar is up, and must stay matchable as ErrLaneNotReady so the
+// worker classifies it as OutcomeLaneNotReady (#567).
+func TestDetectorClassifier_NotReadyDoesNotTrip(t *testing.T) {
+	br := circuit.New(time.Minute, time.Hour)
+	lane := NewDetectorLane(&stubDetector{}, br, nil)
+	notReady := fmt.Errorf("detector not ready: %w", errors.Join(ErrLaneNotReady, errors.New("connection refused")))
+
+	got := detectorClassifier(lane, notReady)
+
+	if br.Trips() != 0 {
+		t.Fatalf("not-ready must not trip the breaker, got %d trips", br.Trips())
+	}
+	if br.Allow() != circuit.StateClosed {
+		t.Fatalf("breaker must stay closed on not-ready, got %v", br.Allow())
+	}
+	if !errors.Is(got, ErrLaneNotReady) {
+		t.Fatalf("returned error must stay matchable as ErrLaneNotReady: %v", got)
+	}
+	if ClassifyOutcome(got) != OutcomeLaneNotReady {
+		t.Fatalf("classifier output must classify as OutcomeLaneNotReady, got %v", ClassifyOutcome(got))
+	}
+}
+
+// TestDetectorClassifier_OutageStillTrips guards that the not-ready carve-out
+// did not weaken the genuine-outage path.
+func TestDetectorClassifier_OutageStillTrips(t *testing.T) {
+	br := circuit.New(time.Minute, time.Hour)
+	lane := NewDetectorLane(&stubDetector{}, br, nil)
+	outage := fmt.Errorf("detector request failed: %w", errors.Join(ErrLaneOutage, errors.New("connection refused")))
+
+	_ = detectorClassifier(lane, outage)
+
+	if br.Trips() == 0 {
+		t.Fatal("a genuine outage must still trip the breaker")
 	}
 }
 

--- a/internal/orchestrator/errors.go
+++ b/internal/orchestrator/errors.go
@@ -25,6 +25,14 @@ var ErrLaneBenignMiss = errors.New("orchestrator: lane benign miss (no result)")
 // and it degrades to OutcomeUnavailable.
 var ErrLaneOutage = errors.New("orchestrator: lane outage")
 
+// ErrLaneNotReady is the sentinel a non-provider lane returns when its backend
+// could not be dialed at all AND the lane has never reached that backend since
+// this process booted -- a startup race, not a genuine outage. The worker
+// RELEASES the item back to pending with no miss increment and no cooldown, and
+// the breaker is NOT tripped, so the next work cycle re-attempts the lane once
+// the sidecar has finished booting (issue #567).
+var ErrLaneNotReady = errors.New("orchestrator: lane not ready (starting up)")
+
 // OutcomeClass classifies a lane's outcome for cross-lane precedence (design
 // doc Gap 4). The precedence rule is "least-certain-negative wins": any signal
 // that we did not truly learn the track is absent (auth, rate-limit, transport,
@@ -55,6 +63,13 @@ const (
 	// would otherwise become the surfaced error and let the worker downgrade a
 	// genuine provider failure to a benign miss, suppressing its backoff.
 	OutcomeLaneOutage
+	// OutcomeLaneNotReady means a non-provider lane could not dial its backend
+	// AND has never reached it since boot (ErrLaneNotReady): a startup race. It
+	// ranks identically to OutcomeLaneOutage (above a benign miss, BELOW a
+	// provider transport failure) so it can never mask a genuine provider
+	// failure, but the worker treats it as a penalty-free release rather than a
+	// deferral (#567).
+	OutcomeLaneNotReady
 	// OutcomeTransport means a retriable failure that is not a clean miss
 	// (timeout, connection failure, an unexpected error).
 	OutcomeTransport
@@ -89,6 +104,8 @@ func ClassifyOutcome(err error) OutcomeClass {
 	case musixmatch.IsBenignMiss(err), errors.Is(err, musixmatch.ErrTruncatedResponse),
 		errors.Is(err, ErrLaneBenignMiss):
 		return OutcomeBenignMiss
+	case errors.Is(err, ErrLaneNotReady):
+		return OutcomeLaneNotReady
 	case errors.Is(err, ErrLaneOutage):
 		return OutcomeLaneOutage
 	default:
@@ -107,6 +124,8 @@ func (c OutcomeClass) precedence() int {
 	case OutcomeBenignMiss:
 		return 1
 	case OutcomeLaneOutage:
+		return 2
+	case OutcomeLaneNotReady:
 		return 2
 	case OutcomeTransport:
 		return 3

--- a/internal/orchestrator/errors_test.go
+++ b/internal/orchestrator/errors_test.go
@@ -23,6 +23,7 @@ func TestClassifyOutcome(t *testing.T) {
 		{"no lyrics is benign miss", fmt.Errorf("x: %w", musixmatch.ErrNoLyrics), OutcomeBenignMiss},
 		{"truncated is benign miss", fmt.Errorf("x: %w", musixmatch.ErrTruncatedResponse), OutcomeBenignMiss},
 		{"generic error is transport", errors.New("connection refused"), OutcomeTransport},
+		{"lane not ready", fmt.Errorf("x: %w", ErrLaneNotReady), OutcomeLaneNotReady},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -62,6 +63,27 @@ func TestClassifyOutcome_LaneSentinels(t *testing.T) {
 	}
 	if got := ClassifyOutcome(ErrLaneOutage); got != OutcomeLaneOutage {
 		t.Errorf("outage sentinel = %v, want OutcomeLaneOutage", got)
+	}
+	if got := ClassifyOutcome(ErrLaneNotReady); got != OutcomeLaneNotReady {
+		t.Errorf("not-ready sentinel = %v, want OutcomeLaneNotReady", got)
+	}
+}
+
+// TestOutcomeLaneNotReady_RanksBelowTransport pins the same masking guard as the
+// outage case: a not-ready detector (startup race) must outrank a clean benign
+// miss but stay strictly below a provider transport failure, so it can never
+// become the surfaced error and downgrade a genuine provider failure (#567).
+func TestOutcomeLaneNotReady_RanksBelowTransport(t *testing.T) {
+	if OutcomeLaneNotReady.precedence() != 2 {
+		t.Fatalf("OutcomeLaneNotReady precedence = %d; want 2", OutcomeLaneNotReady.precedence())
+	}
+	if OutcomeLaneNotReady.precedence() >= OutcomeTransport.precedence() {
+		t.Fatalf("not-ready (%d) must rank below transport (%d)",
+			OutcomeLaneNotReady.precedence(), OutcomeTransport.precedence())
+	}
+	if OutcomeLaneNotReady.precedence() <= OutcomeBenignMiss.precedence() {
+		t.Fatalf("not-ready (%d) must rank above benign miss (%d)",
+			OutcomeLaneNotReady.precedence(), OutcomeBenignMiss.precedence())
 	}
 }
 

--- a/internal/orchestrator/resolve.go
+++ b/internal/orchestrator/resolve.go
@@ -103,6 +103,16 @@ func detectorClassifier(l *Lane, err error) error {
 			slog.Info("lane circuit closed; recovered", "lane", l.Name())
 		}
 		return err
+	case errors.Is(err, ErrLaneNotReady):
+		// Startup race: the sidecar is still booting. Do NOT trip the breaker, so
+		// the next work cycle re-attempts the lane once the sidecar is up. The
+		// worker releases the item penalty-free (no miss, no cooldown) (#567).
+		// (The default branch below would also leave the breaker closed, but this
+		// explicit case gives a distinct log and pins the intent against future
+		// edits to that branch.)
+		slog.Debug("detector lane not ready (sidecar starting up); leaving circuit closed",
+			"lane", l.Name(), "cause", err)
+		return err
 	case errors.Is(err, ErrLaneOutage):
 		res := l.breaker.Trip()
 		slog.Warn("lane circuit opened: detector outage; degrading to providers",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1043,6 +1043,27 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 				return fmt.Errorf("worker: release item %d after lanes unavailable: %w", item.ID, releaseErr)
 			}
 			return errLanesUnavailable
+		case orchestrator.OutcomeLaneNotReady:
+			// The detector sidecar is still booting (dial-refused, never reached
+			// this process). Release the item back to pending with no miss
+			// increment and no cooldown so the next work cycle re-attempts it once
+			// the sidecar is up. Deferring here would charge the track a miss
+			// (toward retirement) plus a multi-day cooldown for a pure boot race,
+			// and misreport an infrastructural race as a lyric outage (#567).
+			//
+			// Unlike OutcomeUnavailable (every lane's breaker open, so NO lane was
+			// consulted -> the whole drain pass idles), the providers WERE consulted
+			// here and returned a clean answer; only the detector could not run. So
+			// return nil to keep draining the rest of the queue rather than
+			// errLanesUnavailable, which wraps errIdle and would halt the pass on a
+			// single booting-detector item.
+			if releaseErr := w.queue.Release(context.WithoutCancel(ctx), item.ID); releaseErr != nil {
+				return fmt.Errorf("worker: release item %d after detector not ready: %w", item.ID, releaseErr)
+			}
+			// The providers gave a clean round-trip (a benign miss under the
+			// not-ready detector), so we are not in a failure backoff.
+			w.consecutiveFailures = 0
+			return nil
 		case orchestrator.OutcomeAuthRateLimit:
 			// A throttle / auth / renewal signal. The lane already tripped its
 			// breaker and emitted the honest classification log; the worker only

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -2168,6 +2168,57 @@ func TestRunOnceDetectorErrorTreatsAsMiss(t *testing.T) {
 	}
 }
 
+// TestRunOnceDetectorNotReadyReleasesWithoutDeferring verifies the #567 fix: a
+// detector dial failure before the lane has ever reached the sidecar (a startup
+// race) RELEASES the item back to pending -- no defer, no miss increment, no
+// cooldown -- rather than deferring it (which would charge the track a miss
+// toward retirement plus a multi-day cooldown for a pure boot race).
+func TestRunOnceDetectorNotReadyReleasesWithoutDeferring(t *testing.T) {
+	track := models.Track{ArtistName: "Singer", TrackName: "Song"}
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 210,
+		Inputs: models.Inputs{
+			Track:      track,
+			Outdir:     "out",
+			Filename:   "song.lrc",
+			SourcePath: "/music/song.flac",
+		},
+	}}}
+	c := &fakeCache{}
+	// Providers miss; the detector sidecar is unreachable (still booting): a
+	// dial failure wrapped in the not-ready sentinel, on a worker that has never
+	// reached the sidecar.
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	det := &fakeDetector{err: fmt.Errorf("detector classify: %w: dial tcp: connect: connection refused", detector.ErrClassifierNotReady)}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(det)
+	w.SetInstrumentalDetectionDefault(true)
+
+	// A not-ready detector releases the item and returns nil so the run loop
+	// keeps draining the rest of the queue -- it must NOT return errIdle (which
+	// errLanesUnavailable wraps), because that would halt the whole pass on a
+	// single booting-detector item even though the providers are healthy (#567).
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce = %v; want nil (penalty-free release, keep draining)", err)
+	}
+
+	// Released, NOT deferred / failed / retired.
+	if len(q.released) != 1 || q.released[0] != 210 {
+		t.Fatalf("released = %v; want [210]", q.released)
+	}
+	if len(q.deferred) != 0 {
+		t.Fatalf("deferred = %v; want none (a boot race must not defer)", q.deferred)
+	}
+	if len(q.failed) != 0 {
+		t.Fatalf("failed = %v; want none", q.failed)
+	}
+	if len(q.retired) != 0 {
+		t.Fatalf("retired = %v; want none", q.retired)
+	}
+}
+
 // TestRunOnceDetectorDisabledWhenNilSourcePath verifies that the detector is
 // skipped when the source path is empty (no audio file available for detection).
 func TestRunOnceDetectorDisabledWhenNilSourcePath(t *testing.T) {


### PR DESCRIPTION
## Summary

- On restart, the worker's first detector `/classify` races the sidecar's startup and gets `connection refused`. Previously this tripped the detector circuit **and deferred the work item** - and a deferral is not harmless: it increments the row's miss count (toward permanent `RetireMiss`) and applies the ~7-day miss cooldown. So a pure infrastructural boot race charged the track a miss and a multi-day stall, reported identically to a genuinely broken sidecar. (The issue's premise that "the row lands in deferred and retries, so nothing is lost" was incorrect - `requeueDeferred` is the miss/cooldown path.)
- Split a dial failure (`ErrClassifierNotReady`) from a reachable-but-non-2xx response (`ErrClassifierUnavailable`). An "ever-reached" gate on the detector lane routes a boot race to `ErrLaneNotReady` -> `OutcomeLaneNotReady` (precedence 2, so it can never mask a provider failure); the worker **releases** the item to pending penalty-free (no miss, no cooldown) and keeps draining. After the first success, or beyond `notReadyBound` (5) attempts, an unreachable sidecar is a genuine `ErrLaneOutage` that trips the breaker and is reported as an outage.
- The gate self-calibrates to real boot time on any hardware - no fixed startup sleep (which the issue explicitly rules out).

## Linked issue

Closes #567

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), via `/prep-pr`.
- [x] Code review pass complete; one important finding fixed before pushing (the not-ready path originally returned `errLanesUnavailable`, which wraps `errIdle` and would have halted the whole drain pass on a single booting-detector item - corrected to release-and-continue with `nil`).
- [x] Commits squashed into one before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT: serve-mode restart-race behavior is covered by unit tests (worker/orchestrator/detector), not a live run - the fix is provider/detector-lane logic with no amd64/GPU dependency.
- [ ] Screenshot - N/A (no web-UI change).
- [ ] `make ui` - N/A (no `.templ`/CSS change).
- [ ] Migration - N/A (no schema/data change).

## Test plan

- [x] `make gate` passes locally (gofmt, build, `go test -race` + coverage, patch coverage 94%, coverage-floor, golangci-lint, actionlint, govulncheck).
- [x] New tests confirmed failing against unfixed code before each fix (TDD):
  - `detector`: a dial error maps to `ErrClassifierNotReady`; a 500 stays `ErrClassifierUnavailable`.
  - `orchestrator`: `OutcomeLaneNotReady` at precedence 2, ranked below transport (no masking); first-dial-error -> not-ready; dial-after-success -> outage; dead-from-boot escalates to outage after exactly `notReadyBound`; breaker stays closed on not-ready, still trips on outage.
  - `worker`: a not-ready detector releases the item (no defer / miss / cooldown) and returns `nil` (keeps draining).
- [x] Patch coverage meets threshold (94.34%; the 3 uncovered lines are the `Release` error branch, mirroring the untested branch of the parallel `OutcomeUnavailable` case).
- [x] Surface: this changes the **serve-mode worker + orchestrator detector lane** error routing; verified by tracing the outcome switch and the run-loop `errIdle`/`nil` unwind.
- [ ] Reviewer follow-ups:
  - [ ] `notReadyBound = 5` is a proposed default (an attempt count, ~5 work-ticks of grace). Confirm the value.

## Not covered

- No live serve-mode restart test (the AC's "verified with the sidecar started after the main container" is exercised by the detector-stub sequence tests, not a real container start).
- `everReached` is process-lifetime sticky: a sidecar redeployed/restarted mid-run is treated as an outage (trip + defer), never re-granted boot-race grace. Deliberate and conservative; noted for awareness.
- No change to the detector's classification behavior, the `/classify` contract, or any provider lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when the classifier service is still starting or temporarily unreachable.
  - Distinguishes startup readiness issues from reachable services returning errors.
  - Retries startup-related failures without applying outage penalties or unnecessary backoff.
  - Returns work items to the pending queue without recording a miss when the classifier is not ready.
  - Preserves outage handling and breaker behavior for genuine service failures.
- **Tests**
  - Added coverage for classifier readiness, outage escalation, lane state transitions, and queue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->