### PR TITLE
feat(worker): memoize detector scores, re-decide deferred rows without re-inference (#582)

### DIFF
--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -132,6 +132,15 @@ type Result struct {
 	// construction time, sourced from the app version (internal/version). Empty
 	// when the detector was constructed without a version (e.g. in tests).
 	Version string
+	// Reusable reports whether this decision was made from a FULL classifier
+	// response (max map present AND the vocal baseline complete), so its scores are
+	// a faithful decision input that may be re-decided from storage later. It is
+	// false for a degraded response (legacy mean-only sidecar, or a partial max
+	// map) where the live path forces not-instrumental via the completeness guards:
+	// such scores (e.g. vocal_peak=0 for want of a max map, not want of vocals)
+	// would wrongly re-decide instrumental if the guards were dropped, so the memo
+	// path must not persist them as reusable telemetry (#582).
+	Reusable bool
 	// Classes is the per-class MEAN probability map from the classified sample,
 	// retained for debugging and observability.
 	Classes map[string]float64

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -61,6 +61,11 @@ func TestHTTPDetectorAboveThresholdIsInstrumental(t *testing.T) {
 	if res.Confidence < 0.90 {
 		t.Fatalf("Confidence = %.3f; want >= 0.90", res.Confidence)
 	}
+	// A healthy response (max map present, baseline complete) is a faithful
+	// decision that may be re-decided from stored scores later (#582).
+	if !res.Reusable {
+		t.Fatalf("Reusable = false; want true for a healthy full response")
+	}
 }
 
 func TestHTTPDetectorBelowThresholdIsMiss(t *testing.T) {
@@ -769,6 +774,13 @@ func TestDetectMissingMaxMapIsNotInstrumental(t *testing.T) {
 	if res.Instrumental {
 		t.Fatal("missing max map must degrade to NOT instrumental (safe)")
 	}
+	// A degraded response (no max map) must NOT be marked reusable: its scores are
+	// not a faithful decision input (vocal_peak is 0 for want of a max map, not for
+	// want of vocals), so re-deciding from them later could wrongly flip to
+	// instrumental (#582 hostile-review I1).
+	if res.Reusable {
+		t.Fatal("a no-max-map degraded response must have Reusable=false")
+	}
 }
 
 // A non-empty max map that DROPS a baseline vocal class (a class present in the
@@ -1339,5 +1351,40 @@ func TestDetectLogLineIncludesVocalClassAndVersion(t *testing.T) {
 	}
 	if !strings.Contains(logged, "detector_version=v9.9.9") {
 		t.Errorf("log line missing detector_version=v9.9.9; got: %s", logged)
+	}
+}
+
+func TestHTTPDetectorModelVersion(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	d, err := NewHTTPDetector(Config{ClassifierURL: "http://127.0.0.1:1/classify", FFmpegPath: ffmpegPath, Version: "v1.2.3"})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+	if got := d.ModelVersion(); got != "v1.2.3" {
+		t.Fatalf("ModelVersion = %q; want v1.2.3", got)
+	}
+}
+
+func TestHTTPDetectorDecideStored(t *testing.T) {
+	ffmpegPath := fakeFFmpeg(t)
+	// Scores: music clears 0.90, vocal peak 0.03, speech mean 0.01.
+	const musicSum, vocalPeak, speechMean = 0.95, 0.03, 0.01
+
+	// vocalMax 0.05 > 0.03 vocal peak -> gate passes -> instrumental.
+	lenient, err := NewHTTPDetector(Config{ClassifierURL: "http://127.0.0.1:1/classify", FFmpegPath: ffmpegPath, MinConfidence: 0.90, VocalMaxConfidence: 0.05})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector lenient: %v", err)
+	}
+	if !lenient.DecideStored(musicSum, vocalPeak, speechMean) {
+		t.Fatalf("DecideStored(lenient) = false; want true (vocal peak %.3f < 0.05)", vocalPeak)
+	}
+
+	// vocalMax 0.01 < 0.03 vocal peak -> gate fails -> not instrumental, same scores.
+	strict, err := NewHTTPDetector(Config{ClassifierURL: "http://127.0.0.1:1/classify", FFmpegPath: ffmpegPath, MinConfidence: 0.90, VocalMaxConfidence: 0.01})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector strict: %v", err)
+	}
+	if strict.DecideStored(musicSum, vocalPeak, speechMean) {
+		t.Fatalf("DecideStored(strict) = true; want false (vocal peak %.3f >= 0.01)", vocalPeak)
 	}
 }

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -319,7 +319,33 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 		WinningVocalClass: winningVocalClass,
 		Version:           d.version,
 		Classes:           resp.Mean,
+		// Reusable only when the response was complete: a degraded response
+		// (no/partial max map) forces not-instrumental above via the guards, and
+		// its scores must not be persisted as reusable telemetry (see Result.Reusable
+		// and #582 hostile-review I1).
+		Reusable: maxAvailable && baselineComplete,
 	}, nil
+}
+
+// ModelVersion returns the detector's configured version string (Config.Version,
+// sourced from the app version at construction). It keys score-cache validity:
+// stored telemetry is reusable only while its recorded detector_version matches
+// this. Empty when the detector was constructed without a version.
+func (d *HTTPDetector) ModelVersion() string {
+	return d.version
+}
+
+// DecideStored re-applies the detector's CURRENT three-gate thresholds to already
+// -computed scores, with no sidecar call. It shares the exact predicate the live
+// path uses (Instrumental), so a stored-score re-decision can never disagree with
+// a fresh inference at the same thresholds. The sidecar-completeness guards
+// (maxAvailable/baselineComplete) are deliberately omitted: they qualify a LIVE
+// classifier response, and stored scores were already accepted when first
+// computed. This lets a threshold recalibration re-decide deferred rows from
+// cached scores (issue #582), mirroring the calibration-sweep contract documented
+// on Instrumental.
+func (d *HTTPDetector) DecideStored(musicSum, vocalPeak, speechMean float64) bool {
+	return Instrumental(musicSum, vocalPeak, speechMean, d.minConfidence, d.vocalMaxConfidence, d.speechMaxConfidence)
 }
 
 // warnUnknownClassesOnce logs, at most once per detector, any configured

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -112,6 +112,19 @@ type WorkItem struct {
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
 	CompletedAt        *time.Time
+	// InstrumentalResult and the five Detector* fields carry the stored audio-
+	// detection outcome + telemetry (SetInstrumentalResult / StampUnclassifiedMiss)
+	// onto the dequeued item so the worker can re-decide a deferred row from cached
+	// scores without re-running YAMNet inference (#582). All are pointers: nil means
+	// the column is NULL (detection never ran for this row), distinct from a real
+	// 0 result or 0.0 score. detector_version keys cache validity - a stored score
+	// is reusable only while it matches the current detector model version.
+	InstrumentalResult *int
+	DetectorMusicSum   *float64
+	DetectorVocalPeak  *float64
+	DetectorSpeechMean *float64
+	DetectorVocalClass *string
+	DetectorVersion    *string
 }
 
 // DBQueue is a SQLite-backed queue for durable lyrics work.
@@ -276,7 +289,7 @@ func (q *DBQueue) Enqueue(ctx context.Context, inputs models.Inputs, priority in
                  ELSE NULL
              END
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`,
 		inputs.Track.ArtistName,
 		inputs.Track.TrackName,
 		inputs.Track.AlbumName,
@@ -344,7 +357,7 @@ const dequeueRandomizedSQL = `UPDATE work_queue
              LIMIT 1
          )
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`
 
 // dequeueDeterministicSQL claims the next ready item in stable FIFO order within
 // a priority tier (created_at, then id).
@@ -360,7 +373,7 @@ const dequeueDeterministicSQL = `UPDATE work_queue
              LIMIT 1
          )
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`
 
 // dequeueBatchedClaimSQL claims the eligible buffered row with the lowest
 // batch_seq and clears its batch_seq in the same atomic statement, so a claimed
@@ -385,7 +398,7 @@ const dequeueBatchedClaimSQL = `UPDATE work_queue
              LIMIT 1
          )
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`
 
 // refillBufferSQL stamps batch_seq = offset + 1 .. offset + N on the next N
 // eligible unbuffered rows, randomizing composition and intra-tier order while
@@ -879,7 +892,7 @@ func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, er
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`,
 		nextAttempts,
 		nextAttemptAt,
 		lastError,
@@ -946,7 +959,7 @@ func (q *DBQueue) Defer(ctx context.Context, id int64, retryAfter time.Duration,
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`,
 		nextAttemptAt,
 		lastError,
 		id,
@@ -998,7 +1011,7 @@ func (q *DBQueue) RetireMiss(ctx context.Context, id int64) (WorkItem, error) {
          WHERE id = ?
            AND status = 'processing'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`,
 		now,
 		missLimitReachedError,
 		id,
@@ -1240,7 +1253,7 @@ type ListFilter struct {
 // optionally filtered by status and capped by limit.
 func (q *DBQueue) List(ctx context.Context, filter ListFilter) (items []WorkItem, retErr error) {
 	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
                        FROM work_queue`
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	const limitClause = ` LIMIT ?`
@@ -1305,7 +1318,7 @@ func (q *DBQueue) Retry(ctx context.Context, id int64) (WorkItem, error) {
          WHERE id = ?
            AND status = 'failed'
          RETURNING id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id`,
+                   miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version`,
 		now,
 		id,
 	)
@@ -1891,7 +1904,7 @@ func detectEligibleClause(globalDefault bool) (clause string, args []any) {
 // detector). Read-only.
 func (q *DBQueue) ListUnclassified(ctx context.Context, opts ListUnclassifiedOptions) (items []WorkItem, retErr error) {
 	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
                        FROM work_queue
                        WHERE instrumental_result IS NULL
                          AND status = 'deferred'
@@ -1971,7 +1984,7 @@ func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOpt
 	// instrumental_result = 1 just before Complete, so a still-'processing' row could
 	// otherwise be picked up and cleared mid-write.
 	const baseQuery = `SELECT id, artist, title, album, album_artist, outdir, filename, source_path, status, priority, attempts,
-                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id
+                       miss_count, providers_version, detect_instrumental, next_attempt_at, last_error, created_at, updated_at, completed_at, output_paths, scan_result_id, instrumental_result, music_sum, vocal_peak, speech_mean, vocal_class, detector_version
                        FROM work_queue WHERE instrumental_result = 1 AND status = 'done'`
 	const orderClause = ` ORDER BY priority DESC, created_at ASC, id ASC`
 	query := baseQuery
@@ -2539,6 +2552,14 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 	var completedAt sql.NullString
 	var scanResultID sql.NullInt64
 	var detectInstrumental sql.NullBool
+	var (
+		instrumentalResult sql.NullInt64
+		musicSum           sql.NullFloat64
+		vocalPeak          sql.NullFloat64
+		speechMean         sql.NullFloat64
+		vocalClass         sql.NullString
+		detectorVersion    sql.NullString
+	)
 	err := row.Scan(
 		&item.ID,
 		&item.Inputs.Track.ArtistName,
@@ -2561,6 +2582,12 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 		&completedAt,
 		&outputPaths,
 		&scanResultID,
+		&instrumentalResult,
+		&musicSum,
+		&vocalPeak,
+		&speechMean,
+		&vocalClass,
+		&detectorVersion,
 	)
 	if err != nil {
 		return WorkItem{}, err
@@ -2571,6 +2598,34 @@ func scanWorkItem(row rowScanner) (WorkItem, error) {
 	if detectInstrumental.Valid {
 		b := detectInstrumental.Bool
 		item.DetectInstrumental = &b
+	}
+	// Carry the stored detector telemetry only when present. Each column is
+	// independently nullable, but SetInstrumentalResult / StampUnclassifiedMiss
+	// always write instrumental_result together with the five score columns, so
+	// in practice they are all present or all NULL (#582).
+	if instrumentalResult.Valid {
+		v := int(instrumentalResult.Int64)
+		item.InstrumentalResult = &v
+	}
+	if musicSum.Valid {
+		v := musicSum.Float64
+		item.DetectorMusicSum = &v
+	}
+	if vocalPeak.Valid {
+		v := vocalPeak.Float64
+		item.DetectorVocalPeak = &v
+	}
+	if speechMean.Valid {
+		v := speechMean.Float64
+		item.DetectorSpeechMean = &v
+	}
+	if vocalClass.Valid {
+		v := vocalClass.String
+		item.DetectorVocalClass = &v
+	}
+	if detectorVersion.Valid {
+		v := detectorVersion.String
+		item.DetectorVersion = &v
 	}
 	item.NextAttemptAt, err = parseTime(nextAttemptAt)
 	if err != nil {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3401,6 +3401,86 @@ func TestDBQueue_SetInstrumentalResultNullTelemetryWhenNotRun(t *testing.T) {
 	}
 }
 
+// TestDequeueCarriesTelemetry verifies that a dequeued WorkItem carries the
+// stored instrumental_result + detector telemetry when a prior detection stamped
+// it, and leaves those fields nil when no detection ran. This is the read path
+// the worker uses to re-decide a deferred row from cached scores without
+// re-inference (#582).
+func TestDequeueCarriesTelemetry(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	// Row A: stamp not-instrumental telemetry, defer it, then re-dequeue.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Vocalist", TrackName: "Ballad"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue A: %v", err)
+	}
+	itemA, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue A: %v", err)
+	}
+	tel := InstrumentalTelemetry{MusicSum: 0.42, VocalPeak: 0.71, SpeechMean: 0.06, VocalClass: "Singing", DetectorVersion: "v9.9.9"}
+	if err := q.SetInstrumentalResult(ctx, itemA.ID, 0, tel); err != nil {
+		t.Fatalf("SetInstrumentalResult A: %v", err)
+	}
+	if _, err := q.Defer(ctx, itemA.ID, time.Hour, nil); err != nil {
+		t.Fatalf("Defer A: %v", err)
+	}
+	// Advance past the deferral so the row is dequeueable again.
+	now = now.Add(2 * time.Hour)
+
+	// Row B: never detected; its telemetry fields must dequeue nil.
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "Composer", TrackName: "Opus"}}, PriorityScan); err != nil {
+		t.Fatalf("Enqueue B: %v", err)
+	}
+
+	// Re-dequeue A (deferred, now eligible) and dequeue B (pending). Deferred
+	// priority (-100) sorts below pending, so B comes first.
+	first, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue first: %v", err)
+	}
+	second, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue second: %v", err)
+	}
+	got := map[int64]WorkItem{first.ID: first, second.ID: second}
+
+	reA := got[itemA.ID]
+	if reA.InstrumentalResult == nil || *reA.InstrumentalResult != 0 {
+		t.Fatalf("A InstrumentalResult = %v; want *0", reA.InstrumentalResult)
+	}
+	if reA.DetectorMusicSum == nil || *reA.DetectorMusicSum != tel.MusicSum {
+		t.Errorf("A DetectorMusicSum = %v; want *%v", reA.DetectorMusicSum, tel.MusicSum)
+	}
+	if reA.DetectorVocalPeak == nil || *reA.DetectorVocalPeak != tel.VocalPeak {
+		t.Errorf("A DetectorVocalPeak = %v; want *%v", reA.DetectorVocalPeak, tel.VocalPeak)
+	}
+	if reA.DetectorSpeechMean == nil || *reA.DetectorSpeechMean != tel.SpeechMean {
+		t.Errorf("A DetectorSpeechMean = %v; want *%v", reA.DetectorSpeechMean, tel.SpeechMean)
+	}
+	if reA.DetectorVocalClass == nil || *reA.DetectorVocalClass != tel.VocalClass {
+		t.Errorf("A DetectorVocalClass = %v; want *%q", reA.DetectorVocalClass, tel.VocalClass)
+	}
+	if reA.DetectorVersion == nil || *reA.DetectorVersion != tel.DetectorVersion {
+		t.Errorf("A DetectorVersion = %v; want *%q", reA.DetectorVersion, tel.DetectorVersion)
+	}
+
+	// Row B is whichever dequeued item is not A.
+	var reB WorkItem
+	for id, it := range got {
+		if id != itemA.ID {
+			reB = it
+		}
+	}
+	if reB.InstrumentalResult != nil || reB.DetectorMusicSum != nil || reB.DetectorVocalPeak != nil ||
+		reB.DetectorSpeechMean != nil || reB.DetectorVocalClass != nil || reB.DetectorVersion != nil {
+		t.Errorf("B telemetry = %+v; want all nil (no detection ran)", reB)
+	}
+}
+
 // TestDBQueue_SetProviderLane verifies SetProviderLane persists the winning lane
 // on a work_queue row and that empty lane is a no-op.
 func TestDBQueue_SetProviderLane(t *testing.T) {

--- a/internal/worker/memo_detector.go
+++ b/internal/worker/memo_detector.go
@@ -1,0 +1,131 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/sydlexius/canticle/internal/detector"
+)
+
+// storedTelemetry is one work_queue row's cached detector scores, primed onto the
+// memoDetector before that item is dispatched. A nil *storedTelemetry means the
+// row has no prior detection, so the memo must run live inference.
+type storedTelemetry struct {
+	Version    string
+	MusicSum   float64
+	VocalPeak  float64
+	SpeechMean float64
+	VocalClass string
+}
+
+// storedDecider is a detector.Detector that can also re-decide already-computed
+// scores against its current thresholds and report its model version. HTTPDetector
+// satisfies it (ModelVersion + DecideStored). A plain detector.Detector that does
+// not implement this can never be memoized, so the memo always infers for it.
+type storedDecider interface {
+	detector.Detector
+	ModelVersion() string
+	DecideStored(musicSum, vocalPeak, speechMean float64) bool
+}
+
+// memoDetector wraps a detector.Detector and, when the wrapped detector can
+// re-decide stored scores, skips the sidecar call for a row whose telemetry was
+// primed and whose stored detector_version still matches the current model
+// version. It re-applies the current three-gate decision to the cached scores
+// instead, so a threshold recalibration re-decides deferred rows with no
+// re-inference (#582). Inference re-runs only when there is no stored result, the
+// model version changed, or the wrapped detector cannot re-decide.
+//
+// It is NOT safe for concurrent use: prime and Detect must be called from the
+// single worker goroutine, one work item at a time, which is the worker's
+// contract. The last-inference state exists so the worker can tell a live run
+// (whose not-instrumental telemetry it must persist) from a cache reuse (already
+// persisted).
+type memoDetector struct {
+	inner   detector.Detector
+	decider storedDecider // non-nil iff inner implements storedDecider
+	primed  *storedTelemetry
+
+	last         detector.Result
+	ranInference bool
+}
+
+// newMemoDetector wraps inner. If inner implements storedDecider, the memo can
+// reuse stored scores; otherwise every Detect delegates to inner.
+func newMemoDetector(inner detector.Detector) *memoDetector {
+	m := &memoDetector{inner: inner}
+	if d, ok := inner.(storedDecider); ok {
+		m.decider = d
+	}
+	return m
+}
+
+// prime sets the stored telemetry for the next Detect call and RESETS the
+// last-inference state. Pass nil when the current item has no prior detection.
+// The worker calls this before every item.
+//
+// The reset is load-bearing: Detect is NOT invoked on every item (the detector
+// lane short-circuits before it when detection is disabled for the item, the
+// source path is empty, or the breaker is open), yet the worker reads
+// lastInference in the miss branch on every pass. Without clearing here, a prior
+// item's live not-instrumental result would survive into an item that never ran
+// Detect and be stamped onto THAT row (cross-item score leak). Resetting to the
+// zero value makes lastInference report ran=false until this item actually runs
+// live inference, so the stamp is skipped for a skipped detection.
+func (m *memoDetector) prime(p *storedTelemetry) {
+	m.primed = p
+	m.last = detector.Result{}
+	m.ranInference = false
+}
+
+// Detect reuses the primed stored scores when they are still valid, otherwise
+// runs live inference on inner. It records the returned result and whether it
+// came from live inference, readable via lastInference.
+func (m *memoDetector) Detect(ctx context.Context, audioPath string) (detector.Result, error) {
+	if m.canReuse() {
+		res := detector.Result{
+			Instrumental:      m.decider.DecideStored(m.primed.MusicSum, m.primed.VocalPeak, m.primed.SpeechMean),
+			Confidence:        m.primed.MusicSum,
+			VocalConfidence:   m.primed.VocalPeak,
+			SpeechConfidence:  m.primed.SpeechMean,
+			WinningVocalClass: m.primed.VocalClass,
+			Version:           m.primed.Version,
+		}
+		m.last = res
+		m.ranInference = false
+		return res, nil
+	}
+	res, err := m.inner.Detect(ctx, audioPath)
+	if err != nil {
+		// A failed live inference stamps no result (the worker's ErrLaneOutage
+		// path re-runs next pass); clear last so a stale prior result is not
+		// mistaken for this pass's outcome.
+		m.last = detector.Result{}
+		m.ranInference = true
+		return detector.Result{}, err
+	}
+	m.last = res
+	m.ranInference = true
+	return res, nil
+}
+
+// canReuse reports whether the primed telemetry can re-decide this item without a
+// sidecar call: the wrapped detector must support re-decision, telemetry must be
+// primed, its version must be non-empty, and it must match the current model
+// version. An empty version can never key cache validity, so it always infers.
+func (m *memoDetector) canReuse() bool {
+	if m.decider == nil || m.primed == nil {
+		return false
+	}
+	if m.primed.Version == "" {
+		return false
+	}
+	return m.primed.Version == m.decider.ModelVersion()
+}
+
+// lastInference returns the result of the most recent Detect and whether it came
+// from live inference (true) rather than a stored-score reuse (false). The worker
+// uses ranInference to persist not-instrumental telemetry only on a first, live
+// detection, never on a reuse pass.
+func (m *memoDetector) lastInference() (detector.Result, bool) {
+	return m.last, m.ranInference
+}

--- a/internal/worker/memo_detector_test.go
+++ b/internal/worker/memo_detector_test.go
@@ -1,0 +1,189 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/detector"
+)
+
+// fakeStoredDecider is a test detector that implements storedDecider: it counts
+// Detect calls, reports a fixed model version, and re-decides stored scores via a
+// swappable decide func so a test can simulate a threshold recalibration without
+// a new inference.
+type fakeStoredDecider struct {
+	version   string
+	detectRes detector.Result
+	detectErr error
+	detectN   int
+	decideFn  func(musicSum, vocalPeak, speechMean float64) bool
+}
+
+func (f *fakeStoredDecider) Detect(_ context.Context, _ string) (detector.Result, error) {
+	f.detectN++
+	if f.detectErr != nil {
+		return detector.Result{}, f.detectErr
+	}
+	return f.detectRes, nil
+}
+
+func (f *fakeStoredDecider) ModelVersion() string { return f.version }
+
+func (f *fakeStoredDecider) DecideStored(musicSum, vocalPeak, speechMean float64) bool {
+	if f.decideFn != nil {
+		return f.decideFn(musicSum, vocalPeak, speechMean)
+	}
+	return false
+}
+
+// plainDetector implements only detector.Detector (not storedDecider), so the
+// memo can never reuse and must always infer.
+type plainDetector struct{ detectN int }
+
+func (p *plainDetector) Detect(_ context.Context, _ string) (detector.Result, error) {
+	p.detectN++
+	return detector.Result{Instrumental: true, Version: "v1"}, nil
+}
+
+func telemetryV1() *storedTelemetry {
+	return &storedTelemetry{Version: "v1", MusicSum: 0.9, VocalPeak: 0.02, SpeechMean: 0.01, VocalClass: "Singing"}
+}
+
+func TestMemoDetectorReusesStoredScoresOnVersionMatch(t *testing.T) {
+	inner := &fakeStoredDecider{version: "v1", decideFn: func(_, _, _ float64) bool { return true }}
+	m := newMemoDetector(inner)
+	m.prime(telemetryV1())
+
+	res, err := m.Detect(context.Background(), "/music/a.flac")
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 0 {
+		t.Fatalf("inner Detect called %d times; want 0 (reuse)", inner.detectN)
+	}
+	if !res.Instrumental {
+		t.Errorf("Instrumental = false; want true (DecideStored)")
+	}
+	if res.Confidence != 0.9 || res.VocalConfidence != 0.02 || res.SpeechConfidence != 0.01 {
+		t.Errorf("reconstructed scores = %+v; want stored telemetry", res)
+	}
+	if res.Version != "v1" {
+		t.Errorf("Version = %q; want v1", res.Version)
+	}
+	last, ran := m.lastInference()
+	if ran {
+		t.Errorf("lastInference ran = true; want false (reuse)")
+	}
+	if !last.Instrumental {
+		t.Errorf("lastInference result not carried")
+	}
+}
+
+func TestMemoDetectorInfersOnVersionMismatch(t *testing.T) {
+	inner := &fakeStoredDecider{version: "v2", detectRes: detector.Result{Instrumental: false, Version: "v2"}}
+	m := newMemoDetector(inner)
+	m.prime(telemetryV1()) // stored under old version
+
+	if _, err := m.Detect(context.Background(), "/music/a.flac"); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("inner Detect called %d times; want 1 (model changed)", inner.detectN)
+	}
+	_, ran := m.lastInference()
+	if !ran {
+		t.Errorf("lastInference ran = false; want true (fresh inference)")
+	}
+}
+
+func TestMemoDetectorInfersWhenNotPrimed(t *testing.T) {
+	inner := &fakeStoredDecider{version: "v1", detectRes: detector.Result{Instrumental: true, Version: "v1"}}
+	m := newMemoDetector(inner)
+	m.prime(nil)
+
+	if _, err := m.Detect(context.Background(), "/music/a.flac"); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("inner Detect called %d times; want 1 (no stored telemetry)", inner.detectN)
+	}
+}
+
+func TestMemoDetectorReuseFollowsRecalibratedThreshold(t *testing.T) {
+	// Same stored scores, same version, but DecideStored now returns true
+	// (simulating a threshold recalibration). The verdict must flip with NO new
+	// inference.
+	inner := &fakeStoredDecider{version: "v1", decideFn: func(_, _, _ float64) bool { return true }}
+	m := newMemoDetector(inner)
+	m.prime(telemetryV1())
+
+	res, err := m.Detect(context.Background(), "/music/a.flac")
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 0 {
+		t.Fatalf("inner Detect called %d times; want 0", inner.detectN)
+	}
+	if !res.Instrumental {
+		t.Errorf("Instrumental = false; want true after recalibration")
+	}
+}
+
+func TestMemoDetectorAlwaysInfersWithoutStoredDecider(t *testing.T) {
+	inner := &plainDetector{}
+	m := newMemoDetector(inner)
+	m.prime(telemetryV1())
+
+	if _, err := m.Detect(context.Background(), "/music/a.flac"); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("inner Detect called %d times; want 1 (inner is not a storedDecider)", inner.detectN)
+	}
+}
+
+func TestMemoDetectorEmptyVersionNeverReuses(t *testing.T) {
+	// A detector with no model version cannot key cache validity, so it must
+	// always infer even when primed.
+	inner := &fakeStoredDecider{version: "", detectRes: detector.Result{Instrumental: true}}
+	m := newMemoDetector(inner)
+	m.prime(&storedTelemetry{Version: "", MusicSum: 0.9})
+
+	if _, err := m.Detect(context.Background(), "/music/a.flac"); err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("inner Detect called %d times; want 1 (empty version never reuses)", inner.detectN)
+	}
+}
+
+func TestMemoDetectorPrimeResetsStaleState(t *testing.T) {
+	// After a live inference on item A, priming for item B must clear the stale
+	// last-inference state: if B never calls Detect (detection skipped), the memo
+	// must NOT report A's result as B's. Guards against a cross-item score leak
+	// where B's row is stamped with A's telemetry (#582 hostile-review C1).
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.40, VocalConfidence: 0.72},
+	}
+	m := newMemoDetector(inner)
+
+	// Item A: live inference.
+	m.prime(nil)
+	if _, err := m.Detect(context.Background(), "/music/a.flac"); err != nil {
+		t.Fatalf("Detect A: %v", err)
+	}
+	if _, ran := m.lastInference(); !ran {
+		t.Fatalf("after A: ran = false; want true")
+	}
+
+	// Item B: prime (detection will be skipped, no Detect call).
+	m.prime(nil)
+	res, ran := m.lastInference()
+	if ran {
+		t.Errorf("after priming B: ran = true; want false (A's state must be cleared)")
+	}
+	if res.Version != "" || res.Confidence != 0 {
+		t.Errorf("after priming B: stale result leaked: %+v; want zero", res)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -172,6 +172,13 @@ type Worker struct {
 	// from it are non-fatal (the miss path continues normally). Set via
 	// EnableAudioDetector.
 	audioDetector detector.Detector
+	// detectorMemo is the typed handle on the memoizing wrapper installed around
+	// audioDetector by EnableAudioDetector (audioDetector points at the same
+	// object). It is how RunOnce primes each item's stored scores before dispatch
+	// and reads back whether the last detection ran live inference. nil when no
+	// detector is configured. Single-goroutine worker contract makes the memo's
+	// per-item prime/last state safe (one item processed at a time). (#582)
+	detectorMemo *memoDetector
 	// detectInstrumentalDefault is the global config default for instrumental
 	// detection, used to resolve work items whose per-item decision is nil (NULL in
 	// the DB, e.g. pre-existing rows). Set via SetInstrumentalDetectionDefault.
@@ -632,7 +639,18 @@ func (w *Worker) EnableVerification(verifier verification.Verifier, belowConfide
 // The confidence threshold is owned by the detector itself (see NewHTTPDetector),
 // so the worker keeps no copy of it.
 func (w *Worker) EnableAudioDetector(d detector.Detector) {
-	w.audioDetector = d
+	if d == nil {
+		w.audioDetector = nil
+		w.detectorMemo = nil
+		_ = w.rebuildOrchestrator()
+		return
+	}
+	// Wrap in the memoizing decorator so the detector lane reuses stored scores
+	// instead of re-running YAMNet on every deferred pass (#582). audioDetector
+	// and detectorMemo point at the SAME object: the lane sees it through the
+	// detector.Detector interface, RunOnce drives it through the typed handle.
+	w.detectorMemo = newMemoDetector(d)
+	w.audioDetector = w.detectorMemo
 	// Rebuild so a detector configured after New (the common case: the config
 	// layer wires it in after construction) inserts the detector lane. The mode
 	// is unchanged (and already valid) and the primary lane is always present,
@@ -1029,6 +1047,11 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	// miss, so a disabled item cleanly skips the detector. Provider lanes never
 	// consult sourcePath, so this substitution has no effect on them.
 	detectorPath := w.detectorPathFor(item)
+	// Prime the memoizing detector with this row's stored scores so the detector
+	// lane can re-decide from them instead of re-running YAMNet, when the stored
+	// detector_version still matches the current model version. Cleared (nil) for
+	// a row with no prior detection so it runs live inference. (#582)
+	w.primeDetectorMemo(item)
 	song, cacheHit, err := w.song(ctx, resolvedTrack, detectorPath, bypassCache)
 	if err == nil {
 		w.lastItemContactedProvider = contactedProvider(song)
@@ -1128,6 +1151,15 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// nothing further to detect; this branch owns only the miss-counter and
 			// defer/requeue duties.
 			w.recordLaneAttempts(context.WithoutCancel(ctx), item.ID, song.LaneAttempts)
+			// Persist the not-instrumental detector telemetry on the FIRST live
+			// detection so later deferred passes can re-decide from the stored scores
+			// instead of re-running YAMNet (#582). Only when the detector actually ran
+			// inference this pass (a reuse pass already has the scores stored) and
+			// returned a not-instrumental verdict carrying a model version. Stamped
+			// while the row is still 'processing' (SetInstrumentalResult is not status-
+			// guarded), mirroring the positive path's stamp-before-complete. Non-fatal:
+			// a failed stamp only costs a re-inference next pass, never correctness.
+			w.stampDetectorMissTelemetry(context.WithoutCancel(ctx), item.ID)
 			if derr := w.requeueDeferred(ctx, item, err); derr != nil {
 				return derr
 			}
@@ -1353,6 +1385,67 @@ func (w *Worker) refreshRecordingIdentity(item queue.WorkItem, track models.Trac
 		track.AlbumName = meta.AlbumName
 	}
 	return track
+}
+
+// primeDetectorMemo hands the memoizing detector this row's stored scores so the
+// detector lane can re-decide from them without re-running inference, when the
+// stored detector_version still matches the current model version. A row missing
+// either instrumental_result or detector_version has no reusable prior detection,
+// so the memo is primed nil and runs live inference. No-op when no detector is
+// configured. (#582)
+func (w *Worker) primeDetectorMemo(item queue.WorkItem) {
+	if w.detectorMemo == nil {
+		return
+	}
+	if item.InstrumentalResult == nil || item.DetectorVersion == nil {
+		w.detectorMemo.prime(nil)
+		return
+	}
+	tel := &storedTelemetry{Version: *item.DetectorVersion}
+	if item.DetectorMusicSum != nil {
+		tel.MusicSum = *item.DetectorMusicSum
+	}
+	if item.DetectorVocalPeak != nil {
+		tel.VocalPeak = *item.DetectorVocalPeak
+	}
+	if item.DetectorSpeechMean != nil {
+		tel.SpeechMean = *item.DetectorSpeechMean
+	}
+	if item.DetectorVocalClass != nil {
+		tel.VocalClass = *item.DetectorVocalClass
+	}
+	w.detectorMemo.prime(tel)
+}
+
+// stampDetectorMissTelemetry persists a not-instrumental detector verdict on the
+// current row so later deferred passes re-decide from the stored scores instead
+// of re-running YAMNet (#582). It writes only when the detector ran LIVE inference
+// this pass (a reuse pass already has the telemetry stored) and returned a not-
+// instrumental result carrying a model version. Non-fatal: a failed stamp only
+// costs a re-inference next pass. No-op when no detector is configured.
+func (w *Worker) stampDetectorMissTelemetry(ctxNoCancel context.Context, id int64) {
+	if w.detectorMemo == nil {
+		return
+	}
+	res, ran := w.detectorMemo.lastInference()
+	// Skip a stamp unless the detector ran live inference this pass, returned a
+	// not-instrumental verdict carrying a model version, AND the response was a
+	// full one (Reusable): a degraded response's scores would wrongly re-decide
+	// instrumental on a later reuse pass, so they must not be stored as reusable
+	// telemetry (#582).
+	if !ran || res.Instrumental || res.Version == "" || !res.Reusable {
+		return
+	}
+	tel := queue.InstrumentalTelemetry{
+		MusicSum:        res.Confidence,
+		VocalPeak:       res.VocalConfidence,
+		SpeechMean:      res.SpeechConfidence,
+		VocalClass:      res.WinningVocalClass,
+		DetectorVersion: res.Version,
+	}
+	if err := w.queue.SetInstrumentalResult(ctxNoCancel, id, 0, tel); err != nil {
+		slog.Warn("worker: stamp not-instrumental telemetry failed; will re-infer next pass", "id", id, "error", err)
+	}
 }
 
 // stampDetectorInstrumental records a detector-sourced instrumental settle from

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3271,3 +3271,275 @@ func TestAllLanesUnavailableIgnoresDetectorUnderParallelMode(t *testing.T) {
 		t.Fatal("under parallel mode the gate must ignore the detector and idle on open provider breakers")
 	}
 }
+
+// buildRedequeuedItem returns the work item as it would re-dequeue after a
+// not-instrumental stamp: carrying the stored telemetry that primeDetectorMemo
+// reads. It mirrors what scanWorkItem now populates on a deferred row (#582).
+func buildRedequeuedItem(base queue.WorkItem, st instrumentalStamp) queue.WorkItem {
+	res := st.Result
+	base.InstrumentalResult = &res
+	base.DetectorMusicSum = &st.Tel.MusicSum
+	base.DetectorVocalPeak = &st.Tel.VocalPeak
+	base.DetectorSpeechMean = &st.Tel.SpeechMean
+	base.DetectorVocalClass = &st.Tel.VocalClass
+	base.DetectorVersion = &st.Tel.DetectorVersion
+	return base
+}
+
+// TestRunOnceDetectorMemoScoresDeferredRowOnce verifies that a not-instrumental
+// deferred row is scored by YAMNet exactly once: pass 1 runs live inference and
+// stamps instrumental_result=0 + telemetry; pass 2 re-decides from the stored
+// scores with no second inference (#582).
+func TestRunOnceDetectorMemoScoresDeferredRowOnce(t *testing.T) {
+	base := queue.WorkItem{
+		ID: 300,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Vocalist", TrackName: "Ballad"},
+			Outdir:     "out",
+			Filename:   "ballad.lrc",
+			SourcePath: "/music/ballad.flac",
+		},
+	}
+	q := &fakeQueue{items: []queue.WorkItem{base}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	// A not-instrumental live result carrying a model version and scores.
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.40, VocalConfidence: 0.72, SpeechConfidence: 0.05, WinningVocalClass: "Singing", Reusable: true},
+	}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(inner)
+	w.SetInstrumentalDetectionDefault(true)
+
+	// Pass 1: live inference, stamp result=0.
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 1: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("after pass 1: detectN = %d; want 1 (first live inference)", inner.detectN)
+	}
+	if len(q.deferred) != 1 || q.deferred[0] != 300 {
+		t.Fatalf("after pass 1: deferred = %v; want [300]", q.deferred)
+	}
+	if len(q.instrumentalStamps) != 1 {
+		t.Fatalf("after pass 1: instrumentalStamps = %d; want 1 (not-instrumental telemetry stamped)", len(q.instrumentalStamps))
+	}
+	st := q.instrumentalStamps[0]
+	if st.Result != 0 || st.Tel.DetectorVersion != "v1" || st.Tel.MusicSum != 0.40 || st.Tel.VocalPeak != 0.72 {
+		t.Fatalf("after pass 1: stamp = %+v; want result 0 + v1 telemetry", st)
+	}
+
+	// Pass 2: re-enqueue the row carrying the stamped telemetry; must NOT re-infer.
+	q.items = append(q.items, buildRedequeuedItem(base, st))
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 2: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("after pass 2: detectN = %d; want 1 (stored scores reused, no re-inference)", inner.detectN)
+	}
+	if len(q.deferred) != 2 {
+		t.Fatalf("after pass 2: deferred = %v; want two deferrals", q.deferred)
+	}
+}
+
+// TestRunOnceDetectorMemoReinfersOnModelVersionBump verifies that a detector
+// model-version change forces re-inference even when stored scores exist (#582).
+func TestRunOnceDetectorMemoReinfersOnModelVersionBump(t *testing.T) {
+	base := queue.WorkItem{
+		ID: 301,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Vocalist", TrackName: "Anthem"},
+			Outdir:     "out",
+			Filename:   "anthem.lrc",
+			SourcePath: "/music/anthem.flac",
+		},
+	}
+	q := &fakeQueue{items: []queue.WorkItem{base}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.30, VocalConfidence: 0.80, SpeechConfidence: 0.04, WinningVocalClass: "Singing", Reusable: true},
+	}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(inner)
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 1: %v", err)
+	}
+	st := q.instrumentalStamps[0]
+
+	// Bump the model version; the stored scores were computed under v1.
+	inner.version = "v2"
+	inner.detectRes.Version = "v2"
+
+	q.items = append(q.items, buildRedequeuedItem(base, st))
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 2: %v", err)
+	}
+	if inner.detectN != 2 {
+		t.Fatalf("detectN = %d; want 2 (model version changed -> re-inference)", inner.detectN)
+	}
+}
+
+// TestRunOnceDetectorMemoRecalibrationReDecidesFromStoredScores verifies that a
+// threshold recalibration (same model version) re-decides a stored not-
+// instrumental row as instrumental from the cached scores, with NO re-inference,
+// settling it done (#582).
+func TestRunOnceDetectorMemoRecalibrationReDecidesFromStoredScores(t *testing.T) {
+	base := queue.WorkItem{
+		ID: 302,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Composer", TrackName: "Etude"},
+			Outdir:     "out",
+			Filename:   "etude.lrc",
+			SourcePath: "/music/etude.flac",
+		},
+	}
+	q := &fakeQueue{items: []queue.WorkItem{base}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.88, VocalConfidence: 0.03, SpeechConfidence: 0.02, WinningVocalClass: "Singing", Reusable: true},
+	}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(inner)
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 1: %v", err)
+	}
+	st := q.instrumentalStamps[0]
+	if st.Result != 0 {
+		t.Fatalf("pass 1 stamp result = %d; want 0", st.Result)
+	}
+
+	// Recalibration: the SAME stored scores now clear the (lowered) threshold.
+	inner.decideFn = func(_, _, _ float64) bool { return true }
+
+	q.items = append(q.items, buildRedequeuedItem(base, st))
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce pass 2: %v", err)
+	}
+	if inner.detectN != 1 {
+		t.Fatalf("detectN = %d; want 1 (re-decided from stored scores, no re-inference)", inner.detectN)
+	}
+	if len(q.completed) != 1 || q.completed[0] != 302 {
+		t.Fatalf("completed = %v; want [302] (recalibration settled it instrumental)", q.completed)
+	}
+	// The settle stamps result=1 (the second stamp after pass 1's result=0).
+	last := q.instrumentalStamps[len(q.instrumentalStamps)-1]
+	if last.Result != 1 || last.Tel.DetectorVersion != "v1" {
+		t.Fatalf("final stamp = %+v; want result 1 + v1 telemetry", last)
+	}
+}
+
+// TestRunOnceDetectorMemoNoStampLeakToSkippedItem verifies that a detected not-
+// instrumental item followed by a detection-DISABLED item does not leak the first
+// item's scores onto the second: the disabled item never runs Detect, so it must
+// receive no instrumental stamp at all (#582 hostile-review C1).
+func TestRunOnceDetectorMemoNoStampLeakToSkippedItem(t *testing.T) {
+	itemA := queue.WorkItem{
+		ID: 310,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Vocalist", TrackName: "Ballad"},
+			Outdir:     "out",
+			Filename:   "ballad.lrc",
+			SourcePath: "/music/ballad.flac",
+		},
+		DetectInstrumental: boolPtr(true),
+	}
+	itemB := queue.WorkItem{
+		ID: 311,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Singer", TrackName: "Anthem"},
+			Outdir:     "out",
+			Filename:   "anthem.lrc",
+			SourcePath: "/music/anthem.flac",
+		},
+		DetectInstrumental: boolPtr(false), // detection OFF for B
+	}
+	q := &fakeQueue{items: []queue.WorkItem{itemA, itemB}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.40, VocalConfidence: 0.72, SpeechConfidence: 0.05, WinningVocalClass: "Singing", Reusable: true},
+	}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(inner)
+	w.SetInstrumentalDetectionDefault(true)
+
+	// Pass 1: item A, detection on -> live inference, stamps result=0.
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce A: %v", err)
+	}
+	// Pass 2: item B, detection off -> Detect never runs.
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce B: %v", err)
+	}
+
+	if inner.detectN != 1 {
+		t.Fatalf("detectN = %d; want 1 (only A ran detection)", inner.detectN)
+	}
+	// Exactly one stamp, and it must be A's (id 310), never B's.
+	for _, st := range q.instrumentalStamps {
+		if st.ID == 311 {
+			t.Fatalf("item B (311) got an instrumental stamp %+v; want none (detection was disabled, scores would be A's)", st)
+		}
+	}
+	if len(q.instrumentalStamps) != 1 || q.instrumentalStamps[0].ID != 310 {
+		t.Fatalf("instrumentalStamps = %+v; want exactly one stamp for id 310", q.instrumentalStamps)
+	}
+}
+
+// TestRunOnceDetectorMemoDegradedResponseNotStamped verifies that a not-
+// instrumental verdict from a DEGRADED detector response (Reusable=false, e.g. a
+// legacy mean-only sidecar) is not stamped as reusable telemetry: its scores are
+// not a faithful decision input, so a later pass must re-infer rather than
+// re-decide from them (#582 hostile-review I1).
+func TestRunOnceDetectorMemoDegradedResponseNotStamped(t *testing.T) {
+	item := queue.WorkItem{
+		ID: 320,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Legacy", TrackName: "Track"},
+			Outdir:     "out",
+			Filename:   "track.lrc",
+			SourcePath: "/music/track.flac",
+		},
+	}
+	q := &fakeQueue{items: []queue.WorkItem{item}}
+	c := &fakeCache{}
+	fetcher := &fakeFetcher{err: musixmatch.ErrNoLyrics}
+	writer := &fakeWriter{}
+	// Degraded: not-instrumental, has a version, but Reusable=false.
+	inner := &fakeStoredDecider{
+		version:   "v1",
+		detectRes: detector.Result{Instrumental: false, Version: "v1", Confidence: 0.99, VocalConfidence: 0.0, Reusable: false},
+	}
+
+	w := New(q, c, fetcher, writer)
+	w.EnableAudioDetector(inner)
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(q.instrumentalStamps) != 0 {
+		t.Fatalf("instrumentalStamps = %+v; want none (degraded response must not be stored as reusable)", q.instrumentalStamps)
+	}
+	if len(q.deferred) != 1 {
+		t.Fatalf("deferred = %v; want the item deferred as a normal miss", q.deferred)
+	}
+}


### PR DESCRIPTION
## Summary

- The serve-mode worker re-ran YAMNet inference on **every** provider-miss pass for already-scored deferred rows. YAMNet scores never change for a track (same audio); only the thresholds applied to them do. This caches the raw scores once and re-applies the current three-gate decision to them on later passes, eliminating redundant ~30ms inference across the ~15k-row deferred backlog.
- A threshold recalibration (like #557's 0.03 -> 0.015) now auto-re-decides deferred rows from stored scores with **no re-inference and no backfill** - the live-path counterpart to #557 (which reverses already-settled positives).
- No user-visible behavior change and **no migration** - all telemetry columns already exist (migrations 024/025). This is internal worker plumbing.
- **Look at first:** `internal/worker/memo_detector.go` (the decorator) and the two hostile-review fixes folded in - `prime()` resets last-inference state to prevent a cross-item score leak, and `detector.Result.Reusable` gates out degraded-sidecar telemetry so it is never re-decided.

## Linked issue

Closes #582

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
- [x] Label set on `gh pr create --label ...` (no CI gate enforces this, but it keeps the tracker usable).
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite). *(N/A - no user-visible change; internal worker memoization.)*
- [ ] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD. *(N/A - no web-UI change.)*
- [ ] `make ui` re-run if any `.templ` or CSS source changed. *(N/A - no templ/CSS change.)*
- [ ] Migration added under `internal/db/migrations/` if this is a one-time data correction. *(N/A - all telemetry columns already exist; migrations 024/025.)*

## Test plan

- [x] `make gate` passes locally (conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, govulncheck).
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. The two hostile-review fixes were TDD'd (each test reproduced the defect first); the fix-verify pass independently reverted each hunk to confirm non-vacuity.
- [x] Patch coverage meets the Codecov threshold - **94.23%** patch coverage (three new files at 100%, `worker.go` at 85.5%).
- [x] Surface stated explicitly: this fixes the **serve-mode worker's detector lane** (re-inference on deferred provider-miss passes). Verified by the worker integration tests asserting `detectN == 1` across two passes.
- [ ] Manual UAT steps:
  - [ ] N/A - no user-facing flow; the effect is fewer sidecar calls, observable only via detector DEBUG logs / inference count.
- [ ] Reviewer follow-ups:
  - [ ] The memo re-decision shares the exact `detector.Instrumental` predicate the live path uses - worth confirming that contract is the one you want load-bearing here.

## Not covered

- Does not change the **positive** (instrumental settle) path - that still stamps `result=1` from the detector-lane song telemetry and is deliberately not cache-stored (unchanged).
- Does not add a targeted re-examination command for the already-scored backlog; existing rows get memoized lazily as they cycle through the worker. A model-version bump or threshold change re-decides them on their next pass.
- The `parallel` provider-dispatch mode is out of scope (the detector lane is installed only under `ordered`, unchanged by this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deferred audio classifications can reuse previously stored detector results when compatible with the current model version.
  * Threshold changes can re-evaluate stored scores without rerunning detection.
  * Detector model versions and reusable-result status are now tracked.
  * Stored detector telemetry is preserved across queue operations.

* **Bug Fixes**
  * Prevented stale detection results from carrying over between items.
  * Degraded or incomplete detector responses are excluded from reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->