### PR TITLE
fix(queue): retry Dequeue/Complete/Fail on SQLITE_BUSY (#625)

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -9,9 +9,17 @@ import (
 	"time"
 
 	"github.com/sydlexius/canticle/internal/backoff"
+	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/normalize"
 )
+
+// dequeueMaxAttempts bounds the SQLITE_BUSY retry loop for the worker-loop
+// transitions (Dequeue/Complete/Fail). It mirrors scan's upsertMaxAttempts: a
+// transient WAL lock clears well within a few geometric-backoff attempts, and a
+// genuinely stuck lock still surfaces once exhausted rather than looping forever
+// (#625).
+const dequeueMaxAttempts = 5
 
 const (
 	// StatusPending marks queued work ready to be processed.
@@ -434,6 +442,28 @@ const refillBufferSQL = `UPDATE work_queue
 // (randomize=true, batch_size<=0), or the shuffled lookahead buffer
 // (randomize=true, batch_size>0, the default). See #571.
 func (q *DBQueue) Dequeue(ctx context.Context) (WorkItem, error) {
+	// Retry the whole claim on SQLITE_BUSY: a concurrent bulk write (a maintenance
+	// UPDATE, a reconcile pass) makes a poll fail with a transient lock, and the
+	// worker is a single serialized loop so every dropped poll is lost throughput
+	// at exactly the moment the DB is busiest. busy_timeout alone does NOT cover
+	// this - SQLITE_BUSY_SNAPSHOT (517), a WAL write-write conflict, fails
+	// immediately regardless of the timeout. Retrying is safe: each path is atomic
+	// (a single claim statement, or dequeueBatched's BeginTx...Commit that rolls
+	// back cleanly on failure), so a retry re-runs from a clean slate. sql.ErrNoRows
+	// is not a SQLITE_BUSY error, so an empty queue returns on the first attempt.
+	// (#625)
+	var item WorkItem
+	err := db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
+		var derr error
+		item, derr = q.dequeueOnce(ctx)
+		return derr
+	})
+	return item, err
+}
+
+// dequeueOnce performs a single claim attempt across the three configured paths.
+// Wrapped by Dequeue in db.RetryOnBusy.
+func (q *DBQueue) dequeueOnce(ctx context.Context) (WorkItem, error) {
 	now := formatTime(q.now())
 	if q.randomized && q.batchSize > 0 {
 		return q.dequeueBatched(ctx, now)
@@ -520,6 +550,17 @@ func (q *DBQueue) dequeueBatched(ctx context.Context, now string) (WorkItem, err
 // scan_results agree. Crash or partial-write between the updates is impossible:
 // SQLite either commits the whole transaction or rolls back.
 func (q *DBQueue) Complete(ctx context.Context, id int64) error {
+	// Retry on SQLITE_BUSY: a dropped Complete has a larger blast radius than a
+	// dropped poll - the finished item stays 'processing' and is re-dequeued and
+	// re-processed. The whole transaction rolls back on a BUSY before commit, so a
+	// retry re-runs cleanly; requireAffected's "not processing" error is not a
+	// SQLITE_BUSY error, so an already-completed row returns immediately. (#625)
+	return db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
+		return q.completeOnce(ctx, id)
+	})
+}
+
+func (q *DBQueue) completeOnce(ctx context.Context, id int64) error {
 	now := formatTime(q.now())
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -860,6 +901,23 @@ func (q *DBQueue) Cleanup(ctx context.Context, inputs models.Inputs) (int64, err
 
 // Fail records a failed attempt and schedules the item after geometric backoff.
 func (q *DBQueue) Fail(ctx context.Context, id int64, cause error) (WorkItem, error) {
+	// Retry on SQLITE_BUSY: a dropped Fail leaves the row wedged in 'processing'
+	// (and the linked scan_results with it), a larger blast radius than a dropped
+	// poll. The transaction rolls back on a BUSY before commit, so a retry re-runs
+	// from a clean read of attempts; sql.ErrNoRows (row not 'processing') is not a
+	// SQLITE_BUSY error and returns immediately. The next_attempt_at recompute on a
+	// retry differs only by the few ms of retry latency, which is immaterial to the
+	// backoff schedule. (#625)
+	var item WorkItem
+	err := db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
+		var ferr error
+		item, ferr = q.failOnce(ctx, id, cause)
+		return ferr
+	})
+	return item, err
+}
+
+func (q *DBQueue) failOnce(ctx context.Context, id int64, cause error) (WorkItem, error) {
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
 		return WorkItem{}, fmt.Errorf("queue: begin fail tx: %w", err)

--- a/internal/queue/queue_busy_test.go
+++ b/internal/queue/queue_busy_test.go
@@ -1,0 +1,216 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/models"
+
+	_ "modernc.org/sqlite"
+)
+
+// lockHoldDuration is how long holdWriteLock keeps the write lock. It comfortably
+// exceeds the 50ms busy_timeout (so the first contended attempt is guaranteed to
+// see SQLITE_BUSY) yet stays well under the retry budget (~1.5s of backoff over 5
+// attempts), so a wrapped op reliably retries into success and the tests are not
+// flaky. (#625)
+const lockHoldDuration = 120 * time.Millisecond
+
+// holdWriteLock opens a SECOND connection to path, holds an open write
+// transaction against it for lockHoldDuration, then commits. It closes
+// lockAcquired once the lock is held so the caller can run its contended
+// operation against a different connection and reliably hit SQLITE_BUSY. Errors
+// are reported on t.
+func holdWriteLock(t *testing.T, ctx context.Context, path string, lockAcquired chan<- struct{}) *sync.WaitGroup {
+	t.Helper()
+	// A dedicated connection with a short busy_timeout so IT never blocks waiting
+	// on the lock it is trying to hold (it is the holder, not a waiter).
+	locker, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(50)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open locker: %v", err)
+	}
+	locker.SetMaxOpenConns(1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() { _ = locker.Close() }()
+		tx, err := locker.BeginTx(ctx, nil)
+		if err != nil {
+			t.Errorf("locker begin: %v", err)
+			close(lockAcquired)
+			return
+		}
+		// A write statement acquires the WAL write lock. UPDATE ... WHERE 1=0
+		// touches no rows but still takes the lock.
+		if _, err := tx.ExecContext(ctx, "UPDATE work_queue SET status = status WHERE 1=0"); err != nil {
+			t.Errorf("locker acquire write lock: %v", err)
+			_ = tx.Rollback()
+			close(lockAcquired)
+			return
+		}
+		close(lockAcquired)
+		time.Sleep(lockHoldDuration)
+		if err := tx.Commit(); err != nil {
+			t.Errorf("locker commit: %v", err)
+		}
+	}()
+	return wg
+}
+
+// newBusyProneQueue opens the queue on a SHORT busy_timeout so a concurrent
+// write surfaces as SQLITE_BUSY quickly (forcing the retry path) rather than
+// blocking for the default 5s. Migrations are applied via db.Open on a separate
+// connection first (the short-timeout handle is only used by the queue).
+func newBusyProneQueue(t *testing.T, path string) (*DBQueue, *sql.DB) {
+	t.Helper()
+	// Apply migrations on a full connection.
+	migrator, err := db.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open migrator: %v", err)
+	}
+	t.Cleanup(func() { _ = migrator.Close() })
+
+	conn, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(50)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open queue conn: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = conn.Close() })
+	return NewDBQueue(conn), migrator
+}
+
+// TestDequeueConcurrentWriterRetries reproduces the #625 contention: a second
+// connection holds the write lock while the worker dequeues. With busy retry,
+// Dequeue must return the row instead of dropping the poll on SQLITE_BUSY.
+func TestDequeueConcurrentWriterRetries(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "busy.db")
+	q, _ := newBusyProneQueue(t, path)
+	// Deterministic single-statement dequeue path (also covers the wrap).
+	q.SetRandomized(false)
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	lockAcquired := make(chan struct{})
+	wg := holdWriteLock(t, ctx, path, lockAcquired)
+	<-lockAcquired
+
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("Dequeue under contention = %v; want nil (must retry past SQLITE_BUSY)", err)
+	}
+	if item.Inputs.Track.ArtistName != "A" {
+		t.Fatalf("dequeued %q; want A", item.Inputs.Track.ArtistName)
+	}
+	wg.Wait()
+}
+
+// TestDequeueBatchedConcurrentWriterRetries covers the PRODUCTION-default dequeue
+// path (randomized + batch_size>0 -> dequeueBatched), whose retry safety is
+// non-trivial: it is a multi-statement BeginTx/refillBuffer/claim/Commit
+// transaction, not a single autocommit statement. A BUSY anywhere before commit
+// must roll the whole transaction back so a retry re-runs from a clean slate
+// (no partial batch_seq mutation, no double-claim). (#625)
+func TestDequeueBatchedConcurrentWriterRetries(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "busy.db")
+	q, _ := newBusyProneQueue(t, path)
+	// Production default: randomized shuffled lookahead buffer.
+	q.SetRandomized(true)
+	q.SetBatchSize(10)
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	lockAcquired := make(chan struct{})
+	wg := holdWriteLock(t, ctx, path, lockAcquired)
+	<-lockAcquired
+
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("batched Dequeue under contention = %v; want nil (must retry past SQLITE_BUSY)", err)
+	}
+	if item.Inputs.Track.ArtistName != "A" {
+		t.Fatalf("dequeued %q; want A", item.Inputs.Track.ArtistName)
+	}
+	wg.Wait()
+}
+
+// TestCompleteConcurrentWriterRetries verifies Complete retries past a transient
+// lock. A dropped Complete would leave a finished item to be re-processed (#625
+// scope audit: higher blast radius than a dropped poll).
+func TestCompleteConcurrentWriterRetries(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "busy.db")
+	q, verify := newBusyProneQueue(t, path)
+	q.SetRandomized(false)
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	lockAcquired := make(chan struct{})
+	wg := holdWriteLock(t, ctx, path, lockAcquired)
+	<-lockAcquired
+
+	if err := q.Complete(ctx, item.ID); err != nil {
+		t.Fatalf("Complete under contention = %v; want nil (must retry past SQLITE_BUSY)", err)
+	}
+	wg.Wait()
+
+	var status string
+	if err := verify.QueryRowContext(ctx, "SELECT status FROM work_queue WHERE id = ?", item.ID).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != "done" {
+		t.Fatalf("status = %q; want done", status)
+	}
+}
+
+// TestFailConcurrentWriterRetries verifies Fail retries past a transient lock. A
+// dropped Fail would leave a row stuck in 'processing' (#625 scope audit).
+func TestFailConcurrentWriterRetries(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "busy.db")
+	q, verify := newBusyProneQueue(t, path)
+	q.SetRandomized(false)
+
+	if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}, PriorityScan); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	item, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	lockAcquired := make(chan struct{})
+	wg := holdWriteLock(t, ctx, path, lockAcquired)
+	<-lockAcquired
+
+	if _, err := q.Fail(ctx, item.ID, context.DeadlineExceeded); err != nil {
+		t.Fatalf("Fail under contention = %v; want nil (must retry past SQLITE_BUSY)", err)
+	}
+	wg.Wait()
+
+	var status string
+	if err := verify.QueryRowContext(ctx, "SELECT status FROM work_queue WHERE id = ?", item.ID).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status == "processing" {
+		t.Fatalf("status = processing; want a terminal/failed state (Fail dropped)")
+	}
+}


### PR DESCRIPTION
## Summary

- The worker's `DBQueue.Dequeue` dropped its poll on `SQLITE_BUSY` instead of retrying. A concurrent bulk write (a maintenance `UPDATE`, a reconcile pass) made the single serialized worker loop skip work cycles, surfaced only as a misleading `WARN worker run failed`. Observed 6x over ~108s in prod on 2026-07-22.
- `busy_timeout=5000` does **not** cover this: half the observed errors were `SQLITE_BUSY_SNAPSHOT` (517), a WAL write-write conflict that fails immediately regardless of the timeout. The existing `db.RetryOnBusy` helper (until now wired into exactly one call site) is the fix.
- **Scope:** wrapped `Dequeue` plus the two higher-blast-radius terminal ops - a dropped `Complete` re-processes a finished item, a dropped `Fail` wedges a row in `processing`. The advisory pre-`Complete` stamps (already log-and-continue) are deliberately left alone.
- **No user-visible behavior change** - impact is throughput (dropped work cycles at the busiest moment), not correctness. Rows were never lost; they were just picked up on a later poll.

## Linked issue

Closes #625

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing. *(Hostile review found no Critical/Important; its one worthwhile Minor - the batched-dequeue path was untested under contention - was fixed by adding `TestDequeueBatchedConcurrentWriterRetries`.)*
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes. *(N/A - no user-visible change; internal retry behavior.)*
- [ ] Screenshot attached for any web-UI change. *(N/A.)*
- [ ] `make ui` re-run if any `.templ` or CSS source changed. *(N/A.)*
- [ ] Migration added under `internal/db/migrations/`. *(N/A - no schema change.)*

## Test plan

- [x] `make gate` passes locally (race tests, patch coverage, coverage-floor, golangci-lint, actionlint, govulncheck).
- [x] New tests confirmed to **fail against unfixed code** before the fix: all four contention tests fail with the exact `SQLITE_BUSY` (the batched test fails with the issue's reported `refill buffer: database is locked` signature) when the retry wrap is bypassed.
- [x] Patch coverage meets threshold - **100%** on `queue.go`.
- [x] Surface stated explicitly: the **serve-mode worker's dequeue + terminal write path**. The contention is reproduced with a second connection holding the WAL write lock while the queue (on a short `busy_timeout`) runs each op.
- [x] Flakiness checked: the tests ran green under `-race -count=10` and `-count=5`. Retry budget (~1.5s of backoff over 5 attempts) comfortably exceeds the 120ms lock hold, and the 120ms hold exceeds the 50ms `busy_timeout` so the first attempt is guaranteed to see `SQLITE_BUSY` (non-vacuous).
- [ ] Manual UAT steps:
  - [ ] N/A - the effect (no dropped polls under contention) is observable only under a concurrent bulk write; covered by the automated contention tests.
- [ ] Reviewer follow-ups:
  - [ ] Graceful-shutdown worst case under *sustained* contention grew: a stuck `WithoutCancel` Complete/Fail is now bounded but uninterruptible for up to ~26s (5x5s busy-wait + backoff) vs ~5s before. It still terminates (no hang), and blocking-to-finish is the intended semantics of a terminal write. Flagging as an observation, not a defect.

## Not covered

- The wider `DBQueue` write surface (`Defer`, `Release`, `RetireMiss`) is intentionally out of scope - those are more self-healing (the row stays eligible on a dropped op), so the marginal value did not justify the diff. The issue's scope-audit reasoning is captured in the commit message.
- Does not change `busy_timeout` or any pragma; the fix is purely the retry wrapper around the three worker-loop transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue reliability when temporary database contention occurs.
  * Queue items can now be claimed, completed, or failed successfully after transient busy errors.

* **Tests**
  * Added coverage for queue operations during concurrent database activity, including batched processing and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->