### PR TITLE
ci: auto-label and auto-assign milestone on PRs from linked issues

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,216 @@
+# Auto-label pull requests from the issues they close.
+#
+# On open/edit/sync, parse "Fixes #N" / "Closes #N" / "Resolves #N" / "Part of
+# #N" references from the PR body, fetch labels from each linked issue, and copy
+# any that exist in the repo's Labels set onto the PR.
+#
+# The "valid label" set is the repo's own Labels list (queried via the API).
+# Manage it through Settings > Labels -- no workflow edit needed to add or rename
+# a label.
+#
+# This is AUTO-LABEL ONLY: it copies labels, it does NOT gate the merge. (The
+# upstream sydlexius/stillwater version also fails a required status check when a
+# PR has no release label; that gate is deliberately omitted here.)
+#
+# Uses pull_request_target so a fork PR cannot redefine the logic. Dependabot PRs
+# are skipped -- they never reference labeled issues.
+
+name: PR Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  auto-label:
+    name: Auto-label from linked issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    steps:
+      - name: Auto-label from linked issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Valid labels = the repo's own Labels set (Settings > Labels).
+            const repoLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const validLabels = new Set(repoLabels.map(l => l.name));
+            core.info(`Repo labels (${validLabels.size}): ${[...validLabels].sort().join(', ')}`);
+
+            // Parse issue references from the PR body. `Part of #N` is the house
+            // convention for an epic-child PR (links without auto-closing); it must
+            // be recognized or a PR that references only its epic is silently
+            // skipped.
+            const body = context.payload.pull_request.body || '';
+            const pattern = /\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|part\s+of)\s+#(\d+)/gi;
+            const issueNumbers = [];
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              const n = parseInt(match[1], 10);
+              if (!issueNumbers.includes(n)) issueNumbers.push(n);
+            }
+
+            if (issueNumbers.length === 0) {
+              core.info('No issue references found in PR body -- skipping auto-label');
+              return;
+            }
+            core.info(`Linked issues: ${issueNumbers.map(n => '#' + n).join(', ')}`);
+
+            // Collect labels from each linked issue that exist in the repo set.
+            const toApply = new Set();
+            for (const num of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                if (issue.data.pull_request) {
+                  core.info(`#${num} is a pull request, skipping`);
+                  continue;
+                }
+                for (const label of issue.data.labels) {
+                  if (validLabels.has(label.name)) toApply.add(label.name);
+                }
+              } catch (err) {
+                core.warning(`Could not fetch issue #${num}: ${err.message}`);
+              }
+            }
+
+            if (toApply.size === 0) {
+              core.info('No matching labels found on linked issues');
+              return;
+            }
+
+            // ---------------------------------------------------------------
+            // Dedupe mutually-exclusive families, elevating to the most
+            // conservative member present.
+            //
+            // The union above is correct for ADDITIVE labels (ci, bug, docker,
+            // ...): a PR closing several issues really is all of those. It is
+            // WRONG for a mutually-exclusive family: a PR closing three issues of
+            // differing priority would otherwise be tagged priority: high + medium
+            // + low at once. Each family collapses to exactly ONE member, elevated
+            // to the most conservative value present (a PR closing N issues IS the
+            // union of that work, so elevate rather than take the lowest).
+            //
+            // Canticle's only mutually-exclusive family today is `priority:`.
+            // Array ordered MOST-conservative first (index 0 wins).
+            const EXCLUSIVE_FAMILIES = {
+              priority: ['priority: critical', 'priority: high', 'priority: medium', 'priority: low'],
+            };
+
+            // Guard the table against label renames/additions: a repo label that
+            // LOOKS like a family member but is not ranked would fall through as an
+            // additive label and silently re-introduce the union this fixes. Fail
+            // loudly instead.
+            const ranked = new Set(Object.values(EXCLUSIVE_FAMILIES).flat());
+            const unranked = [...validLabels].filter(
+              l => /^(priority):/.test(l) && !ranked.has(l)
+            );
+            if (unranked.length > 0) {
+              core.setFailed(
+                `Label(s) ${unranked.join(', ')} look like members of a mutually-exclusive ` +
+                `family but are not ranked in EXCLUSIVE_FAMILIES in this workflow. ` +
+                `Add them (most-conservative first) so the elevator can order them.`
+              );
+              return;
+            }
+
+            // Resolve each family against the union AND the PR's current labels, so
+            // a PR that is ALREADY mislabeled gets repaired, not just prevented.
+            // Read current labels from the API, not the (possibly stale) event
+            // payload snapshot.
+            const prNow = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const existing = new Set(prNow.data.labels.map(l => l.name));
+            const toRemove = new Set();
+
+            // THE PR WINS. Linked-issue labels only SEED a family the PR has not
+            // already decided; they never override a decision made on the PR --
+            // otherwise a manual priority set on the PR would be stomped on every
+            // push by a differing priority inherited from a linked issue.
+            for (const [family, order] of Object.entries(EXCLUSIVE_FAMILIES)) {
+              const onPR = order.filter(l => existing.has(l));
+              const fromIssues = order.filter(l => toApply.has(l));
+
+              if (onPR.length > 0) {
+                // The PR has decided this family. Issue labels do not get a vote.
+                for (const l of fromIssues) toApply.delete(l);
+                const winner = onPR[0];                // order is most-conservative first
+                for (const loser of onPR.slice(1)) toRemove.add(loser);
+                if (onPR.length > 1) {
+                  core.info(
+                    `${family}: PR carries ${onPR.length} conflicting members; ` +
+                    `elevated to "${winner}" (removing ${onPR.slice(1).join(', ')})`
+                  );
+                } else if (fromIssues.length > 0 && fromIssues[0] !== winner) {
+                  core.info(
+                    `${family}: PR already set "${winner}"; ` +
+                    `NOT overriding it with "${fromIssues[0]}" from a linked issue`
+                  );
+                }
+                continue;
+              }
+
+              // Undecided on the PR -- seed it from the linked issues.
+              if (fromIssues.length === 0) continue;
+              const winner = fromIssues[0];
+              for (const loser of fromIssues.slice(1)) toApply.delete(loser);
+              if (fromIssues.length > 1) {
+                core.info(
+                  `${family}: seeded from linked issues, elevated to "${winner}" ` +
+                  `(dropped ${fromIssues.slice(1).join(', ')})`
+                );
+              }
+            }
+
+            // Remove losing family members already on the PR. removeLabel fires an
+            // `unlabeled` event, but this workflow does not listen for label events
+            // (see the `on:` types), so it cannot re-trigger itself.
+            for (const loser of toRemove) {
+              core.info(`Removing conflicting label: ${loser}`);
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  name: loser,
+                });
+              } catch (err) {
+                // 404 = already gone (race with a concurrent run). Anything else is
+                // real: surface it rather than leaving a conflicting label on.
+                if (err.status === 404) {
+                  core.info(`  ${loser} was already removed`);
+                } else {
+                  core.warning(`Could not remove ${loser}: ${err.message}`);
+                }
+              }
+            }
+
+            const missing = [...toApply].filter(l => !existing.has(l));
+            if (missing.length === 0) {
+              core.info('No new labels to apply');
+              return;
+            }
+
+            core.info(`Applying labels: ${missing.join(', ')}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: missing,
+            });

--- a/.github/workflows/pr-milestone.yml
+++ b/.github/workflows/pr-milestone.yml
@@ -1,0 +1,151 @@
+# Automatically assign a milestone to PRs based on the issues they reference.
+# Parses "Fixes #N", "Closes #N", "Resolves #N", and "Part of #N" from the PR
+# body, looks up each issue's milestone, and assigns the first one found.
+# Warns via comment if referenced issues have conflicting milestones.
+#
+# Ported from sydlexius/stillwater's pr-milestone.yml. Canticle organizes its
+# backlog into domain milestones (Instrumental Detection, Word-Sync & Generation,
+# Lyric Timing & Validation, ...), so a PR closing a filed issue inherits that
+# issue's domain automatically.
+#
+# Only assigns when the PR has NO milestone -- a manual choice is never
+# overwritten. Uses pull_request_target so a fork PR cannot redefine the logic.
+
+name: PR Milestone
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+    # Skip bot PRs (Dependabot, etc.) -- they never reference milestone issues
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Assign milestone from linked issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Parse issue references: Fixes #N, Closes #N, Resolves #N, Part of #N.
+            // `Part of #N` is the house convention for an epic-child PR: it links
+            // the PR to the epic WITHOUT auto-closing it (GitHub only auto-closes
+            // on fixes/closes/resolves). Omitting it from this pattern would make
+            // the automation silently skip a PR that references only its epic.
+            const pattern = /\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|part\s+of)\s+#(\d+)/gi;
+            const issueNumbers = [];
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              const num = parseInt(match[1], 10);
+              if (!issueNumbers.includes(num)) {
+                issueNumbers.push(num);
+              }
+            }
+
+            if (issueNumbers.length === 0) {
+              core.info('No issue references found in PR body, skipping');
+              return;
+            }
+
+            core.info(`Found issue references: ${issueNumbers.map(n => '#' + n).join(', ')}`);
+
+            // Look up milestones for each referenced issue
+            const milestones = new Map();
+            for (const num of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                if (issue.data.pull_request) {
+                  core.info(`#${num} is a pull request, skipping`);
+                  continue;
+                }
+                if (issue.data.milestone) {
+                  const ms = issue.data.milestone;
+                  if (!milestones.has(ms.number)) {
+                    milestones.set(ms.number, { title: ms.title, number: ms.number, issues: [] });
+                  }
+                  milestones.get(ms.number).issues.push(num);
+                }
+              } catch (err) {
+                core.warning(`Could not fetch issue #${num}: ${err.message}`);
+              }
+            }
+
+            if (milestones.size === 0) {
+              core.info('No referenced issues have milestones, skipping');
+              return;
+            }
+
+            const entries = Array.from(milestones.values());
+            const target = entries[0];
+
+            // Warn if issues reference conflicting milestones (upsert to avoid spam)
+            if (milestones.size > 1) {
+              const sentinel = '<!-- pr-milestone-conflict -->';
+              const list = entries
+                .map(m => `- **${m.title}** (from ${m.issues.map(n => '#' + n).join(', ')})`)
+                .join('\n');
+              const warningBody = [
+                sentinel,
+                'This PR references issues from multiple milestones:',
+                '',
+                list,
+                '',
+                `Auto-assigned the milestone from the first match: **${target.title}**.`,
+                'Update manually if this is incorrect.',
+              ].join('\n');
+
+              // Find existing warning comment to update instead of creating a new one
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+              });
+              const existing = comments.data.find(c => c.body && c.body.includes(sentinel));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: warningBody,
+                });
+                core.info('Updated existing conflict warning comment');
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: warningBody,
+                });
+              }
+
+              core.warning(`Conflicting milestones detected, assigned "${target.title}"`);
+            }
+
+            // Only auto-assign when the PR has no milestone; respect manual choices
+            if (pr.milestone) {
+              core.info(`PR already has milestone "${pr.milestone.title}", not overwriting`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              milestone: target.number,
+            });
+
+            core.info(`Assigned milestone "${target.title}" to PR #${pr.number}`);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,22 @@
+# NOTE ON codecov/patch TIMING -- do not "fix" this by adding after_n_builds.
+#
+# Codecov posts its commit status once `after_n_builds` uploads have arrived, and
+# that key DEFAULTS TO 1. This repo performs AT MOST ONE upload: ci.yml's single
+# `coverage-upload` job ships the merged Go profile and nothing else uploads. So
+# the default is correct and setting after_n_builds explicitly would be a no-op.
+#
+# "At most one", not "exactly one": `coverage-upload` needs the `test` job, which
+# is gated `if: needs.changes.outputs.code == 'true'`. A docs-only or workflow-
+# only PR runs no tests, produces no coverage artifact, and performs ZERO uploads
+# -- so it gets no patch status at all. That is expected; do NOT "fix" a missing
+# status on a docs-only PR.
+#
+# Keep the upload count DETERMINISTIC. If a second uploader is ever added, a
+# fixed `after_n_builds: 2` would hang the status forever on any run where one
+# uploader is conditionally skipped -- worse than firing early. The premature red
+# 0% that this comment guards against (seen in sydlexius/stillwater) was caused by
+# a SECOND racing uploader, never by the threshold. Do not add one.
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

- Port two PR-automation workflows from `sydlexius/stillwater` (near-verbatim, vetted configs): **`pr-labels.yml`** auto-copies a linked issue's labels onto the PR, and **`pr-milestone.yml`** auto-assigns the PR's milestone from its linked issue. Both parse `Fixes`/`Closes`/`Resolves`/`Part of #N` from the PR body.
- Directly leverages the new **8-domain milestone partition**: a PR that closes a filed issue now inherits that issue's domain milestone automatically.
- Also documents codecov's single-uploader invariant in `codecov.yml` to guard against the premature-red-0% failure mode (a second racing uploader) seen in Stillwater.

## Linked issue

_(No filed issue - this is CI infrastructure. Assigned to the Packaging, CI & Release milestone manually.)_

## What was adapted for canticle

- **`pr-labels.yml` is AUTO-LABEL ONLY.** Stillwater's version also fails a required status check when a PR has no release label; that gate is deliberately **dropped** here - non-blocking, no change to canticle's merge gate.
- **Mutually-exclusive-family elevator keeps only the `priority:` family** (canticle has no `scope:`/`docs:` families). Added the missing **`priority: critical`** label so the family is complete (critical/high/medium/low). A PR closing several issues of differing priority collapses to the single most-conservative one instead of carrying all three.
- **Manual choices win:** an existing milestone or priority already set on the PR is never overwritten by an inherited one.
- SHA-pinned `actions/github-script@3a2844b` (verified = `v9.0.0`).

## Behavior note

Both use `pull_request_target`, which runs the workflow from **main**, not the PR branch (the security property that stops a fork PR redefining the logic). So these can't self-demonstrate on their own PR - the first real exercise is the **next** PR opened after this merges.

## Gates

- [x] `make gate` passes locally (actionlint on both workflows, `codecovcli` dry-run validates `codecov.yml`, typos, govulncheck).
- [x] `codecov.yml` validated against the Codecov API (`/validate` -> "Valid!").
- [x] `actions/github-script` SHA pin verified to resolve to `v9.0.0`.
- [ ] Full runtime exercise deferred to the next PR (pull_request_target runs from main, so it is inert on this PR).

## Not covered

- No auto-label/milestone runtime test on this PR (inert by `pull_request_target` design, above).
- Does not add a required label gate (intentional - auto-label only).
