### PR TITLE
feat(reconcile): resume cursor + realized-outcome backup for instrumental recalibrate (#515, #516)

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -250,6 +250,7 @@ type ScanReconcileInstrumentalRecalibrateCmd struct {
 	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default covers every library"`
 	Yes        bool   `arg:"--yes" help:"actually write markers and settle/reset rows (without it, prints what would change)"`
 	Limit      int    `arg:"--limit" help:"maximum number of candidate rows to process (0 = unlimited)" default:"0"`
+	AfterID    int64  `arg:"--after-id" help:"resume cursor: only consider rows whose work_queue id is greater (forward direction only). Pass the 'resume with --after-id=N' value printed by a prior --limit run to advance past already-examined rows" default:"0"`
 	Backup     string `arg:"--backup" help:"path for the JSONL backup of changed rows (default: <db-dir>/reconcile-instrumental-recalibrate-backup-<ts>.jsonl)" default:""`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 	// Reverse selects the TIGHTENING direction: re-decide rows already settled

--- a/internal/commands/reconcile_instrumental.go
+++ b/internal/commands/reconcile_instrumental.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,6 +17,10 @@ import (
 // written and fsynced before the row is mutated so an applied change always has
 // its restorable record.
 type reconcileInstrumentalBackup struct {
+	// Type discriminates the intent record (this shape) from the outcome record
+	// (reconcileInstrumentalOutcome) in the same JSONL. Absent on records written
+	// before #515; a reader must treat a missing Type as "intent".
+	Type       string `json:"type,omitempty"`
 	QueueID    int64  `json:"queue_id"`
 	Artist     string `json:"artist"`
 	Title      string `json:"title"`
@@ -36,8 +39,21 @@ type reconcileInstrumentalBackup struct {
 	At           time.Time `json:"at"`
 }
 
+// reconcileInstrumentalOutcome is the second JSONL record for a row: the realized
+// result appended AFTER the mutation resolves, so a restore replays only rows
+// whose outcome is "applied" (#515). Mirrors the recalibrate sibling's outcome
+// record so both share the backup-trail contract.
+type reconcileInstrumentalOutcome struct {
+	Type      string    `json:"type"` // always "outcome"
+	QueueID   int64     `json:"queue_id"`
+	Outcome   string    `json:"outcome"`             // applied | skipped | failed
+	Ambiguous bool      `json:"ambiguous,omitempty"` // failed-but-maybe-applied settle
+	At        time.Time `json:"at"`
+}
+
 func appendReconcileInstrumentalBackup(f *os.File, ch instrumentalbackfill.Change) error {
 	rec := reconcileInstrumentalBackup{
+		Type:         "intent",
 		QueueID:      ch.QueueID,
 		Artist:       ch.Artist,
 		Title:        ch.Title,
@@ -51,18 +67,22 @@ func appendReconcileInstrumentalBackup(f *os.File, ch instrumentalbackfill.Chang
 		Detector:     ch.Telemetry.DetectorVersion,
 		At:           time.Now().UTC(),
 	}
-	b, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("marshal backup record: %w", err)
-	}
-	if _, err := f.Write(append(b, '\n')); err != nil {
-		return fmt.Errorf("write backup record: %w", err)
-	}
-	// fsync before the row is mutated (the identityrepair backup-first rule).
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("sync backup record: %w", err)
-	}
-	return nil
+	// appendJSONLSynced is shared with the recalibrate sibling (defined in
+	// reconcile_instrumental_recalibrate.go): both records get identical
+	// marshal+append+fsync durability (the identityrepair backup-first rule).
+	return appendJSONLSynced(f, rec)
+}
+
+// appendReconcileInstrumentalOutcome appends the realized-outcome record for a
+// row, fsynced like the intent record so the trail is crash-durable (#515).
+func appendReconcileInstrumentalOutcome(f *os.File, o instrumentalbackfill.Outcome) error {
+	return appendJSONLSynced(f, reconcileInstrumentalOutcome{
+		Type:      "outcome",
+		QueueID:   o.QueueID,
+		Outcome:   o.Status,
+		Ambiguous: o.Ambiguous,
+		At:        time.Now().UTC(),
+	})
 }
 
 // runReconcileInstrumental is CLI wiring over internal/instrumentalbackfill: it
@@ -108,6 +128,14 @@ func runReconcileInstrumental(ctx context.Context, out io.Writer, args ScanRecon
 				backup = f
 			}
 			return appendReconcileInstrumentalBackup(backup, ch)
+		},
+		Outcome: func(o instrumentalbackfill.Outcome) error {
+			// A nil handle means Report failed to open the backup; the engine
+			// already reports that row as failed, so there is nothing to append to.
+			if backup == nil {
+				return nil
+			}
+			return appendReconcileInstrumentalOutcome(backup, o)
 		},
 	})
 	if err != nil {

--- a/internal/commands/reconcile_instrumental_recalibrate.go
+++ b/internal/commands/reconcile_instrumental_recalibrate.go
@@ -18,6 +18,11 @@ import (
 // acted on, written and fsynced before the row is mutated so an applied
 // change always has its restorable record.
 type reconcileInstrumentalRecalibrateBackup struct {
+	// Type discriminates the two records a row can produce in the JSONL: "intent"
+	// (this shape, written before the mutation) and "outcome" (the realized result
+	// appended after, see reconcileInstrumentalRecalibrateOutcome). Absent on
+	// records written before #515; a reader must treat a missing Type as "intent".
+	Type        string    `json:"type,omitempty"`
 	QueueID     int64     `json:"queue_id"`
 	Artist      string    `json:"artist"`
 	Title       string    `json:"title"`
@@ -28,8 +33,21 @@ type reconcileInstrumentalRecalibrateBackup struct {
 	At          time.Time `json:"at"`
 }
 
+// reconcileInstrumentalRecalibrateOutcome is the second JSONL record for a row:
+// the realized result appended AFTER the mutation resolves, so a restore replays
+// only rows whose outcome is "applied" and never a "skipped" no-op (#515). Keyed
+// by QueueID to the earlier intent record.
+type reconcileInstrumentalRecalibrateOutcome struct {
+	Type      string    `json:"type"` // always "outcome"
+	QueueID   int64     `json:"queue_id"`
+	Outcome   string    `json:"outcome"`             // applied | skipped | failed
+	Ambiguous bool      `json:"ambiguous,omitempty"` // failed-but-maybe-applied settle
+	At        time.Time `json:"at"`
+}
+
 func appendReconcileInstrumentalRecalibrateBackup(f *os.File, ch instrumentalrecalib.Change) error {
 	rec := reconcileInstrumentalRecalibrateBackup{
+		Type:        "intent",
 		QueueID:     ch.QueueID,
 		Artist:      ch.Artist,
 		Title:       ch.Title,
@@ -39,6 +57,26 @@ func appendReconcileInstrumentalRecalibrateBackup(f *os.File, ch instrumentalrec
 		MarkerPaths: ch.MarkerPaths,
 		At:          time.Now().UTC(),
 	}
+	return appendJSONLSynced(f, rec)
+}
+
+// appendReconcileInstrumentalRecalibrateOutcome appends the realized-outcome
+// record for a row. Like the intent record it is fsynced, so the backup trail is
+// durable across a crash between the mutation and the next row (#515).
+func appendReconcileInstrumentalRecalibrateOutcome(f *os.File, o instrumentalrecalib.Outcome) error {
+	return appendJSONLSynced(f, reconcileInstrumentalRecalibrateOutcome{
+		Type:      "outcome",
+		QueueID:   o.QueueID,
+		Outcome:   o.Status,
+		Ambiguous: o.Ambiguous,
+		At:        time.Now().UTC(),
+	})
+}
+
+// appendJSONLSynced marshals rec, appends it as one JSONL line, and fsyncs --
+// the shared write path for both the intent and outcome records so they get
+// identical durability (the identityrepair backup-first rule).
+func appendJSONLSynced(f *os.File, rec any) error {
 	b, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("marshal backup record: %w", err)
@@ -46,7 +84,6 @@ func appendReconcileInstrumentalRecalibrateBackup(f *os.File, ch instrumentalrec
 	if _, err := f.Write(append(b, '\n')); err != nil {
 		return fmt.Errorf("write backup record: %w", err)
 	}
-	// fsync before the row is mutated (the identityrepair backup-first rule).
 	if err := f.Sync(); err != nil {
 		return fmt.Errorf("sync backup record: %w", err)
 	}
@@ -93,9 +130,18 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 	if args.Reverse {
 		run = rc.Reverse
 	}
+	// --after-id is a forward-direction resume cursor; the Reverse path lists a
+	// different row set (confirmed instrumentals), so the cursor does not apply
+	// there. Reject the combination loudly rather than silently ignore it.
+	if args.Reverse && args.AfterID > 0 {
+		_, _ = fmt.Fprintln(out, "reconcile-instrumental-recalibrate: --after-id is not supported with --reverse (the cursor is forward-direction only)")
+		return 1
+	}
+
 	res, err := run(ctx, instrumentalrecalib.Options{
 		LibraryID:      env.libraryID,
 		Limit:          args.Limit,
+		AfterID:        args.AfterID,
 		DryRun:         !args.Yes,
 		MinConfidence:  env.cfg.InstrumentalDetector.MinConfidence,
 		VocalMax:       env.cfg.InstrumentalDetector.VocalMaxConfidence,
@@ -121,6 +167,15 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 				backup = f
 			}
 			return appendReconcileInstrumentalRecalibrateBackup(backup, ch)
+		},
+		Outcome: func(o instrumentalrecalib.Outcome) error {
+			// The intent record (Report) already opened the backup; a nil handle
+			// here means Report itself failed to open it, and the engine reports
+			// that row's outcome as failed. Nothing to append to, so skip.
+			if backup == nil {
+				return nil
+			}
+			return appendReconcileInstrumentalRecalibrateOutcome(backup, o)
 		},
 	})
 	if err != nil {
@@ -155,6 +210,13 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 	}
 	if args.Yes && (res.Settled > 0 || res.ResetStale > 0 || res.Reversed > 0) {
 		_, _ = fmt.Fprintf(out, "backup of changed rows written to %s\n", backupPath)
+	}
+	// Resume cursor (#516): only the forward direction pages by id, and only a
+	// --limit-capped run can leave more behind (a full run examined everything).
+	// A run that filled its --limit may have more rows past MaxExaminedID, so tell
+	// the operator how to continue without re-selecting the rows just examined.
+	if !args.Reverse && args.Limit > 0 && res.Total == args.Limit && res.MaxExaminedID > 0 {
+		_, _ = fmt.Fprintf(out, "more rows may remain; resume with --after-id=%d\n", res.MaxExaminedID)
 	}
 	if res.Errors > 0 {
 		return 1

--- a/internal/commands/reconcile_instrumental_recalibrate_test.go
+++ b/internal/commands/reconcile_instrumental_recalibrate_test.go
@@ -3,8 +3,10 @@ package commands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -347,5 +349,114 @@ func TestRunReconcileInstrumentalRecalibrate_BackupOpenFailure(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "errors=1") {
 		t.Errorf("want the backup-open failure counted as an error; got: %s", buf.String())
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_BackupRecordsOutcome verifies the JSONL
+// backup carries BOTH an intent record (before the mutation) and an outcome
+// record (applied, after), so a restore can tell a committed change from a
+// no-op (#515).
+func TestRunReconcileInstrumentalRecalibrate_BackupRecordsOutcome(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+	backupPath := filepath.Join(dir, "backup.jsonl")
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{
+		ConfigPath: cfgPath, Yes: true, Backup: backupPath,
+	}); code != 0 {
+		t.Fatalf("exit=%d\n%s", code, buf.String())
+	}
+
+	data, err := os.ReadFile(backupPath) //nolint:gosec // G304: test-controlled path
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	var sawIntent, sawOutcome bool
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var rec struct {
+			Type    string `json:"type"`
+			QueueID int64  `json:"queue_id"`
+			Outcome string `json:"outcome"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		if rec.QueueID != id {
+			t.Fatalf("record for id=%d; want %d", rec.QueueID, id)
+		}
+		switch rec.Type {
+		case "intent":
+			sawIntent = true
+		case "outcome":
+			sawOutcome = true
+			if rec.Outcome != "applied" {
+				t.Errorf("outcome=%q; want applied", rec.Outcome)
+			}
+		default:
+			t.Fatalf("unexpected record type %q", rec.Type)
+		}
+	}
+	if !sawIntent || !sawOutcome {
+		t.Fatalf("backup missing records: intent=%v outcome=%v\n%s", sawIntent, sawOutcome, data)
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_AfterIDRejectedWithReverse verifies the
+// forward-only --after-id cursor is refused (exit 1) when combined with
+// --reverse, rather than silently ignored (#516).
+func TestRunReconcileInstrumentalRecalibrate_AfterIDRejectedWithReverse(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+
+	var buf bytes.Buffer
+	code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{
+		ConfigPath: cfgPath, Reverse: true, AfterID: 5,
+	})
+	if code != 1 {
+		t.Fatalf("exit=%d; want 1 for --after-id with --reverse\n%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "not supported with --reverse") {
+		t.Errorf("want a clear rejection message; got:\n%s", buf.String())
+	}
+}
+
+// TestRunReconcileInstrumentalRecalibrate_ResumeCursorPrinted verifies that a
+// forward --limit run that fills its cap prints the resume cursor so the operator
+// can page past the rows just examined (#516).
+func TestRunReconcileInstrumentalRecalibrate_ResumeCursorPrinted(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeRecalibrateCfg(t, cfgPath, dbPath)
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+
+	// --limit 1 with one candidate: Total == limit, so the run may have left more
+	// behind and must print the resume cursor pointing at the examined id.
+	var buf bytes.Buffer
+	if code := runReconcileInstrumentalRecalibrate(ctx, &buf, ScanReconcileInstrumentalRecalibrateCmd{
+		ConfigPath: cfgPath, Yes: true, Limit: 1,
+	}); code != 0 {
+		t.Fatalf("exit=%d\n%s", code, buf.String())
+	}
+	want := "resume with --after-id=" + strconv.FormatInt(id, 10)
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("want %q in output; got:\n%s", want, buf.String())
 	}
 }

--- a/internal/commands/reconcile_instrumental_test.go
+++ b/internal/commands/reconcile_instrumental_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -352,5 +353,66 @@ func TestRunReconcileInstrumental_DetectorNotConfigured(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "backfill instrumental verdicts") {
 		t.Errorf("message should name this command, not the sibling reconcile; got:\n%s", buf.String())
+	}
+}
+
+// TestRunReconcileInstrumental_BackupRecordsOutcome verifies the backfill CLI
+// writes BOTH an intent and an outcome (applied) JSONL record, mirroring the
+// recalibrate sibling so both share the backup-trail contract (#515).
+func TestRunReconcileInstrumental_BackupRecordsOutcome(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	outdir := filepath.Join(dir, "music")
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		t.Fatalf("mkdir music: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(instrumentalClassifierResponse))
+	}))
+	defer srv.Close()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeReconcileCfg(t, cfgPath, dbPath, srv.URL, fakeFFmpegCmd(t))
+	id := seedUnclassifiedDeferred(t, ctx, dbPath, outdir)
+	backupPath := filepath.Join(dir, "backup.jsonl")
+
+	var buf bytes.Buffer
+	if code := runReconcileInstrumental(ctx, &buf, ScanReconcileInstrumentalCmd{
+		ConfigPath: cfgPath, Yes: true, Backup: backupPath,
+	}); code != 0 {
+		t.Fatalf("exit=%d\n%s", code, buf.String())
+	}
+
+	data, err := os.ReadFile(backupPath) //nolint:gosec // G304: test-controlled path
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	var sawIntent, sawOutcome bool
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var rec struct {
+			Type    string `json:"type"`
+			QueueID int64  `json:"queue_id"`
+			Outcome string `json:"outcome"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		if rec.QueueID != id {
+			t.Fatalf("record for id=%d; want %d", rec.QueueID, id)
+		}
+		switch rec.Type {
+		case "intent":
+			sawIntent = true
+		case "outcome":
+			sawOutcome = true
+			if rec.Outcome != "applied" {
+				t.Errorf("outcome=%q; want applied", rec.Outcome)
+			}
+		default:
+			t.Fatalf("unexpected record type %q", rec.Type)
+		}
+	}
+	if !sawIntent || !sawOutcome {
+		t.Fatalf("backup missing records: intent=%v outcome=%v\n%s", sawIntent, sawOutcome, data)
 	}
 }

--- a/internal/instrumentalbackfill/instrumentalbackfill.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill.go
@@ -78,6 +78,30 @@ type Change struct {
 	Telemetry   queue.InstrumentalTelemetry
 }
 
+// Outcome statuses reported to Options.Outcome after a change's mutation
+// resolves. The intent record (Options.Report) is written BEFORE the mutation for
+// crash safety and so cannot say whether the change landed; a restore must
+// consult the matching Outcome and replay only the ones confirmed applied (#515).
+// This mirrors internal/instrumentalrecalib's Outcome so both sibling reconcile
+// commands share the same backup-trail contract.
+const (
+	OutcomeApplied = "applied" // mutation committed (settled, stamped, or a peer settled it)
+	OutcomeSkipped = "skipped" // worker-claimed / row-gone: nothing written, nothing to revert
+	OutcomeFailed  = "failed"  // a Report/stamp/marker error, or an ambiguous settle (see Ambiguous)
+)
+
+// Outcome is the realized result of one change, handed to Options.Outcome after
+// the mutation resolves so the backup trail records what actually happened rather
+// than only intent (#515). Keyed by QueueID to the earlier Report record.
+type Outcome struct {
+	QueueID int64
+	Status  string
+	// Ambiguous marks the settle-commit-unknown case: the settle may have landed
+	// and the marker was left in place, so a restore must verify before reverting
+	// rather than treat it as a clean no-op.
+	Ambiguous bool
+}
+
 // Result counts one Run.
 //
 // The verdict counts and the mutation counts are deliberately separate axes.
@@ -118,6 +142,13 @@ type Options struct {
 	// aborts that row's mutation and counts an error; it never aborts the Run.
 	// Nil disables it.
 	Report func(Change) error
+	// Outcome is invoked once per change AFTER its mutation resolves, carrying the
+	// realized result (applied/skipped/failed) so the backup trail records what
+	// actually happened, not just the earlier Report intent (#515). Fires for
+	// every row that reached the mutation stage, including a Report failure. Never
+	// fires in a dry run. An Outcome error is best-effort logged and does not abort
+	// the Run. Nil disables it.
+	Outcome func(Outcome) error
 	// Preview is invoked once per instrumental change in a dry run instead of
 	// mutating. Nil disables it.
 	Preview func(Change)
@@ -226,6 +257,7 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			if opts.Report != nil {
 				if err := opts.Report(change); err != nil {
 					res.Errors++
+					b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed})
 					continue
 				}
 			}
@@ -233,13 +265,16 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			stamped, err := b.store.StampUnclassifiedMiss(ctx, item.ID, tel)
 			if err != nil {
 				res.Errors++
+				b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed})
 				continue
 			}
 			if !stamped {
 				res.SkippedClaimed++
+				b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeSkipped})
 				continue
 			}
 			res.RowsStamped++
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeApplied})
 			continue
 		}
 
@@ -257,6 +292,7 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 		if opts.Report != nil {
 			if err := opts.Report(change); err != nil {
 				res.Errors++
+				b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed})
 				continue
 			}
 		}
@@ -272,6 +308,7 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			// claim instrumental against an incomplete set of sidecars. The DB was not
 			// touched, so removing what did land is unambiguously correct.
 			res.MarkersWritten -= b.rollback(written, &res)
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed})
 			continue
 		}
 
@@ -287,30 +324,57 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 			res.Errors++
 			slog.Warn("instrumentalbackfill: settle failed after the marker was written; leaving the marker in place because the commit outcome is unknown",
 				"id", item.ID, "markers", written, "error", err)
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed, Ambiguous: true})
 			continue
 		}
 
 		switch outcome {
 		case queue.Settled:
 			res.RowsSettled++
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeApplied})
 		case queue.SettleAlreadyInstrumental:
 			// A PEER BACKFILL settled this row first with the same verdict. The marker
 			// on disk is correct -- it is the peer's, and ours is byte-identical. Do
 			// NOT remove it: that would delete a valid result over a race we lost
 			// harmlessly.
+			//
+			// OutcomeApplied reflects the end STATE (row done+instrumental), not
+			// authorship: the DB verdict was established by a DIFFERENT actor
+			// (classifyNoSettle keys only on status='done' AND instrumental_result=1).
+			// A future restore reverting OutcomeApplied rows will also revert a
+			// peer-established verdict -- sound as a state reversal, but if actor
+			// attribution ever matters this arm is where a distinct status belongs.
+			// No restore tool exists yet (#515).
 			res.SkippedAlreadySettled++
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeApplied})
 		case queue.SettleClaimed, queue.SettleRowGone:
 			// A worker owns the row, or it is gone. Nothing was written to the DB, so
 			// our marker is an orphan the database has no record of: take it back.
 			res.MarkersWritten -= b.rollback(written, &res)
 			res.SkippedClaimed++
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeSkipped})
 		case queue.SettleFailed:
 			// Unreachable: a failure returns a non-nil error, handled above.
 			res.Errors++
+			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeFailed})
 		}
 	}
 
 	return res, nil
+}
+
+// reportOutcome hands a realized Outcome to Options.Outcome when set. An error
+// from the callback is best-effort logged and swallowed: the mutation already
+// happened, so failing to append its outcome record must not abort the Run or
+// change the row's fate -- it only degrades the backup trail's completeness (#515).
+func (b *Backfiller) reportOutcome(opts Options, o Outcome) {
+	if opts.Outcome == nil {
+		return
+	}
+	if err := opts.Outcome(o); err != nil {
+		slog.Warn("instrumentalbackfill: could not record change outcome to the backup trail",
+			"id", o.QueueID, "status", o.Status, "error", err)
+	}
 }
 
 // writeMarkers writes the instrumental marker to every output path for item,

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -186,6 +186,80 @@ func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
 	}
 }
 
+// TestRun_OutcomeReportsAppliedAfterSettle verifies the realized-outcome callback
+// fires applied AFTER the settle, so the backup trail records what landed and not
+// just intent (#515).
+func TestRun_OutcomeReportsAppliedAfterSettle(t *testing.T) {
+	var order []string
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.order = &order
+	w := &fakeWriter{order: &order}
+
+	var outcomes []Outcome
+	_, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		Report:              func(Change) error { order = append(order, "backup"); return nil },
+		Outcome: func(o Outcome) error {
+			order = append(order, "outcome")
+			outcomes = append(outcomes, o)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0].QueueID != 1 || outcomes[0].Status != OutcomeApplied || outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one {id=1 applied} record", outcomes)
+	}
+	// Outcome must come AFTER the settle -- it reports the realized result.
+	want := []string{"backup", "marker", "settle", "outcome"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v; want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v; want %v", order, want)
+		}
+	}
+}
+
+// TestRun_OutcomeReportsSkippedOnClaim verifies a stamp-claimed negative verdict
+// fires skipped (nothing landed), and TestRun_OutcomeReportsAmbiguous the
+// ambiguous-settle failed case (#515).
+func TestRun_OutcomeReportsSkippedOnClaim(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.stampClaimed = true // negative verdict, but a worker claimed the row
+
+	var outcomes []Outcome
+	_, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		Outcome:             func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeSkipped {
+		t.Fatalf("outcomes=%+v; want one skipped record", outcomes)
+	}
+}
+
+func TestRun_OutcomeReportsAmbiguousOnSettleError(t *testing.T) {
+	store := newFakeStore(item(1, "/music/a.flac"))
+	store.settleErr = errors.New("commit failed")
+
+	var outcomes []Outcome
+	_, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(context.Background(), Options{
+		GlobalDetectDefault: true,
+		Outcome:             func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeFailed || !outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one {failed ambiguous} record", outcomes)
+	}
+}
+
 // A Report failure must abort that row's mutation entirely: the whole point of
 // backup-first is that a change never exists without its restorable record.
 func TestRun_ReportFailureAbortsRowMutation(t *testing.T) {
@@ -515,14 +589,24 @@ func TestRun_PeerSettledRowKeepsItsMarker(t *testing.T) {
 	store := newFakeStore(it)
 	store.settleOutcome = queue.SettleAlreadyInstrumental // a peer got there first
 
+	var outcomes []Outcome
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
-		context.Background(), Options{GlobalDetectDefault: true, Report: func(Change) error { return nil }})
+		context.Background(), Options{
+			GlobalDetectDefault: true,
+			Report:              func(Change) error { return nil },
+			Outcome:             func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+		})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
 	if res.SkippedAlreadySettled != 1 {
 		t.Errorf("res = %+v; want SkippedAlreadySettled=1", res)
+	}
+	// The peer-settled row reports OutcomeApplied (verdict on disk), the documented
+	// #515 contract -- see the engine comment on this arm. Pin it here.
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeApplied || outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one applied record", outcomes)
 	}
 	for _, p := range MarkerPaths(it.Inputs) {
 		if _, err := os.Stat(p); err != nil {

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -85,6 +85,40 @@ type Change struct {
 	MarkerPaths []string
 }
 
+// Outcome statuses reported to Options.Outcome after a change's mutation
+// resolves. The intent record (Options.Report) is written BEFORE the mutation
+// for crash safety, so it alone cannot say whether the change actually landed; a
+// restore tool must consult the matching Outcome record and replay only the ones
+// confirmed applied (#515).
+const (
+	// OutcomeApplied: the mutation committed (row settled/reset, or a peer had
+	// already settled it with the same verdict). Safe to trust; a restore reverts
+	// exactly these.
+	OutcomeApplied = "applied"
+	// OutcomeSkipped: a serve-mode worker claimed the row (or it was gone) between
+	// the listing and the mutation, so nothing was written. Not restorable -- there
+	// is nothing to revert.
+	OutcomeSkipped = "skipped"
+	// OutcomeFailed: the change did not complete (a Report/reset/marker error, or
+	// an ambiguous settle whose commit outcome is unknown -- see Outcome.Ambiguous).
+	OutcomeFailed = "failed"
+)
+
+// Outcome is the realized result of one change, handed to Options.Outcome after
+// the mutation resolves so the backup trail records what actually happened rather
+// than only intent (#515). Keyed by QueueID to the earlier Report record.
+type Outcome struct {
+	QueueID int64
+	// Status is OutcomeApplied, OutcomeSkipped, or OutcomeFailed.
+	Status string
+	// Ambiguous marks the one case where OutcomeFailed does NOT mean "no change":
+	// SettleInstrumental returned an error that may have come from Commit itself,
+	// so the settle may or may not have landed and the marker was deliberately
+	// left in place. A restore must treat an ambiguous-failed row as
+	// possibly-applied (verify before reverting), never as a clean no-op.
+	Ambiguous bool
+}
+
 // Result counts one Run.
 type Result struct {
 	Total          int // candidate vocal-gate rejections considered
@@ -93,6 +127,13 @@ type Result struct {
 	ResetStale     int // rows reset to never-classified (cross-version pass)
 	SkippedClaimed int // rows a serve-mode worker claimed mid-recalibration
 	Errors         int // non-fatal per-row failures
+
+	// MaxExaminedID is the highest work_queue id this run looked at (0 if no
+	// candidates). Feed it back as the next run's AfterID to resume past the rows
+	// this run already examined -- the forward-direction resume cursor (#516).
+	// Because candidates are listed ORDER BY id, it is the id of the last row in
+	// the returned set.
+	MaxExaminedID int64
 
 	// Reverse-direction counters (Reverse only).
 	Reversed             int // settled instrumentals reverted under a tightened gate
@@ -106,6 +147,13 @@ type Options struct {
 	LibraryID *int64
 	// Limit caps the candidate set when > 0.
 	Limit int
+	// AfterID is a resume cursor (#516): when > 0, only candidate rows whose
+	// work_queue id is strictly greater are considered. Combined with the
+	// MaxExaminedID reported in Result, an operator can page through the backlog
+	// with repeated bounded --limit runs without re-selecting the same low-id
+	// non-passing rows every time. 0 starts from the beginning. Forward
+	// (loosening) direction only; the Reverse path lists a different row set.
+	AfterID int64
 	// DryRun previews without mutating anything.
 	DryRun bool
 	// MinConfidence, VocalMax, SpeechMax are the (presumably loosened)
@@ -121,6 +169,14 @@ type Options struct {
 	// aborts that row's mutation and counts an error; it never aborts the
 	// Run. Nil disables it.
 	Report func(Change) error
+	// Outcome is invoked once per change AFTER its mutation resolves, carrying the
+	// realized result (applied/skipped/failed) so the backup trail records what
+	// actually happened, not just the earlier Report intent (#515). Fires for
+	// every row that reached the mutation stage, including a Report failure (so a
+	// restore can see the intent never applied). Never fires in a dry run. An
+	// Outcome error is best-effort logged and does not abort the Run. Nil disables
+	// it.
+	Outcome func(Outcome) error
 	// Preview is invoked once per change in a dry run instead of mutating.
 	// Nil disables it.
 	Preview func(Change)
@@ -146,11 +202,18 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 	rows, err := r.store.ListVocalGateRejections(ctx, queue.ListVocalGateRejectionsOptions{
 		LibraryID: opts.LibraryID,
 		Limit:     opts.Limit,
+		AfterID:   opts.AfterID,
 	})
 	if err != nil {
 		return res, fmt.Errorf("instrumentalrecalib: list vocal-gate rejections: %w", err)
 	}
 	res.Total = len(rows)
+	// The list is ORDER BY id, so the last row carries the highest id examined --
+	// the cursor to resume past on the next run (#516). Set before the loop so an
+	// early ctx cancellation still reports how far the selection reached.
+	if len(rows) > 0 {
+		res.MaxExaminedID = rows[len(rows)-1].ID
+	}
 
 	for _, row := range rows {
 		if err := ctx.Err(); err != nil {
@@ -192,6 +255,9 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 		if opts.Report != nil {
 			if err := opts.Report(change); err != nil {
 				res.Errors++
+				// The intent record failed to persist, so the mutation is not
+				// attempted; record the failure so a restore knows nothing applied.
+				r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeFailed})
 				continue
 			}
 		}
@@ -200,15 +266,18 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 			reset, err := r.store.ResetInstrumentalToUnclassified(ctx, row.ID)
 			if err != nil {
 				res.Errors++
+				r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeFailed})
 				continue
 			}
 			if !reset {
 				// A worker claimed the row (it is no longer 'deferred') between the
 				// list and here: nothing to reset.
 				res.SkippedClaimed++
+				r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeSkipped})
 				continue
 			}
 			res.ResetStale++
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeApplied})
 			continue
 		}
 
@@ -218,6 +287,7 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 			res.Errors++
 			// Never settle a verdict whose marker did not fully land.
 			res.MarkersWritten -= r.rollback(written, &res)
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeFailed})
 			continue
 		}
 
@@ -230,23 +300,39 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 			res.Errors++
 			slog.Warn("instrumentalrecalib: settle failed after the marker was written; leaving the marker in place because the commit outcome is unknown",
 				"id", row.ID, "markers", written, "error", err)
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeFailed, Ambiguous: true})
 			continue
 		}
 
 		switch outcome {
 		case queue.Settled:
 			res.Settled++
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeApplied})
 		case queue.SettleAlreadyInstrumental:
 			// A PEER settled this row first with the same verdict; the marker on
-			// disk is correct (byte-identical). Do not remove it.
+			// disk is correct (byte-identical) and is left in place.
+			//
+			// This reports OutcomeApplied because the end STATE is what the run
+			// intended (row done+instrumental, marker on disk). But the DB verdict
+			// was established by a DIFFERENT actor -- classifyNoSettle keys only on
+			// status='done' AND instrumental_result=1, not on which run wrote it. A
+			// future restore that reverts every OutcomeApplied row will therefore
+			// also revert a verdict this run did not create. That is acceptable as a
+			// STATE reversal (the row really is instrumental regardless of author),
+			// but if the restore tool ever needs actor attribution, this arm is
+			// where a distinct status (e.g. applied-by-peer) belongs. No restore
+			// tool exists yet, so nothing reverts today (#515).
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeApplied})
 		case queue.SettleClaimed, queue.SettleRowGone:
 			// A worker owns the row, or it is gone. Nothing was written to the DB,
 			// so our marker is an orphan: take it back.
 			res.MarkersWritten -= r.rollback(written, &res)
 			res.SkippedClaimed++
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeSkipped})
 		case queue.SettleFailed:
 			// Unreachable: a failure returns a non-nil error, handled above.
 			res.Errors++
+			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeFailed})
 		}
 	}
 
@@ -290,6 +376,20 @@ func (r *Recalibrator) rollback(written []string, res *Result) int {
 		}
 	}
 	return len(written)
+}
+
+// reportOutcome hands a realized Outcome to Options.Outcome when set. An error
+// from the callback is best-effort logged and swallowed: the mutation has already
+// happened, so failing to append its outcome record must not abort the Run or
+// change the row's fate -- it only degrades the backup trail's completeness (#515).
+func (r *Recalibrator) reportOutcome(opts Options, o Outcome) {
+	if opts.Outcome == nil {
+		return
+	}
+	if err := opts.Outcome(o); err != nil {
+		slog.Warn("instrumentalrecalib: could not record change outcome to the backup trail",
+			"id", o.QueueID, "status", o.Status, "error", err)
+	}
 }
 
 // outputPath derives the marker's output directory and base filename from

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -244,6 +244,157 @@ func TestRun_SkipsStillNonPassingRow(t *testing.T) {
 	}
 }
 
+// TestRun_AfterIDResumeCursor verifies the engine threads AfterID into the
+// listing and reports MaxExaminedID for the next run's cursor (#516). The
+// multi-row id ordering is covered at the queue layer
+// (TestListVocalGateRejections_AfterID); here one still-non-passing row proves
+// the threading and the cursor bookkeeping.
+func TestRun_AfterIDResumeCursor(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	// Still non-passing (VocalPeak above the gate) so it is skipped, not mutated,
+	// and stays selectable for the second run -- the exact stall #516 addresses.
+	id := seedRejection(t, q, "/music/spoken.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.50, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	w := &fakeWriter{}
+	r := New(q, w)
+	opts := Options{DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0"}
+
+	// No cursor: the row is examined; MaxExaminedID reports its id.
+	res, err := r.Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Total != 1 || res.MaxExaminedID != id {
+		t.Fatalf("run: Total=%d MaxExaminedID=%d; want 1 and %d", res.Total, res.MaxExaminedID, id)
+	}
+
+	// Cursor at the row's id: it is excluded, nothing left, MaxExaminedID resets 0.
+	optsAfter := opts
+	optsAfter.AfterID = id
+	res, err = r.Run(ctx, optsAfter)
+	if err != nil {
+		t.Fatalf("run after-id: %v", err)
+	}
+	if res.Total != 0 || res.MaxExaminedID != 0 {
+		t.Fatalf("after-id run: Total=%d MaxExaminedID=%d; want 0 and 0 (cursor excludes the row)", res.Total, res.MaxExaminedID)
+	}
+}
+
+// TestRun_OutcomeReportsApplied verifies that a version-matched settle fires an
+// Outcome{applied} AFTER the mutation, so the backup trail records the realized
+// result and not just the pre-mutation intent (#515).
+func TestRun_OutcomeReportsApplied(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	id := seedRejection(t, q, "/music/violin.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	var reports []Change
+	var outcomes []Outcome
+	r := New(q, &fakeWriter{})
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Report:  func(ch Change) error { reports = append(reports, ch); return nil },
+		Outcome: func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 1 {
+		t.Fatalf("Settled=%d; want 1", res.Settled)
+	}
+	if len(reports) != 1 || reports[0].QueueID != id {
+		t.Fatalf("reports=%+v; want one intent record for id=%d", reports, id)
+	}
+	if len(outcomes) != 1 || outcomes[0].QueueID != id || outcomes[0].Status != OutcomeApplied || outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one {id=%d applied} record", outcomes, id)
+	}
+}
+
+// TestRun_OutcomeReportsSkippedOnClaim verifies a worker-claimed row (settle
+// returns SettleClaimed) fires Outcome{skipped}, so a restore does not try to
+// revert a change that never landed (#515).
+func TestRun_OutcomeReportsSkippedOnClaim(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	claimed := queue.SettleClaimed
+	store := &fakeStore{DBQueue: q, settleOutcome: &claimed}
+
+	seedRejection(t, q, "/music/violin.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	var outcomes []Outcome
+	r := New(store, &fakeWriter{})
+	if _, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Outcome: func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeSkipped {
+		t.Fatalf("outcomes=%+v; want one skipped record", outcomes)
+	}
+}
+
+// TestRun_OutcomeReportsAmbiguousOnSettleError verifies a settle error (ambiguous
+// commit) fires Outcome{failed, ambiguous}, flagging that the change may have
+// landed and must be verified before a restore reverts it (#515).
+func TestRun_OutcomeReportsAmbiguousOnSettleError(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+	store := &fakeStore{DBQueue: q, settleErr: errors.New("commit failed")}
+
+	seedRejection(t, q, "/music/violin.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	var outcomes []Outcome
+	r := New(store, &fakeWriter{})
+	res, err := r.Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Outcome: func(o Outcome) error { outcomes = append(outcomes, o); return nil },
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Errors != 1 {
+		t.Fatalf("Errors=%d; want 1", res.Errors)
+	}
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeFailed || !outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one {failed ambiguous} record", outcomes)
+	}
+}
+
+// TestRun_DryRunEmitsNoOutcome verifies a dry run never fires Outcome (it mutates
+// nothing, so there is no realized result to record) (#515).
+func TestRun_DryRunEmitsNoOutcome(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/violin.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+
+	outcomeCalls := 0
+	r := New(q, &fakeWriter{})
+	if _, err := r.Run(ctx, Options{
+		DryRun: true, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Outcome: func(Outcome) error { outcomeCalls++; return nil },
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if outcomeCalls != 0 {
+		t.Fatalf("Outcome fired %d times in a dry run; want 0", outcomeCalls)
+	}
+}
+
 func TestRun_DryRunDoesNotMutate(t *testing.T) {
 	ctx := context.Background()
 	q := openTestQueue(t)
@@ -559,14 +710,23 @@ func TestRun_SettleAlreadyInstrumentalKeepsMarker(t *testing.T) {
 
 	w := &fakeWriter{}
 	r := New(store, w)
+	var outcomes []Outcome
 	res, err := r.Run(ctx, Options{
 		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+		Outcome: func(o Outcome) error { outcomes = append(outcomes, o); return nil },
 	})
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	if res.Settled != 0 || res.SkippedClaimed != 0 || res.Errors != 0 || res.MarkersWritten != 1 {
 		t.Fatalf("expected the marker kept and no error/skip/settle counted, got %+v", res)
+	}
+	// A peer-settled row reports OutcomeApplied (the verdict is on disk), even
+	// though a DIFFERENT actor established it -- the documented #515 contract this
+	// test pins. If this ever changes to a distinct status, update the engine
+	// comment and the restore contract together.
+	if len(outcomes) != 1 || outcomes[0].Status != OutcomeApplied || outcomes[0].Ambiguous {
+		t.Fatalf("outcomes=%+v; want one applied record for the peer-settled row", outcomes)
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -2087,6 +2087,12 @@ func (q *DBQueue) ListInstrumental(ctx context.Context, opts ListInstrumentalOpt
 type ListVocalGateRejectionsOptions struct {
 	LibraryID *int64
 	Limit     int
+	// AfterID is a resume cursor: when > 0, only rows whose work_queue id is
+	// strictly greater are returned. Because rows are listed ORDER BY id and a
+	// non-passing row is skipped (not mutated), a repeated small --limit run
+	// would otherwise re-select the same low-id non-passing rows forever; passing
+	// the highest id examined by the prior run advances past them (#516).
+	AfterID int64
 }
 
 // StampedRejection is one instrumental_result=0 row with its stored telemetry,
@@ -2139,6 +2145,12 @@ func (q *DBQueue) ListVocalGateRejections(ctx context.Context, opts ListVocalGat
 	libClause, libArgs := recheckLibraryClause(opts.LibraryID)
 	query += libClause //nolint:gosec // G202: libClause is a package-constant fragment from recheckLibraryClause, never user-built SQL
 	args = append(args, libArgs...)
+	// Resume cursor (#516): exclude rows a prior --limit pass already examined.
+	// Bound before the ORDER BY / LIMIT so the cap applies to the remaining rows.
+	if opts.AfterID > 0 {
+		query += ` AND id > ?`
+		args = append(args, opts.AfterID)
+	}
 	query += ` ORDER BY id`
 	if opts.Limit > 0 {
 		query += ` LIMIT ?`

--- a/internal/queue/queue_recalib_test.go
+++ b/internal/queue/queue_recalib_test.go
@@ -505,6 +505,45 @@ func TestListVocalGateRejections_Limit(t *testing.T) {
 	}
 }
 
+// TestListVocalGateRejections_AfterID verifies the resume cursor: AfterID
+// excludes every row at or below that work_queue id, so a repeated --limit run
+// advances past low-id rows a prior pass already examined instead of re-selecting
+// them (#516).
+func TestListVocalGateRejections_AfterID(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	var ids []int64
+	for i := 0; i < 3; i++ {
+		id := seedDeferredRow(t, q, "Artist", fmt.Sprintf("Title%d", i), fmt.Sprintf("/music/%d.flac", i))
+		if _, err := q.StampUnclassifiedMiss(ctx, id, InstrumentalTelemetry{MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0"}); err != nil {
+			t.Fatalf("stamp: %v", err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Cursor at the first row's id: only the two higher-id rows remain, in id order.
+	got, err := q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{AfterID: ids[0]})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d; want 2 (AfterID must exclude rows <= the cursor)", len(got))
+	}
+	if got[0].ID != ids[1] || got[1].ID != ids[2] {
+		t.Fatalf("got ids [%d %d]; want [%d %d] (ascending, past the cursor)", got[0].ID, got[1].ID, ids[1], ids[2])
+	}
+
+	// AfterID composes with Limit: cursor past the first, cap at one -> just ids[1].
+	got, err = q.ListVocalGateRejections(ctx, ListVocalGateRejectionsOptions{AfterID: ids[0], Limit: 1})
+	if err != nil {
+		t.Fatalf("list with limit: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != ids[1] {
+		t.Fatalf("got %+v; want single row id=%d", got, ids[1])
+	}
+}
+
 func TestListDetectorInstrumentalMarkers(t *testing.T) {
 	q := NewDBQueue(openQueueTestDB(t))
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Two hardening fixes for the `scan reconcile-instrumental*` commands, both deferred from #514 as cross-cutting siblings (same files: `instrumentalrecalib` + `instrumentalbackfill` + `queue` + the reconcile CLI).

- **#516 `--after-id` resume cursor:** `ListVocalGateRejections` lists `ORDER BY id`, and a non-passing row is *skipped* (not mutated), so a repeated small `--limit` run re-selected the same low-id rows and never advanced. Added an `AfterID` cursor (`WHERE id > ?`), a `--after-id` CLI flag, and a `resume with --after-id=N` print on a limit-capped forward run. Rejected with `--reverse` (forward-direction only).
- **#515 realized-outcome backup:** the JSONL backup recorded intent *before* the mutation, so a failed/skipped attempt was indistinguishable from a committed one. Added an `Outcome` callback to **both** siblings, fired *after* each mutation with `applied | skipped | failed` (+`ambiguous` for the settle-commit-unknown case), appended as a second type-discriminated JSONL record. A restore replays only `applied` rows.

## Linked issue

Closes #515, closes #516

## Notes for review

- The `SettleAlreadyInstrumental -> applied` mapping is a deliberate **state reversal, not actor attribution**: a peer may have established the DB verdict, so a future restore reverting `applied` rows would also revert a peer's verdict. No restore tool exists yet, so nothing reverts today. The contract is documented on both engines' arms and pinned by tests. If actor attribution ever matters, that arm is where a distinct status belongs. (Flagged by the pre-push hostile review; kept as-is with honest docs rather than inventing a premature status.)
- Both records are fsynced (intent before mutation, outcome after); a crash between them leaves intent-present + no-outcome = "attempted, result unknown," the intended recoverable state.
- The two backup records carry a `type` discriminator (`intent`/`outcome`); a reader treats a missing `type` as `intent` for pre-#515 backups.

## Gates

- [x] `make gate` passes locally (race tests, patch coverage 86%, coverage-floor, golangci-lint, actionlint, govulncheck).
- [x] New tests confirmed to fail against unfixed code before the fix (cursor: `AfterID`/`MaxExaminedID`; outcome: every mutation arm incl. the peer-settle mapping and the ambiguous-settle case; CLI: both siblings assert the JSONL carries intent + outcome records).
- [x] Patch coverage meets threshold: 86.27% on the diff.
- [x] Surface stated: the `scan reconcile-instrumental` and `reconcile-instrumental-recalibrate` CLI commands + their engines. Verified via the CLI backup-file round-trip tests.

## Not covered

- The restore/replay tool that would consume the outcome records does not exist yet (out of scope; #515 only makes the trail *recordable*).
- No schema change; the cursor and outcome records are CLI/engine-level only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable processing with the `--after-id` cursor for forward runs.
  * Limited runs now display a cursor for continuing from the last examined item.
  * Reconciliation backups now include both planned actions and realized outcomes.
  * Outcomes identify whether each item was applied, skipped, or failed, including ambiguous results.

* **Bug Fixes**
  * Prevented unsupported combinations of reverse processing and forward resume cursors.
  * Improved outcome tracking across settlement, skipped, and error scenarios.
  * Dry runs no longer record mutation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->