### PR TITLE
feat(scan): cache exact per-file audio duration for lyric revalidation (#441)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Every package with a one-line purpose. `cmd/mxlrcgo-svc/main.go` is the entry po
 - `db` -- pure-Go SQLite (`modernc.org/sqlite`) open/migrate (goose), WAL, foreign keys, busy-retry, and a read-only open path; migrations in `internal/db/migrations/`.
 - `cache` -- lyrics cache repository (`CacheRepo`) over SQLite.
 - `scanfail` -- `Store` recording files that consistently fail metadata read, so the scanner skips them until mtime/size changes; satisfies `scanner.MetadataFailureStore`.
+- `audiodur` -- exact per-file audio duration cache (`Store`) keyed by path and validated by (mtime, size); filled opportunistically wherever a file is already open, from that read's own handle rather than a path re-stat. A miss is `unknown_duration`, never an error (#441). The consumer that would look the cache up (#442) does not exist yet.
 - `queue` -- the in-memory `InputsQueue` (fetch mode) and the durable SQLite `DBQueue` (serve/worker mode) with priority tiers and randomized within-tier dequeue. Completion stamps (`SetOutcomeType`, `SetCompletionProvenance`, `SetTimingOutcome`) are written before `Complete` while the row is still `processing`; each is non-fatal, since the output is already on disk by then.
 - `library` -- library-root CRUD repository (`Add`/`List`/`Get`/`GetByName`/`Update`/`Remove`).
 - `scan` -- library scanning: `Enqueuer`, the `scan_results` `Repo`, and the periodic scheduler that enqueues missing lyrics.

--- a/internal/audiodur/audiodur.go
+++ b/internal/audiodur/audiodur.go
@@ -1,0 +1,78 @@
+// Package audiodur caches the exact audio duration of a file, in integer
+// seconds, keyed by absolute path and validated by (mtime, size). It exists so
+// the revalidation path (#441) reads a file's header once per file VERSION
+// rather than once per pass: internal/timing needs an exact duration for its
+// calibrated 2s tolerance, and re-deriving it means opening the file, which on a
+// spun-down array costs a disk spin-up rather than merely I/O.
+//
+// A MISS IS NOT AN ERROR. An absent or stale entry yields (0, false), and
+// callers pass that 0 straight to timing.Evaluate, which returns
+// UnknownDuration -- an existing, already-tested fail-open branch. A cold cache
+// is therefore correct, merely uninformative.
+//
+// See internal/scanfail for the same path+mtime+size validation pattern.
+package audiodur
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Store reads and writes cached durations in the audio_durations table. It is
+// safe for concurrent use because the underlying *sql.DB is.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store backed by db.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Lookup returns the cached duration for path when the file still matches the
+// mtime and size it was recorded at. found is false for BOTH an absent row and a
+// stale one, because the two are the same fact to a caller: no usable duration.
+// A miss returns 0 seconds, which timing.Evaluate treats as UnknownDuration.
+//
+// mtimeNano is ModTime().UnixNano(), so a same-second rewrite to the same byte
+// size still reads as changed.
+func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) (int, bool, error) {
+	var seconds int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT duration_seconds FROM audio_durations
+		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? LIMIT 1`,
+		path, mtimeNano, size,
+	).Scan(&seconds)
+	if err == nil {
+		return seconds, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	return 0, false, fmt.Errorf("audiodur: lookup %q: %w", path, err)
+}
+
+// Record caches seconds as the duration of path at the given mtime and size,
+// replacing any previous entry for that path. Recording a non-positive duration
+// is a no-op: absence is how this table represents "unknown", so storing a 0
+// would make "never read" indistinguishable from "measured as zero-length".
+func (s *Store) Record(ctx context.Context, path string, mtimeNano, size int64, seconds int) error {
+	if seconds <= 0 {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO audio_durations (file_path, mtime_nsec, size_bytes, duration_seconds)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(file_path) DO UPDATE SET
+		     mtime_nsec       = excluded.mtime_nsec,
+		     size_bytes       = excluded.size_bytes,
+		     duration_seconds = excluded.duration_seconds`,
+		path, mtimeNano, size, seconds,
+	)
+	if err != nil {
+		return fmt.Errorf("audiodur: record %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/audiodur/audiodur_test.go
+++ b/internal/audiodur/audiodur_test.go
@@ -1,0 +1,140 @@
+package audiodur_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/audiodur"
+	"github.com/sydlexius/canticle/internal/db"
+)
+
+func openTestStore(t *testing.T) *audiodur.Store {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return audiodur.New(sqlDB)
+}
+
+func TestLookup_UnknownPathIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	secs, found, err := s.Lookup(ctx, "/music/never-seen.flac", 100, 200)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if found {
+		t.Fatal("an unrecorded file must be a miss")
+	}
+	if secs != 0 {
+		t.Fatalf("a miss must yield 0 seconds, got %d", secs)
+	}
+}
+
+func TestRecordThenLookupHits(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.Record(ctx, "/music/song.flac", 100, 200, 210); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	secs, found, err := s.Lookup(ctx, "/music/song.flac", 100, 200)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if !found {
+		t.Fatal("a recorded file with unchanged mtime+size must hit")
+	}
+	if secs != 210 {
+		t.Fatalf("got %d seconds, want 210", secs)
+	}
+}
+
+func TestChangedMtimeOrSizeIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.Record(ctx, "/music/song.flac", 100, 200, 210); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if _, found, err := s.Lookup(ctx, "/music/song.flac", 101, 200); err != nil {
+		t.Fatalf("Lookup changed mtime: %v", err)
+	} else if found {
+		t.Fatal("a changed mtime must invalidate the cached duration")
+	}
+
+	if _, found, err := s.Lookup(ctx, "/music/song.flac", 100, 201); err != nil {
+		t.Fatalf("Lookup changed size: %v", err)
+	} else if found {
+		t.Fatal("a changed size must invalidate the cached duration")
+	}
+}
+
+// A same-second rewrite to the same byte size must still read as changed. This
+// is the whole reason mtime is stored at nanosecond precision; a second-level
+// stamp would collide here and serve a stale duration.
+func TestNanosecondPrecisionInvalidates(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	const sameSecond = int64(1_700_000_000_000_000_000)
+	if err := s.Record(ctx, "/music/song.flac", sameSecond, 200, 210); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	_, found, err := s.Lookup(ctx, "/music/song.flac", sameSecond+1, 200)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if found {
+		t.Fatal("a one-nanosecond mtime change must invalidate the cached duration")
+	}
+}
+
+func TestRecordUpsertsOnRepeat(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.Record(ctx, "/music/song.flac", 100, 200, 210); err != nil {
+		t.Fatalf("Record first: %v", err)
+	}
+	// The file was re-encoded: new mtime, new size, new duration, same path.
+	if err := s.Record(ctx, "/music/song.flac", 300, 400, 215); err != nil {
+		t.Fatalf("Record second: %v", err)
+	}
+
+	if _, found, err := s.Lookup(ctx, "/music/song.flac", 100, 200); err != nil {
+		t.Fatalf("Lookup old version: %v", err)
+	} else if found {
+		t.Fatal("the superseded file version must no longer hit")
+	}
+
+	secs, found, err := s.Lookup(ctx, "/music/song.flac", 300, 400)
+	if err != nil {
+		t.Fatalf("Lookup new version: %v", err)
+	}
+	if !found || secs != 215 {
+		t.Fatalf("got (%d, %v), want (215, true)", secs, found)
+	}
+}
+
+// Absence is how this table represents "unknown", so a non-positive duration
+// must not be stored -- otherwise "never read" and "measured zero-length"
+// become indistinguishable on lookup.
+func TestRecordIgnoresNonPositiveDuration(t *testing.T) {
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if err := s.Record(ctx, "/music/unknown.flac", 100, 200, 0); err != nil {
+		t.Fatalf("Record zero: %v", err)
+	}
+	if _, found, err := s.Lookup(ctx, "/music/unknown.flac", 100, 200); err != nil {
+		t.Fatalf("Lookup: %v", err)
+	} else if found {
+		t.Fatal("a zero duration must not be cached")
+	}
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -23,6 +23,7 @@ import (
 	"github.com/BurntSushi/toml"
 	arg "github.com/alexflint/go-arg"
 	"github.com/sydlexius/canticle/internal/app"
+	"github.com/sydlexius/canticle/internal/audiodur"
 	"github.com/sydlexius/canticle/internal/auth"
 	"github.com/sydlexius/canticle/internal/cache"
 	"github.com/sydlexius/canticle/internal/config"
@@ -1039,6 +1040,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// and exposed via CacheStats.
 	cacheRepo := cache.New(sqlDB)
 	w := worker.New(workQ, cacheRepo, fetcher, writer)
+	w.SetDurationStore(audiodur.New(sqlDB))
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	w.SetCircuitBackoff(time.Duration(cfg.API.CircuitBackoffBase)*time.Second, time.Duration(cfg.API.CircuitOpenDuration)*time.Second)
 	// Dispatch strategy and the parallel-mode synced-upgrade window. Set before the
@@ -2113,7 +2115,10 @@ func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, gl
 		Results:   results,
 		// Persist metadata-read failures so a permanently-malformed file is not
 		// re-read (and re-warned about) on every scheduled/watched scan (#376).
-		Scanner: scanner.NewScanner(scanner.WithMetadataFailureStore(scanfail.New(sqlDB))),
+		Scanner: scanner.NewScanner(
+			scanner.WithMetadataFailureStore(scanfail.New(sqlDB)),
+			scanner.WithDurationStore(audiodur.New(sqlDB)),
+		),
 		Options: opts,
 		OnScanComplete: func(ctx context.Context, lib models.Library, found []models.ScanResult) error {
 			enqueued, cacheHits, err := enq.EnqueuePending(ctx, lib)

--- a/internal/db/migrations/035_audio_durations.sql
+++ b/internal/db/migrations/035_audio_durations.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Exact per-file audio duration in integer seconds (#441), cached so the
+-- revalidation path reads a file's header once per file VERSION rather than once
+-- per pass. internal/timing needs an exact duration for its calibrated 2s
+-- tolerance; the lyrics_cache duration_bucket (migration 014) is a floor
+-- quantizer keyed by (artist, title, duration_bucket) and cannot serve a
+-- per-file 2s comparison.
+--
+-- KEYED BY PATH, DELIBERATELY. Computing any content or tag identity (MBID,
+-- ISRC, AcoustID, a content hash) requires OPENING the file -- and that same
+-- open already yields the duration, so an identity-keyed hit would save nothing.
+-- Path plus mtime plus size is the only key derivable from readdir/stat WITHOUT
+-- opening the file, which is exactly the property that makes this cache pay for
+-- itself on an array whose disks are kept spun down. Move-durable row identity
+-- is a real but SEPARATE concern, tracked as #640.
+--
+-- VALIDATION IS LOAD-BEARING, NOT DEFENSIVE. Re-encodes and mass retags are
+-- normal in a large library -- a meaningful fraction of files routinely end up
+-- newer than their own sidecar -- so an unvalidated duration cache would be
+-- wrong on many rows. mtime_nsec + size_bytes makes staleness structurally
+-- impossible rather than merely unlikely: a changed file simply stops matching
+-- and its stale row is inert, exactly as scanner_metadata_failures (migration
+-- 023) documents. Nanosecond precision matters for the same reason it does
+-- there -- a same-second rewrite to the same byte size must still read as
+-- changed.
+--
+-- A MISS IS NOT AN ERROR. Consumers treat an absent or stale row as duration 0,
+-- which internal/timing.Evaluate already returns as 'unknown_duration' and every
+-- consumer already fails open on. A cold cache is therefore CORRECT, merely
+-- uninformative; no backfill is required and none is possible without reading
+-- every file.
+--
+-- duration_seconds is only ever a POSITIVE measured value. The unknown case is
+-- represented by the ABSENCE of a row, never by a stored 0, so that "we have
+-- never read this file" and "this file is zero seconds long" stay distinct.
+-- The CHECK constraints below enforce that invariant (and a non-empty key) at
+-- the schema level rather than relying on Go alone; unlike migration 034's
+-- additive columns on an existing table, this table is newly created here, so
+-- there is no later SQLite table-rebuild cost to adding them now.
+CREATE TABLE audio_durations (
+    file_path        TEXT    PRIMARY KEY CHECK (file_path <> ''),
+    mtime_nsec       INTEGER NOT NULL,
+    size_bytes       INTEGER NOT NULL,
+    duration_seconds INTEGER NOT NULL CHECK (duration_seconds > 0)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS audio_durations;
+-- +goose StatementEnd

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -106,11 +106,17 @@ func ReadArtistIdentity(path string) (artist, albumArtist string, err error) {
 // AudioMetadata carries the recording disambiguators a provider query needs from
 // an audio file's tags. The zero values are the documented "absent" sentinels:
 // TrackLength 0 is the unknown-duration sentinel normalize.DurationBucket keys
-// on, and an empty string means the tag is absent.
+// on, and an empty string means the tag is absent. MTimeNano and SizeBytes are
+// the open file handle's own identity (ModTime().UnixNano() and Size(), stat'd
+// before the handle is closed) rather than a re-resolution of the path; zero
+// means the identity could not be determined (a stat failure), matching the
+// same "absent" convention as the other fields.
 type AudioMetadata struct {
 	TrackLength int
 	ISRC        string
 	AlbumName   string
+	MTimeNano   int64
+	SizeBytes   int64
 }
 
 // ReadAudioMetadata opens the audio file at path and returns the recording
@@ -137,7 +143,19 @@ func ReadAudioMetadata(path string) (AudioMetadata, error) {
 		slog.Debug("duration parse failed; using 0", "file", path, "error", derr)
 		dur = 0
 	}
-	return AudioMetadata{TrackLength: dur, ISRC: extractISRC(m), AlbumName: m.Album()}, nil
+	var mtimeNano, sizeBytes int64
+	if info, serr := f.Stat(); serr != nil {
+		slog.Debug("could not stat open handle for identity; using zero sentinel", "file", path, "error", serr)
+	} else {
+		mtimeNano, sizeBytes = info.ModTime().UnixNano(), info.Size()
+	}
+	return AudioMetadata{
+		TrackLength: dur,
+		ISRC:        extractISRC(m),
+		AlbumName:   m.Album(),
+		MTimeNano:   mtimeNano,
+		SizeBytes:   sizeBytes,
+	}, nil
 }
 
 // audioFileTypeForExt returns the audioduration type constant for a lower-case
@@ -175,6 +193,19 @@ type MetadataFailureStore interface {
 	RecordFailure(ctx context.Context, path string, mtimeNano, size int64, readErr error) error
 }
 
+// DurationStore banks the exact audio duration this scan already computed, so
+// the revalidation path (#441) does not have to re-open the file to learn it.
+// A nil store disables the feature entirely.
+//
+// This is deliberately a WRITE-ONLY seam here: the scanner has the file open and
+// has already paid for the header read, so it never needs to consult the cache,
+// only fill it.
+type DurationStore interface {
+	// Record caches seconds as the duration of path at the given mtime and size.
+	// mtimeNano is ModTime().UnixNano().
+	Record(ctx context.Context, path string, mtimeNano, size int64, seconds int) error
+}
+
 // Scanner handles parsing input sources and populating the work queue.
 type Scanner struct {
 	// probeFunc, when set, is used as the duration probe instead of audioduration
@@ -183,6 +214,9 @@ type Scanner struct {
 	// failures, when set, lets the scanner skip files that previously failed
 	// metadata read (and warn only once per file-version). Nil disables it.
 	failures MetadataFailureStore
+	// durations, when set, banks each computed duration for the revalidation
+	// path (#441). Nil disables it.
+	durations DurationStore
 }
 
 // Option configures a Scanner at construction.
@@ -192,6 +226,12 @@ type Option func(*Scanner)
 // consistently fail metadata read until they change on disk (issue #376).
 func WithMetadataFailureStore(s MetadataFailureStore) Option {
 	return func(sc *Scanner) { sc.failures = s }
+}
+
+// WithDurationStore wires a store so each duration the scan computes is banked
+// for the revalidation path (#441) instead of discarded. Nil disables it.
+func WithDurationStore(s DurationStore) Option {
+	return func(sc *Scanner) { sc.durations = s }
 }
 
 // ScanOptions controls library directory traversal and queue eligibility.
@@ -305,6 +345,41 @@ func (sc *Scanner) probeDuration(f *os.File, ext string) (int, error) {
 		return sc.probeFunc(f.Name())
 	}
 	return audioDuration(f, ext)
+}
+
+// recordDuration banks a computed duration for the revalidation path (#441).
+//
+// The mtime/size stamp is taken from the already-open file handle f, not by
+// re-resolving path. f.Stat() describes the fd's own inode -- the exact bytes
+// probeDuration just read the header from in production (the probeFunc test
+// seam instead takes f.Name(), a path, so this guarantee is a production-only
+// property, not one the seam itself upholds) -- so the (duration, mtime, size)
+// tuple always describes one inode by construction. If a tagger's
+// write-tmp-then-rename lands between the header read and this call, a
+// path-based stat would pick up the replacement file's mtime/size while the
+// duration on the row is still the superseded file's, caching a wrong
+// duration as permanently valid. Stat'ing the handle instead means a swap in
+// that window makes the row inert against the new file (a miss, the correct
+// degrade-open direction) rather than a confidently wrong hit that nothing
+// ever invalidates.
+//
+// Non-fatal by construction: a bookkeeping write must never fail a scan whose
+// real work already succeeded, so every failure path logs at Debug and returns.
+// A zero or negative duration is skipped because absence is how audio_durations
+// represents "unknown"; storing a 0 would make "never read" indistinguishable
+// from "measured zero-length".
+func (sc *Scanner) recordDuration(ctx context.Context, path string, f *os.File, seconds int) {
+	if sc.durations == nil || seconds <= 0 {
+		return
+	}
+	info, err := f.Stat()
+	if err != nil {
+		slog.Debug("could not stat for duration cache; skipping", "file", path, "error", err)
+		return
+	}
+	if err := sc.durations.Record(ctx, path, info.ModTime().UnixNano(), info.Size(), seconds); err != nil {
+		slog.Debug("duration cache write failed; continuing", "file", path, "error", err)
+	}
 }
 
 // extractISRC returns the ISRC from audio tag metadata, or "" if absent.
@@ -726,6 +801,12 @@ func (sc *Scanner) scanDir(ctx context.Context, dir string, opts ScanOptions, de
 				slog.Debug("duration parse failed; using 0", "file", file.Name(), "error", durErr)
 				dur = 0
 			}
+			// Bank the duration we just paid a header read for (#441). The stamp
+			// comes from the open handle f, not a path re-stat, so no path is
+			// re-resolved -- and on an array whose disks spin down, not
+			// re-opening it later is the whole point. Best-effort: a cache write
+			// must never fail a scan.
+			sc.recordDuration(ctx, filePath, f, dur)
 			isrc = extractISRC(m)
 			recordingMBID = extractRecordingMBID(m)
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/testutil"
 )
 
 // minimalID3v2 is a minimal ID3v2.3 tag with TIT2 ("Test Title") and TPE1
@@ -517,5 +519,207 @@ func TestScanLibrary_WindowNeverResurrectsATerminalClass(t *testing.T) {
 					tc.sidecarTime.Format("2006-01"))
 			}
 		})
+	}
+}
+
+// recordingDurationStore captures what the scanner banks, so the test asserts on
+// the recorded tuple rather than on a DB round-trip.
+type recordingDurationStore struct {
+	paths   []string
+	mtimes  []int64
+	sizes   []int64
+	seconds []int
+}
+
+func (r *recordingDurationStore) Record(_ context.Context, path string, mtimeUnixNano, size int64, seconds int) error {
+	r.paths = append(r.paths, path)
+	r.mtimes = append(r.mtimes, mtimeUnixNano)
+	r.sizes = append(r.sizes, size)
+	r.seconds = append(r.seconds, seconds)
+	return nil
+}
+
+// The scanner already computes a duration during enrichment and discards it.
+// Banking it costs no extra disk I/O, and is the primary fill path for the
+// revalidation cache (#441).
+func TestScanRecordsDurationWhenEnriching(t *testing.T) {
+	dir := t.TempDir()
+	// 44100 Hz * 210s = 9,261,000 samples, so the FLAC header yields an exact
+	// 210s duration for audioduration to parse -- no probeFunc override needed.
+	const sampleRate, totalSamples uint32 = 44100, 44100 * 210
+	if err := testutil.WriteFLACFile(dir, "song.flac", sampleRate, totalSamples); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	path := filepath.Join(dir, "song.flac")
+
+	store := &recordingDurationStore{}
+	sc := NewScanner(WithDurationStore(store))
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+
+	if len(store.paths) != 1 {
+		t.Fatalf("recorded %d durations, want 1", len(store.paths))
+	}
+	if store.paths[0] != path {
+		t.Fatalf("recorded path %q, want %q", store.paths[0], path)
+	}
+	if store.seconds[0] != 210 {
+		t.Fatalf("recorded %ds, want 210s", store.seconds[0])
+	}
+}
+
+// With enrichment off the scanner never probes the duration, so there is nothing
+// to bank and the store must not be touched.
+func TestScanRecordsNothingWhenEnrichmentDisabled(t *testing.T) {
+	dir := t.TempDir()
+	const sampleRate, totalSamples uint32 = 44100, 44100 * 210
+	if err := testutil.WriteFLACFile(dir, "song.flac", sampleRate, totalSamples); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	store := &recordingDurationStore{}
+	sc := NewScanner(WithDurationStore(store))
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: false})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1 (track must still be scanned)", len(results))
+	}
+
+	if len(store.paths) != 0 {
+		t.Fatalf("recorded %d durations with enrichment off, want 0", len(store.paths))
+	}
+}
+
+// TestScanRecordsDurationFromOpenHandleNotPath pins the fix for the defect
+// where recordDuration stamped the cache row with a path-based stat
+// (os.DirEntry.Info()) taken AFTER the header read, rather than a stat of the
+// already-open file handle the duration was actually read from. A path-based
+// stat is vulnerable to a tagger's write-tmp-then-rename swapping the file
+// between the header read and the stat, banking a wrong duration under a new
+// file's mtime/size, where it would validate as fresh forever.
+//
+// A live mid-scan rename race is impractical to force deterministically at
+// the scheduler level, but the discriminating half of it -- "does the stamp
+// come from the open fd or from re-resolving the path" -- is directly
+// testable on Unix: an already-open fd keeps referring to its original inode
+// even after the directory entry at that path is repointed by rename(2). So
+// the probeFunc test seam (invoked immediately before recordDuration, see
+// probeDuration) performs exactly that swap -- renaming a differently-sized
+// replacement file over the scanned path -- between the header read and the
+// stamp. A handle-derived stat (f.Stat(), the fix) is blind to the swap and
+// still reports the ORIGINAL file's mtime/size; a path-derived stat
+// (entry.Info(), the pre-fix bug) lazily re-Lstats the path at call time and
+// picks up the REPLACEMENT file's mtime/size instead. This test asserts the
+// former and, run against the pre-fix code, fails by observing the latter --
+// see the git history for the empirical check.
+func TestScanRecordsDurationFromOpenHandleNotPath(t *testing.T) {
+	dir := t.TempDir()
+	const sampleRate, totalSamples uint32 = 44100, 44100 * 210
+	if err := testutil.WriteFLACFile(dir, "song.flac", sampleRate, totalSamples); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	path := filepath.Join(dir, "song.flac")
+
+	wantInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat fixture: %v", err)
+	}
+
+	store := &recordingDurationStore{}
+	sc := NewScanner(WithDurationStore(store))
+
+	// The swap happens inside probeFunc, which runs at exactly the point the
+	// production code calls probeDuration -- immediately before recordDuration,
+	// after the header (and open fd) already exist. Writing the replacement to
+	// a temp name and renaming it over path (rather than truncating path in
+	// place) is what makes the fd and the path diverge: rename repoints the
+	// directory entry to a new inode while the already-open fd keeps its old
+	// one, mirroring a tagger's write-tmp-then-rename.
+	sc.probeFunc = func(p string) (int, error) {
+		if p != path {
+			return 210, nil
+		}
+		// A VORBIS_COMMENT block makes the replacement a different size than
+		// the header-only original, so a path re-stat is distinguishable from
+		// the handle stat by size alone.
+		replacement := testutil.GenerateFLACExtended(sampleRate, totalSamples, map[string]string{"TITLE": "swapped"})
+		tmp := path + ".swap"
+		if err := os.WriteFile(tmp, replacement, 0o644); err != nil { //nolint:gosec // test fixture file
+			return 0, fmt.Errorf("write replacement: %w", err)
+		}
+		if err := os.Rename(tmp, path); err != nil {
+			return 0, fmt.Errorf("swap replacement over original: %w", err)
+		}
+		return 210, nil
+	}
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+	if len(store.paths) != 1 {
+		t.Fatalf("recorded %d durations, want 1", len(store.paths))
+	}
+
+	// Sanity: confirm the swap actually changed what's on disk, else the test
+	// proves nothing regardless of which stat source recordDuration used.
+	replacedInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if replacedInfo.Size() == wantInfo.Size() {
+		t.Fatalf("replacement file is the same size (%d) as the original; swap did not change the on-disk file, test cannot discriminate", replacedInfo.Size())
+	}
+
+	if got, want := store.sizes[0], wantInfo.Size(); got != want {
+		t.Errorf("recorded size %d, want %d (size of the ORIGINAL file via the open handle, not the replacement at the same path)", got, want)
+	}
+	if got, want := store.mtimes[0], wantInfo.ModTime().UnixNano(); got != want {
+		t.Errorf("recorded mtime %d, want %d (mtime of the ORIGINAL file via the open handle, not the replacement at the same path)", got, want)
+	}
+}
+
+// TestScanRecordsNothingForZeroDuration directly exercises recordDuration's
+// seconds<=0 guard, which scanDir relies on since it always calls
+// recordDuration regardless of whether probeDuration succeeded (a parse
+// failure degrades to duration 0, not a skipped call). Without this guard a
+// zero/unparsable duration would bank a bogus row that reads as "measured
+// zero-length" rather than "never read", so the guard is load-bearing, not
+// defensive.
+func TestScanRecordsNothingForZeroDuration(t *testing.T) {
+	dir := t.TempDir()
+	const sampleRate, totalSamples uint32 = 44100, 44100 * 210
+	if err := testutil.WriteFLACFile(dir, "song.flac", sampleRate, totalSamples); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	store := &recordingDurationStore{}
+	sc := NewScanner(WithDurationStore(store))
+	// probeFunc stands in for a parse failure: probeDuration returns 0 with no
+	// error, exactly what audioDuration degrades to on an unparsable header.
+	sc.probeFunc = func(string) (int, error) { return 0, nil }
+
+	results, err := sc.ScanLibrary(context.Background(), dir, ScanOptions{MaxDepth: 1, EnrichRecording: true})
+	if err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results; want 1", len(results))
+	}
+
+	if len(store.paths) != 0 {
+		t.Fatalf("recorded %d durations for a zero duration, want 0", len(store.paths))
 	}
 }

--- a/internal/worker/duration_capture_test.go
+++ b/internal/worker/duration_capture_test.go
@@ -1,0 +1,198 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// recordingWorkerDurationStore captures what the worker banks, so tests assert
+// on path and seconds without a real audiodur.Store.
+type recordingWorkerDurationStore struct {
+	paths   []string
+	seconds []int
+	mtimes  []int64
+	sizes   []int64
+}
+
+func (r *recordingWorkerDurationStore) Record(_ context.Context, path string, mtimeNano, size int64, seconds int) error {
+	r.paths = append(r.paths, path)
+	r.seconds = append(r.seconds, seconds)
+	r.mtimes = append(r.mtimes, mtimeNano)
+	r.sizes = append(r.sizes, size)
+	return nil
+}
+
+// refreshRecordingIdentity already re-reads the duration at fetch time and
+// discards it after building the provider query. Banking it makes the queue path
+// a second zero-cost fill site for the revalidation cache (#441).
+func TestWorkerRecordsRefreshedDuration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(path, []byte("not-real-audio-but-a-real-file"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	store := &recordingWorkerDurationStore{}
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 210, ISRC: "TEST00000001", MTimeNano: 12345, SizeBytes: 999}}
+	w := New(&fakeQueue{}, &fakeCache{}, refreshFetcher(), &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+	w.SetDurationStore(store)
+
+	item := queue.WorkItem{ID: 1}
+	item.Inputs.SourcePath = path
+
+	got := w.refreshRecordingIdentity(context.Background(), item, models.Track{ArtistName: "A", TrackName: "T"})
+
+	if got.TrackLength != 210 {
+		t.Fatalf("refreshed TrackLength = %d, want 210", got.TrackLength)
+	}
+	if len(store.paths) != 1 || store.paths[0] != path {
+		t.Fatalf("recorded paths = %v, want exactly [%q]", store.paths, path)
+	}
+	if store.seconds[0] != 210 {
+		t.Fatalf("recorded %ds, want 210s", store.seconds[0])
+	}
+}
+
+// A metadata read that returns a duration but no file identity (the open
+// handle's stat failed, or the caller assembled AudioMetadata without it) must
+// bank nothing: storing a duration under a zero mtime/size would let it
+// validate as fresh against any file, defeating the whole point of stamping
+// identity from the read's own handle rather than a path re-stat.
+func TestWorkerRecordsNothingWithoutIdentity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	store := &recordingWorkerDurationStore{}
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 210}}
+	w := New(&fakeQueue{}, &fakeCache{}, refreshFetcher(), &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+	w.SetDurationStore(store)
+
+	item := queue.WorkItem{ID: 1}
+	item.Inputs.SourcePath = path
+
+	w.refreshRecordingIdentity(context.Background(), item, models.Track{ArtistName: "A", TrackName: "T"})
+
+	if len(store.paths) != 0 {
+		t.Fatalf("recorded %d durations without identity, want 0", len(store.paths))
+	}
+}
+
+// TestWorkerRecordsDurationFromReadIdentityNotPath pins the fix for the defect
+// where recordDuration stamped the cache row with a fresh os.Stat(path) taken
+// AFTER w.readMetadata had already opened, read, and closed the file, rather
+// than the identity of the handle the duration was actually read from. By the
+// time recordDuration ran, a path-based stat was re-resolving the path from
+// scratch -- vulnerable to a tagger's write-tmp-then-rename swapping the file
+// between the metadata read and the stat, banking a wrong duration under a new
+// file's mtime/size, where it would validate as fresh forever.
+//
+// This proves the fix directly: the fake reader returns a fixed identity
+// (mtimeNano/size) for the READ, while a completely different file sits at the
+// path when recordDuration runs. A path-based stat would observe the on-disk
+// (different) file's identity; the fix uses the reader's returned identity
+// unconditionally, so it must record the reader's values, never the on-disk
+// file's.
+func TestWorkerRecordsDurationFromReadIdentityNotPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(path, []byte("original-bytes"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	const readMTime, readSize = int64(1000), int64(111)
+	store := &recordingWorkerDurationStore{}
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 210, MTimeNano: readMTime, SizeBytes: readSize}}
+	w := New(&fakeQueue{}, &fakeCache{}, refreshFetcher(), &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+	w.SetDurationStore(store)
+
+	// Simulate a tagger's write-tmp-then-rename landing between the metadata
+	// read (already captured above via the fake) and recordDuration running:
+	// replace the on-disk file with different content, so a path-based stat
+	// would see a different size than what the read reported.
+	if err := os.WriteFile(path, []byte("replacement-bytes-longer-than-original"), 0o600); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	onDisk, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if onDisk.Size() == readSize {
+		t.Fatalf("replacement file is the same size (%d) as the read identity; swap does not change on-disk size, test cannot discriminate", onDisk.Size())
+	}
+
+	item := queue.WorkItem{ID: 1}
+	item.Inputs.SourcePath = path
+
+	w.refreshRecordingIdentity(context.Background(), item, models.Track{ArtistName: "A", TrackName: "T"})
+
+	if len(store.paths) != 1 {
+		t.Fatalf("recorded %d durations, want 1", len(store.paths))
+	}
+	if store.mtimes[0] != readMTime || store.sizes[0] != readSize {
+		t.Fatalf("recorded (mtime=%d, size=%d), want the read identity (mtime=%d, size=%d) not the on-disk file's (size=%d)",
+			store.mtimes[0], store.sizes[0], readMTime, readSize, onDisk.Size())
+	}
+}
+
+// A metadata read that yields no duration must bank nothing: absence is how the
+// table represents "unknown".
+func TestWorkerRecordsNothingWithoutDuration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	store := &recordingWorkerDurationStore{}
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 0}}
+	w := New(&fakeQueue{}, &fakeCache{}, refreshFetcher(), &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+	w.SetDurationStore(store)
+
+	item := queue.WorkItem{ID: 1}
+	item.Inputs.SourcePath = path
+
+	w.refreshRecordingIdentity(context.Background(), item, models.Track{ArtistName: "A", TrackName: "T"})
+
+	if len(store.paths) != 0 {
+		t.Fatalf("recorded %d durations for an unknown duration, want 0", len(store.paths))
+	}
+}
+
+// A nil duration store must leave the existing refresh behavior untouched.
+func TestWorkerRefreshWithoutDurationStoreIsUnaffected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "song.flac")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	r := &fakeMetadataReader{meta: scanner.AudioMetadata{TrackLength: 210}}
+	w := New(&fakeQueue{}, &fakeCache{}, refreshFetcher(), &fakeWriter{})
+	w.SetRecordingEnrichmentDefault(true)
+	w.SetMetadataReader(r.read)
+
+	item := queue.WorkItem{ID: 1}
+	item.Inputs.SourcePath = path
+
+	got := w.refreshRecordingIdentity(context.Background(), item, models.Track{ArtistName: "A", TrackName: "T"})
+	if got.TrackLength != 210 {
+		t.Fatalf("refreshed TrackLength = %d, want 210", got.TrackLength)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -121,6 +121,20 @@ const escalationThreshold = 5
 // identityrepair's IdentityReader.
 type MetadataReader func(path string) (scanner.AudioMetadata, error)
 
+// DurationStore banks the exact audio duration the fetch path already re-read
+// from disk, so the revalidation path (#441) does not have to open the file
+// again. A nil store disables the feature.
+//
+// Declared here rather than reused from internal/scanner's identical interface
+// because the worker is the consumer: it declares the narrow interface it
+// needs rather than depending on a producer package's type for a shape this
+// small. Both are satisfied by *audiodur.Store.
+type DurationStore interface {
+	// Record caches seconds as the duration of path at the given mtime and size.
+	// mtimeNano is ModTime().UnixNano().
+	Record(ctx context.Context, path string, mtimeNano, size int64, seconds int) error
+}
+
 // Worker consumes queued lyrics work one item at a time. The scan_results
 // writeback for successful completions is handled atomically inside
 // queue.DBQueue.Complete, so the worker has no separate ledger dependency.
@@ -139,6 +153,10 @@ type Worker struct {
 	// answers with its default recording, which writes a live or remastered cut's
 	// lyrics onto a studio track. Defaults to scanner.ReadAudioMetadata.
 	readMetadata MetadataReader
+	// durations, when set, banks the duration refreshRecordingIdentity re-read
+	// from disk, so the revalidation path (#441) does not re-open the file. Nil
+	// disables it.
+	durations DurationStore
 	// enrichRecordingDefault mirrors config.Enrichment.Enabled. When false the
 	// operator has opted out of reading ISRC and duration, and a scan leaves them
 	// empty, so the fetch-time refresh is skipped too and serve mode sends exactly
@@ -682,6 +700,12 @@ func (w *Worker) SetMetadataReader(r MetadataReader) {
 	w.readMetadata = r
 }
 
+// SetDurationStore wires a store so the duration re-read at fetch time is banked
+// for the revalidation path (#441) instead of discarded. Nil disables it.
+func (w *Worker) SetDurationStore(s DurationStore) {
+	w.durations = s
+}
+
 // SetDetectorOrdering selects whether the detector lane goes first ("front") or
 // last (any other value, e.g. "demoted") among the dispatch lanes, then
 // rebuilds the orchestrator. A nil audioDetector makes this a no-op at build
@@ -1034,7 +1058,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 	// before anything reads resolvedTrack, so the cache lookup, the provider query,
 	// and the cache store all see the same values. Any later position would break
 	// the read/write key agreement the comment above promises.
-	resolvedTrack = w.refreshRecordingIdentity(item, resolvedTrack)
+	resolvedTrack = w.refreshRecordingIdentity(ctx, item, resolvedTrack)
 
 	// A configured providers generation that no longer matches the stamp the item
 	// was enqueued under means a cached result (if any) predates the current
@@ -1362,7 +1386,16 @@ func (w *Worker) detectorPathFor(item queue.WorkItem) string {
 // business, not the fetch path's. A read error logs at Warn (loud-skip, mirroring
 // detectorPathFor); a disabled enrichment switch and an absent source path are
 // expected states and log nothing.
-func (w *Worker) refreshRecordingIdentity(item queue.WorkItem, track models.Track) models.Track {
+//
+// ctx is threaded through to the best-effort duration-cache write (#441), which
+// piggybacks on this read rather than reopening the file later. This is the
+// caller's ordinary cancelable context, not the non-cancelable one that
+// stampTimingOutcome/stampCompletionProvenance take: those run after the item's
+// output is already on disk, where losing a bookkeeping write to cancellation
+// would be a real loss. Here the cache write is a pure optimization: if it is
+// skipped, the next pass simply re-reads the header, so there is nothing to
+// protect from cancellation.
+func (w *Worker) refreshRecordingIdentity(ctx context.Context, item queue.WorkItem, track models.Track) models.Track {
 	if !w.enrichRecordingDefault || w.readMetadata == nil {
 		return track
 	}
@@ -1377,6 +1410,9 @@ func (w *Worker) refreshRecordingIdentity(item queue.WorkItem, track models.Trac
 	}
 	if meta.TrackLength > 0 {
 		track.TrackLength = meta.TrackLength
+		// Bank the duration this read already paid for (#441). Best-effort: a
+		// cache write must never fail or defer an item.
+		w.recordDuration(ctx, item.Inputs.SourcePath, meta, meta.TrackLength)
 	}
 	if meta.ISRC != "" {
 		track.ISRC = meta.ISRC
@@ -1385,6 +1421,35 @@ func (w *Worker) refreshRecordingIdentity(item queue.WorkItem, track models.Trac
 		track.AlbumName = meta.AlbumName
 	}
 	return track
+}
+
+// recordDuration banks a fetch-time duration for the revalidation path (#441).
+//
+// The mtime/size stamp comes from meta (the scanner.AudioMetadata the fetch-time
+// read already returned), not from a fresh os.Stat(path). By the time this runs,
+// w.readMetadata has already opened, read, and closed the file (see
+// scanner.ReadAudioMetadata), so a path-based stat here would re-resolve the
+// path rather than describe the file the duration was actually read from -- the
+// same write-tmp-then-rename hazard scanner.recordDuration guards against
+// (internal/scanner/scanner.go). meta.MTimeNano/SizeBytes are stat'd from the
+// still-open handle before it closes, so they always describe the read's own
+// inode. A zero identity (stat on the handle failed) is skipped, matching how a
+// zero duration is skipped: absence is how the table represents "unknown", and
+// storing a guessed identity would let a wrong row validate as fresh forever.
+//
+// Non-fatal at every step, matching the sibling stamp convention here: a
+// bookkeeping write must never fail an item whose real work has succeeded.
+func (w *Worker) recordDuration(ctx context.Context, path string, meta scanner.AudioMetadata, seconds int) {
+	if w.durations == nil || seconds <= 0 || strings.TrimSpace(path) == "" {
+		return
+	}
+	if meta.MTimeNano == 0 && meta.SizeBytes == 0 {
+		slog.Debug("no file identity from fetch-time read; skipping duration cache", "path", path)
+		return
+	}
+	if err := w.durations.Record(ctx, path, meta.MTimeNano, meta.SizeBytes, seconds); err != nil {
+		slog.Debug("duration cache write failed; continuing", "path", path, "error", err)
+	}
 }
 
 // primeDetectorMemo hands the memoizing detector this row's stored scores so the


### PR DESCRIPTION
## Summary

- `internal/timing` needs an exact per-file duration for its calibrated 2s tolerance. The `lyrics_cache` `duration_bucket` is a floor quantizer keyed by `(artist, title, duration_bucket)`, so it cannot serve a per-file comparison. This adds migration 035 (`audio_durations`, keyed by path and validated by mtime+size) and the `internal/audiodur` store over it.
- The cache is filled OPPORTUNISTICALLY at the two sites that already open the file and already compute the duration before discarding it (`scanner.scanDir` and the worker's fetch-time `refreshRecordingIdentity`), so capture costs no additional file opens. That matters on an array whose disks are kept spun down, where spin-up events rather than total I/O are the cost.
- **Look at this first:** both capture sites derive the validation stamp from the OPEN HANDLE, never by re-resolving the path. A path re-stat after the header read lets a tagger's write-tmp-then-rename produce a row holding the old file's duration stamped with the new file's identity, which then validates as fresh forever. Stat'ing the handle stamps the superseded inode instead, so such a row is merely inert: a miss, which fails open to `unknown_duration`. Both halves of this were defects caught in review, not designed in.
- No user-visible behavior change. `audiodur.Lookup` has no caller yet by design; it lands ahead of its consumers, the revalidate CLI (#442) and the serve sweep (#443). A cache miss needs no new code path, since it yields 0, which `timing.Evaluate` already returns as `UnknownDuration` and every consumer already fails open on.

## Linked issue

Closes #441, closes #641

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
- [x] Label set on `gh pr create --label ...` (no CI gate enforces this, but it keeps the tracker usable).
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite). N/A: no user-visible change. The cache has no consumer until #442/#443, so there is no surface to exercise by hand.
- [ ] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD. N/A: no web-UI change.
- [ ] `make ui` re-run if any `.templ` or CSS source changed. N/A: no templ or CSS source changed.
- [x] Migration added under `internal/db/migrations/` if this is a one-time data correction. Migration 035 creates the table. It is new and unreleased on this branch, so the CHECK constraints were added at creation rather than deferred (SQLite needs a table rebuild to add one later).

## Test plan

- [x] `make gate` passes locally, all stages green. Patch coverage 93.33%. Package floors improved: `internal/scanner` 68% -> 78%, `internal/worker` 83% -> 87%.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Proven by mutation, three-run protocol (pass on fixed code, revert, confirm fail, restore):
  - `TestScanRecordsDurationFromOpenHandleNotPath` -- reverting to a path re-stat gives `recorded size 88, want 42`. The first version of this test passed against the buggy code and was rewritten after review caught it.
  - `TestWorkerRecordsDurationFromReadIdentityNotPath` -- reverting gives `recorded (mtime=..., size=38), want the read identity (mtime=1000, size=111)`.
  - `TestWorkerRecordsNothingWithoutIdentity` and `TestScanRecordsNothingForZeroDuration` -- each pins its own guard; deleting only that guard fails the test.
- [x] Patch coverage meets the Codecov threshold. 93.33%, threshold 70%.
- [x] Which **surface** this change fixes is stated explicitly. This writes to the new `audio_durations` table only. It does not touch `provider_outcomes` (which `/metrics` reads) or `lane_attempts` (which the dashboard reads), so neither surface changes.
- [ ] Manual UAT steps (list the specific flows exercised):
  - [ ] N/A this PR: nothing reads the cache until #442/#443, so a hand-run exercises no observable behavior. The capture sites are covered by the mutation-proven tests above.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - **PR size override.** 834 hand-written LOC across 9 files, 34 over the 800 threshold (4%). Accepted deliberately: the alternative was shipping the worker capture site with a known cache-poisoning bug and closing it separately. Splitting the stack was considered; the two halves share the `AudioMetadata` seam, so the cut would have straddled it.
  - **Path canonicalization is NOT addressed here and needs a decision before #442 consumes the cache.** The scanner keys rows by the operator's root spelling verbatim, while webhook-created work carries an `EvalSymlinks`-resolved `SourcePath`. With a typical `/music -> /mnt/array/music` layout one inode can get two rows, and a lookup keyed one way misses rows written the other. Separately, a symlinked file's PK is the link path while its stamp describes the target inode, so the cheap readdir-side validation can never match it. Both are schema-key questions rather than bugs in this diff; filing separately.
  - Two accepted Minors: the worker's inner `seconds <= 0` guard is unreachable (its caller already gates on `meta.TrackLength > 0`) and is kept as defense in depth; `CHECK (file_path <> '')` does not reject a whitespace-only path, which no call site can produce.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent audio-duration caching for scanned and refreshed media files.
  * Cached durations are automatically invalidated when file size or modification time changes.
  * Duration data is captured during scanning and fetch-time metadata refreshes to reduce repeated file processing.
  * Unknown or unavailable durations remain safely unrecorded.

* **Bug Fixes**
  * Improved duration-cache accuracy by preserving file identity from the originally opened file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->