### PR TITLE
feat(scan): capture audio metadata comprehensively into the DB (#646)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -24,6 +24,12 @@ extend-ignore-re = ["\\b[0-9a-f]{7,40}\\b"]
 TIT2 = "TIT2"
 TPE1 = "TPE1"
 TPE = "TPE"
+TPOS = "TPOS"
+TCON = "TCON"
+TDRC = "TDRC"
+TRCK = "TRCK"
+TCOM = "TCOM"
+TSRC = "TSRC"
 # typos' en-us locale does not flag -logue/-log variants, so enforce the US
 # spelling explicitly (the repo standard; the rest of the tree uses "catalog").
 catalogue = "catalog"

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -253,6 +253,38 @@ Every applied move is recorded (before the rename) as a JSONL line - `{"old_path
 
 **Note:** the exact tier requires ISRC/MBID-tagged audio. Libraries whose files carry no such tags fall back to the heuristic tier (single-candidate-per-directory + name guard).
 
+## Index Metadata
+
+`scan index-metadata` walks a library's audio files and records the complete tag set into the `audio_metadata` table. This populates audio metadata coverage independently of fetch history - a library that has never had lyrics fetched can be indexed to record ISRC, MBID, duration, and other technical metadata from the audio files themselves.
+
+The command is designed to be cheap on repeat runs. A file whose (path, mtime, size) still matches its existing row is skipped without being opened, so re-running over an unchanged library performs almost no I/O and also doubles as a coverage check.
+
+```sh
+# Preview what would be indexed across all libraries (dry run, the default)
+canticle scan index-metadata
+
+# Index a single library (name or numeric id)
+canticle scan index-metadata --library "Main Music"
+
+# Apply the indexing
+canticle scan index-metadata --yes
+
+# Pilot run: index no more than 1000 files before stopping
+canticle scan index-metadata --limit 1000 --yes
+
+# Re-run to verify coverage on unchanged files (prints file count and total coverage)
+canticle scan index-metadata --yes
+```
+
+- **Dry-run by default.** It prints what would be indexed; pass `--yes` to actually write metadata rows.
+- **Cheap by default.** Files are checked against their (path, mtime, size) key first. A match means the file is already indexed and unchanged; it is skipped without opening. A second pass over an unchanged library is therefore nearly free and serves as a coverage spot-check.
+- **No backup.** Unlike the `reconcile-*` commands, `index-metadata` is purely additive and destroys nothing, so there is no JSONL backup to restore.
+- **Scale context.** A full library of approximately 84,000 files requires one header read per file, not a full-file read. The operation is I/O-bound on the filesystem, not the audio metadata parser.
+- `--library <name|id>` scopes the run to a single library; default indexes every configured library root.
+- `--limit <n>` caps the number of files walked (0 = no limit); useful for a pilot run before applying to the full library.
+
+See the Rollout section of issue #646 for operational guidance: capture row counts before starting, dry-run on the smallest library first to verify field coverage and error rates, then live-run and immediately re-run to confirm the skip logic is working.
+
 ## Shell completion
 
 ```sh

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -281,7 +281,7 @@ canticle scan index-metadata --yes
 - **No backup.** Unlike the `reconcile-*` commands, `index-metadata` is purely additive and destroys nothing, so there is no JSONL backup to restore.
 - **Scale context.** A full library of approximately 84,000 files requires one header read per file, not a full-file read. The operation is I/O-bound on the filesystem, not the audio metadata parser.
 - `--library <name|id>` scopes the run to a single library; default indexes every configured library root.
-- `--limit <n>` caps the number of files walked (0 = no limit); useful for a pilot run before applying to the full library.
+- `--limit <n>` caps the number of files newly read and recorded (0 = no limit); already-indexed files are still walked and skipped for free, and do not count against the budget. The cap is shared across every library root in one run, not applied per root. Useful for a pilot run before applying to the full library.
 
 See the Rollout section of issue #646 for operational guidance: capture row counts before starting, dry-run on the smallest library first to verify field coverage and error rates, then live-run and immediately re-run to confirm the skip logic is working.
 

--- a/internal/audiometa/audiometa.go
+++ b/internal/audiometa/audiometa.go
@@ -1,0 +1,143 @@
+// Package audiometa stores the comprehensive per-file audio metadata read by
+// scanner.ReadAudioFacts, keyed by canonical path and validated by
+// (mtime, size). It exists so questions about the library are one SQL query
+// away, and so DB coverage reflects what is on disk rather than fetch history
+// (#646).
+//
+// A MISS IS NOT AN ERROR. An absent or stale row yields false, because the two
+// are the same fact to a caller: no usable record. Absence of a row means
+// "never read this file"; a row of empty values means "read it, and these tags
+// are genuinely absent". Keeping those distinct is why Record never writes a
+// row it did not actually read.
+//
+// The mbid and isrc columns are indexed for the move-durable re-link in #640.
+// This package writes them; nothing reads them by identity yet.
+//
+// See internal/audiodur for the same path+mtime+size validation pattern.
+package audiometa
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// Store reads and writes rows in the audio_metadata table. It is safe for
+// concurrent use because the underlying *sql.DB is.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store backed by db.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// DB returns the underlying *sql.DB for test access to query metadata directly.
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
+// Lookup reports whether a current record exists for path -- that is, a row
+// whose recorded mtime and size still match the file on disk. It returns false
+// for BOTH an absent row and a stale one, because to a caller they are the same
+// fact: this file needs reading.
+//
+// mtimeNano is ModTime().UnixNano(), so a same-second rewrite to the same byte
+// size still reads as changed.
+func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) (bool, error) {
+	var one int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT 1 FROM audio_metadata
+		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? LIMIT 1`,
+		path, mtimeNano, size,
+	).Scan(&one)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, fmt.Errorf("audiometa: lookup %q: %w", path, err)
+}
+
+// Record stores facts as the metadata for path, replacing any previous row.
+//
+// path MUST be the canonical form (#643): use
+// pathutil.RebaseUnderCanonicalRoot under a walk, or pathutil.CanonicalPath for
+// a single file. A key built any other way produces a duplicate row for the
+// same inode, not merely a stale one.
+func (s *Store) Record(ctx context.Context, path string, facts scanner.AudioFacts) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO audio_metadata (
+		     file_path, mtime_nsec, size_bytes, mbid, isrc,
+		     artist, album_artist, title, album, composer, genre,
+		     year, track_no, track_total, disc_no, disc_total,
+		     format, file_type, duration_seconds
+		 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		 ON CONFLICT(file_path) DO UPDATE SET
+		     mtime_nsec       = excluded.mtime_nsec,
+		     size_bytes       = excluded.size_bytes,
+		     mbid             = excluded.mbid,
+		     isrc             = excluded.isrc,
+		     artist           = excluded.artist,
+		     album_artist     = excluded.album_artist,
+		     title            = excluded.title,
+		     album            = excluded.album,
+		     composer         = excluded.composer,
+		     genre            = excluded.genre,
+		     year             = excluded.year,
+		     track_no         = excluded.track_no,
+		     track_total      = excluded.track_total,
+		     disc_no          = excluded.disc_no,
+		     disc_total       = excluded.disc_total,
+		     format           = excluded.format,
+		     file_type        = excluded.file_type,
+		     duration_seconds = excluded.duration_seconds,
+		     indexed_at       = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`,
+		path, facts.MTimeNano, facts.SizeBytes, facts.MBID, facts.ISRC,
+		facts.Artist, facts.AlbumArtist, facts.Title, facts.Album, facts.Composer, facts.Genre,
+		facts.Year, facts.TrackNo, facts.TrackTotal, facts.DiscNo, facts.DiscTotal,
+		facts.Format, facts.FileType, facts.TrackLength,
+	)
+	if err != nil {
+		return fmt.Errorf("audiometa: record %q: %w", path, err)
+	}
+	return nil
+}
+
+// Coverage returns how many files currently have a metadata row, satisfying
+// #646's "coverage is measurable" criterion.
+//
+// If pathPrefix is non-empty, the count is scoped to rows whose file_path
+// starts with pathPrefix, so a caller can answer "how many files in library N
+// have complete metadata" (#646 AC). pathPrefix should be a canonical root
+// (pathutil.CanonicalRoot) with a trailing path separator already appended by
+// the caller, so a sibling directory sharing the same string prefix (e.g.
+// "/music/root" vs "/music/root2") is not counted in.
+//
+// The match is a plain substr/length comparison, not a SQL LIKE, precisely so
+// that '_' and '%' in a real path (e.g. "My_Album") are compared literally
+// rather than as SQL wildcards -- an escaped LIKE would work too, but a
+// non-pattern comparison sidesteps the escaping question entirely.
+func (s *Store) Coverage(ctx context.Context, pathPrefix string) (int, error) {
+	var (
+		n   int
+		err error
+	)
+	if pathPrefix == "" {
+		err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audio_metadata`).Scan(&n)
+	} else {
+		err = s.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM audio_metadata WHERE substr(file_path, 1, length(?)) = ?`,
+			pathPrefix, pathPrefix,
+		).Scan(&n)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("audiometa: coverage: %w", err)
+	}
+	return n, nil
+}

--- a/internal/audiometa/audiometa_test.go
+++ b/internal/audiometa/audiometa_test.go
@@ -1,0 +1,270 @@
+package audiometa_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/audiometa"
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+func newTestDB(t *testing.T) *audiometa.Store {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return audiometa.New(sqlDB)
+}
+
+func TestRecordThenLookupHitsWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+
+	facts := scanner.AudioFacts{
+		MTimeNano: 1234567890, SizeBytes: 4096,
+		MBID: "mb-uuid", ISRC: "USRC12345678",
+		Artist: "A", Title: "T", Album: "Al", Genre: "G", Year: 1997,
+		TrackNo: 3, TrackTotal: 12, DiscNo: 1, DiscTotal: 2,
+		Format: "ID3v2.4", FileType: "MP3", TrackLength: 210,
+	}
+	if err := s.Record(ctx, "/lib/a.mp3", facts); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	found, err := s.Lookup(ctx, "/lib/a.mp3", 1234567890, 4096)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if !found {
+		t.Error("Lookup found = false, want true for an unchanged file")
+	}
+}
+
+func TestLookupMissesWhenFileChanged(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	if err := s.Record(ctx, "/lib/a.mp3", scanner.AudioFacts{MTimeNano: 1000, SizeBytes: 4096}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// Same size, mtime moved by one nanosecond: a same-second rewrite to the
+	// same byte size must still read as changed.
+	found, err := s.Lookup(ctx, "/lib/a.mp3", 1001, 4096)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if found {
+		t.Error("Lookup found = true for a changed file; staleness check is not working")
+	}
+}
+
+func TestLookupMissesWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	found, err := s.Lookup(ctx, "/lib/never-seen.mp3", 1, 1)
+	if err != nil {
+		t.Fatalf("an absent row must not be an error: %v", err)
+	}
+	if found {
+		t.Error("Lookup found = true for an absent row")
+	}
+}
+
+func TestRecordUpsertsInPlace(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	if err := s.Record(ctx, "/lib/a.mp3", scanner.AudioFacts{MTimeNano: 1, SizeBytes: 1, Genre: "Old"}); err != nil {
+		t.Fatalf("first Record: %v", err)
+	}
+	if err := s.Record(ctx, "/lib/a.mp3", scanner.AudioFacts{MTimeNano: 2, SizeBytes: 2, Genre: "New"}); err != nil {
+		t.Fatalf("second Record: %v", err)
+	}
+
+	var n int
+	sqlDB := s.DB()
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audio_metadata WHERE file_path='/lib/a.mp3'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("row count = %d, want 1 (Record must upsert, not accumulate)", n)
+	}
+	var genre string
+	if err := sqlDB.QueryRow(`SELECT genre FROM audio_metadata WHERE file_path='/lib/a.mp3'`).Scan(&genre); err != nil {
+		t.Fatalf("select genre: %v", err)
+	}
+	if genre != "New" {
+		t.Errorf("genre = %q, want %q (upsert must overwrite)", genre, "New")
+	}
+}
+
+func TestAbsentAndEmptySurviveRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	// Only identity set: every descriptive field must round-trip as its sentinel.
+	if err := s.Record(ctx, "/lib/bare.mp3", scanner.AudioFacts{MTimeNano: 5, SizeBytes: 6}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	var genre, mbid string
+	var year int
+	sqlDB := s.DB()
+	err := sqlDB.QueryRow(`SELECT genre, mbid, year FROM audio_metadata WHERE file_path='/lib/bare.mp3'`).Scan(&genre, &mbid, &year)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if genre != "" || mbid != "" || year != 0 {
+		t.Errorf("sentinels = %q/%q/%d, want empty/empty/0", genre, mbid, year)
+	}
+}
+
+// TestRecordRoundTripsEveryColumnDistinctly closes a gap left by the other
+// tests here: they only ever assert genre/mbid/year round-trip, so a
+// transposition among the other 15 columns (e.g. Artist and AlbumArtist
+// swapped, or DiscNo and DiscTotal swapped) would compile and pass every
+// existing test. Every field below is given a DISTINCT, recognizable value --
+// two fields sharing a value would make a swap between them undetectable --
+// and every column is read back and checked against the field that should
+// have produced it.
+func TestRecordRoundTripsEveryColumnDistinctly(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+
+	facts := scanner.AudioFacts{
+		MTimeNano:   111111,
+		SizeBytes:   222222,
+		MBID:        "mbid-value",
+		ISRC:        "isrc-value",
+		Artist:      "artist-value",
+		AlbumArtist: "album-artist-value",
+		Title:       "title-value",
+		Album:       "album-value",
+		Composer:    "composer-value",
+		Genre:       "genre-value",
+		Year:        1991,
+		TrackNo:     3,
+		TrackTotal:  12,
+		DiscNo:      2,
+		DiscTotal:   4,
+		Format:      "format-value",
+		FileType:    "filetype-value",
+		TrackLength: 333,
+	}
+	if err := s.Record(ctx, "/lib/full.mp3", facts); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var got struct {
+		mtimeNsec, sizeBytes                                           int64
+		mbid, isrc, artist, albumArtist, title, album, composer, genre string
+		format, fileType                                               string
+		year, trackNo, trackTotal, discNo, discTotal, durationSeconds  int
+	}
+	err := s.DB().QueryRow(`
+		SELECT mtime_nsec, size_bytes, mbid, isrc, artist, album_artist, title, album,
+		       composer, genre, year, track_no, track_total, disc_no, disc_total,
+		       format, file_type, duration_seconds
+		FROM audio_metadata WHERE file_path = '/lib/full.mp3'`).Scan(
+		&got.mtimeNsec, &got.sizeBytes, &got.mbid, &got.isrc, &got.artist, &got.albumArtist,
+		&got.title, &got.album, &got.composer, &got.genre, &got.year, &got.trackNo,
+		&got.trackTotal, &got.discNo, &got.discTotal, &got.format, &got.fileType, &got.durationSeconds,
+	)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"mtime_nsec", got.mtimeNsec, facts.MTimeNano},
+		{"size_bytes", got.sizeBytes, facts.SizeBytes},
+		{"mbid", got.mbid, facts.MBID},
+		{"isrc", got.isrc, facts.ISRC},
+		{"artist", got.artist, facts.Artist},
+		{"album_artist", got.albumArtist, facts.AlbumArtist},
+		{"title", got.title, facts.Title},
+		{"album", got.album, facts.Album},
+		{"composer", got.composer, facts.Composer},
+		{"genre", got.genre, facts.Genre},
+		{"year", got.year, facts.Year},
+		{"track_no", got.trackNo, facts.TrackNo},
+		{"track_total", got.trackTotal, facts.TrackTotal},
+		{"disc_no", got.discNo, facts.DiscNo},
+		{"disc_total", got.discTotal, facts.DiscTotal},
+		{"format", got.format, facts.Format},
+		{"file_type", got.fileType, facts.FileType},
+		{"duration_seconds", got.durationSeconds, facts.TrackLength},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("column %s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestCoverageCountsIndexedRows(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	for _, p := range []string{"/lib/a.mp3", "/lib/b.mp3", "/lib/c.mp3"} {
+		if err := s.Record(ctx, p, scanner.AudioFacts{MTimeNano: 1, SizeBytes: 1}); err != nil {
+			t.Fatalf("Record %s: %v", p, err)
+		}
+	}
+	n, err := s.Coverage(ctx, "")
+	if err != nil {
+		t.Fatalf("Coverage: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("Coverage = %d, want 3", n)
+	}
+}
+
+// TestCoverageScopesByPathPrefix proves a --library scoped coverage count
+// includes only rows under that root, and that the prefix comparison is not a
+// SQL LIKE pattern match: one of the roots' paths contains a literal
+// underscore, which is a LIKE wildcard and would over-match "My.Album" style
+// paths (any single character) if the predicate were a naive LIKE without
+// ESCAPE. Finding 3.
+func TestCoverageScopesByPathPrefix(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+
+	rootA := "/library/Root_A/"
+	rootB := "/library/RootB/"
+	for _, p := range []string{rootA + "My_Album/a.mp3", rootA + "b.mp3"} {
+		if err := s.Record(ctx, p, scanner.AudioFacts{MTimeNano: 1, SizeBytes: 1}); err != nil {
+			t.Fatalf("Record %s: %v", p, err)
+		}
+	}
+	if err := s.Record(ctx, rootB+"c.mp3", scanner.AudioFacts{MTimeNano: 1, SizeBytes: 1}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	// A decoy row that a naive unescaped LIKE '/library/Root_A/%' predicate
+	// would wrongly match, since '_' matches any single character in SQL LIKE:
+	// "Root_A" would also match "RootXA". A correct, non-pattern comparison
+	// must exclude it from rootA's count.
+	decoy := "/library/RootXA/decoy.mp3"
+	if err := s.Record(ctx, decoy, scanner.AudioFacts{MTimeNano: 1, SizeBytes: 1}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	n, err := s.Coverage(ctx, rootA)
+	if err != nil {
+		t.Fatalf("Coverage: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("Coverage(%q) = %d, want 2 (rootB row must not be counted)", rootA, n)
+	}
+
+	n, err = s.Coverage(ctx, rootB)
+	if err != nil {
+		t.Fatalf("Coverage: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Coverage(%q) = %d, want 1", rootB, n)
+	}
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -147,6 +147,7 @@ type ScanCmd struct {
 	ReconcileLRC                     *ScanReconcileLRCCmd                     `arg:"subcommand:reconcile-lrc" help:"rewrite existing .lrc sidecars that stack multiple timestamps on one line into the expanded, universally-readable form (issue #470)"`
 	ReconcileMarkerProvenance        *ScanReconcileMarkerProvenanceCmd        `arg:"subcommand:reconcile-marker-provenance" help:"backfill provenance headers onto detector-written instrumental markers (#502)"`
 	ReconcileDetectorStats           *ScanReconcileDetectorStatsCmd           `arg:"subcommand:reconcile-detector-stats" help:"attribute historical audio detections to the detector lane's statistics; reads recorded verdicts only, makes no detector-sidecar requests (issue #537)"`
+	IndexMetadata                    *ScanIndexMetadataCmd                    `arg:"subcommand:index-metadata" help:"walk a library and record the full audio tag set into audio_metadata (issue #646)"`
 }
 
 // ScanReconcileDetectorStatsCmd attributes historical audio detections to the
@@ -194,6 +195,20 @@ type ScanReconcileIdentityCmd struct {
 	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default reconciles every library"`
 	Yes        bool   `arg:"--yes" help:"actually apply corrections (without it, prints what would change)"`
 	Backup     string `arg:"--backup" help:"path for the JSONL backup of corrected rows (default: <db-dir>/reconcile-identity-backup-<ts>.jsonl)" default:""`
+	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
+}
+
+// ScanIndexMetadataCmd walks a library's audio files and records the full tag
+// set into audio_metadata (#646), so library questions are answerable by query
+// and coverage stops depending on fetch history. Dry-run unless --yes.
+//
+// Re-running is cheap: a file whose (path, mtime, size) still matches its row
+// is skipped without being opened, so a second pass over an unchanged library
+// does almost no I/O and doubles as a coverage check.
+type ScanIndexMetadataCmd struct {
+	Library    string `arg:"--library" help:"limit to a single library (name or numeric id); default indexes every library"`
+	Yes        bool   `arg:"--yes" help:"actually write the metadata rows (without it, prints what would be indexed)"`
+	Limit      int    `arg:"--limit" help:"stop after this many files (0 = no limit); for a bounded pilot run" default:"0"`
 	ConfigPath string `arg:"--config" help:"path to config file (default: XDG)" default:""`
 }
 
@@ -1963,6 +1978,12 @@ func runScanCmd(ctx context.Context, out io.Writer, args ScanCmd) int {
 			sub.ConfigPath = args.ConfigPath
 		}
 		return runReconcileDetectorStats(ctx, out, sub)
+	case args.IndexMetadata != nil:
+		sub := *args.IndexMetadata
+		if sub.ConfigPath == "" {
+			sub.ConfigPath = args.ConfigPath
+		}
+		return runIndexMetadata(ctx, out, sub)
 	default:
 		return runScan(ctx, out, args)
 	}

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -29,7 +29,7 @@ var completionSubcommands = []string{
 var completionCandidates = map[string][]string{
 	"fetch":      {"--outdir", "--cooldown", "--depth", "--update", "--upgrade", "--bfs", "--token", "--config", "--album", "--probe", "--isrc", "--duration", "--spotify-id"},
 	"serve":      {"--listen", "--outdir", "--token", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--scan-interval", "--sweep-interval", "--work-interval"},
-	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "reconcile-marker-provenance", "reconcile-detector-stats", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only", "--unsynced-before"},
+	"scan":       {"results", "clear", "reconcile", "reconcile-instrumental", "reconcile-instrumental-recalibrate", "reconcile-paths", "reconcile-identity", "reconcile-lrc", "reconcile-marker-provenance", "reconcile-detector-stats", "index-metadata", "--config", "--depth", "--update", "--upgrade", "--bfs", "--embedded-lyrics", "--only", "--unsynced-before"},
 	"library":    {"add", "list", "remove", "update"},
 	"keys":       {"create", "list", "revoke"},
 	"secrets":    {"import", "set", "list"},

--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -1,0 +1,291 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sydlexius/canticle/internal/audiometa"
+	"github.com/sydlexius/canticle/internal/config"
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/library"
+	"github.com/sydlexius/canticle/internal/pathutil"
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// runIndexMetadata walks a library's audio files and records the full tag set
+// into audio_metadata (#646). Dry-run by default; --yes writes. A file whose
+// (path, mtime, size) still matches its row is skipped without being opened,
+// so a re-run over an unchanged library is nearly free and doubles as a
+// coverage check.
+//
+// There is deliberately no JSONL backup here, unlike the reconcile-* commands:
+// this operation is purely additive and destroys nothing, so there is nothing
+// to restore.
+func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadataCmd) int {
+	cfg, err := config.Load(args.ConfigPath)
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		return 1
+	}
+	sqlDB, err := db.Open(ctx, cfg.DB.Path)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		return 1
+	}
+	defer sqlDB.Close() //nolint:errcheck // best-effort close on shutdown
+
+	libRepo := library.New(sqlDB)
+	var roots []string
+	if strings.TrimSpace(args.Library) != "" {
+		lib, rerr := resolveLibrary(ctx, libRepo, args.Library)
+		if rerr != nil {
+			if errors.Is(rerr, sql.ErrNoRows) {
+				_, _ = fmt.Fprintf(out, "library %q not found\n", args.Library)
+				return 1
+			}
+			slog.Error("failed to resolve library", "error", rerr)
+			return 1
+		}
+		roots = []string{lib.Path}
+	} else {
+		libs, lerr := libRepo.List(ctx)
+		if lerr != nil {
+			slog.Error("failed to list libraries", "error", lerr)
+			return 1
+		}
+		for _, l := range libs {
+			roots = append(roots, l.Path)
+		}
+	}
+	if len(roots) == 0 {
+		_, _ = fmt.Fprintln(out, "index-metadata: no library roots configured")
+		return 0
+	}
+
+	store := audiometa.New(sqlDB)
+
+	// A --library run scopes the printed coverage number to that library's
+	// canonical root, per #646's AC ("how many files in library N have
+	// complete metadata"); a whole-library-set run keeps the global total.
+	// Resolved once, outside the walk loop, from the same roots list.
+	coveragePrefix := ""
+	if len(roots) == 1 && strings.TrimSpace(args.Library) != "" {
+		_, canonRoot := pathutil.CanonicalRoot(roots[0])
+		coveragePrefix = canonRoot + string(os.PathSeparator)
+	}
+
+	// workDone is hoisted here (not declared per-root inside walkIndexMetadata)
+	// so --limit is a per-RUN budget, not a per-ROOT one: with N roots, a
+	// per-root counter would let up to Limit*N files be read in one invocation
+	// (finding: --limit is per-root, not per-run). Threading it as a *int
+	// alongside the other counters makes the budget carry over correctly from
+	// one root to the next, exactly like walked/indexed/skipped/unreadable.
+	var walked, indexed, skipped, unreadable, walkErrors, workDone int
+	limitReached := false
+	interrupted := false
+	for _, root := range roots {
+		if limitReached {
+			break
+		}
+		// A root that cannot even be stat'd (unmounted NAS, permission denied
+		// on the mount point, a typo'd path) must never read as a silently
+		// empty walk: filepath.WalkDir would otherwise invoke walkFn once
+		// with the error and immediately stop, producing "walked 0" that
+		// looks identical to a genuinely empty, healthy library. Stat the
+		// root up front, count it as a hard walk error, and skip walking it
+		// -- the other configured roots still get processed, but the run's
+		// exit code (below) will reflect that this root was unreachable.
+		if _, serr := os.Stat(root); serr != nil {
+			slog.Error("index-metadata: library root is unreachable; skipping", "root", root, "error", serr)
+			walkErrors++
+			continue
+		}
+		if err := walkIndexMetadata(ctx, store, root, args, &walked, &indexed, &skipped, &unreadable, &walkErrors, &workDone, &limitReached); err != nil {
+			if errors.Is(err, context.Canceled) {
+				slog.Info("index-metadata: interrupted", "walked", walked, "indexed", indexed)
+				interrupted = true
+				break
+			}
+			slog.Error("index-metadata failed", "error", err)
+			return 1
+		}
+	}
+
+	// On interrupt, the incoming ctx is already canceled, so a Coverage query
+	// against it would fail and the operator would lose the summary for work
+	// already committed to the DB. context.WithoutCancel keeps the same
+	// deadline-less lineage but drops the cancellation, so the query still
+	// runs against the (uncanceled) sqlDB connection.
+	coverageCtx := ctx
+	if interrupted {
+		coverageCtx = context.WithoutCancel(ctx)
+	}
+	coverage, cerr := store.Coverage(coverageCtx, coveragePrefix)
+	if cerr != nil {
+		slog.Error("index-metadata: failed to read coverage", "error", cerr)
+		return 1
+	}
+
+	verb := "would index"
+	if args.Yes {
+		verb = "indexed"
+	}
+	_, _ = fmt.Fprintf(out, "index-metadata: walked %d file(s); %s %d (%d skipped unchanged, %d unreadable, %d walk error(s)); coverage now %d row(s)%s\n",
+		walked, verb, indexed, skipped, unreadable, walkErrors, coverage, suffixDryRun(args.Yes))
+	// An operator-initiated Ctrl-C after partial, already-committed work is
+	// not a failure: the work done so far is real and the summary above
+	// reports it accurately, so exit 0 rather than 1. A genuine error path
+	// (config/db/walk failure) still returns 1 above.
+	//
+	// walkErrors > 0, though, IS a failure worth a non-zero exit: it means a
+	// library root could not be stat'd, or a subtree could not be traversed
+	// (permission denied, an unmounted filesystem going away mid-walk), so
+	// the printed counts are a floor, not the true state of the library. An
+	// operator reading exit 0 here would reasonably believe the run was
+	// complete; on an 84k-file production library the realistic case is a
+	// vanished NAS mount producing "walked 0", which must not report success.
+	// This is distinct from per-FILE unreadable counts, which are expected
+	// noise on a large library and intentionally keep exit 0.
+	if walkErrors > 0 {
+		return 1
+	}
+	return 0
+}
+
+// walkIndexMetadata walks one library root's audio files, updating the running
+// counters. It canonicalizes root exactly once (#643) -- via
+// pathutil.CanonicalRoot -- and rebases every file under it with
+// pathutil.RebaseUnderCanonicalRoot, so the metadata key matches the one a
+// library scan would produce for the same file. Building the key any other way
+// produces a duplicate row for the same inode, not merely a stale one.
+//
+// --limit is charged against WORK DONE (files actually read via
+// scanner.ReadAudioFacts, whether or not the read succeeded), never against
+// files skipped because an already-current row covers them. A file already
+// indexed costs only a stat and a cache lookup, not a tag read, so letting it
+// consume limit budget would mean a bounded run over a mostly-indexed library
+// never reaches the files that actually need reading -- repeated `--limit N`
+// runs would reprocess the same first N unindexed files forever instead of
+// advancing through the library (issue: --limit cannot resume). Gating the
+// limit on work-done instead makes resumability fall out for free: each run
+// picks up wherever the previous one's budget ran out, with no stored cursor.
+//
+// workDone is a *int owned by the caller (runIndexMetadata), not a local
+// declared fresh per call, because --limit is a per-RUN budget across ALL
+// configured roots, not a per-root allowance: a local counter here would
+// reset to zero at the start of every root, letting a run over N roots read
+// up to Limit*N files (finding: --limit is per-root, not per-run).
+func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string, args ScanIndexMetadataCmd,
+	walked, indexed, skipped, unreadable, walkErrors, workDone *int, limitReached *bool,
+) error {
+	absRoot, canonRoot := pathutil.CanonicalRoot(root)
+	return filepath.WalkDir(absRoot, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// A per-entry walk error (permission denied on a subtree, a
+			// directory that vanished mid-walk) must not abort the whole
+			// run, but it also must not be invisible: it means the walk did
+			// NOT see everything under this root, so the counters below are
+			// a floor, not a complete accounting. walkErrors surfaces that in
+			// the summary line and drives runIndexMetadata's exit code; Debug
+			// is still the right level for the per-entry detail on an 84k-
+			// file library (see the per-file unreadable path below for the
+			// same reasoning), but the aggregate is no longer silent.
+			slog.Debug("index-metadata: error walking path; skipping", "path", p, "error", walkErr)
+			*walkErrors++
+			return nil //nolint:nilerr // reason: a single unreadable directory entry must not abort the whole walk
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !scanner.IsAudioFile(d.Name()) {
+			return nil
+		}
+
+		// walked reports every audio file the walk reaches, independent of the
+		// limit; only the limit gate below cares about work done.
+		*walked++
+		canonPath := pathutil.RebaseUnderCanonicalRoot(absRoot, canonRoot, p)
+
+		// d.Info() is an LSTAT: for a symlinked audio file it describes the
+		// symlink itself, not its target. scanner.ReadAudioFacts, though,
+		// opens the file and stamps MTimeNano/SizeBytes from an FSTAT on that
+		// open handle -- the target's stat, not the link's. Those two never
+		// agree for a symlink (a link's own size is the length of the path
+		// text it holds, typically far smaller than the target audio file),
+		// so store.Lookup's (mtime, size) key would never hit and the file
+		// would be re-read and re-recorded on every single run forever --
+		// unbounded repeated tag-read I/O on exactly the spun-down disks this
+		// skip-before-open design exists to protect (finding 3).
+		//
+		// The fix is to follow the link when stat'ing an individual file, via
+		// os.Stat instead of d.Info(), so the stamp we look up against is
+		// taken from the same target the tag reader will open. This is
+		// deliberately narrower than resolving the file's path for the
+		// audio_metadata KEY: migration 035's comment block resolves symlinks
+		// only for the library ROOT, once per scan, specifically to avoid an
+		// EvalSymlinks per file on a large tree. Following a symlink's stat
+		// here costs no extra syscall of that kind -- os.Stat is a single
+		// syscall, no different in cost from the os.Lstat a symlinked
+		// DirEntry would otherwise need -- and d.Type() already carries the
+		// symlink bit for free from readdir, so detecting the case adds no
+		// extra syscall either. It does not touch canonPath (the key), only
+		// the stamp used to decide whether the file has already been read.
+		var info os.FileInfo
+		var ierr error
+		if d.Type()&fs.ModeSymlink != 0 {
+			info, ierr = os.Stat(p)
+		} else {
+			info, ierr = d.Info()
+		}
+		if ierr != nil {
+			slog.Debug("index-metadata: could not stat file; counting unreadable", "file", p, "error", ierr)
+			*unreadable++
+			return nil
+		}
+		mtimeNano, size := info.ModTime().UnixNano(), info.Size()
+
+		hit, lerr := store.Lookup(ctx, canonPath, mtimeNano, size)
+		if lerr != nil {
+			return fmt.Errorf("index-metadata: lookup %q: %w", canonPath, lerr)
+		}
+		if hit {
+			*skipped++
+			return nil
+		}
+
+		// This file needs real work (a tag read). Only now does it count
+		// against --limit: an already-indexed file above never reaches here.
+		if args.Limit > 0 && *workDone >= args.Limit {
+			*limitReached = true
+			return filepath.SkipAll
+		}
+
+		facts, ferr := scanner.ReadAudioFacts(p)
+		if ferr != nil {
+			slog.Debug("index-metadata: failed to read audio tags; counting unreadable", "file", p, "error", ferr)
+			*unreadable++
+			*workDone++
+			return nil
+		}
+
+		if args.Yes {
+			if rerr := store.Record(ctx, canonPath, facts); rerr != nil {
+				return fmt.Errorf("index-metadata: record %q: %w", canonPath, rerr)
+			}
+		}
+		*indexed++
+		*workDone++
+		return nil
+	})
+}

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -1,0 +1,561 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/library"
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/testutil"
+)
+
+// setupIndexMetadata builds a config + DB + one library rooted at a temp dir
+// containing the given tagged audio files (each written with a distinct
+// artist/title so a lookup can tell them apart), following the setup idiom
+// from reconcile_lrc_test.go / reconcile_identity_test.go.
+func setupIndexMetadata(t *testing.T, filenames ...string) (cfgPath, dbPath, root string) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath = filepath.Join(dir, "test.db")
+	cfgPath = filepath.Join(dir, "config.toml")
+	root = filepath.Join(dir, "music")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	reconcilePathsCfg(t, cfgPath, dbPath)
+
+	for i, name := range filenames {
+		artist := "Artist" + string(rune('A'+i))
+		if err := testutil.WriteAudioFile(root, name, artist, "Title", "Album", ""); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := library.New(sqlDB).Add(ctx, root, "lib", models.LibrarySettings{}); err != nil {
+		t.Fatalf("library.Add: %v", err)
+	}
+	return cfgPath, dbPath, root
+}
+
+// addSecondLibrary adds another library root (with the given files) to the
+// same DB that setupIndexMetadata already configured, for tests that need two
+// distinct library roots sharing one DB.
+func addSecondLibrary(t *testing.T, dbPath, name string, filenames ...string) {
+	t.Helper()
+	ctx := context.Background()
+	root := filepath.Join(filepath.Dir(dbPath), name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	for i, fn := range filenames {
+		artist := "Artist" + string(rune('A'+i))
+		if err := testutil.WriteAudioFile(root, fn, artist, "Title", "Album", ""); err != nil {
+			t.Fatalf("write fixture %s: %v", fn, err)
+		}
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := library.New(sqlDB).Add(ctx, root, name, models.LibrarySettings{}); err != nil {
+		t.Fatalf("library.Add: %v", err)
+	}
+}
+
+func countAudioMetadataRows(t *testing.T, dbPath string) int {
+	t.Helper()
+	return countRows(t, context.Background(), dbPath, "audio_metadata")
+}
+
+// indexedFilePaths returns the file_path column of every audio_metadata row,
+// sorted, for tests that need to know WHICH files were indexed rather than
+// just how many.
+func indexedFilePaths(t *testing.T, dbPath string) []string {
+	t.Helper()
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	rows, err := sqlDB.QueryContext(ctx, "SELECT file_path FROM audio_metadata ORDER BY file_path")
+	if err != nil {
+		t.Fatalf("query file_path: %v", err)
+	}
+	defer rows.Close() //nolint:errcheck // test cleanup
+	var got []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan file_path: %v", err)
+		}
+		got = append(got, p)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return got
+}
+
+func TestIndexMetadataDryRunWritesNothing(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3")
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{
+		ConfigPath: cfgPath,
+		// Yes deliberately false: dry-run is the default.
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; output: %s", code, out.String())
+	}
+
+	if n := countAudioMetadataRows(t, dbPath); n != 0 {
+		t.Errorf("dry run wrote %d rows, want 0", n)
+	}
+	if !strings.Contains(out.String(), "would index") {
+		t.Errorf("dry-run output must say what it would do; got: %s", out.String())
+	}
+}
+
+func TestIndexMetadataYesWritesRows(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3")
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{
+		ConfigPath: cfgPath,
+		Yes:        true,
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; output: %s", code, out.String())
+	}
+
+	if n := countAudioMetadataRows(t, dbPath); n != 2 {
+		t.Errorf("indexed %d rows, want 2", n)
+	}
+}
+
+func TestIndexMetadataSecondPassSkipsUnchangedFiles(t *testing.T) {
+	cfgPath, _, _ := setupIndexMetadata(t, "a.mp3", "b.mp3")
+	ctx := context.Background()
+
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first pass exit = %d: %s", code, first.String())
+	}
+
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("second pass exit = %d: %s", code, second.String())
+	}
+	// The whole point of the validation rule: an unchanged file is not reopened.
+	if !strings.Contains(second.String(), "2 skipped") {
+		t.Errorf("second pass must skip both unchanged files; got: %s", second.String())
+	}
+}
+
+func TestIndexMetadataUnreadableFileIsCountedNotFatal(t *testing.T) {
+	// A file with a supported extension but garbage content: the walk must
+	// count it and continue, never abort the run.
+	cfgPath, _, root := setupIndexMetadata(t, "good.mp3")
+	if err := os.WriteFile(filepath.Join(root, "bad.mp3"), []byte("not a real audio file"), 0o644); err != nil { //nolint:gosec // test fixture file
+		t.Fatalf("write garbage file: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+	if code != 0 {
+		t.Fatalf("an unreadable file must not fail the run; exit = %d: %s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "1 unreadable") {
+		t.Errorf("output must report the unreadable count; got: %s", out.String())
+	}
+}
+
+func TestIndexMetadataLibraryNotFound(t *testing.T) {
+	cfgPath, _, _ := setupIndexMetadata(t, "a.mp3")
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Library: "no-such-library"})
+	if code != 1 {
+		t.Fatalf("exit=%d want 1; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "not found") {
+		t.Errorf("want 'not found'; got: %s", out.String())
+	}
+}
+
+func TestIndexMetadataNoLibraryRoots(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	cfgPath := filepath.Join(dir, "config.toml")
+	reconcilePathsCfg(t, cfgPath, dbPath)
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sqlDB.Close()
+
+	var out bytes.Buffer
+	if code := runIndexMetadata(ctx, &out, ScanIndexMetadataCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "no library roots") {
+		t.Errorf("output: %q", out.String())
+	}
+}
+
+func TestIndexMetadataLimit(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3", "c.mp3")
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true, Limit: 2})
+	if code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if n := countAudioMetadataRows(t, dbPath); n != 2 {
+		t.Errorf("indexed %d rows, want 2 (limit)", n)
+	}
+}
+
+// TestIndexMetadataLimitResumesAcrossRuns proves --limit accounting is
+// charged against work done, not files walked: a second bounded run must
+// advance to the files the first run did not reach, not reprocess the same
+// ones. Before the fix, the limit gate counted every file the walk reached
+// (including ones skipped as already-current), so a second `--limit 2` run
+// over 4 files re-hit files 1-2 forever and never reached 3-4. Finding 1.
+func TestIndexMetadataLimitResumesAcrossRuns(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3", "c.mp3", "d.mp3")
+	ctx := context.Background()
+
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true, Limit: 2}); code != 0 {
+		t.Fatalf("first pass exit=%d out=%s", code, first.String())
+	}
+	firstRows := indexedFilePaths(t, dbPath)
+	if len(firstRows) != 2 {
+		t.Fatalf("first pass indexed %d rows, want 2: %v", len(firstRows), firstRows)
+	}
+
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true, Limit: 2}); code != 0 {
+		t.Fatalf("second pass exit=%d out=%s", code, second.String())
+	}
+	allRows := indexedFilePaths(t, dbPath)
+	if len(allRows) != 4 {
+		t.Fatalf("after two bounded runs of 2, want all 4 files indexed; got %d: %v", len(allRows), allRows)
+	}
+
+	// The second pass's own counters must show it did fresh work, not a
+	// repeat of the first pass's files: 2 walked-and-already-indexed
+	// (skipped) plus 2 newly indexed.
+	if !strings.Contains(second.String(), "indexed 2") || !strings.Contains(second.String(), "2 skipped") {
+		t.Errorf("second pass must skip the 2 already-indexed files and index 2 new ones; got: %s", second.String())
+	}
+}
+
+// cancelDuringWalkCtx wraps a real, live context and cancels it the first
+// time Err() is called after arm() has been invoked. filepath.WalkDir's
+// walkFn checks ctx.Err() once per audio file reached (see walkIndexMetadata),
+// so arming after config load / db open / library listing have already
+// happened (all of which run before the walk starts) lets the cancellation
+// land squarely inside the walk, on the next file it looks at -- reproducing
+// an operator's Ctrl-C mid-walk without a fixed, brittle call count.
+type cancelDuringWalkCtx struct {
+	context.Context
+	cancel context.CancelFunc
+	armed  atomic.Bool
+}
+
+func newCancelDuringWalkCtx() *cancelDuringWalkCtx {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &cancelDuringWalkCtx{Context: ctx, cancel: cancel}
+}
+
+func (c *cancelDuringWalkCtx) arm() { c.armed.Store(true) }
+
+func (c *cancelDuringWalkCtx) Err() error {
+	if c.armed.Load() {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+// TestIndexMetadataInterruptStillPrintsSummary proves that a cancellation
+// landing mid-walk (an operator's Ctrl-C) does not lose the summary line for
+// work already committed to the DB before the interrupt: the coverage query
+// taken after the walk stops on context.Canceled must not itself use the
+// now-canceled context (it would fail, and the operator would get nothing).
+// Finding 2.
+func TestIndexMetadataInterruptStillPrintsSummary(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3", "c.mp3")
+
+	ctx := newCancelDuringWalkCtx()
+
+	var out bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runIndexMetadata(ctx, &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+	}()
+
+	// Arm only once config load / db open / library listing are done and at
+	// least one file has actually been committed, so the interrupt genuinely
+	// lands mid-walk with real partial work behind it, not before the walk
+	// even starts.
+	deadline := time.Now().Add(5 * time.Second)
+	for countAudioMetadataRows(t, dbPath) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the first row to be committed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	ctx.arm()
+
+	var code int
+	select {
+	case code = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the interrupted run to finish")
+	}
+
+	// An operator-initiated interrupt after partial, already-committed work
+	// is not treated as a failure.
+	if code != 0 {
+		t.Fatalf("interrupted run exit=%d, want 0; out=%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "index-metadata: walked") || !strings.Contains(out.String(), "coverage now") {
+		t.Fatalf("interrupted run must still print the summary line; got: %s", out.String())
+	}
+	// Whatever the walk committed before stopping must be reflected in the
+	// printed coverage number, not silently dropped.
+	rows := countAudioMetadataRows(t, dbPath)
+	if rows == 0 {
+		t.Fatalf("expected at least one row committed before the interrupt, got 0")
+	}
+	wantCoverage := fmt.Sprintf("coverage now %d row(s)", rows)
+	if !strings.Contains(out.String(), wantCoverage) {
+		t.Errorf("printed coverage must reflect the %d rows actually committed; got: %s", rows, out.String())
+	}
+}
+
+// TestIndexMetadataLibraryScopesCoverage proves --library scopes the printed
+// coverage number to that library's own root, not the whole DB: before the
+// fix, Coverage had no predicate and always printed the global total, so a
+// single-library run over "lib1" would misleadingly report rows belonging to
+// a second, unrelated library too. Finding 3.
+func TestIndexMetadataLibraryScopesCoverage(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3")
+	addSecondLibrary(t, dbPath, "lib2", "c.mp3", "d.mp3", "e.mp3")
+
+	// Index everything first, across both libraries, so the DB genuinely
+	// holds rows for both -- the scoping claim is only meaningful if a
+	// global-scope run WOULD report more than the targeted library's own
+	// count.
+	var seed bytes.Buffer
+	if code := runIndexMetadata(context.Background(), &seed, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("seed run exit=%d out=%s", code, seed.String())
+	}
+	if total := countAudioMetadataRows(t, dbPath); total != 5 {
+		t.Fatalf("sanity: seed run should index all 5 files across both libraries, got %d", total)
+	}
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{
+		ConfigPath: cfgPath,
+		Yes:        true,
+		Library:    "lib",
+	})
+	if code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+
+	// Only "lib"'s own 2 rows must be reported, never the global 5 -- the
+	// bug this guards against is a Coverage query with no predicate at all.
+	if !strings.Contains(out.String(), "coverage now 2 row(s)") {
+		t.Errorf("scoped coverage must count only the targeted library's 2 rows, not the global 5; got: %s", out.String())
+	}
+}
+
+// TestIndexMetadataUnreachableRootFailsRun proves a library root that
+// vanishes (unmounted NAS, deleted directory, the realistic production
+// failure) is reported as a hard failure, not a silently-empty successful
+// walk. Before the fix, filepath.WalkDir's very first callback invocation
+// for an unstat-able root took the walkErr branch, which logged at Debug and
+// returned nil without incrementing any counter -- the run printed "walked 0
+// file(s) ... coverage now 0 row(s)" and exited 0, indistinguishable from a
+// genuinely empty, healthy library. Finding: CRITICAL 1.
+func TestIndexMetadataUnreachableRootFailsRun(t *testing.T) {
+	cfgPath, _, root := setupIndexMetadata(t, "a.mp3")
+	// Simulate the root vanishing (an unmounted NAS) by removing it after the
+	// library has already been registered against that path.
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("remove root: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+	if code == 0 {
+		t.Fatalf("an unreachable library root must not exit 0; out: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "walk error") {
+		t.Errorf("output must report the walk error count; got: %s", out.String())
+	}
+}
+
+// TestIndexMetadataPerEntryWalkErrorFailsRun proves the PER-ENTRY walk-error
+// path (a subtree that fails mid-walk, e.g. permission denied on a
+// subdirectory) is counted and fails the run, distinct from
+// TestIndexMetadataUnreachableRootFailsRun above which covers the ROOT-STAT
+// failure. Here the root itself stats fine (so the walk begins successfully),
+// but a subdirectory chmod'd to 000 makes filepath.WalkDir report an error for
+// that one subtree partway through.
+func TestIndexMetadataPerEntryWalkErrorFailsRun(t *testing.T) {
+	if os.Geteuid() == 0 {
+		// Root ignores directory permission bits entirely, so chmod 000 would
+		// not deny access and this test would silently assert nothing.
+		t.Skip("cannot exercise a permission-denied walk error as root")
+	}
+
+	cfgPath, _, root := setupIndexMetadata(t, "good.mp3")
+
+	blocked := filepath.Join(root, "blocked")
+	if err := os.Mkdir(blocked, 0o755); err != nil {
+		t.Fatalf("mkdir blocked subdir: %v", err)
+	}
+	if err := testutil.WriteAudioFile(blocked, "hidden.mp3", "ArtistZ", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture in blocked subdir: %v", err)
+	}
+	if err := os.Chmod(blocked, 0o000); err != nil {
+		t.Fatalf("chmod blocked subdir: %v", err)
+	}
+	t.Cleanup(func() {
+		// t.TempDir()'s cleanup cannot remove a directory it cannot read into;
+		// restore permissions so teardown succeeds instead of failing the run
+		// with an unrelated-looking cleanup error.
+		if err := os.Chmod(blocked, 0o700); err != nil {
+			t.Fatalf("restore blocked subdir permissions: %v", err)
+		}
+	})
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+	if code != 1 {
+		t.Fatalf("a per-entry walk error must fail the run; exit=%d out=%s", code, out.String())
+	}
+	if strings.Contains(out.String(), "0 walk error") || !strings.Contains(out.String(), "walk error") {
+		t.Errorf("output must report a non-zero walk-error count; got: %s", out.String())
+	}
+}
+
+// TestIndexMetadataLimitIsPerRunNotPerRoot proves --limit is a single budget
+// shared across ALL configured library roots in one invocation, not a fresh
+// allowance handed to each root. Before the fix, workDone was declared local
+// to walkIndexMetadata (called once per root), so a run over multiple roots
+// could read up to Limit * (number of roots) files. A single-root test
+// cannot catch this bug by construction, since with one root "per run" and
+// "per root" are the same budget -- hence three roots here. Finding:
+// CRITICAL 2.
+func TestIndexMetadataLimitIsPerRunNotPerRoot(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3", "b.mp3") // root 1: 2 files
+	addSecondLibrary(t, dbPath, "lib2", makeNames(10)...)         // root 2: 10 files
+	addSecondLibrary(t, dbPath, "lib3", makeNames(10)...)         // root 3: 10 files
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true, Limit: 3})
+	if code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if n := countAudioMetadataRows(t, dbPath); n != 3 {
+		t.Errorf("indexed %d rows across 3 roots with --limit 3, want exactly 3 (budget must be per-run, not per-root)", n)
+	}
+}
+
+// makeNames returns n distinct audio filenames for a root that needs more
+// files than the standard fixture set provides.
+func makeNames(n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("f%02d.mp3", i)
+	}
+	return names
+}
+
+// TestIndexMetadataSymlinkedFileIsSkippedOnSecondRun proves a symlinked audio
+// file is not re-read and re-recorded on every single run. Before the fix,
+// the per-file stat used d.Info() -- an LSTAT describing the symlink itself
+// -- while scanner.ReadAudioFacts stamps MTimeNano/SizeBytes from an FSTAT on
+// the opened (target) file. Those two never agreed for a symlink, so
+// store.Lookup's (mtime, size) key never hit and the file was indexed again
+// on every run. Finding: IMPORTANT 3.
+func TestIndexMetadataSymlinkedFileIsSkippedOnSecondRun(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t, "real.mp3")
+	linkPath := filepath.Join(root, "link.mp3")
+	if err := os.Symlink(filepath.Join(root, "real.mp3"), linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	ctx := context.Background()
+
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first pass exit=%d out=%s", code, first.String())
+	}
+	// Both real.mp3 and link.mp3 are distinct audio_metadata keys (rebased
+	// under the canonical root as separate path strings), so the first pass
+	// indexes 2 rows.
+	if n := countAudioMetadataRows(t, dbPath); n != 2 {
+		t.Fatalf("first pass indexed %d rows, want 2 (real.mp3 + link.mp3): %s", n, first.String())
+	}
+
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("second pass exit=%d out=%s", code, second.String())
+	}
+	if !strings.Contains(second.String(), "indexed 0") || !strings.Contains(second.String(), "2 skipped") {
+		t.Errorf("second pass over a symlinked file must skip it (matching mtime/size via the followed target stat), not re-index it; got: %s", second.String())
+	}
+}
+
+func TestIndexMetadataConfigLoadError(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "bad.toml")
+	if err := os.WriteFile(cfgPath, []byte("not = valid = toml ]["), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+	var out bytes.Buffer
+	if code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath}); code != 1 {
+		t.Fatalf("exit=%d want 1 for invalid config", code)
+	}
+}
+
+func TestIndexMetadata_IsRecognizedSubcommand(t *testing.T) {
+	if !usesSubcommand([]string{"scan", "index-metadata"}) {
+		t.Error("`scan index-metadata` not recognized as a subcommand invocation")
+	}
+}
+
+func TestRunScanCmd_DispatchesIndexMetadata(t *testing.T) {
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "a.mp3")
+	var out bytes.Buffer
+	code := runScanCmd(context.Background(), &out, ScanCmd{
+		ConfigPath:    cfgPath,
+		IndexMetadata: &ScanIndexMetadataCmd{Yes: true},
+	})
+	if code != 0 {
+		t.Fatalf("exit=%d out=%s", code, out.String())
+	}
+	if n := countAudioMetadataRows(t, dbPath); n != 1 {
+		t.Errorf("dispatched run indexed %d rows, want 1", n)
+	}
+}

--- a/internal/commands/unsynced_before.go
+++ b/internal/commands/unsynced_before.go
@@ -49,7 +49,8 @@ func scanSubcommandSelected(args ScanCmd) bool {
 		args.ReconcileIdentity != nil ||
 		args.ReconcileLRC != nil ||
 		args.ReconcileMarkerProvenance != nil ||
-		args.ReconcileDetectorStats != nil
+		args.ReconcileDetectorStats != nil ||
+		args.IndexMetadata != nil
 }
 
 // resolveUnsyncedBefore parses the scan --unsynced-before cutoff into the

--- a/internal/commands/unsynced_before_test.go
+++ b/internal/commands/unsynced_before_test.go
@@ -111,6 +111,7 @@ func TestScanSubcommandSelected(t *testing.T) {
 		{"reconcile-lrc", ScanCmd{ReconcileLRC: &ScanReconcileLRCCmd{}}},
 		{"reconcile-marker-provenance", ScanCmd{ReconcileMarkerProvenance: &ScanReconcileMarkerProvenanceCmd{}}},
 		{"reconcile-detector-stats", ScanCmd{ReconcileDetectorStats: &ScanReconcileDetectorStatsCmd{}}},
+		{"index-metadata", ScanCmd{IndexMetadata: &ScanIndexMetadataCmd{}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/db/migrations/036_audio_metadata.sql
+++ b/internal/db/migrations/036_audio_metadata.sql
@@ -1,0 +1,97 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Comprehensive per-file audio metadata (#646). Every fact the tag layer
+-- exposes about one file, so questions about the library are one SQL query
+-- away instead of unanswerable, and so coverage stops being a function of
+-- fetch history.
+--
+-- KEYED BY PATH, WITH IDENTITY AS AN INDEX -- the central decision, and the
+-- one most likely to be re-litigated. Recording MBID was considered as the
+-- primary key and rejected on three independent grounds:
+--
+--   1. COVERAGE. The 2026-07-20 library census (2,000 files sampled across all
+--      four roots via the shipped reader, 0 read errors) measured ISRC at 41.7%
+--      overall -- Music 49.2%, Classical 50.2%, VGM 24.4%, Kids_Music 43.0%.
+--      Roughly 58% of tracks carry no ISRC at all, and MBID is Picard-written
+--      so it is likely scarcer still. A primary key absent from the majority of
+--      rows is not a key.
+--   2. NOT UNIQUE. Reissues share an ISRC. MBID fails from the other direction:
+--      one recording legitimately appears as several distinct FILES -- on an
+--      album, on a compilation, at a different bitrate. An identity-keyed table
+--      would merge rows describing genuinely different files.
+--   3. VALIDATION REQUIRES THE PATH. Staleness is decided by (path, mtime,
+--      size), knowable from readdir and stat WITHOUT opening the file.
+--      Validating an identity-keyed row would mean opening the file to learn
+--      its key, defeating the check entirely.
+--
+-- Most of what this table holds -- codec, size, mtime, track number on this
+-- disc -- are facts about a FILE, not about a recording, so path-keying also
+-- matches what the record describes. This is the same split migration 035
+-- argued for audio_durations: a key checkable without opening the file and a
+-- key that survives a move are different keys serving different jobs. The
+-- resolution is to key on the first and index the second.
+--
+-- A file with no identifier still gets a complete metadata row; it forgoes only
+-- the strongest re-link tier (#640), degrading to that design's heuristic tier
+-- and then to keep-and-report. Nobody loses metadata for lacking an MBID.
+--
+-- KEY CANONICALIZATION follows #643 exactly: file_path is the
+-- operator-configured library root resolved to an absolute, symlink-free path
+-- ONCE PER SCAN (filepath.Abs then filepath.EvalSymlinks), with the
+-- walk-relative remainder joined back on. Use pathutil.RebaseUnderCanonicalRoot
+-- under a walk and pathutil.CanonicalPath for a single file. Writing a key any
+-- other way produces a duplicate row for the same inode, not merely a stale one.
+--
+-- VALIDATION IS LOAD-BEARING, NOT DEFENSIVE, for the same reason as 035:
+-- re-encodes and mass retags are normal in a large library, so an unvalidated
+-- record would be wrong on many rows. mtime_nsec + size_bytes makes staleness
+-- structurally impossible rather than merely unlikely. Nanosecond precision
+-- matters so a same-second rewrite to the same byte size still reads as changed.
+--
+-- ABSENT VS EMPTY: a missing tag is stored as '' (strings) or 0 (numerics), the
+-- same documented sentinels scanner.AudioFacts uses. "Never read this file" is
+-- represented by the ABSENCE OF A ROW, never by a row of empty values.
+--
+-- LYRIC TEXT AND COVER ART ARE DELIBERATELY ABSENT. tag.Metadata exposes both.
+-- Lyrics would place copyrighted material in the database and give the
+-- extracted-lyrics lane (#538) a route to ingest its own output; cover art is a
+-- blob that would dwarf every other column. Do not add either without a
+-- consumer that justifies it.
+CREATE TABLE audio_metadata (
+    file_path    TEXT    PRIMARY KEY CHECK (file_path <> ''),
+    mtime_nsec   INTEGER NOT NULL,
+    size_bytes   INTEGER NOT NULL,
+
+    -- Recording identity: move-durable, indexed. Empty means absent.
+    mbid         TEXT    NOT NULL DEFAULT '',
+    isrc         TEXT    NOT NULL DEFAULT '',
+
+    -- Descriptive. Empty string / 0 are the documented absent sentinels.
+    artist       TEXT    NOT NULL DEFAULT '',
+    album_artist TEXT    NOT NULL DEFAULT '',
+    title        TEXT    NOT NULL DEFAULT '',
+    album        TEXT    NOT NULL DEFAULT '',
+    composer     TEXT    NOT NULL DEFAULT '',
+    genre        TEXT    NOT NULL DEFAULT '',
+    year         INTEGER NOT NULL DEFAULT 0,
+    track_no     INTEGER NOT NULL DEFAULT 0,
+    track_total  INTEGER NOT NULL DEFAULT 0,
+    disc_no      INTEGER NOT NULL DEFAULT 0,
+    disc_total   INTEGER NOT NULL DEFAULT 0,
+    format       TEXT    NOT NULL DEFAULT '',
+    file_type    TEXT    NOT NULL DEFAULT '',
+    duration_seconds INTEGER NOT NULL DEFAULT 0,
+
+    indexed_at   DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Partial indexes: the identity lookups #640 performs only ever match non-empty
+-- values, so indexing the ~58% empty rows would be dead weight.
+CREATE INDEX idx_audio_metadata_mbid ON audio_metadata(mbid) WHERE mbid <> '';
+CREATE INDEX idx_audio_metadata_isrc ON audio_metadata(isrc) WHERE isrc <> '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS audio_metadata;
+-- +goose StatementEnd

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -78,14 +78,14 @@ func openAndReadTags(path string) (tag.Metadata, *os.File, error) {
 // the full-library scan loop. It wraps the same extractISRC/extractRecordingMBID
 // and tag readers scanDir uses, so realign's exact-match tier sees exactly the
 // identity signals a scan would. A missing tag yields an empty string, not an
-// error; only an open/parse failure returns an error.
+// error; only an open/parse failure returns an error. It now projects over
+// ReadAudioFacts so tag access has one implementation.
 func ReadAudioProvenance(path string) (isrc, mbid, artist, title string, err error) {
-	m, f, rerr := openAndReadTags(path)
-	if rerr != nil {
-		return "", "", "", "", rerr
+	facts, err := ReadAudioFacts(path)
+	if err != nil {
+		return "", "", "", "", err
 	}
-	defer func() { _ = f.Close() }()
-	return extractISRC(m), extractRecordingMBID(m), extractArtist(m), m.Title(), nil
+	return facts.ISRC, facts.MBID, facts.Artist, facts.Title, nil
 }
 
 // ReadArtistIdentity opens the audio file at path and returns its corrected
@@ -94,14 +94,14 @@ func ReadAudioProvenance(path string) (isrc, mbid, artist, title string, err err
 // reconcile-identity backfill uses to re-derive a row's identity from disk,
 // where the mangled boundaries the DB already stored cannot be recovered. An
 // open or parse failure returns a non-empty error so the caller can skip the
-// row rather than mistake a read failure for a genuinely empty artist.
+// row rather than mistake a read failure for a genuinely empty artist. It now
+// projects over ReadAudioFacts so tag access has one implementation.
 func ReadArtistIdentity(path string) (artist, albumArtist string, err error) {
-	m, f, rerr := openAndReadTags(path)
-	if rerr != nil {
-		return "", "", rerr
+	facts, err := ReadAudioFacts(path)
+	if err != nil {
+		return "", "", err
 	}
-	defer func() { _ = f.Close() }()
-	return extractArtist(m), extractAlbumArtist(m), nil
+	return facts.Artist, facts.AlbumArtist, nil
 }
 
 // AudioMetadata carries the recording disambiguators a provider query needs from
@@ -129,33 +129,119 @@ type AudioMetadata struct {
 //
 // A missing tag, an unparsable duration, or an unsupported extension is not an
 // error and yields the zero-value sentinel; only an open or parse failure returns
-// an error, matching ReadAudioProvenance and ReadArtistIdentity.
+// an error, matching ReadAudioProvenance and ReadArtistIdentity. It now projects
+// over ReadAudioFacts so tag access has one implementation.
 func ReadAudioMetadata(path string) (AudioMetadata, error) {
+	facts, err := ReadAudioFacts(path)
+	if err != nil {
+		return AudioMetadata{}, err
+	}
+	return AudioMetadata{
+		TrackLength: facts.TrackLength,
+		ISRC:        facts.ISRC,
+		AlbumName:   facts.Album,
+		MTimeNano:   facts.MTimeNano,
+		SizeBytes:   facts.SizeBytes,
+	}, nil
+}
+
+// AudioFacts is everything the tag layer exposes about one audio file, read
+// from a single open handle. It is the one comprehensive reader (#646): the
+// narrower exported readers below are projections over it, so tag access has
+// exactly one implementation and a fourth narrow reader is never needed.
+//
+// The zero values are the documented "absent" sentinels throughout, matching
+// AudioMetadata's existing convention: an empty string means the tag is absent,
+// 0 means a numeric tag is absent, and TrackLength 0 is the unknown-duration
+// sentinel normalize.DurationBucket keys on. MTimeNano and SizeBytes are the
+// open handle's own identity (ModTime().UnixNano() and Size(), stat'd before
+// the handle closes) rather than a re-resolution of the path; zero means a stat
+// failure, the same "absent" convention.
+//
+// DELIBERATELY EXCLUDED: tag.Metadata also exposes Lyrics() and Picture().
+// Lyric text stays out because it would place copyrighted material in the
+// database with no consumer asking for it, and because it would hand the
+// extracted-lyrics lane (#538) a route to ingest its own output -- the
+// self-ingestion loop that design makes impossible by construction. Picture()
+// stays out because an image blob would dwarf every other column. Either is one
+// line to add if a consumer ever justifies it.
+type AudioFacts struct {
+	// File identity, from the open handle's own Stat.
+	MTimeNano int64
+	SizeBytes int64
+
+	// Recording identity -- move-durable, indexed in audio_metadata for #640.
+	MBID string
+	ISRC string
+
+	// Descriptive.
+	Artist      string
+	AlbumArtist string
+	Title       string
+	Album       string
+	Composer    string
+	Genre       string
+	Year        int
+	TrackNo     int
+	TrackTotal  int
+	DiscNo      int
+	DiscTotal   int
+	Format      string
+	FileType    string
+	TrackLength int
+}
+
+// ReadAudioFacts opens the audio file at path and returns every fact the tag
+// layer exposes about it, from one open handle.
+//
+// A missing tag, an unparsable duration, or an unsupported extension is not an
+// error and yields the zero-value sentinel; only an open or parse failure
+// returns an error, matching the narrower readers above.
+func ReadAudioFacts(path string) (AudioFacts, error) {
 	m, f, rerr := openAndReadTags(path)
 	if rerr != nil {
-		return AudioMetadata{}, rerr
+		return AudioFacts{}, rerr
 	}
 	defer func() { _ = f.Close() }()
+
 	// audioduration seeks to 0 internally, so f may sit at any offset after
-	// tag.ReadFrom; no rewind is needed here. A parse failure degrades to the
+	// tag.ReadFrom; no rewind is needed. A parse failure degrades to the
 	// unknown-duration sentinel exactly as scanDir does.
 	dur, derr := audioDuration(f, strings.ToLower(filepath.Ext(path)))
 	if derr != nil {
 		slog.Debug("duration parse failed; using 0", "file", path, "error", derr)
 		dur = 0
 	}
+
 	var mtimeNano, sizeBytes int64
 	if info, serr := f.Stat(); serr != nil {
 		slog.Debug("could not stat open handle for identity; using zero sentinel", "file", path, "error", serr)
 	} else {
 		mtimeNano, sizeBytes = info.ModTime().UnixNano(), info.Size()
 	}
-	return AudioMetadata{
-		TrackLength: dur,
-		ISRC:        extractISRC(m),
-		AlbumName:   m.Album(),
+
+	trackNo, trackTotal := m.Track()
+	discNo, discTotal := m.Disc()
+
+	return AudioFacts{
 		MTimeNano:   mtimeNano,
 		SizeBytes:   sizeBytes,
+		MBID:        extractRecordingMBID(m),
+		ISRC:        extractISRC(m),
+		Artist:      extractArtist(m),
+		AlbumArtist: extractAlbumArtist(m),
+		Title:       m.Title(),
+		Album:       m.Album(),
+		Composer:    m.Composer(),
+		Genre:       m.Genre(),
+		Year:        m.Year(),
+		TrackNo:     trackNo,
+		TrackTotal:  trackTotal,
+		DiscNo:      discNo,
+		DiscTotal:   discTotal,
+		Format:      string(m.Format()),
+		FileType:    string(m.FileType()),
+		TrackLength: dur,
 	}, nil
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -53,13 +53,17 @@ func IsAudioFile(name string) bool {
 // returned handle is nil, so a caller that checks the error first can never leak
 // it.
 func openAndReadTags(path string) (tag.Metadata, *os.File, error) {
-	// reason: G304 - path is never attacker-supplied at any of the three call
-	// sites, and the invariant differs per caller: ReadAudioProvenance takes a
-	// configured library root + scanned filename confined via pathutil upstream;
+	// reason: G304 - path is never attacker-supplied at any call site, and the
+	// invariant differs per caller: ReadAudioProvenance takes a configured
+	// library root + scanned filename confined via pathutil upstream;
 	// ReadArtistIdentity takes a scan_results file_path written from a configured
 	// library root; ReadAudioMetadata takes a work_queue source_path, likewise
-	// written from a configured library root and confined via pathutil upstream.
-	f, oerr := os.Open(path) //nolint:gosec // reason: see the G304 note above -- all three callers supply a path derived from a configured library root
+	// written from a configured library root and confined via pathutil upstream;
+	// ReadAudioFacts (the comprehensive reader the other three now project over,
+	// #646) is additionally reached from the scan index-metadata walk, whose
+	// paths are rebased onto a canonical library root via
+	// pathutil.RebaseUnderCanonicalRoot and so carry the same invariant.
+	f, oerr := os.Open(path) //nolint:gosec // reason: see the G304 note above -- every caller supplies a path derived from a configured library root
 	if oerr != nil {
 		return nil, nil, fmt.Errorf("open %s: %w", path, oerr)
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -845,4 +846,114 @@ func mapKeys(m map[string]int) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+func TestReadAudioFactsReadsFullTagSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "track.mp3")
+	// WriteAudioFileExtended is the existing testutil fixture helper for ID3-tagged audio.
+	if err := testutil.WriteAudioFileExtended(dir, "track.mp3", "Test Artist", "Test Title", "Test Album", "", map[string]string{
+		"TPE2": "Test Album Artist",
+		"TCOM": "Test Composer",
+		"TCON": "Test Genre",
+		"TDRC": "1997",
+		"TRCK": "3/12",
+		"TPOS": "1/2",
+		"TSRC": "US-TEST-97-00123",
+	}, map[string]string{
+		"musicbrainz_recordingid": "test-mbid-uuid",
+	}); err != nil {
+		t.Fatalf("WriteAudioFileExtended: %v", err)
+	}
+
+	got, err := ReadAudioFacts(path)
+	if err != nil {
+		t.Fatalf("ReadAudioFacts: %v", err)
+	}
+
+	if got.Artist != "Test Artist" {
+		t.Errorf("Artist = %q, want %q", got.Artist, "Test Artist")
+	}
+	if got.AlbumArtist != "Test Album Artist" {
+		t.Errorf("AlbumArtist = %q, want %q", got.AlbumArtist, "Test Album Artist")
+	}
+	if got.Title != "Test Title" {
+		t.Errorf("Title = %q, want %q", got.Title, "Test Title")
+	}
+	if got.Album != "Test Album" {
+		t.Errorf("Album = %q, want %q", got.Album, "Test Album")
+	}
+	if got.Composer != "Test Composer" {
+		t.Errorf("Composer = %q, want %q", got.Composer, "Test Composer")
+	}
+	if got.Genre != "Test Genre" {
+		t.Errorf("Genre = %q, want %q", got.Genre, "Test Genre")
+	}
+	if got.Year != 1997 {
+		t.Errorf("Year = %d, want 1997", got.Year)
+	}
+	if got.TrackNo != 3 || got.TrackTotal != 12 {
+		t.Errorf("Track = %d/%d, want 3/12", got.TrackNo, got.TrackTotal)
+	}
+	if got.DiscNo != 1 || got.DiscTotal != 2 {
+		t.Errorf("Disc = %d/%d, want 1/2", got.DiscNo, got.DiscTotal)
+	}
+	if got.Format == "" || got.FileType == "" {
+		t.Errorf("Format/FileType = %q/%q, want both non-empty", got.Format, got.FileType)
+	}
+	// Identity comes from the open handle's own Stat, never a path re-stat.
+	if got.MTimeNano == 0 || got.SizeBytes == 0 {
+		t.Errorf("MTimeNano/SizeBytes = %d/%d, want both non-zero", got.MTimeNano, got.SizeBytes)
+	}
+	if got.MBID != "test-mbid-uuid" {
+		t.Errorf("MBID = %q, want %q", got.MBID, "test-mbid-uuid")
+	}
+	if got.ISRC != "US-TEST-97-00123" {
+		t.Errorf("ISRC = %q, want %q", got.ISRC, "US-TEST-97-00123")
+	}
+}
+
+func TestReadAudioFactsAbsentTagsAreSentinelsNotErrors(t *testing.T) {
+	// A file with only the minimum tags: every other field must come back as its
+	// documented zero-value sentinel, and this must NOT be an error.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "track.mp3")
+	if err := testutil.WriteAudioFile(dir, "track.mp3", "", "Only Title", "", ""); err != nil {
+		t.Fatalf("WriteAudioFile: %v", err)
+	}
+
+	got, err := ReadAudioFacts(path)
+	if err != nil {
+		t.Fatalf("absent tags must not error: %v", err)
+	}
+	if got.Title != "Only Title" {
+		t.Errorf("Title = %q, want %q", got.Title, "Only Title")
+	}
+	if got.Genre != "" || got.Composer != "" {
+		t.Errorf("absent string tags = %q/%q, want empty sentinels", got.Genre, got.Composer)
+	}
+	if got.Year != 0 || got.TrackNo != 0 || got.DiscNo != 0 {
+		t.Errorf("absent numeric tags = %d/%d/%d, want 0 sentinels", got.Year, got.TrackNo, got.DiscNo)
+	}
+}
+
+func TestReadAudioFactsOpenFailureIsAnError(t *testing.T) {
+	_, err := ReadAudioFacts(filepath.Join(t.TempDir(), "does-not-exist.mp3"))
+	if err == nil {
+		t.Fatal("a missing file must return an error, not a zero-value struct")
+	}
+}
+
+func TestReadAudioFactsNeverExposesLyricsOrPicture(t *testing.T) {
+	// Guards the deliberate exclusion: lyric text must never enter the DB
+	// (copyright, and it would give the #538 extracted lane a self-ingestion
+	// route), and cover art would dwarf every other column. A reflective check
+	// so adding such a field later fails loudly rather than silently shipping.
+	tp := reflect.TypeOf(AudioFacts{})
+	for i := 0; i < tp.NumField(); i++ {
+		name := strings.ToLower(tp.Field(i).Name)
+		if strings.Contains(name, "lyric") || strings.Contains(name, "picture") || strings.Contains(name, "artwork") {
+			t.Errorf("AudioFacts must not carry field %q: lyrics and cover art are deliberately excluded", tp.Field(i).Name)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- **DB coverage of audio metadata has depended on fetch history rather than on what is on disk.** `scan_results` held only artist/title/album/album_artist plus the normalized keys, and none of the other fields `dhowden/tag` exposes (year, genre, track/disc, composer, codec) were read anywhere in the tree. This adds one comprehensive reader, a durable home for what it reads, and an operator-run pass to populate it.
- **User-visible change: one new command, `scan index-metadata`.** Dry-run by default; `--yes` writes. Nothing else changes behavior: the three existing readers keep their signatures and every call site is untouched.
- **Look at the migration first.** `036_audio_metadata.sql` carries the rationale for the one decision most likely to be re-litigated: the table is keyed on the canonical **path**, with `mbid`/`isrc` as **indexed columns**, not as the primary key. MBID was considered as the key and rejected on three grounds: coverage (ISRC measured 41.7% library-wide, so ~58% of tracks carry none, and MBID is Picard-written so scarcer), non-uniqueness (reissues share an ISRC; one recording spans several distinct files), and validation (staleness needs a key checkable *without* opening the file). Same split migration 035 already argued for `audio_durations`.

**Size override:** 1,446 hand-written LOC / 13 files, over the 800/10 threshold. Rationale: the work was already decomposed as PR 1 of 2, with #640 carved out. The reader, table, store, and command are one vertical slice: each is dead code without the others, and `internal/audiometa` has no caller until the command exists. Production code alone is 603 LOC; **56% of the diff (805 LOC) is tests**, including gap-closing and regression tests review specifically asked for.

Lyric text and cover art are deliberately excluded from the reader and the schema: lyrics would place copyrighted material in the DB and give the #538 extracted lane a self-ingestion route, and cover art would dwarf every other column. A reflective test guards the exclusion so a future field addition fails loudly.

## Linked issue

Closes #646

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
- [x] Label set on `gh pr create --label ...` (no CI gate enforces this, but it keeps the tracker usable).
- [ ] **UAT performed for user-visible changes (run the binary, not just the test suite).** Partially: the review process ran the built binary against temp fixtures extensively (multi-root `--limit`, unreachable roots, symlinks, unicode/apostrophe/`%`/`_` paths, permission-denied subtrees, 20k-file scale). **Not yet run against the real library** -- that is the deliberate next step (Kids_Music pilot, see Test plan).
- [x] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD. *(N/A -- no web-UI change.)*
- [x] `make ui` re-run if any `.templ` or CSS source changed. *(N/A -- no templ or CSS change.)*
- [x] Migration added under `internal/db/migrations/` if this is a one-time data correction. *(Migration 036 adds the table; this is a new store, not a data correction.)*

## Test plan

- [x] `make gate` passes locally.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Every new test in this branch was mutation-tested: the production line it guards was broken, the test confirmed to FAIL, then restored and the restore verified by diff. One test that survived its mutation (the per-entry walk-error counter) was found and a real guard added in response.
- [x] Patch coverage meets the Codecov threshold. **84.66%** against a 70% threshold.
- [x] Which **surface** this change fixes is stated explicitly, and was verified by looking at that surface. The surface is the new `audio_metadata` table, verified by querying SQLite rows directly (not just via the store's own API) in both tests and reviewer probes.
- [ ] Manual UAT steps (list the specific flows exercised):
  - [ ] Dry run on Kids_Music (1,902 files, the smallest root, and representative rather than a lucky corner: its 43.0% ISRC coverage closely tracks the library-wide 41.7%, so both the identity-present and identity-absent paths are exercised). Check files found against the census figure, the read-failure count, and the absent-vs-empty split per field.
  - [ ] Live run on Kids_Music, then immediately re-run: the second pass should report ~1,902 skipped. That is the real test of the staleness rule and it is cheap.
  - [ ] Full library (~84k files, all four roots).
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] **The `--limit` budget accounting** (`index_metadata.go`). It has now been fixed twice for two distinct bugs: first that skipped files consumed budget (so repeated bounded runs never advanced), then that the budget was per-root rather than per-run (so `--limit 3` across three roots wrote 5 rows). Both are covered by tests now, but the area has earned scrutiny.
  - [ ] **The symlink stamp fix.** The skip check now uses `os.Stat` for symlinked entries (detected via `d.Type()&fs.ModeSymlink`, free from readdir) because `d.Info()` is an lstat while `scanner.ReadAudioFacts` stamps from `f.Stat()` on the open handle, so a symlinked file could never match its own row and was re-read forever. Worth confirming this does not contradict migration 035's deliberate choice not to resolve per-file symlinks for the *path key* -- the key is untouched here; only the mtime/size stamp follows the link.

## Not covered

- **#640 is out of scope by design.** `mbid` and `isrc` are written by this PR and read by nothing. Re-linking rows by identity instead of deleting them on a move ships as PR 2, so the destructive `prune` path is reviewed on its own rather than buried in a large additive diff.
- **No other audio-opening path was wired to populate the table for free.** The scan loop, the worker, and the detector all still read narrowly. That is consistent with this PR's additive framing, but it is a decision rather than an oversight: opportunistic capture at those sites is follow-up work.
- **The backfill is not paced.** The design called for pacing so it does not starve the worker, and there is no `--pace` knob yet. Measured on the library host at ~7.6ms per header read (300-file sample, almost entirely I/O wait), so a full ~84k run is roughly 10-30 minutes. Irrelevant at pilot scale; a `--pace` flag (milliseconds between files, default 0, skipped files not sleeping) is planned before the full-library run.
- **Per-library coverage is by canonical-path prefix, not a `library_id` column.** `Coverage` takes an optional path prefix and matches with `substr(file_path,1,length(?))=?` rather than `LIKE` (so `_` and `%` in real paths stay literal). Adding a `library_id` column was deliberately out of scope.
- **An open question, tracked but not diagnosed:** prod shows zero rows with a non-empty `isrc` or `mbid` across all `done` `work_queue` rows, though migration 033 created those columns for #620's completion provenance. One query, not an investigation. It does not affect this PR's design, but if that stamping path is not firing, tiers 1 and 2 of #640's re-link ladder will have nothing to match on from existing data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `scan index-metadata` to index audio tag metadata independently of lyric history.
  - Supports library scoping, preview mode, confirmation to apply changes, and per-run file limits.
  - Skips unchanged files on repeat runs and reports indexing coverage and results.
  - Handles interruptions and individual unreadable files without losing completed work.

- **Documentation**
  - Added CLI reference guidance and examples for previewing, applying, scoping, limiting, and verifying metadata indexing.

- **Bug Fixes**
  - Corrected scan subcommand selection and shell completion for metadata indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->