### PR TITLE
feat(identity): extract the shared resolver and persist row identity

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -910,3 +910,93 @@ func TestMigration034TimingOutcomeUpDown(t *testing.T) {
 		}
 	}
 }
+
+// TestMigration037ScanResultsIdentityUpDown verifies migration 037 adds
+// scan_results.isrc/recording_mbid as nullable-semantics (” = absent)
+// additive columns, that a pre-existing row reads back empty (never a
+// fabricated identity), that non-empty values round-trip, and that the
+// down-migration removes both columns and their partial indexes.
+func TestMigration037ScanResultsIdentityUpDown(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "mig037.db")
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	applyOpenPragmas(ctx, t, sqlDB)
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 36); err != nil {
+		t.Fatalf("UpTo(36): %v", err)
+	}
+
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO libraries (path, name) VALUES ('/music', 'Music')`,
+	); err != nil {
+		t.Fatalf("seed library: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status)
+         VALUES (1, '/music/a.flac', 'Artist', 'Title', 'pending')`,
+	); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	if _, err := provider.UpTo(ctx, 37); err != nil {
+		t.Fatalf("UpTo(37): %v", err)
+	}
+
+	// A pre-existing row reads back empty identity, never NULL and never a
+	// fabricated value -- '' is the documented "never enriched" sentinel.
+	var isrc, mbid string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT isrc, recording_mbid FROM scan_results WHERE file_path = '/music/a.flac'`).Scan(&isrc, &mbid); err != nil {
+		t.Fatalf("query identity columns: %v", err)
+	}
+	if isrc != "" || mbid != "" {
+		t.Errorf("pre-existing row identity = (%q, %q); want empty", isrc, mbid)
+	}
+
+	// Non-empty values round-trip.
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE scan_results SET isrc = 'USABC1234567', recording_mbid = 'mbid-abc-123' WHERE file_path = '/music/a.flac'`,
+	); err != nil {
+		t.Fatalf("update identity columns: %v", err)
+	}
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT isrc, recording_mbid FROM scan_results WHERE file_path = '/music/a.flac'`).Scan(&isrc, &mbid); err != nil {
+		t.Fatalf("re-query identity columns: %v", err)
+	}
+	if isrc != "USABC1234567" || mbid != "mbid-abc-123" {
+		t.Errorf("identity = (%q, %q); want (USABC1234567, mbid-abc-123)", isrc, mbid)
+	}
+
+	// Down-migration removes both columns and their partial indexes.
+	if _, err := provider.DownTo(ctx, 36); err != nil {
+		t.Fatalf("DownTo(36): %v", err)
+	}
+	for _, col := range []string{"isrc", "recording_mbid"} {
+		var name string
+		err := sqlDB.QueryRowContext(ctx,
+			`SELECT name FROM pragma_table_info('scan_results') WHERE name = ?`, col).Scan(&name)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("%s column still present after down-migration (err=%v, name=%q); want removed", col, err, name)
+		}
+	}
+	for _, idx := range []string{"idx_scan_results_mbid", "idx_scan_results_isrc"} {
+		var name string
+		err := sqlDB.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`, idx).Scan(&name)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("index %s still present after down-migration (err=%v); want removed", idx, err)
+		}
+	}
+}

--- a/internal/db/migrations/037_scan_results_identity.sql
+++ b/internal/db/migrations/037_scan_results_identity.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Path-invariant recording identity on scan_results (#640): the MusicBrainz
+-- recording MBID and ISRC embedded in a file's tags, additive columns following
+-- the 008/025/033 idiom, both nullable (unset = never enriched, matching the
+-- EnrichRecording-gated extraction that already populates models.Track.ISRC /
+-- RecordingMBID at scan time but previously dropped both before insert).
+--
+-- WHY scan_results AND NOT internal/audiometa'S audio_metadata TABLE (#646).
+-- audio_metadata already stores mbid/isrc, but it is populated only by the
+-- standalone `index-metadata` CLI command, and it is keyed by a DIFFERENT
+-- canonicalization scheme (pathutil.CanonicalRoot/RebaseUnderCanonicalRoot,
+-- symlink-resolved) than scan_results.file_path / work_queue.source_path (the
+-- raw configured-root spelling, per scanner.ScanLibrary's walk -- see
+-- internal/scanner/scanner.go). A join between the two would silently miss
+-- rows whenever a library root is a symlink, which migration 035's own comments
+-- document as a real deployment shape. Keeping identity ON scan_results avoids
+-- that mismatch entirely: the gone row and the surviving-file candidate pool
+-- are both read from the exact same table, keyed the exact same way, and
+-- populated by the exact same scan loop that already extracts these tags today.
+--
+-- This is prune's exact-tier read side. The write side is
+-- internal/scan/repository.go's baseUpsert/upsertBatch, sourced from
+-- models.ScanResult.Track.ISRC / RecordingMBID -- no new tag parsing, since
+-- internal/scanner already extracts both when EnrichRecording is on.
+ALTER TABLE scan_results ADD COLUMN isrc TEXT NOT NULL DEFAULT '';
+ALTER TABLE scan_results ADD COLUMN recording_mbid TEXT NOT NULL DEFAULT '';
+
+-- Partial indexes: prune's exact tier only ever looks up a NON-EMPTY value (an
+-- orphaned row with an empty identity is retained-and-reported without a
+-- lookup at all), so indexing the majority-empty rows (coverage is well under
+-- half library-wide, per the 036 census) would be dead weight.
+CREATE INDEX idx_scan_results_mbid ON scan_results(recording_mbid) WHERE recording_mbid != '';
+CREATE INDEX idx_scan_results_isrc ON scan_results(isrc) WHERE isrc != '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_scan_results_isrc;
+DROP INDEX IF EXISTS idx_scan_results_mbid;
+ALTER TABLE scan_results DROP COLUMN recording_mbid;
+ALTER TABLE scan_results DROP COLUMN isrc;
+-- +goose StatementEnd

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -24,6 +24,8 @@
 package identity
 
 import (
+	"iter"
+	"slices"
 	"strings"
 
 	"github.com/sydlexius/canticle/internal/normalize"
@@ -116,16 +118,51 @@ func candidateValue(c Candidate, key string) string {
 // ref) when exactly one candidate matches at the first key that matched
 // anything, and (VerdictConflict, "") when more than one candidate shares that
 // value.
+//
+// This is the slice form, for a caller whose candidate pool is already
+// materialized in memory at no further cost (internal/prune holds its pool as
+// scan_results rows already loaded and stat-checked). A caller for whom
+// producing a candidate is EXPENSIVE -- internal/realign must read ID3 tags off
+// disk to learn a candidate's identity -- must use ResolveExactSeq instead, so
+// no candidate is ever realized unless the ladder actually needs to inspect it.
+// Both forms run the same decision logic: this one is a one-line delegation.
 func ResolveExact(orphanMBID, orphanISRC string, keys Keys, pool []Candidate) (Verdict, string) {
+	return ResolveExactSeq(orphanMBID, orphanISRC, keys, slices.Values(pool))
+}
+
+// ResolveExactSeq is ResolveExact over a lazy candidate sequence, and is the
+// sole implementation of the exact tier's decision logic.
+//
+// The sequence is pulled ONLY from inside the per-key loop, and only once the
+// orphan is known to carry a non-empty value for that key. An orphan with no
+// identity at all therefore never iterates candidates even once, so a caller
+// whose iteration performs I/O (realign reading tags off disk) pays nothing for
+// the case it cannot possibly resolve. This ordering is load-bearing, not an
+// optimization detail: materializing the pool before the key loop reads every
+// candidate file in a directory to answer a question that needed no reads,
+// which is exactly the regression this signature exists to prevent.
+//
+// The sequence is re-iterated once per identity key that the orphan carries a
+// value for (at most len(keys) times, and only until a key produces a match).
+// A caller whose realization is expensive should therefore memoize it; realign
+// does, via its per-plan provenance cache.
+func ResolveExactSeq(orphanMBID, orphanISRC string, keys Keys, candidates iter.Seq[Candidate]) (Verdict, string) {
 	for _, key := range keys {
 		id := strings.TrimSpace(orphanValue(orphanMBID, orphanISRC, key))
 		if id == "" {
 			continue
 		}
 		var matches []string
-		for _, c := range pool {
+		for c := range candidates {
 			if strings.EqualFold(strings.TrimSpace(candidateValue(c, key)), id) {
 				matches = append(matches, c.Ref)
+				// Two matches already settle this key as a conflict, and a
+				// conflict carries no ref, so nothing a third match could add
+				// changes the answer. Stop pulling: for realign that is one
+				// fewer tag read per remaining candidate.
+				if len(matches) > 1 {
+					break
+				}
 			}
 		}
 		switch len(matches) {

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,0 +1,166 @@
+// Package identity implements the shared exact-match and heuristic
+// name-similarity tiers used to re-attach something (a lyric sidecar, a
+// database row) to the audio file it belongs to after a move, rename, or
+// reorganization (#640).
+//
+// It exists so two independently-written resolvers never disagree about where
+// a file went. Before this package, internal/realign carried a private
+// four-tier resolver for re-attaching orphaned .lrc/.txt sidecars to renamed
+// audio; internal/prune needed the exact same exact/heuristic matching logic to
+// decide whether a work_queue/scan_results row whose source vanished was
+// genuinely deleted or merely moved. Two copies of "does this ISRC/MBID/name
+// match that candidate" would eventually drift -- one resolver could re-link a
+// sidecar to file A while the other re-links the DB row to file B, silently
+// pointing a lyric file and its own database record at two different audio
+// files. This package is that one shared ladder; both realign and prune build
+// Candidate sets from their own data and delegate the verdict here.
+//
+// The package is deliberately free of filesystem and database concerns: it
+// takes plain values in and returns a plain verdict out. Both callers own
+// building their candidate pool (realign walks a directory tree and reads tags;
+// prune queries scan_results for the library's other rows) and own interpreting
+// the verdict (realign renames a file; prune re-links or retains a database
+// row).
+package identity
+
+import (
+	"strings"
+
+	"github.com/sydlexius/canticle/internal/normalize"
+)
+
+// Verdict is the outcome of the exact-match tier.
+type Verdict int
+
+const (
+	// VerdictNone means no candidate matched any configured identity key: the
+	// orphan carries no usable identifier that this candidate pool can resolve.
+	VerdictNone Verdict = iota
+	// VerdictUnique means exactly one candidate matched, at the first identity
+	// key (in caller-supplied order) that produced any match at all.
+	VerdictUnique
+	// VerdictConflict means more than one candidate shares the same identity
+	// value at the first key that produced a match -- an ambiguity that must
+	// never be resolved by guessing.
+	VerdictConflict
+)
+
+// Candidate is one abstract match target: a file, or the surviving side of a
+// database row, carrying the same identity/name signals the orphan side is
+// compared against. Ref is an opaque handle the caller round-trips back out of
+// a Unique verdict (a file path for realign, a row/source-path for prune);
+// this package never interprets it.
+type Candidate struct {
+	Ref    string
+	MBID   string
+	ISRC   string
+	Artist string
+	Title  string
+}
+
+// Keys is the ordered set of identity fields the exact tier consults, most
+// authoritative first. NormalizeKeys produces this from raw config input.
+type Keys []string
+
+// NormalizeKeys lowercases, filters to the known identity keys ("mbid",
+// "isrc"), and de-duplicates while preserving order. Shared by realign and
+// prune so both read config.RealignConfig.IdentityKeys the same way and can
+// never disagree about key precedence.
+func NormalizeKeys(keys []string) Keys {
+	seen := map[string]bool{}
+	out := make(Keys, 0, len(keys))
+	for _, k := range keys {
+		k = strings.ToLower(strings.TrimSpace(k))
+		if k != "mbid" && k != "isrc" {
+			continue
+		}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, k)
+	}
+	return out
+}
+
+// orphanValue returns the value the caller carries for identity key k, from
+// an orphan's known mbid/isrc pair.
+func orphanValue(mbid, isrc, key string) string {
+	switch key {
+	case "mbid":
+		return mbid
+	case "isrc":
+		return isrc
+	}
+	return ""
+}
+
+// candidateValue returns c's value for identity key k.
+func candidateValue(c Candidate, key string) string {
+	switch key {
+	case "mbid":
+		return c.MBID
+	case "isrc":
+		return c.ISRC
+	}
+	return ""
+}
+
+// ResolveExact finds the unique candidate in pool whose MBID or ISRC matches
+// the orphan's, honoring keys order (most authoritative first: the first key
+// that produces ANY match at all decides the verdict, so a conflict at the
+// primary key is never silently rescued by a secondary key that happens to be
+// unambiguous).
+//
+// Returns (VerdictNone, "") when no key in the pool matches, (VerdictUnique,
+// ref) when exactly one candidate matches at the first key that matched
+// anything, and (VerdictConflict, "") when more than one candidate shares that
+// value.
+func ResolveExact(orphanMBID, orphanISRC string, keys Keys, pool []Candidate) (Verdict, string) {
+	for _, key := range keys {
+		id := strings.TrimSpace(orphanValue(orphanMBID, orphanISRC, key))
+		if id == "" {
+			continue
+		}
+		var matches []string
+		for _, c := range pool {
+			if strings.EqualFold(strings.TrimSpace(candidateValue(c, key)), id) {
+				matches = append(matches, c.Ref)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			continue
+		case 1:
+			return VerdictUnique, matches[0]
+		default:
+			return VerdictConflict, ""
+		}
+	}
+	return VerdictNone, ""
+}
+
+// HeuristicNameGuard scores an orphan's artist/title (or a positional stem,
+// when no name is available on either side) against one candidate's
+// artist/title via Jaro-Winkler, and reports whether the score clears
+// minConfidence. It degrades to true when neither side carries a name at all,
+// so a purely positional pairing (a single orphan matched with a single
+// missing-sidecar file in the same directory) still succeeds -- the guard has
+// nothing to disprove.
+func HeuristicNameGuard(orphanArtist, orphanTitle, orphanStem string, candidate Candidate, candidateStem string, minConfidence float64) (bool, float64) {
+	hasOrphanName := orphanArtist != "" || orphanTitle != ""
+	hasCandidateName := candidate.Artist != "" || candidate.Title != ""
+	if !hasOrphanName && !hasCandidateName {
+		return true, 0
+	}
+	orphanStr := orphanStem
+	if hasOrphanName {
+		orphanStr = strings.TrimSpace(orphanArtist + " " + orphanTitle)
+	}
+	candidateStr := candidateStem
+	if hasCandidateName {
+		candidateStr = strings.TrimSpace(candidate.Artist + " " + candidate.Title)
+	}
+	score := normalize.MatchConfidence(orphanStr, candidateStr)
+	return score >= minConfidence, score
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -117,6 +117,18 @@ func TestHeuristicNameGuard_BelowThreshold(t *testing.T) {
 	}
 }
 
+// TestResolveExact_CandidateIdentityIsTrimmed: the CANDIDATE side is trimmed
+// too, not just the orphan's. Tag writers pad values (a fixed-width ID3 frame,
+// a trailing newline), and an untrimmed comparison would silently miss the one
+// correct file and report VerdictNone -- a false "no match" that leaves the
+// sidecar orphaned rather than re-attached.
+func TestResolveExact_CandidateIdentityIsTrimmed(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "  abc-123\n"}}
+	if v, ref := ResolveExact("abc-123", "", NormalizeKeys([]string{"mbid"}), pool); v != VerdictUnique || ref != "a" {
+		t.Fatalf("padded CANDIDATE MBID = (%v,%q), want (Unique,a)", v, ref)
+	}
+}
+
 // TestHeuristicNameGuard_NoNamesDegradesToPositional: when neither side
 // carries a name, the guard has nothing to disprove and returns true.
 func TestHeuristicNameGuard_NoNamesDegradesToPositional(t *testing.T) {

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,0 +1,127 @@
+package identity
+
+import "testing"
+
+func TestNormalizeKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"order preserved", []string{"mbid", "isrc"}, []string{"mbid", "isrc"}},
+		{"reordered input honored", []string{"isrc", "mbid"}, []string{"isrc", "mbid"}},
+		{"case and whitespace", []string{" MBID ", "Isrc"}, []string{"mbid", "isrc"}},
+		{"unknown filtered", []string{"mbid", "spotify_id", "isrc"}, []string{"mbid", "isrc"}},
+		{"dedup keeps first", []string{"mbid", "mbid", "isrc"}, []string{"mbid", "isrc"}},
+		{"empty", nil, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeKeys(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("NormalizeKeys(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("NormalizeKeys(%v) = %v, want %v", tt.in, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveExact_Unique(t *testing.T) {
+	pool := []Candidate{
+		{Ref: "a", MBID: "abc-123"},
+		{Ref: "b", MBID: "def-456"},
+	}
+	v, ref := ResolveExact("abc-123", "", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictUnique || ref != "a" {
+		t.Fatalf("ResolveExact = (%v, %q), want (Unique, a)", v, ref)
+	}
+}
+
+func TestResolveExact_None(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "abc-123"}}
+	v, ref := ResolveExact("zzz-999", "", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictNone || ref != "" {
+		t.Fatalf("ResolveExact = (%v, %q), want (None, \"\")", v, ref)
+	}
+}
+
+func TestResolveExact_NoIdentity(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "abc-123"}}
+	v, ref := ResolveExact("", "", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictNone || ref != "" {
+		t.Fatalf("ResolveExact with no orphan identity = (%v, %q), want (None, \"\")", v, ref)
+	}
+}
+
+func TestResolveExact_Conflict(t *testing.T) {
+	pool := []Candidate{
+		{Ref: "a", MBID: "abc-123"},
+		{Ref: "b", MBID: "abc-123"},
+	}
+	v, ref := ResolveExact("abc-123", "", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictConflict || ref != "" {
+		t.Fatalf("ResolveExact duplicate MBID = (%v, %q), want (Conflict, \"\")", v, ref)
+	}
+}
+
+// TestResolveExact_KeyOrderPrecedence: MBID is checked before ISRC. A conflict
+// at the MBID tier must not be silently rescued by an unambiguous ISRC match --
+// the first key that produces ANY match decides the verdict.
+func TestResolveExact_KeyOrderPrecedence(t *testing.T) {
+	pool := []Candidate{
+		{Ref: "a", MBID: "shared-mbid", ISRC: "isrc-a"},
+		{Ref: "b", MBID: "shared-mbid", ISRC: "isrc-b"},
+	}
+	v, ref := ResolveExact("shared-mbid", "isrc-a", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictConflict || ref != "" {
+		t.Fatalf("ResolveExact = (%v, %q), want (Conflict, \"\") -- MBID conflict must not be rescued by an unambiguous ISRC", v, ref)
+	}
+}
+
+// TestResolveExact_FallsThroughToSecondaryKey: when the primary key (mbid)
+// matches nothing at all (not a conflict, a true miss), the secondary key
+// (isrc) is still consulted.
+func TestResolveExact_FallsThroughToSecondaryKey(t *testing.T) {
+	pool := []Candidate{{Ref: "a", ISRC: "isrc-a"}}
+	v, ref := ResolveExact("", "isrc-a", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictUnique || ref != "a" {
+		t.Fatalf("ResolveExact = (%v, %q), want (Unique, a) via ISRC fallback", v, ref)
+	}
+}
+
+// TestResolveExact_CaseInsensitive: identity comparison is case-insensitive,
+// matching realign's original resolveExact behavior.
+func TestResolveExact_CaseInsensitive(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "ABC-123"}}
+	v, ref := ResolveExact("abc-123", "", NormalizeKeys([]string{"mbid"}), pool)
+	if v != VerdictUnique || ref != "a" {
+		t.Fatalf("ResolveExact case-insensitive = (%v, %q), want (Unique, a)", v, ref)
+	}
+}
+
+func TestHeuristicNameGuard_AboveThreshold(t *testing.T) {
+	ok, score := HeuristicNameGuard("The Artist", "The Title", "stem", Candidate{Artist: "The Artist", Title: "The Title"}, "stem2", 0.75)
+	if !ok {
+		t.Fatalf("HeuristicNameGuard identical names: ok=false score=%v, want true", score)
+	}
+}
+
+func TestHeuristicNameGuard_BelowThreshold(t *testing.T) {
+	ok, _ := HeuristicNameGuard("Completely Different Artist", "Totally Other Title", "stem", Candidate{Artist: "Zzz", Title: "Qqq"}, "stem2", 0.9)
+	if ok {
+		t.Fatalf("HeuristicNameGuard dissimilar names: ok=true, want false")
+	}
+}
+
+// TestHeuristicNameGuard_NoNamesDegradesToPositional: when neither side
+// carries a name, the guard has nothing to disprove and returns true.
+func TestHeuristicNameGuard_NoNamesDegradesToPositional(t *testing.T) {
+	ok, score := HeuristicNameGuard("", "", "stem", Candidate{}, "stem2", 0.75)
+	if !ok || score != 0 {
+		t.Fatalf("HeuristicNameGuard with no names = (%v, %v), want (true, 0)", ok, score)
+	}
+}

--- a/internal/identity/lazy_test.go
+++ b/internal/identity/lazy_test.go
@@ -1,0 +1,119 @@
+package identity
+
+import (
+	"iter"
+	"testing"
+)
+
+// countingSeq returns a candidate sequence plus a pointer to the number of
+// candidates actually REALIZED (yielded). A caller whose realization is a disk
+// read cares about this number, not about the pool's size.
+func countingSeq(pool []Candidate) (iter.Seq[Candidate], *int) {
+	n := 0
+	return func(yield func(Candidate) bool) {
+		for _, c := range pool {
+			n++
+			if !yield(c) {
+				return
+			}
+		}
+	}, &n
+}
+
+// The whole point of the Seq form: an orphan carrying no identity value for
+// any configured key must never realize a single candidate. This is the
+// package-level twin of the realign repro that measures readProv invocations.
+func TestResolveExactSeq_NoOrphanIdentityRealizesNothing(t *testing.T) {
+	pool := make([]Candidate, 25)
+	for i := range pool {
+		pool[i] = Candidate{Ref: "r", MBID: "m", ISRC: "i"}
+	}
+	seq, realized := countingSeq(pool)
+	if v, ref := ResolveExactSeq("", "", NormalizeKeys([]string{"mbid", "isrc"}), seq); v != VerdictNone || ref != "" {
+		t.Fatalf("ResolveExactSeq = (%v,%q), want (None,\"\")", v, ref)
+	}
+	if *realized != 0 {
+		t.Fatalf("realized %d candidates for an identity-less orphan, want 0", *realized)
+	}
+}
+
+// A whitespace-only identity is treated as absent, so it too must realize
+// nothing -- the trim happens before the pull, not after.
+func TestResolveExactSeq_WhitespaceOnlyIdentityRealizesNothing(t *testing.T) {
+	seq, realized := countingSeq([]Candidate{{Ref: "a", MBID: "m"}})
+	if v, _ := ResolveExactSeq("   ", "", NormalizeKeys([]string{"mbid"}), seq); v != VerdictNone {
+		t.Fatalf("whitespace identity = %v, want VerdictNone", v)
+	}
+	if *realized != 0 {
+		t.Fatalf("realized %d candidates for a whitespace-only identity, want 0", *realized)
+	}
+}
+
+// A key the orphan has no value for must not trigger a pass over the pool:
+// only keys the orphan actually carries cost an iteration.
+func TestResolveExactSeq_OnlyCarriedKeysIterate(t *testing.T) {
+	pool := []Candidate{{Ref: "a", ISRC: "isrc-a"}, {Ref: "b", ISRC: "isrc-b"}}
+	seq, realized := countingSeq(pool)
+	// keys = [mbid, isrc] but the orphan carries only isrc: exactly one pass.
+	if v, ref := ResolveExactSeq("", "isrc-b", NormalizeKeys([]string{"mbid", "isrc"}), seq); v != VerdictUnique || ref != "b" {
+		t.Fatalf("ResolveExactSeq = (%v,%q), want (Unique,b)", v, ref)
+	}
+	if *realized != len(pool) {
+		t.Fatalf("realized %d, want %d (one pass over the pool, mbid skipped)", *realized, len(pool))
+	}
+}
+
+// A second match settles the key as a conflict, and a conflict carries no ref,
+// so the resolver must stop pulling rather than realize the rest of the pool.
+func TestResolveExactSeq_ConflictStopsPullingEarly(t *testing.T) {
+	pool := []Candidate{
+		{Ref: "a", MBID: "dup"},
+		{Ref: "b", MBID: "dup"},
+		{Ref: "c", MBID: "dup"},
+		{Ref: "d", MBID: "dup"},
+	}
+	seq, realized := countingSeq(pool)
+	if v, ref := ResolveExactSeq("dup", "", NormalizeKeys([]string{"mbid"}), seq); v != VerdictConflict || ref != "" {
+		t.Fatalf("ResolveExactSeq = (%v,%q), want (Conflict,\"\")", v, ref)
+	}
+	if *realized != 2 {
+		t.Fatalf("realized %d candidates, want 2 (stop at the second match)", *realized)
+	}
+}
+
+// A primary-key MISS still costs a full pass, then falls through to the
+// secondary key for a second pass. Pins the re-iteration contract the doc
+// comment promises (and that realign's provenance cache makes free).
+func TestResolveExactSeq_FallthroughReiterates(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "other", ISRC: "isrc-a"}}
+	seq, realized := countingSeq(pool)
+	if v, ref := ResolveExactSeq("no-such-mbid", "isrc-a", NormalizeKeys([]string{"mbid", "isrc"}), seq); v != VerdictUnique || ref != "a" {
+		t.Fatalf("ResolveExactSeq = (%v,%q), want (Unique,a)", v, ref)
+	}
+	if *realized != 2*len(pool) {
+		t.Fatalf("realized %d, want %d (one pass per carried key)", *realized, 2*len(pool))
+	}
+}
+
+// The slice form must be observably identical to the Seq form -- it is the
+// prune-side entry point, and one implementation is the entire premise of this
+// package.
+func TestResolveExact_SliceMatchesSeq(t *testing.T) {
+	pool := []Candidate{
+		{Ref: "a", MBID: "m-a", ISRC: "i-a"},
+		{Ref: "b", MBID: "m-b", ISRC: "i-a"},
+	}
+	keys := NormalizeKeys([]string{"mbid", "isrc"})
+	cases := []struct{ mbid, isrc string }{
+		{"m-a", ""}, {"", "i-a"}, {"m-zzz", "i-a"}, {"", ""}, {"m-b", "i-a"},
+	}
+	for _, tc := range cases {
+		seq, _ := countingSeq(pool)
+		wantV, wantRef := ResolveExactSeq(tc.mbid, tc.isrc, keys, seq)
+		gotV, gotRef := ResolveExact(tc.mbid, tc.isrc, keys, pool)
+		if gotV != wantV || gotRef != wantRef {
+			t.Fatalf("ResolveExact(%q,%q) = (%v,%q), Seq = (%v,%q): the two forms must agree",
+				tc.mbid, tc.isrc, gotV, gotRef, wantV, wantRef)
+		}
+	}
+}

--- a/internal/identity/repro_hostile_test.go
+++ b/internal/identity/repro_hostile_test.go
@@ -1,0 +1,58 @@
+package identity
+
+import "testing"
+
+// REPRO 1: the case-0 fallthrough (primary key PRESENT but matching nothing,
+// secondary key rescues) is not covered by any existing test.
+// TestResolveExact_FallsThroughToSecondaryKey passes orphanMBID="", which exits
+// at the `id == ""` guard, a DIFFERENT branch. This exercises the real one.
+func TestRepro_FallthroughWhenPrimaryPresentButUnmatched(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "other-mbid", ISRC: "isrc-a"}}
+	v, ref := ResolveExact("orphan-mbid-not-in-pool", "isrc-a", NormalizeKeys([]string{"mbid", "isrc"}), pool)
+	if v != VerdictUnique || ref != "a" {
+		t.Fatalf("ResolveExact = (%v,%q), want (Unique,a): a primary-key MISS must fall through to ISRC", v, ref)
+	}
+}
+
+// REPRO 2: the positional-degrade condition is &&; with only ONE side naming
+// itself, the guard compares a name against a STEM. No existing test pins this.
+func TestRepro_OneSidedNameComparesNameAgainstStem(t *testing.T) {
+	// Orphan has no name, candidate does. Guard must NOT degrade to true.
+	ok, score := HeuristicNameGuard("", "", "zzzzz-unrelated-stem", Candidate{Artist: "The Artist", Title: "The Title"}, "cand-stem", 0.9)
+	if ok {
+		t.Fatalf("one-sided name with unrelated stem: ok=true score=%v, want false", score)
+	}
+}
+
+// REPRO 3: threshold boundary. score == minConfidence must PASS (>=).
+func TestRepro_ThresholdBoundaryIsInclusive(t *testing.T) {
+	_, score := HeuristicNameGuard("A", "B", "s", Candidate{Artist: "A", Title: "C"}, "s2", 0.0)
+	ok, _ := HeuristicNameGuard("A", "B", "s", Candidate{Artist: "A", Title: "C"}, "s2", score)
+	if !ok {
+		t.Fatalf("score == minConfidence (%v) must pass the guard (>=), got false", score)
+	}
+}
+
+// REPRO 4: whitespace-only / padded orphan identity.
+func TestRepro_WhitespaceIdentity(t *testing.T) {
+	pool := []Candidate{{Ref: "a", MBID: "abc-123"}}
+	if v, ref := ResolveExact("  abc-123  ", "", NormalizeKeys([]string{"mbid"}), pool); v != VerdictUnique || ref != "a" {
+		t.Fatalf("padded orphan MBID = (%v,%q), want (Unique,a)", v, ref)
+	}
+	// Whitespace-only identity must be treated as absent, not matched against
+	// a whitespace-only candidate value.
+	poolWS := []Candidate{{Ref: "a", MBID: "   "}}
+	if v, ref := ResolveExact("   ", "", NormalizeKeys([]string{"mbid"}), poolWS); v != VerdictNone {
+		t.Fatalf("whitespace-only identity = (%v,%q), want VerdictNone", v, ref)
+	}
+}
+
+// REPRO 5: empty-string candidate identity must never match an orphan whose
+// value at that key is empty -- the "everything with no ISRC is the same track"
+// catastrophe. (Guarded by the id=="" continue; pinning it.)
+func TestRepro_EmptyCandidateIdentityNeverMatches(t *testing.T) {
+	pool := []Candidate{{Ref: "a"}, {Ref: "b"}, {Ref: "c"}}
+	if v, ref := ResolveExact("", "", NormalizeKeys([]string{"mbid", "isrc"}), pool); v != VerdictNone {
+		t.Fatalf("empty orphan vs empty pool = (%v,%q), want VerdictNone", v, ref)
+	}
+}

--- a/internal/realign/lazy_test.go
+++ b/internal/realign/lazy_test.go
@@ -1,0 +1,100 @@
+package realign
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/identity"
+	"github.com/sydlexius/canticle/internal/lyrics"
+)
+
+// resolveExact hands the shared resolver a LAZY sequence, so when the resolver
+// stops pulling (a second match already settles the key as a conflict, and a
+// conflict carries no ref) the adapter must honor yield's false return and
+// stop reading. Ignoring it would leave the verdict correct while silently
+// reading every remaining audio file off disk -- the same class of defect as
+// the eager-materialize regression, just narrower.
+func TestResolveExact_StopsReadingOnceConflictIsSettled(t *testing.T) {
+	const poolSize = 20
+	pool := make([]string, poolSize)
+	prov := map[string]audioProvenance{}
+	for i := range pool {
+		p := fmt.Sprintf("/lib/t%02d.flac", i)
+		pool[i] = p
+		prov[p] = audioProvenance{isrc: "SHARED-ISRC"} // every file conflicts
+	}
+
+	reads := 0
+	getProv := func(p string) audioProvenance {
+		reads++
+		return prov[p]
+	}
+
+	tags := lyrics.ProvenanceTags{ISRC: "SHARED-ISRC"}
+	got, status := resolveExact(tags, identity.NormalizeKeys([]string{"isrc"}), pool, getProv)
+	if status != "conflict" || got != "" {
+		t.Fatalf("resolveExact = (%q,%q), want (\"\",\"conflict\")", got, status)
+	}
+	if reads != 2 {
+		t.Errorf("getProv called %d times to settle a conflict; want 2 -- the adapter "+
+			"must return when yield reports the resolver has stopped pulling", reads)
+	}
+}
+
+// A candidate whose tag read FAILED must never enter the pool. readProv can
+// return a partially-populated provenance alongside its error (a truncated or
+// malformed tag block), and admitting that half-read identity would let a file
+// the reader could not actually vouch for win the exact tier -- silently
+// re-attaching a sidecar to the wrong audio.
+func TestResolveExact_PartialReadWithErrorIsNeverAMatch(t *testing.T) {
+	good := "/lib/good.flac"
+	broken := "/lib/broken.flac"
+	prov := map[string]audioProvenance{
+		// The broken file's half-parsed tags happen to carry the orphan's ISRC.
+		broken: {isrc: "USABC1234567", err: errors.New("truncated tag block")},
+		good:   {isrc: "USZZZ9999999"},
+	}
+	getProv := func(p string) audioProvenance { return prov[p] }
+
+	tags := lyrics.ProvenanceTags{ISRC: "USABC1234567"}
+	got, status := resolveExact(tags, identity.NormalizeKeys([]string{"isrc"}), []string{broken, good}, getProv)
+	if status != "none" || got != "" {
+		t.Fatalf("resolveExact = (%q,%q), want (\"\",\"none\"): an errored read must not "+
+			"supply a matchable identity", got, status)
+	}
+}
+
+// End-to-end twin of the above: an unreadable audio file must not be planned
+// as an exact-tier move for an orphan whose ISRC its failed read appeared to
+// carry. The orphan is left ambiguous rather than moved onto a file whose tags
+// were never successfully read.
+func TestPlanLibrary_ErroredProvenanceReadIsNotAnExactMatch(t *testing.T) {
+	root := tempRoot(t)
+	broken := filepath.Join(root, "Album", "broken.flac")
+	other := filepath.Join(root, "Album", "other.flac")
+	orphan := filepath.Join(root, "Album", "orphan.lrc")
+	write(t, broken, "audio")
+	write(t, other, "audio")
+	write(t, filepath.Join(root, "Album", "other.lrc"), "x") // other is not an orphan target
+	write(t, orphan, "[isrc:USABC1234567]\n[00:01.00]hi\n")
+
+	r, lib := newRealigner(root, defaultCfg(), nil)
+	r.readProv = func(path string) (isrc, mbid, artist, title string, err error) {
+		if path == broken {
+			return "USABC1234567", "", "", "", errors.New("truncated tag block")
+		}
+		return "", "", "", "", nil
+	}
+
+	res, err := r.PlanLibrary(lib)
+	if err != nil {
+		t.Fatalf("PlanLibrary: %v", err)
+	}
+	for _, mv := range res.Moves {
+		if mv.Method == "exact" {
+			t.Fatalf("planned an exact-tier move %+v from a file whose tag read failed", mv)
+		}
+	}
+}

--- a/internal/realign/realign.go
+++ b/internal/realign/realign.go
@@ -460,24 +460,38 @@ func walk(root string) (map[string]*dirEntry, []string, error) {
 	return dirs, allAudio, nil
 }
 
-// resolveExact is a thin adapter over the shared identity.ResolveExact tier:
-// it builds identity.Candidate values from realign's pool/getProv (reading
-// provenance from the audio file, since realign has no persisted identity
-// store of its own), then delegates the match to the shared package so
-// sidecar re-attachment can never disagree with prune's row re-linking about
-// where a file went. Returns ("", "none") on no match, (path, "unique") on a
-// single match, and ("", "conflict") when more than one audio shares the same
-// id.
+// resolveExact is a thin adapter over the shared identity exact tier: it hands
+// the shared resolver a LAZY sequence of identity.Candidate values over
+// realign's pool, each realized by getProv (an ID3 tag READ off disk, since
+// realign has no persisted identity store of its own). Delegating the verdict
+// keeps sidecar re-attachment from ever disagreeing with prune's row
+// re-linking about where a file went.
+//
+// The sequence -- not a materialized slice -- is what preserves the
+// pre-extraction access pattern: identity.ResolveExactSeq pulls candidates
+// only from inside its per-key loop and only for a key the orphan actually
+// carries a value for, so an orphan with no [isrc:]/[mbid:] header reads ZERO
+// audio files here (it used to read the entire pool). getProv memoizes per
+// plan() run, so the at-most-once-per-key re-iteration costs no extra reads.
+//
+// Returns ("", "none") on no match, (path, "unique") on a single match, and
+// ("", "conflict") when more than one audio shares the same id.
 func resolveExact(tags lyrics.ProvenanceTags, identityKeys identity.Keys, pool []string, getProv func(string) audioProvenance) (string, string) {
-	candidates := make([]identity.Candidate, 0, len(pool))
-	for _, a := range pool {
-		pv := getProv(a)
-		if pv.err != nil {
-			continue
+	candidates := func(yield func(identity.Candidate) bool) {
+		for _, a := range pool {
+			pv := getProv(a)
+			if pv.err != nil {
+				// Unreadable audio cannot be matched on identity it never
+				// yielded; skip it rather than let a zero-valued provenance
+				// masquerade as an empty-but-present identity.
+				continue
+			}
+			if !yield(identity.Candidate{Ref: a, MBID: pv.mbid, ISRC: pv.isrc, Artist: pv.artist, Title: pv.title}) {
+				return
+			}
 		}
-		candidates = append(candidates, identity.Candidate{Ref: a, MBID: pv.mbid, ISRC: pv.isrc, Artist: pv.artist, Title: pv.title})
 	}
-	verdict, ref := identity.ResolveExact(tags.MBID, tags.ISRC, identityKeys, candidates)
+	verdict, ref := identity.ResolveExactSeq(tags.MBID, tags.ISRC, identityKeys, candidates)
 	switch verdict {
 	case identity.VerdictUnique:
 		return ref, "unique"

--- a/internal/realign/realign.go
+++ b/internal/realign/realign.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 
 	"github.com/sydlexius/canticle/internal/config"
+	"github.com/sydlexius/canticle/internal/identity"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
-	"github.com/sydlexius/canticle/internal/normalize"
 	"github.com/sydlexius/canticle/internal/pathutil"
 	"github.com/sydlexius/canticle/internal/scanner"
 )
@@ -144,7 +144,7 @@ func (r *Realigner) plan(scopeRoot, poolRoot string, libraryID int64) (Result, e
 		pool = poolAudio
 	}
 
-	identityKeys := NormalizeIdentityKeys(r.cfg.IdentityKeys)
+	identityKeys := identity.NormalizeKeys(r.cfg.IdentityKeys)
 	provCache := map[string]audioProvenance{}
 	getProv := func(p string) audioProvenance {
 		if v, ok := provCache[p]; ok {
@@ -183,7 +183,7 @@ func (r *Realigner) plan(scopeRoot, poolRoot string, libraryID int64) (Result, e
 
 // classifyDir classifies every orphan in one directory into the four tiers,
 // appending moves/skips to res.
-func (r *Realigner) classifyDir(dir string, de *dirEntry, pool, identityKeys []string, getProv func(string) audioProvenance, claimed map[string]bool, libraryID int64, res *Result) {
+func (r *Realigner) classifyDir(dir string, de *dirEntry, pool []string, identityKeys identity.Keys, getProv func(string) audioProvenance, claimed map[string]bool, libraryID int64, res *Result) {
 	audioStems := stemSet(de.audio)
 	sidecarStems := stemSet(de.sidecars)
 	orphans := make([]string, 0)
@@ -460,58 +460,42 @@ func walk(root string) (map[string]*dirEntry, []string, error) {
 	return dirs, allAudio, nil
 }
 
-// resolveExact finds the unique audio file in pool whose embedded ISRC or MBID
-// matches the orphan's, honoring identityKeys order (most authoritative first).
-// Returns ("", "none") on no match, (path, "unique") on a single match, and
-// ("", "conflict") when more than one audio shares the same id.
-func resolveExact(tags lyrics.ProvenanceTags, identityKeys, pool []string, getProv func(string) audioProvenance) (string, string) {
-	for _, key := range identityKeys {
-		id := strings.TrimSpace(orphanKeyValue(tags, key))
-		if id == "" {
+// resolveExact is a thin adapter over the shared identity.ResolveExact tier:
+// it builds identity.Candidate values from realign's pool/getProv (reading
+// provenance from the audio file, since realign has no persisted identity
+// store of its own), then delegates the match to the shared package so
+// sidecar re-attachment can never disagree with prune's row re-linking about
+// where a file went. Returns ("", "none") on no match, (path, "unique") on a
+// single match, and ("", "conflict") when more than one audio shares the same
+// id.
+func resolveExact(tags lyrics.ProvenanceTags, identityKeys identity.Keys, pool []string, getProv func(string) audioProvenance) (string, string) {
+	candidates := make([]identity.Candidate, 0, len(pool))
+	for _, a := range pool {
+		pv := getProv(a)
+		if pv.err != nil {
 			continue
 		}
-		var matches []string
-		for _, a := range pool {
-			pv := getProv(a)
-			if pv.err != nil {
-				continue
-			}
-			if strings.EqualFold(strings.TrimSpace(audioKeyValue(pv, key)), id) {
-				matches = append(matches, a)
-			}
-		}
-		switch len(matches) {
-		case 0:
-			continue
-		case 1:
-			return matches[0], "unique"
-		default:
-			return "", "conflict"
-		}
+		candidates = append(candidates, identity.Candidate{Ref: a, MBID: pv.mbid, ISRC: pv.isrc, Artist: pv.artist, Title: pv.title})
 	}
-	return "", "none"
+	verdict, ref := identity.ResolveExact(tags.MBID, tags.ISRC, identityKeys, candidates)
+	switch verdict {
+	case identity.VerdictUnique:
+		return ref, "unique"
+	case identity.VerdictConflict:
+		return "", "conflict"
+	default:
+		return "", "none"
+	}
 }
 
-// heuristicNameGuard implements the min_confidence name guard for the heuristic
-// tier, comparing the orphan's [ar:]/[ti:] header (or sidecar stem) against the
-// candidate audio's artist/title via Jaro-Winkler. Degrades to positional matching
-// (returns true) when neither side yields a name, so a plain .txt still realigns.
+// heuristicNameGuard is a thin adapter over the shared
+// identity.HeuristicNameGuard tier, comparing the orphan's [ar:]/[ti:] header
+// (or sidecar stem) against the candidate audio's artist/title via
+// Jaro-Winkler. Degrades to positional matching (returns true) when neither
+// side yields a name, so a plain .txt still realigns.
 func heuristicNameGuard(tags lyrics.ProvenanceTags, orphanStem string, audio audioProvenance, audioStem string, minConf float64) (bool, float64) {
-	hasOrphanName := tags.Artist != "" || tags.Title != ""
-	hasAudioName := audio.artist != "" || audio.title != ""
-	if !hasOrphanName && !hasAudioName {
-		return true, 0
-	}
-	orphanStr := orphanStem
-	if hasOrphanName {
-		orphanStr = strings.TrimSpace(tags.Artist + " " + tags.Title)
-	}
-	audioStr := audioStem
-	if hasAudioName {
-		audioStr = strings.TrimSpace(audio.artist + " " + audio.title)
-	}
-	score := normalize.MatchConfidence(orphanStr, audioStr)
-	return score >= minConf, score
+	candidate := identity.Candidate{Artist: audio.artist, Title: audio.title}
+	return identity.HeuristicNameGuard(tags.Artist, tags.Title, orphanStem, candidate, audioStem, minConf)
 }
 
 // appendBackup writes and fsyncs one JSONL backup record for an applied move, so
@@ -580,40 +564,10 @@ func stemSet(paths []string) map[string]bool {
 
 // NormalizeIdentityKeys lowercases, filters to the known identity keys (mbid,
 // isrc), and de-duplicates while preserving order. Exported so the CLI can render
-// the effective key list in its header.
+// the effective key list in its header. Delegates to the shared
+// identity.NormalizeKeys so realign and prune read config.RealignConfig the
+// same way; kept as a []string-returning wrapper so the existing CLI call site
+// (internal/commands/realign.go) needs no signature change.
 func NormalizeIdentityKeys(keys []string) []string {
-	seen := map[string]bool{}
-	out := make([]string, 0, len(keys))
-	for _, k := range keys {
-		k = strings.ToLower(strings.TrimSpace(k))
-		if k != "mbid" && k != "isrc" {
-			continue
-		}
-		if seen[k] {
-			continue
-		}
-		seen[k] = true
-		out = append(out, k)
-	}
-	return out
-}
-
-func orphanKeyValue(tags lyrics.ProvenanceTags, key string) string {
-	switch key {
-	case "mbid":
-		return tags.MBID
-	case "isrc":
-		return tags.ISRC
-	}
-	return ""
-}
-
-func audioKeyValue(pv audioProvenance, key string) string {
-	switch key {
-	case "mbid":
-		return pv.mbid
-	case "isrc":
-		return pv.isrc
-	}
-	return ""
+	return []string(identity.NormalizeKeys(keys))
 }

--- a/internal/realign/repro_hostile_test.go
+++ b/internal/realign/repro_hostile_test.go
@@ -1,0 +1,60 @@
+package realign
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestRepro_AdapterReadsWholePoolEvenWithNoOrphanIdentity measures how many
+// times readProv (a real per-file tag READ on disk in production) is invoked
+// while planning ONE orphan that carries NO identity tags at all.
+//
+// Pre-extraction, resolveExact looped keys OUTERMOST and called getProv lazily
+// inside the per-key candidate loop, so an orphan with no [isrc:]/[mbid:]
+// header hit `id == ""` for every key and returned "none" having read ZERO
+// audio files; only the heuristic tier's single getProv(missingAudio[0]) call
+// followed. The new adapter builds the identity.Candidate pool for the ENTIRE
+// pool BEFORE calling identity.ResolveExact, so every pool file is read.
+//
+// The provenance cache bounds this to once per file per plan() run rather than
+// per orphan, so it is an amplification, not an unbounded blowup.
+func TestRepro_AdapterReadsWholePoolEvenWithNoOrphanIdentity(t *testing.T) {
+	root := tempRoot(t)
+	const poolSize = 25
+
+	// One directory holding a single orphan sidecar with no provenance header
+	// and its (renamed) audio partner: the positional dirPair case.
+	dir := filepath.Join(root, "Pair")
+	write(t, filepath.Join(dir, "new-name.flac"), "audio")
+	write(t, filepath.Join(dir, "old-name.lrc"), "[00:01.00]hi\n")
+
+	// Unrelated audio elsewhere in the library, each already paired with a
+	// sidecar so it is never an orphan target -- pure candidate-pool bulk.
+	for i := range poolSize {
+		other := filepath.Join(root, "Other", fmt.Sprintf("t%02d.flac", i))
+		write(t, other, "audio")
+		write(t, filepath.Join(root, "Other", fmt.Sprintf("t%02d.lrc", i)), "x")
+	}
+
+	cfg := defaultCfg()
+	cfg.CrossDirectory = true // library-wide pool, the reactive-realign shape
+
+	r, lib := newRealigner(root, cfg, nil)
+	reads := 0
+	r.readProv = func(path string) (isrc, mbid, artist, title string, err error) {
+		reads++
+		return "", "", "", "", nil
+	}
+
+	if _, err := r.PlanLibrary(lib); err != nil {
+		t.Fatalf("PlanLibrary: %v", err)
+	}
+
+	t.Logf("readProv invocations for 1 identity-less orphan, pool of %d: %d", poolSize+1, reads)
+	// Pre-extraction behavior was 1 (the heuristic tier's single lookup).
+	if reads > 1 {
+		t.Errorf("readProv called %d times; the pre-extraction resolver called it 1 time "+
+			"(lazy, per-key). The adapter now materializes the whole candidate pool up front.", reads)
+	}
+}

--- a/internal/scan/repository.go
+++ b/internal/scan/repository.go
@@ -58,8 +58,16 @@ const UpsertBatchSize = 500
 // already waits per attempt, so a handful of retries is ample.
 const upsertMaxAttempts = 5
 
-const baseUpsert = `INSERT INTO scan_results (library_id, file_path, artist, title, album, album_artist, artist_key, title_key, outdir, filename, status)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+// isrc/recording_mbid use COALESCE(NULLIF(excluded.x, ”), x) rather than a
+// plain overwrite: extraction is gated behind the per-library EnrichRecording
+// toggle (internal/scanner.go), so a later rescan with enrichment off (or a
+// file whose tags briefly failed to parse) arrives with an empty value. A
+// plain overwrite would let that pass silently erase an identity a previous
+// enriched scan had already captured -- destroying exactly the move-durable
+// signal #640's prune re-link depends on. An incoming NON-empty value still
+// always wins, so a genuine retag is still picked up.
+const baseUpsert = `INSERT INTO scan_results (library_id, file_path, artist, title, album, album_artist, artist_key, title_key, outdir, filename, status, isrc, recording_mbid)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(library_id, file_path) DO UPDATE SET
                  artist = excluded.artist,
                  title = excluded.title,
@@ -68,7 +76,9 @@ const baseUpsert = `INSERT INTO scan_results (library_id, file_path, artist, tit
                  artist_key = excluded.artist_key,
                  title_key = excluded.title_key,
                  outdir = excluded.outdir,
-                 filename = excluded.filename`
+                 filename = excluded.filename,
+                 isrc = COALESCE(NULLIF(excluded.isrc, ''), isrc),
+                 recording_mbid = COALESCE(NULLIF(excluded.recording_mbid, ''), recording_mbid)`
 
 // Upsert stores scan results for a library, keyed by library_id and file_path.
 // On conflict, status is preserved by default; pass ForceStatus to overwrite.
@@ -168,6 +178,8 @@ func upsertBatch(ctx context.Context, tx *sql.Tx, libraryID int64, results []mod
 			res.Outdir,
 			res.Filename,
 			insertStatus,
+			res.Track.ISRC,
+			res.Track.RecordingMBID,
 		); err != nil {
 			return fmt.Errorf("scan: upsert %s: %w", res.FilePath, err)
 		}
@@ -178,7 +190,7 @@ func upsertBatch(ctx context.Context, tx *sql.Tx, libraryID int64, results []mod
 // ListByLibrary returns persisted scan results for a library in stable ID order.
 func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []models.ScanResult, retErr error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at
+		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at, isrc, recording_mbid
          FROM scan_results
          WHERE library_id = ?
          ORDER BY id ASC`,
@@ -203,7 +215,7 @@ func (r *Repo) ListByLibrary(ctx context.Context, libraryID int64) (results []mo
 // ListPendingByLibrary returns pending scan results for a library in stable ID order.
 func (r *Repo) ListPendingByLibrary(ctx context.Context, libraryID int64) (results []models.ScanResult, retErr error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at
+		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at, isrc, recording_mbid
          FROM scan_results
          WHERE library_id = ?
            AND status = ?
@@ -243,6 +255,8 @@ func scanResultRows(rows *sql.Rows) ([]models.ScanResult, error) {
 			&res.Filename,
 			&res.Status,
 			&res.CreatedAt,
+			&res.Track.ISRC,
+			&res.Track.RecordingMBID,
 		); err != nil {
 			return nil, err
 		}
@@ -269,7 +283,7 @@ type Filter struct {
 
 // List returns persisted scan results matching filter in stable ID order.
 func (r *Repo) List(ctx context.Context, filter Filter) (results []models.ScanResult, retErr error) {
-	const baseQuery = `SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at
+	const baseQuery = `SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at, isrc, recording_mbid
                        FROM scan_results`
 	const orderClause = ` ORDER BY id ASC`
 	var args []any
@@ -328,7 +342,7 @@ func (r *Repo) FindByTrack(ctx context.Context, artist, title string) (results [
 		return nil, nil
 	}
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at
+		`SELECT id, library_id, file_path, artist, title, album, album_artist, outdir, filename, status, created_at, isrc, recording_mbid
                        FROM scan_results
                        WHERE artist_key = ? AND title_key = ?
                        ORDER BY CASE status WHEN 'done' THEN 1 ELSE 0 END ASC, id ASC`,
@@ -356,7 +370,7 @@ func (r *Repo) FindByTrack(ctx context.Context, artist, title string) (results [
 // through work_queue_scan_results is the only way to surface tracks that are
 // parked behind a miss cooldown rather than actively in flight.
 func (r *Repo) ListDeferred(ctx context.Context, filter Filter) (results []models.ScanResult, retErr error) {
-	query := `SELECT DISTINCT sr.id, sr.library_id, sr.file_path, sr.artist, sr.title, sr.album, sr.album_artist, sr.outdir, sr.filename, sr.status, sr.created_at
+	query := `SELECT DISTINCT sr.id, sr.library_id, sr.file_path, sr.artist, sr.title, sr.album, sr.album_artist, sr.outdir, sr.filename, sr.status, sr.created_at, sr.isrc, sr.recording_mbid
               FROM scan_results sr
               JOIN work_queue_scan_results j ON j.scan_result_id = sr.id
               JOIN work_queue wq ON wq.id = j.work_queue_id

--- a/internal/scan/repository_test.go
+++ b/internal/scan/repository_test.go
@@ -72,6 +72,69 @@ func TestRepo_UpsertAndListByLibrary(t *testing.T) {
 	}
 }
 
+// TestRepo_UpsertAndListRoundTripsIdentity verifies scan_results.isrc/
+// recording_mbid (migration 037) survive an upsert and a subsequent
+// read-back, and that a later upsert with EMPTY identity values does not
+// erase identity a previous enriched scan had already captured (#640) -- only
+// an incoming non-empty value overwrites.
+func TestRepo_UpsertAndListRoundTripsIdentity(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	libRepo := library.New(sqlDB)
+	scanRepo := scan.New(sqlDB)
+
+	lib, err := libRepo.Add(ctx, "/music", "Music", models.LibrarySettings{})
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+
+	results := []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title", ISRC: "USABC1234567", RecordingMBID: "mbid-abc-123"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+	}}
+	if err := scanRepo.Upsert(ctx, lib.ID, results, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert initial: %v", err)
+	}
+	got, err := scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(got) != 1 || got[0].Track.ISRC != "USABC1234567" || got[0].Track.RecordingMBID != "mbid-abc-123" {
+		t.Fatalf("round-trip = %+v; want ISRC=USABC1234567 MBID=mbid-abc-123", got)
+	}
+
+	// A later rescan with EnrichRecording off (or a transient tag-read miss)
+	// arrives with empty identity. It must not clobber the previously
+	// captured values.
+	results[0].Track.ISRC = ""
+	results[0].Track.RecordingMBID = ""
+	if err := scanRepo.Upsert(ctx, lib.ID, results, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert with empty identity: %v", err)
+	}
+	got, err = scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary after empty upsert: %v", err)
+	}
+	if len(got) != 1 || got[0].Track.ISRC != "USABC1234567" || got[0].Track.RecordingMBID != "mbid-abc-123" {
+		t.Fatalf("after empty-identity upsert = %+v; want identity preserved (ISRC=USABC1234567 MBID=mbid-abc-123)", got)
+	}
+
+	// A genuine retag with a NEW non-empty value still overwrites.
+	results[0].Track.ISRC = "USXYZ7654321"
+	if err := scanRepo.Upsert(ctx, lib.ID, results, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert with new identity: %v", err)
+	}
+	got, err = scanRepo.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary after retag: %v", err)
+	}
+	if len(got) != 1 || got[0].Track.ISRC != "USXYZ7654321" {
+		t.Fatalf("after retag ISRC = %q; want USXYZ7654321", got[0].Track.ISRC)
+	}
+}
+
 func TestRepo_FindByTrackMatchesNormalizedKeys(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)


### PR DESCRIPTION
## Summary

- Extracts realign's private exact-tier resolver into a new shared `internal/identity` package, so sidecar re-attachment and DB row re-linking cannot diverge. Sidecar re-attachment (realign) and row re-linking (prune) observe the SAME event from two sides; two independently-written resolvers would eventually disagree and leave the `.lrc` and the DB row pointing at different audio.
- Adds migration 037 (`recording_mbid`/`isrc` on `scan_results`, partial index) and persists identity the existing EnrichRecording-gated extraction already read and previously dropped before insert. No additional disk I/O.
- **Foundation only.** Nothing consumes the resolver yet except realign; prune's use lands in a follow-up PR so the destructive path stays reviewable on its own.

## Linked issue

Part of #640

## Behavior preservation

`internal/realign/realign_test.go` is **unmodified** and passes through the new adapters -- that is the evidence the extraction preserved resolution outcomes rather than tests being fitted to new code.

A pre-push hostile review found that argument was necessary but not sufficient: it proved outcomes were preserved, but not the **access pattern**. The first extraction materialized the whole candidate pool before resolving, so an orphan carrying no identity caused 26 tag reads where the original did 1. `439c7dc` fixes that -- `ResolveExactSeq` takes an `iter.Seq[Candidate]` and is the sole implementation; `ResolveExact` keeps its slice signature as a one-line delegation. Realign supplies a sequence that reads tags on demand; prune will pass already-loaded `scan_results` rows with no I/O.

Laziness is pinned by tests rather than left to a comment.

## Also fixed (found by mutation testing during the fix)

- The adapter propagates `yield`'s false return, so a settled conflict genuinely stops reading.
- A candidate whose **tag read failed** is now kept out of the pool -- previously a half-parsed identity from a truncated tag block could win the exact tier and attach a lyric file to the wrong song.
- Candidate-side `TrimSpace` (padded ID3 values) is covered.

## Test plan

- [x] `make gate` green
- [x] Patch coverage 96.88% (93/96); identity.go 97.0%, realign.go 95.0%, repository.go 100%
- [x] `realign_test.go` unmodified and passing
- [x] Six hostile-review reproduction tests retained and passing (0 deletions)
- [x] 14 mutations run against the fix (threshold direction, key precedence swap, verdict inversion, guard removal, eager re-materialization, break placement, EqualFold, trim removal) -- all 14 killed
- [x] golangci-lint 0 issues, actionlint, govulncheck clean
- [ ] Reviewer follow-ups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent ISRC and recording MBID metadata to scan results.
  * Improved exact and heuristic matching for reconnecting files and metadata after moves or renames.
  * Preserved existing identity values when later scan updates omit them.
  * Added conflict detection and safer handling of ambiguous or incomplete matches.

* **Bug Fixes**
  * Prevented failed metadata reads and empty identities from producing incorrect matches.
  * Improved matching consistency for whitespace, capitalization, and fallback identity keys.

* **Tests**
  * Added comprehensive coverage for migrations, identity persistence, matching behavior, conflicts, and lazy resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->