### PR TITLE
feat(prune): consult the shared identity resolver before deleting rows

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1183,7 +1183,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runSweeper(runCtx, sqlDB, sweepInterval)
+			runSweeper(runCtx, sqlDB, sweepInterval, cfg.Realign.IdentityKeys)
 		}()
 	}
 	// One-shot identity-repair backfill (#466): correct run-together multi-value
@@ -1808,8 +1808,9 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 // also reconciles any rows that predate this feature. Caller guarantees interval
 // > 0. A per-run failure is logged and the loop continues; the sweep is a
 // backstop and must never take down serve.
-func runSweeper(ctx context.Context, sqlDB *sql.DB, interval time.Duration) {
+func runSweeper(ctx context.Context, sqlDB *sql.DB, interval time.Duration, identityKeys []string) {
 	pruner := prune.New(sqlDB)
+	pruner.SetIdentityKeys(identityKeys)
 	sweep := func() {
 		res, err := pruner.Sweep(ctx, prune.SweepOptions{Granularity: prune.Directory})
 		if err != nil {
@@ -1867,6 +1868,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
 	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	pruner := prune.New(sqlDB)
+	pruner.SetIdentityKeys(cfg.Realign.IdentityKeys)
 	wch := watcher.New(watchCfg, library.New(sqlDB), func(ctx context.Context, lib models.Library, path string) error {
 		return sched.RunOnceForPath(ctx, lib, path)
 	}, func(ctx context.Context, path string) error {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1802,12 +1802,21 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 	}
 }
 
-// runSweeper runs the periodic path-reconciliation sweep: on each tick it prunes
-// queue/scan rows whose source file has vanished, at Directory granularity (one
-// stat per directory) so the unattended backstop stays disk-cheap. Its first run
-// also reconciles any rows that predate this feature. Caller guarantees interval
-// > 0. A per-run failure is logged and the loop continues; the sweep is a
-// backstop and must never take down serve.
+// runSweeper runs the periodic path-reconciliation sweep: on each tick it
+// reconciles queue/scan rows whose source file has vanished, at Directory
+// granularity (one stat per directory) so the unattended backstop stays
+// disk-cheap. Its first run also reconciles any rows that predate this feature.
+// Caller guarantees interval > 0. A per-run failure is logged and the loop
+// continues; the sweep is a backstop and must never take down serve.
+//
+// All THREE #640 outcomes are logged, not just the delete: this is the only
+// surface an unattended sweep has. A relink silently moved a row to a new path,
+// and a RETAIN is the keep-and-report path -- a row prune deliberately declined
+// to touch because its identity was absent, ambiguous, or its target already
+// owned. Logging only the prune count would leave an operator unable to tell
+// "nothing to do" apart from "a row has been quietly held back on every tick
+// since the move", which is precisely the state a human needs to resolve.
+// Retained rows are logged at Warn (they need a human), relinks at Info.
 func runSweeper(ctx context.Context, sqlDB *sql.DB, interval time.Duration, identityKeys []string) {
 	pruner := prune.New(sqlDB)
 	pruner.SetIdentityKeys(identityKeys)
@@ -1821,6 +1830,18 @@ func runSweeper(ctx context.Context, sqlDB *sql.DB, interval time.Duration, iden
 		}
 		if res.ScanResults > 0 || res.WorkItems > 0 {
 			slog.Info("path-reconciliation sweep pruned rows for vanished sources", "scan_results", res.ScanResults, "work_items", res.WorkItems)
+		}
+		if len(res.Relinked) > 0 {
+			slog.Info("path-reconciliation sweep relinked moved sources", "sources", len(res.Relinked),
+				"first_old_path", res.Relinked[0].OldPath, "first_new_path", res.Relinked[0].NewPath)
+		}
+		if len(res.Retained) > 0 {
+			// One exemplar rather than the whole set: a large reorganization can
+			// retain thousands, and a per-row line would drown the log. The count
+			// tells an operator the scale; the exemplar plus reason tells them what
+			// to go look at. `scan reconcile-paths` enumerates the full set.
+			slog.Warn("path-reconciliation sweep retained sources it declined to act on; run `scan reconcile-paths` to review",
+				"sources", len(res.Retained), "first_source_path", res.Retained[0].SourcePath, "first_reason", res.Retained[0].Reason)
 		}
 	}
 	slog.Info("path-reconciliation sweeper started", "interval", interval)

--- a/internal/commands/reconcile_paths.go
+++ b/internal/commands/reconcile_paths.go
@@ -20,23 +20,40 @@ import (
 	"github.com/sydlexius/canticle/internal/prune"
 )
 
-// reconcilePathsBackupRecord is one JSONL line capturing the rows pruned for a
-// vanished source path so the operation is auditable and hand-restorable
-// (re-enqueue Inputs, re-scan). Written before the delete commits.
+// reconcilePathsBackupRecord is one JSONL line capturing the outcome for one
+// source path -- pruned, relinked, or retained -- so the operation is auditable
+// and hand-restorable (re-enqueue Inputs, re-scan, or undo a relink by
+// reversing OldPath/NewPath). Written before the corresponding mutation
+// commits (backup-first); a retained row is never a mutation, so its record is
+// purely informational.
 type reconcilePathsBackupRecord struct {
+	Action        string          `json:"action"` // "pruned", "relinked", or "retained"
 	SourcePath    string          `json:"source_path"`
 	ScanResultIDs []int64         `json:"scan_result_ids,omitempty"`
 	WorkItemIDs   []int64         `json:"work_item_ids,omitempty"`
 	Inputs        []models.Inputs `json:"inputs,omitempty"`
+	// NewPath, MBID, ISRC, and Reason are populated for "relinked"/"retained"
+	// records; empty for "pruned".
+	NewPath string `json:"new_path,omitempty"`
+	MBID    string `json:"mbid,omitempty"`
+	ISRC    string `json:"isrc,omitempty"`
+	Reason  string `json:"reason,omitempty"`
 }
 
 // runReconcilePaths reconciles the durable queue and scan-result cache against
-// the filesystem: rows whose source audio file no longer exists are deleted so a
-// renamed/merged/deleted track cannot leave a permanently-failing or wedged row
-// behind (#453). It runs at Exact granularity (every source_path is statted
-// individually), so single-file renames within a surviving directory are caught,
-// unlike the disk-cheap periodic sweep. Dry-run by default; --yes applies and
-// writes a JSONL backup.
+// the filesystem. A row whose source audio file cannot be found is no longer
+// deleted unconditionally (#640): its stored MBID/ISRC is first checked
+// against every other file present in the library via the shared
+// internal/identity resolver -- realign's same exact tier, so a bulk move can
+// never leave a sidecar and its database row disagreeing about where a file
+// went. A unique match RE-LINKS the row to its new location, preserving every
+// telemetry/timing/provenance column; identity that is absent or ambiguous is
+// RETAINED and reported, never guessed at. Only identity that is present but
+// matches nothing anywhere is genuinely PRUNED, so the table does not grow
+// without bound. Runs at Exact granularity (every source_path is statted
+// individually), so single-file renames within a surviving directory are
+// caught, unlike the disk-cheap periodic sweep. Dry-run by default; --yes
+// applies and writes a JSONL backup covering every outcome.
 func runReconcilePaths(ctx context.Context, out io.Writer, args ScanReconcilePathsCmd) int {
 	cfg, err := config.Load(args.ConfigPath)
 	if err != nil {
@@ -76,28 +93,82 @@ func runReconcilePaths(ctx context.Context, out io.Writer, args ScanReconcilePat
 			}
 		}
 	}()
-	// report is invoked once per pruned source before its delete commits. In
-	// dry-run it is a no-op (nothing is deleted, so nothing needs backing up);
-	// under --yes it lazily opens the backup and appends a restorable record.
-	report := func(row prune.PrunedRow) error {
+	openBackup := func() error {
+		if backupFile != nil {
+			return nil
+		}
+		f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
+		if ferr != nil {
+			return fmt.Errorf("open reconcile-paths backup %q: %w", backupPath, ferr)
+		}
+		backupFile = f
+		return nil
+	}
+	// Each report hook fires once per outcome, before its mutation commits (or,
+	// in dry-run, for the outcome that would occur). Under --yes it lazily opens
+	// the shared backup file and appends a restorable record; in dry-run
+	// nothing is mutated, so nothing needs backing up.
+	reportPruned := func(row prune.PrunedRow) error {
 		if !args.Yes {
 			return nil
 		}
-		if backupFile == nil {
-			f, ferr := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: backupPath is operator-supplied (--backup) or derived from the configured db dir, not untrusted input
-			if ferr != nil {
-				return fmt.Errorf("open reconcile-paths backup %q: %w", backupPath, ferr)
-			}
-			backupFile = f
+		if err := openBackup(); err != nil {
+			return err
 		}
-		return appendReconcilePathsBackup(backupFile, row)
+		return appendReconcilePathsBackup(backupFile, reconcilePathsBackupRecord{
+			Action:        "pruned",
+			SourcePath:    row.SourcePath,
+			ScanResultIDs: row.ScanResultIDs,
+			WorkItemIDs:   row.WorkItemIDs,
+			Inputs:        row.Inputs,
+		})
+	}
+	reportRelinked := func(row prune.RelinkedRow) error {
+		if !args.Yes {
+			return nil
+		}
+		if err := openBackup(); err != nil {
+			return err
+		}
+		return appendReconcilePathsBackup(backupFile, reconcilePathsBackupRecord{
+			Action:        "relinked",
+			SourcePath:    row.OldPath,
+			NewPath:       row.NewPath,
+			ScanResultIDs: row.ScanResultIDs,
+			WorkItemIDs:   row.WorkItemIDs,
+			MBID:          row.MBID,
+			ISRC:          row.ISRC,
+		})
+	}
+	// Retaining never mutates the database, so this record is purely
+	// informational and is written the same way in dry-run and real runs --
+	// gated on args.Yes anyway, matching the other two hooks, so a dry-run
+	// preview never writes a backup file at all.
+	reportRetained := func(row prune.RetainedRow) error {
+		if !args.Yes {
+			return nil
+		}
+		if err := openBackup(); err != nil {
+			return err
+		}
+		return appendReconcilePathsBackup(backupFile, reconcilePathsBackupRecord{
+			Action:     "retained",
+			SourcePath: row.SourcePath,
+			MBID:       row.MBID,
+			ISRC:       row.ISRC,
+			Reason:     row.Reason,
+		})
 	}
 
-	res, err := prune.New(sqlDB).Sweep(ctx, prune.SweepOptions{
-		LibraryID:   libID,
-		Granularity: prune.Exact,
-		DryRun:      !args.Yes,
-		Report:      report,
+	pruner := prune.New(sqlDB)
+	pruner.SetIdentityKeys(cfg.Realign.IdentityKeys)
+	res, err := pruner.Sweep(ctx, prune.SweepOptions{
+		LibraryID:      libID,
+		Granularity:    prune.Exact,
+		DryRun:         !args.Yes,
+		Report:         reportPruned,
+		ReportRelinked: reportRelinked,
+		ReportRetained: reportRetained,
 	})
 	if err != nil {
 		slog.Error("reconcile-paths failed", "error", err)
@@ -105,26 +176,24 @@ func runReconcilePaths(ctx context.Context, out io.Writer, args ScanReconcilePat
 	}
 
 	verb := "would prune"
+	relinkVerb := "would relink"
 	if args.Yes {
 		verb = "pruned"
+		relinkVerb = "relinked"
 	}
-	_, _ = fmt.Fprintf(out, "reconcile-paths: %s %d source(s) with a vanished file (%d scan_results, %d work_items)%s\n",
-		verb, len(res.Pruned), res.ScanResults, res.WorkItems, suffixDryRun(args.Yes))
+	_, _ = fmt.Fprintf(out, "reconcile-paths: %s %d source(s) with a vanished file (%d scan_results, %d work_items), %s %d source(s) to a moved file, retained %d source(s) with unresolved identity%s\n",
+		verb, len(res.Pruned), res.ScanResults, res.WorkItems, relinkVerb, len(res.Relinked), len(res.Retained), suffixDryRun(args.Yes))
 	if backupFile != nil {
-		_, _ = fmt.Fprintf(out, "backup of pruned rows written to %s\n", backupPath)
+		_, _ = fmt.Fprintf(out, "backup of pruned/relinked/retained rows written to %s\n", backupPath)
 	}
 	return 0
 }
 
-// appendReconcilePathsBackup writes one JSONL record for a pruned source and
-// flushes it to disk, so the backup is durable before the delete it protects.
-func appendReconcilePathsBackup(f *os.File, row prune.PrunedRow) error {
-	rec := reconcilePathsBackupRecord{
-		SourcePath:    row.SourcePath,
-		ScanResultIDs: row.ScanResultIDs,
-		WorkItemIDs:   row.WorkItemIDs,
-		Inputs:        row.Inputs,
-	}
+// appendReconcilePathsBackup writes one JSONL record for an outcome and
+// flushes it to disk, so the backup is durable before the mutation it
+// protects (a retained record protects nothing, but is written the same way
+// for a single consistent format).
+func appendReconcilePathsBackup(f *os.File, rec reconcilePathsBackupRecord) error {
 	b, err := json.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("marshal reconcile-paths backup record: %w", err)

--- a/internal/commands/reconcile_paths_relink_test.go
+++ b/internal/commands/reconcile_paths_relink_test.go
@@ -1,0 +1,251 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/queue"
+)
+
+// seedReconcilePathsRowWithIdentity is seedReconcilePathsRow plus an explicit
+// recording_mbid, so the caller controls whether the seeded row is a relink
+// candidate (identity shared with a present file), a retain candidate
+// (identity absent), or a genuine-delete candidate (identity present but
+// unique/unmatched) -- the three outcomes runReconcilePaths must now report
+// distinctly (#640).
+func seedReconcilePathsRowWithIdentity(t *testing.T, ctx context.Context, dbPath, filePath, mbid string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	res, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, recording_mbid) VALUES (1, ?, 'Artist', 'Title', 'processing', ?)`,
+		filePath, mbid)
+	if err != nil {
+		t.Fatalf("insert scan_result: %v", err)
+	}
+	srID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("scan_result id: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	q.SetRandomized(false)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "Artist", TrackName: filepath.Base(filePath)},
+		SourcePath:   filePath,
+		OutputPaths:  []models.OutputPath{{Outdir: filepath.Dir(filePath), Filename: filepath.Base(filePath)}},
+		ScanResultID: srID,
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	// Mimic the wedged state the ticket targets: a failed queue row.
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = 'failed' WHERE id = ?`, item.ID); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+}
+
+// seedReconcilePathsPresentFile inserts a bare, unlinked scan_results row for
+// a file that already exists on disk, carrying mbid -- the present-file
+// candidate side of a relink match (as if a rescan had already discovered the
+// file at its new location).
+func seedReconcilePathsPresentFile(t *testing.T, ctx context.Context, dbPath, filePath, mbid string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write present source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed present: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid)
+         VALUES (1, ?, 'Artist', 'Title', 'pending', ?, ?, ?)`,
+		filePath, filepath.Dir(filePath), filepath.Base(filePath), mbid,
+	); err != nil {
+		t.Fatalf("insert present scan_result: %v", err)
+	}
+}
+
+// TestReconcilePaths_RelinkDryRunReportsWithoutMutating: a gone row whose
+// identity resolves uniquely to a present file elsewhere in the library is
+// reported as a relink candidate in the summary line, with the database left
+// untouched and no backup written (dry-run by default, matching the delete
+// path's existing ergonomics).
+func TestReconcilePaths_RelinkDryRunReportsWithoutMutating(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	oldPath := filepath.Join(root, "ArtistM", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistM", "AlbumNew", "01. track.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, oldPath, "mbid-m-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedReconcilePathsPresentFile(t, ctx, dbPath, newPath, "mbid-m-shared")
+
+	var buf bytes.Buffer
+	if code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "would relink 1 source") {
+		t.Errorf("want 'would relink 1 source'; got: %s", buf.String())
+	}
+	if n := countRows(t, ctx, dbPath, "scan_results"); n != 2 {
+		t.Errorf("dry-run mutated scan_results: n=%d, want 2 (both survive)", n)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "reconcile-paths-backup-*.jsonl")); len(matches) != 0 {
+		t.Errorf("dry-run wrote a backup: %v", matches)
+	}
+}
+
+// TestReconcilePaths_RelinkApplyUpdatesSourceAndBacksUpWithAction: --yes
+// performs the relink (moving the surviving work_queue row's source_path to
+// the new location and deleting the stale scan_results row), and the JSONL
+// backup record for it carries action="relinked" plus the old/new paths and
+// the identity that drove the match -- the shape the CLI docstring promises.
+func TestReconcilePaths_RelinkApplyUpdatesSourceAndBacksUpWithAction(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	oldPath := filepath.Join(root, "ArtistN", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistN", "AlbumNew", "01. track.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, oldPath, "mbid-n-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedReconcilePathsPresentFile(t, ctx, dbPath, newPath, "mbid-n-shared")
+
+	var buf bytes.Buffer
+	if code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "relinked 1 source") {
+		t.Errorf("want 'relinked 1 source'; got: %s", buf.String())
+	}
+	// Exactly one scan_results row remains (the present one, now the sole
+	// owner); the stale gone-path row was removed by the relink.
+	if n := countRows(t, ctx, dbPath, "scan_results"); n != 1 {
+		t.Errorf("after relink scan_results=%d, want 1", n)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "reconcile-paths-backup-*.jsonl"))
+	if len(matches) != 1 {
+		t.Fatalf("want exactly one backup file; got %v", matches)
+	}
+	b, err := os.ReadFile(matches[0]) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	var rec reconcilePathsBackupRecord
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &rec); err != nil {
+		t.Fatalf("decode backup: %v", err)
+	}
+	if rec.Action != "relinked" || rec.SourcePath != oldPath || rec.NewPath != newPath || rec.MBID != "mbid-n-shared" {
+		t.Errorf("backup record = %+v; want action=relinked source=%q new=%q mbid=mbid-n-shared", rec, oldPath, newPath)
+	}
+}
+
+// TestReconcilePaths_RetainedReportsAndBacksUpWithReason: a gone row with no
+// stored identity is neither pruned nor relinked -- it is retained, and under
+// --yes the backup captures the reason so an operator understands why the row
+// survives.
+func TestReconcilePaths_RetainedReportsAndBacksUpWithReason(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	gone := filepath.Join(root, "ArtistO", "01. gone.flac")
+	// No identity: mbid="" is the "never enriched" sentinel scan_results uses.
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, gone, "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "retained 1 source") {
+		t.Errorf("want 'retained 1 source'; got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "pruned 0 source") {
+		t.Errorf("want 'pruned 0 source' (identity-absent must not be deleted); got: %s", buf.String())
+	}
+	if n := countRows(t, ctx, dbPath, "scan_results"); n != 1 {
+		t.Errorf("retained row was mutated: scan_results=%d, want 1 (kept)", n)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "reconcile-paths-backup-*.jsonl"))
+	if len(matches) != 1 {
+		t.Fatalf("want exactly one backup file; got %v", matches)
+	}
+	b, err := os.ReadFile(matches[0]) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	var rec reconcilePathsBackupRecord
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &rec); err != nil {
+		t.Fatalf("decode backup: %v", err)
+	}
+	if rec.Action != "retained" || rec.SourcePath != gone || rec.Reason == "" {
+		t.Errorf("backup record = %+v; want action=retained source=%q with a non-empty reason", rec, gone)
+	}
+}
+
+// TestReconcilePaths_BackupOpenFailureFailsTheRun: when the backup path
+// cannot be opened for writing (its parent directory does not exist), the
+// command surfaces the failure via a non-zero exit rather than silently
+// dropping the record -- the backup-first invariant means a report failure
+// must abort, not proceed unrecorded.
+func TestReconcilePaths_BackupOpenFailureFailsTheRun(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	gone := filepath.Join(root, "ArtistP", "01. gone.flac")
+	seedReconcilePathsRow(t, ctx, dbPath, gone)
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	badBackup := filepath.Join(root, "no-such-parent-dir", "backup.jsonl")
+	var buf bytes.Buffer
+	code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath, Yes: true, Backup: badBackup})
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1 for an unopenable backup path; out=%s", code, buf.String())
+	}
+}
+
+// TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary: --library scoping
+// narrows the present-file candidate pool the same way it narrows the gone
+// candidates, exercising the SweepOptions.LibraryID wiring on the relink path
+// specifically (the delete path's library scoping is already covered by
+// TestReconcilePaths_LibraryScoped).
+func TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	oldPath := filepath.Join(root, "ArtistQ", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistQ", "AlbumNew", "01. track.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, oldPath, "mbid-q-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedReconcilePathsPresentFile(t, ctx, dbPath, newPath, "mbid-q-shared")
+
+	var buf bytes.Buffer
+	if code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath, Library: "lib", Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "relinked 1 source") {
+		t.Errorf("want 'relinked 1 source'; got: %s", buf.String())
+	}
+}

--- a/internal/commands/reconcile_paths_relink_test.go
+++ b/internal/commands/reconcile_paths_relink_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/library"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
 )
@@ -143,8 +144,43 @@ func TestReconcilePaths_RelinkApplyUpdatesSourceAndBacksUpWithAction(t *testing.
 	if n := countRows(t, ctx, dbPath, "scan_results"); n != 1 {
 		t.Errorf("after relink scan_results=%d, want 1", n)
 	}
+	// The DATABASE artifact, not just the summary line: the surviving
+	// work_queue row actually points at the new location. A relink that
+	// reported success but left source_path on the vanished path would still
+	// satisfy the count assertion above.
+	if got := reconcilePathsWorkQueueSource(t, ctx, dbPath, oldPath, newPath); got != newPath {
+		t.Errorf("work_queue.source_path = %q, want %q", got, newPath)
+	}
 
-	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "reconcile-paths-backup-*.jsonl"))
+	// The backup is THE recovery artifact for a destructive path -- an operator
+	// undoes a relink by reversing OldPath/NewPath out of it -- so decode every
+	// line and assert the whole set, rather than only the first line. A stray
+	// extra record, or a missing new_path, makes the file unusable for restore.
+	recs := readReconcilePathsBackup(t, filepath.Dir(dbPath))
+	if len(recs) != 1 {
+		t.Fatalf("backup holds %d records, want exactly 1: %+v", len(recs), recs)
+	}
+	rec := recs[0]
+	if rec.Action != "relinked" || rec.SourcePath != oldPath || rec.NewPath != newPath || rec.MBID != "mbid-n-shared" {
+		t.Errorf("backup record = %+v; want action=relinked source=%q new=%q mbid=mbid-n-shared", rec, oldPath, newPath)
+	}
+	// Both halves of the reversal must be present and distinct, or the record
+	// cannot be undone.
+	if rec.NewPath == "" || rec.NewPath == rec.SourcePath {
+		t.Errorf("backup record is not reversible: source=%q new=%q", rec.SourcePath, rec.NewPath)
+	}
+	// The work_queue ids are what a hand-restore would target.
+	if len(rec.WorkItemIDs) != 1 {
+		t.Errorf("backup record work_item_ids = %v, want exactly one id to restore against", rec.WorkItemIDs)
+	}
+}
+
+// readReconcilePathsBackup finds the single reconcile-paths backup file in dir
+// and decodes EVERY JSONL line, so a caller can assert the complete record set
+// rather than only whichever record happens to land first.
+func readReconcilePathsBackup(t *testing.T, dir string) []reconcilePathsBackupRecord {
+	t.Helper()
+	matches, _ := filepath.Glob(filepath.Join(dir, "reconcile-paths-backup-*.jsonl"))
 	if len(matches) != 1 {
 		t.Fatalf("want exactly one backup file; got %v", matches)
 	}
@@ -152,13 +188,18 @@ func TestReconcilePaths_RelinkApplyUpdatesSourceAndBacksUpWithAction(t *testing.
 	if err != nil {
 		t.Fatalf("read backup: %v", err)
 	}
-	var rec reconcilePathsBackupRecord
-	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &rec); err != nil {
-		t.Fatalf("decode backup: %v", err)
+	var recs []reconcilePathsBackupRecord
+	for i, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec reconcilePathsBackupRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("decode backup line %d (%q): %v", i+1, line, err)
+		}
+		recs = append(recs, rec)
 	}
-	if rec.Action != "relinked" || rec.SourcePath != oldPath || rec.NewPath != newPath || rec.MBID != "mbid-n-shared" {
-		t.Errorf("backup record = %+v; want action=relinked source=%q new=%q mbid=mbid-n-shared", rec, oldPath, newPath)
-	}
+	return recs
 }
 
 // TestReconcilePaths_RetainedReportsAndBacksUpWithReason: a gone row with no
@@ -188,18 +229,11 @@ func TestReconcilePaths_RetainedReportsAndBacksUpWithReason(t *testing.T) {
 		t.Errorf("retained row was mutated: scan_results=%d, want 1 (kept)", n)
 	}
 
-	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(dbPath), "reconcile-paths-backup-*.jsonl"))
-	if len(matches) != 1 {
-		t.Fatalf("want exactly one backup file; got %v", matches)
+	recs := readReconcilePathsBackup(t, filepath.Dir(dbPath))
+	if len(recs) != 1 {
+		t.Fatalf("backup holds %d records, want exactly 1: %+v", len(recs), recs)
 	}
-	b, err := os.ReadFile(matches[0]) //nolint:gosec // test-controlled path
-	if err != nil {
-		t.Fatalf("read backup: %v", err)
-	}
-	var rec reconcilePathsBackupRecord
-	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &rec); err != nil {
-		t.Fatalf("decode backup: %v", err)
-	}
+	rec := recs[0]
 	if rec.Action != "retained" || rec.SourcePath != gone || rec.Reason == "" {
 		t.Errorf("backup record = %+v; want action=retained source=%q with a non-empty reason", rec, gone)
 	}
@@ -226,11 +260,17 @@ func TestReconcilePaths_BackupOpenFailureFailsTheRun(t *testing.T) {
 	}
 }
 
-// TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary: --library scoping
-// narrows the present-file candidate pool the same way it narrows the gone
-// candidates, exercising the SweepOptions.LibraryID wiring on the relink path
-// specifically (the delete path's library scoping is already covered by
-// TestReconcilePaths_LibraryScoped).
+// TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary: a --library-scoped
+// run relinks a gone row to a present file in that same library, exercising the
+// SweepOptions.LibraryID wiring on the relink path specifically (the delete
+// path's library scoping is already covered by TestReconcilePaths_LibraryScoped).
+//
+// This is the POSITIVE half only. The complementary negative -- that a present
+// file in a DIFFERENT library is never a relink target -- is covered by
+// TestReconcilePaths_RelinkNeverCrossesLibraryBoundary below, because the two
+// halves turn on different mechanisms: --library narrows which GONE rows are
+// considered, while the present-file candidate pool is always scoped to the
+// gone row's OWN library regardless of the flag.
 func TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary(t *testing.T) {
 	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
 	oldPath := filepath.Join(root, "ArtistQ", "AlbumOld", "01. track.flac")
@@ -247,5 +287,132 @@ func TestReconcilePaths_ScopedRelinkOnlyMatchesWithinLibrary(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "relinked 1 source") {
 		t.Errorf("want 'relinked 1 source'; got: %s", buf.String())
+	}
+	// The artifact: the work_queue row actually moved to the in-library path.
+	if got := reconcilePathsWorkQueueSource(t, ctx, dbPath, oldPath, newPath); got != newPath {
+		t.Errorf("work_queue.source_path = %q, want %q", got, newPath)
+	}
+}
+
+// seedSecondLibrary adds a second library root (with one surviving file, so the
+// availability guard treats it as mounted) and returns its path and id.
+func seedSecondLibrary(t *testing.T, ctx context.Context, dbPath, dir, name string) (string, int64) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir second root: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open second library: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	lib, err := library.New(sqlDB).Add(ctx, dir, name, models.LibrarySettings{})
+	if err != nil {
+		t.Fatalf("library.Add second: %v", err)
+	}
+	return dir, lib.ID
+}
+
+// seedPresentFileInLibrary is seedReconcilePathsPresentFile for a library other
+// than the default id 1.
+func seedPresentFileInLibrary(t *testing.T, ctx context.Context, dbPath string, libraryID int64, filePath, mbid string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write present source: %v", err)
+	}
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open seed present: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid)
+         VALUES (?, ?, 'Artist', 'Title', 'pending', ?, ?, ?)`,
+		libraryID, filePath, filepath.Dir(filePath), filepath.Base(filePath), mbid,
+	); err != nil {
+		t.Fatalf("insert present scan_result in library %d: %v", libraryID, err)
+	}
+}
+
+// reconcilePathsWorkQueueSource returns the source_path of the work_queue row
+// currently at either wantOld or wantNew, so a caller can assert whether the
+// relink moved it. Fails if neither is present.
+func reconcilePathsWorkQueueSource(t *testing.T, ctx context.Context, dbPath, wantOld, wantNew string) string {
+	t.Helper()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open work_queue: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	var got string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT source_path FROM work_queue WHERE source_path IN (?, ?) LIMIT 1`, wantOld, wantNew).Scan(&got); err != nil {
+		t.Fatalf("query work_queue source_path (old=%q new=%q): %v", wantOld, wantNew, err)
+	}
+	return got
+}
+
+// TestReconcilePaths_RelinkNeverCrossesLibraryBoundary: the negative half of
+// library scoping. A gone row in library A whose MBID matches a present file in
+// library B is NOT relinked to it -- the present-file candidate pool is built
+// per gone row from that row's OWN library_id, so a match in another library is
+// invisible to it. Without that scoping, a reorganization that happened to
+// duplicate an MBID across two libraries would silently re-point library A's
+// row (and all its telemetry) at a file in library B.
+//
+// The run is deliberately UNSCOPED (no --library): the pool narrowing under
+// test is not the flag's doing, so leaving the flag off proves the boundary
+// holds on its own. Identity present with no match in its own library is a
+// genuine delete under the CLI's PolicyFull, so the row is pruned, not relinked
+// -- and the library-B file is untouched.
+func TestReconcilePaths_RelinkNeverCrossesLibraryBoundary(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	otherRoot, otherLibID := seedSecondLibrary(t, ctx, dbPath, filepath.Join(filepath.Dir(root), "music2"), "lib2")
+
+	// Gone row in library 1.
+	oldPath := filepath.Join(root, "ArtistU", "AlbumOld", "01. track.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, oldPath, "mbid-u-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	// Keep library 1's root non-empty so it counts as available.
+	seedReconcilePathsRow(t, ctx, dbPath, filepath.Join(root, "ArtistV", "01. kept.flac"))
+	// The tempting-but-forbidden target: same MBID, different library.
+	crossPath := filepath.Join(otherRoot, "ArtistU", "AlbumNew", "01. track.flac")
+	seedPresentFileInLibrary(t, ctx, dbPath, otherLibID, crossPath, "mbid-u-shared")
+
+	var buf bytes.Buffer
+	if code := runReconcilePaths(ctx, &buf, ScanReconcilePathsCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("exit=%d out=%s", code, buf.String())
+	}
+	if strings.Contains(buf.String(), "relinked 1 source") {
+		t.Fatalf("relinked ACROSS a library boundary; got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "relinked 0 source") {
+		t.Errorf("want 'relinked 0 source'; got: %s", buf.String())
+	}
+	// The artifact: no work_queue row points at the other library's file.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	var crossed int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM work_queue WHERE source_path = ?`, crossPath).Scan(&crossed); err != nil {
+		t.Fatalf("count crossed rows: %v", err)
+	}
+	if crossed != 0 {
+		t.Errorf("%d work_queue row(s) were re-pointed at %s in another library, want 0", crossed, crossPath)
+	}
+	// Library B's own scan_results row is untouched by library A's reconcile.
+	var otherSurvives int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM scan_results WHERE file_path = ?`, crossPath).Scan(&otherSurvives); err != nil {
+		t.Fatalf("count other-library row: %v", err)
+	}
+	if otherSurvives != 1 {
+		t.Errorf("the other library's scan_results row was disturbed: %d rows, want 1", otherSurvives)
 	}
 }

--- a/internal/commands/reconcile_paths_test.go
+++ b/internal/commands/reconcile_paths_test.go
@@ -19,7 +19,11 @@ import (
 
 // seedReconcilePathsRow inserts a scan_results row for filePath plus a linked
 // work_queue item (with a real file on disk), so reconcile-paths has a source to
-// stat. Returns nothing; the tests assert via row counts and command output.
+// stat. It stamps a recording_mbid unique to filePath (no match ANYWHERE in
+// the library) so the row still hits the #640 genuine-delete outcome the
+// existing assertions here exercise -- an identity-absent row would instead be
+// retained, not deleted. Returns nothing; the tests assert via row counts and
+// command output.
 func seedReconcilePathsRow(t *testing.T, ctx context.Context, dbPath, filePath string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
@@ -34,8 +38,8 @@ func seedReconcilePathsRow(t *testing.T, ctx context.Context, dbPath, filePath s
 	}
 	defer sqlDB.Close() //nolint:errcheck // test cleanup
 	res, err := sqlDB.ExecContext(ctx,
-		`INSERT INTO scan_results (library_id, file_path, artist, title, status) VALUES (1, ?, 'Artist', 'Title', 'processing')`,
-		filePath)
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, recording_mbid) VALUES (1, ?, 'Artist', 'Title', 'processing', ?)`,
+		filePath, "mbid-nomatch-"+filePath)
 	if err != nil {
 		t.Fatalf("insert scan_result: %v", err)
 	}
@@ -301,7 +305,7 @@ func TestRunSweeperStartupReconciles(t *testing.T) {
 	// then cancel once it has reconciled to exit the ticker loop.
 	cctx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
-	go func() { runSweeper(cctx, sqlDB, time.Hour); close(done) }()
+	go func() { runSweeper(cctx, sqlDB, time.Hour, nil); close(done) }()
 
 	count := func() int {
 		var n int

--- a/internal/commands/reconcile_paths_test.go
+++ b/internal/commands/reconcile_paths_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -325,4 +327,125 @@ func TestRunSweeperStartupReconciles(t *testing.T) {
 	}
 	cancel()
 	<-done
+}
+
+// TestRunSweeperLogsRelinkAndRetainOutcomes: the periodic sweep is unattended,
+// so its LOG is the only surface an operator has. A relink silently moved a row
+// to a new path and a retain is the keep-and-report path -- a row the sweep
+// deliberately declined to touch, which will be declined again on every
+// subsequent tick until a human resolves it. Logging only the prune count made
+// both outcomes invisible.
+//
+// One sweep is driven over a fixture that produces BOTH: a gone row whose MBID
+// resolves uniquely to a present file (relink) and a gone row with no identity
+// at all (retain, "never deleted on a guess").
+func TestRunSweeperLogsRelinkAndRetainOutcomes(t *testing.T) {
+	ctx, cfgPath, dbPath, root := setupReconcilePaths(t)
+	_ = cfgPath
+
+	// Relink pair: the gone row's directory is removed (Directory granularity),
+	// and a present file elsewhere in the library carries the same MBID.
+	goneMoved := filepath.Join(root, "ArtistR", "AlbumOld", "01. track.flac")
+	movedTo := filepath.Join(root, "ArtistR", "AlbumNew", "01. track.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, goneMoved, "mbid-r-shared")
+	seedReconcilePathsPresentFile(t, ctx, dbPath, movedTo, "mbid-r-shared")
+	// Retain row: identity absent, so it is kept and reported, never deleted.
+	goneNoIdentity := filepath.Join(root, "ArtistS", "01. gone.flac")
+	seedReconcilePathsRowWithIdentity(t, ctx, dbPath, goneNoIdentity, "")
+	// A surviving track keeps the library root non-empty so the availability
+	// guard treats it as mounted.
+	seedReconcilePathsRow(t, ctx, dbPath, filepath.Join(root, "ArtistT", "01. kept.flac"))
+
+	for _, dir := range []string{filepath.Dir(goneMoved), filepath.Dir(goneNoIdentity)} {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("remove %s: %v", dir, err)
+		}
+	}
+
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+
+	var logBuf lockedBuffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() { runSweeper(cctx, sqlDB, time.Hour, nil); close(done) }()
+
+	// Wait for the startup sweep to emit both lines, then stop the ticker loop.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s := logBuf.String()
+		if strings.Contains(s, "relinked moved sources") && strings.Contains(s, "retained sources") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	got := logBuf.String()
+	// The relink line, with the paths an operator needs to verify the move.
+	if !strings.Contains(got, "relinked moved sources") {
+		t.Errorf("sweep did not log the relink outcome; log:\n%s", got)
+	}
+	if !strings.Contains(got, goneMoved) || !strings.Contains(got, movedTo) {
+		t.Errorf("relink log line lacks the old/new paths (want %q -> %q); log:\n%s", goneMoved, movedTo, got)
+	}
+	// The retain line, with the path and a non-empty reason.
+	if !strings.Contains(got, "retained sources it declined to act on") {
+		t.Errorf("sweep did not log the retain outcome -- a held-back row would be invisible; log:\n%s", got)
+	}
+	if !strings.Contains(got, goneNoIdentity) {
+		t.Errorf("retain log line lacks the retained source path %q; log:\n%s", goneNoIdentity, got)
+	}
+	if !strings.Contains(got, "identity absent") {
+		t.Errorf("retain log line lacks the reason; log:\n%s", got)
+	}
+	// A retained row needs a human, so it must not be buried at Info.
+	if !strings.Contains(got, "level=WARN") {
+		t.Errorf("retain outcome was not logged at WARN; log:\n%s", got)
+	}
+	// The artifact behind the log: the retained row really did survive, and the
+	// relinked row's work_queue entry really did move.
+	var kept int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM scan_results WHERE file_path = ?`, goneNoIdentity).Scan(&kept); err != nil {
+		t.Fatalf("count retained: %v", err)
+	}
+	if kept != 1 {
+		t.Errorf("retained row was deleted: %d rows for %s, want 1", kept, goneNoIdentity)
+	}
+	var moved int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM work_queue WHERE source_path = ?`, movedTo).Scan(&moved); err != nil {
+		t.Fatalf("count relinked: %v", err)
+	}
+	if moved != 1 {
+		t.Errorf("relinked work_queue row not at the new path: %d rows for %s, want 1", moved, movedTo)
+	}
+}
+
+// lockedBuffer is a concurrency-safe io.Writer for capturing slog output from
+// the sweeper goroutine while the test goroutine polls it. slog handlers do not
+// serialize writes across goroutines, and bytes.Buffer is not safe for
+// concurrent use, so -race would flag a bare buffer here.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -3,12 +3,28 @@
 // deleted so a renamed/merged/deleted track cannot leave a permanently-failing
 // or wedged row behind (#453).
 //
-// The filesystem is the sole authority for "gone": a source path is pruned only
-// when os.Stat of that path (Exact granularity) or its directory (Directory
-// granularity) fails. The same primitive backs three callers -- a watcher-
-// reactive prune on Remove/Rename events, a lazy periodic sweep, and the
-// `scan reconcile-paths` CLI -- so the reconciliation rule lives in exactly one
-// place.
+// The filesystem is the sole authority for "gone": a source path is a
+// candidate for removal only when os.Stat of that path (Exact granularity) or
+// its directory (Directory granularity) fails. The same primitive backs three
+// callers -- a watcher-reactive prune on Remove/Rename events, a lazy periodic
+// sweep, and the `scan reconcile-paths` CLI -- so the reconciliation rule
+// lives in exactly one place.
+//
+// A gone row is no longer deleted unconditionally (#640): before deleting,
+// reconcile consults the row's stored MBID/ISRC (populated by the scan loop
+// into scan_results.isrc/recording_mbid, migration 037) against every OTHER
+// still-present file in the library via the shared internal/identity exact
+// tier -- the SAME resolver internal/realign uses to re-attach orphaned lyric
+// sidecars, so a bulk move can never leave the sidecar pointing at one file and
+// the database row pointing at another. A unique match RE-LINKS the row to its
+// new path, preserving every telemetry/timing/provenance column the row
+// carries; identity that is absent or ambiguous is never guessed at -- the row
+// is KEPT and reported, because a wrongly-kept row is inert while a
+// wrongly-deleted one destroys a GPU-class inference result. Only a row whose
+// identity is present but matches nothing anywhere in the library is a genuine
+// delete, and the reactive PrunePath path never performs one at all (relink or
+// retain only), leaving genuine deletion to the periodic sweep and the CLI, by
+// which time a rescan has had time to settle.
 package prune
 
 import (
@@ -22,6 +38,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/sydlexius/canticle/internal/identity"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/pathutil"
 )
@@ -42,6 +59,26 @@ const (
 	Exact
 )
 
+// Policy controls whether reconcile is allowed to perform a genuine delete
+// once a gone row's identity is present but resolves to no candidate anywhere
+// in the library.
+type Policy int
+
+const (
+	// PolicyFull allows every outcome: relink, retain, or genuine delete. Used
+	// by the periodic sweep and the CLI, both of which run well after any
+	// rescan of a moved file's new location would have completed.
+	PolicyFull Policy = iota
+	// PolicyRelinkOrRetain never performs a genuine delete: a gone row with
+	// identity that resolves to nothing is retained-and-reported instead, the
+	// same as an ambiguous or absent identity. Used by the reactive PrunePath,
+	// which fires the instant a filesystem event reports a path gone -- before
+	// a corresponding rescan of the file's new location could plausibly have
+	// populated the present-file candidate pool, so a "no match anywhere"
+	// verdict at that moment cannot be trusted to mean "genuinely deleted".
+	PolicyRelinkOrRetain
+)
+
 // PrunedRow describes one gone source path and the rows removed for it, for
 // summaries and JSONL backups.
 type PrunedRow struct {
@@ -56,12 +93,43 @@ type PrunedRow struct {
 	Inputs []models.Inputs
 }
 
+// RelinkedRow describes one gone source path whose identity resolved uniquely
+// to a present file elsewhere in the library: the linked work_queue row(s) had
+// their source_path/outdir/filename updated to the new location, and the
+// stale scan_results row was removed -- every telemetry/timing/provenance
+// column on the work_queue row is left untouched.
+type RelinkedRow struct {
+	OldPath       string
+	NewPath       string
+	ScanResultIDs []int64
+	WorkItemIDs   []int64
+	// MBID/ISRC are whichever identity values the gone row carried and that
+	// drove the match (both may be set; only one may have been the one an
+	// operator cares to inspect).
+	MBID string
+	ISRC string
+}
+
+// RetainedRow describes one gone source path that was deliberately NOT
+// deleted: its identity was absent, ambiguous (matched more than one present
+// file), or -- under PolicyRelinkOrRetain -- present but as-yet unresolved.
+// Never guessed at; a wrongly-kept row is inert, so the safe default is to
+// keep it and report why.
+type RetainedRow struct {
+	SourcePath string
+	Reason     string
+	MBID       string
+	ISRC       string
+}
+
 // Result reports the totals and per-row detail of a prune (or, in dry-run, what
-// would be pruned).
+// would happen).
 type Result struct {
 	ScanResults int
 	WorkItems   int
 	Pruned      []PrunedRow
+	Relinked    []RelinkedRow
+	Retained    []RetainedRow
 }
 
 // SweepOptions controls a whole-scope reconciliation sweep.
@@ -77,33 +145,75 @@ type SweepOptions struct {
 	// Report, when set, is invoked once per pruned source path before the delete
 	// commits, so a caller can back up or log each row.
 	Report func(PrunedRow) error
+	// ReportRelinked, when set, is invoked once per relinked source path before
+	// the update commits (or, in dry-run, for the row that would be relinked).
+	ReportRelinked func(RelinkedRow) error
+	// ReportRetained, when set, is invoked once per retained source path.
+	// Retaining never mutates the database, so this fires the same way in
+	// dry-run and real runs.
+	ReportRetained func(RetainedRow) error
 }
 
 // Pruner reconciles work_queue and scan_results against the filesystem.
 type Pruner struct {
-	db *sql.DB
+	db           *sql.DB
+	identityKeys identity.Keys
 }
 
-// New returns a Pruner backed by db.
+// New returns a Pruner backed by db, with the default identity-key order
+// (mbid, then isrc) for the exact-match re-link tier. Call SetIdentityKeys to
+// honor an operator's configured config.RealignConfig.IdentityKeys order --
+// the same config realign reads, so the two subsystems can never disagree
+// about key precedence.
 func New(db *sql.DB) *Pruner {
-	return &Pruner{db: db}
+	return &Pruner{db: db, identityKeys: identity.NormalizeKeys([]string{"mbid", "isrc"})}
+}
+
+// SetIdentityKeys overrides the identity-key order the exact-match re-link
+// tier consults, most authoritative first. Pass config.RealignConfig.IdentityKeys.
+// An empty or all-unknown result from identity.NormalizeKeys is ignored (the
+// existing order is kept) so a caller's misconfiguration cannot silently
+// disable re-link matching altogether.
+func (p *Pruner) SetIdentityKeys(keys []string) {
+	if normalized := identity.NormalizeKeys(keys); len(normalized) > 0 {
+		p.identityKeys = normalized
+	}
 }
 
 // PrunePath reconciles the rows whose source path is at or under path, statting
 // each candidate source file individually (Exact granularity). It is the
 // reactive entry point: the caller already learned path vanished from a
 // filesystem event, so this does no rescan -- only per-candidate os.Stat checks
-// plus the DB deletes (disk-cheap, not a directory walk). A removed directory is
+// plus the DB writes (disk-cheap, not a directory walk). A removed directory is
 // handled naturally -- every candidate source under it fails os.Stat.
+//
+// Runs under PolicyRelinkOrRetain: a gone row here is either relinked (its
+// identity resolves uniquely to an already-present file) or retained, never
+// genuinely deleted -- see PolicyRelinkOrRetain's doc for why.
 func (p *Pruner) PrunePath(ctx context.Context, path string) (Result, error) {
-	return p.reconcile(ctx, scope{prefix: path, scoped: true}, nil, Exact, false, nil)
+	return p.reconcile(ctx, scope{prefix: path, scoped: true}, nil, Exact, false, PolicyRelinkOrRetain, reportHooks{})
 }
 
 // Sweep reconciles every candidate source path in scope. Directory granularity
 // is the cheap backstop; Exact is the thorough operator-invoked pass. With
-// DryRun set it reports without mutating.
+// DryRun set it reports without mutating. Runs under PolicyFull: a gone row
+// whose identity is present but resolves to no candidate anywhere in the
+// library is genuinely deleted, since the periodic sweep and the CLI both run
+// well after any rescan of a moved file's new location would have settled.
 func (p *Pruner) Sweep(ctx context.Context, opts SweepOptions) (Result, error) {
-	return p.reconcile(ctx, scope{}, opts.LibraryID, opts.Granularity, opts.DryRun, opts.Report)
+	return p.reconcile(ctx, scope{}, opts.LibraryID, opts.Granularity, opts.DryRun, PolicyFull, reportHooks{
+		Prune:    opts.Report,
+		Relinked: opts.ReportRelinked,
+		Retained: opts.ReportRetained,
+	})
+}
+
+// reportHooks bundles the three optional per-outcome callbacks so internal
+// plumbing has one parameter instead of three.
+type reportHooks struct {
+	Prune    func(PrunedRow) error
+	Relinked func(RelinkedRow) error
+	Retained func(RetainedRow) error
 }
 
 // scope narrows candidate source paths to those at or under prefix. A zero scope
@@ -131,13 +241,25 @@ func (s scope) childRange() (lower, upper string) {
 	return s.prefix + sep, s.prefix + string(filepath.Separator+1)
 }
 
-// candidate is a source path with the row detail needed to prune and back it up.
+// candidate is a source path with the row detail needed to prune, relink, or
+// back it up.
 type candidate struct {
 	scanResultIDs []int64
 	workItems     []workRow
 	// processing is true when any linked work_queue row is still 'processing',
 	// so the whole source is deferred (the worker owns it) to avoid a half-prune.
 	processing bool
+	// libraryID scopes the present-file candidate pool this row's identity is
+	// matched against. Known whenever a scan_results row backs this source;
+	// nil for a link-less work_queue-only candidate (no scan_results row at
+	// all), which falls back to an unscoped, whole-database search.
+	libraryID *int64
+	// mbid/isrc are this row's own stored identity, preferring
+	// scan_results.recording_mbid/isrc (re-read on every scan, so it can never
+	// be stale for a since-deleted file) and falling back to
+	// work_queue.mbid/isrc (migration 033, the provider's resolved identity at
+	// fetch time) only when scan_results carries none.
+	mbid, isrc string
 }
 
 // workRow is a work_queue row's restorable detail.
@@ -148,9 +270,11 @@ type workRow struct {
 
 // reconcile is the shared core behind PrunePath and Sweep. It gathers candidate
 // source paths, uses os.Stat (per granularity) as the sole authority for gone,
-// applies the in-flight guard, and atomically deletes the gone rows across
-// work_queue and scan_results (the junction is cleaned by ON DELETE CASCADE).
-func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Granularity, dryRun bool, report func(PrunedRow) error) (Result, error) {
+// applies the in-flight guard, classifies each gone candidate via the shared
+// identity resolver into prune/relink/retain, and applies the result --
+// deleting genuinely-gone rows, relinking rows whose identity resolved
+// elsewhere, and reporting (never mutating) retained rows.
+func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Granularity, dryRun bool, policy Policy, hooks reportHooks) (Result, error) {
 	bySource, err := p.gatherCandidates(ctx, sc, libraryID)
 	if err != nil {
 		return Result{}, err
@@ -164,9 +288,12 @@ func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Gr
 	if err != nil {
 		return Result{}, err
 	}
+	idx := newPresentIndex(p.db, roots)
 
 	statCache := make(map[string]bool) // directory -> exists (Directory granularity)
 	var res Result
+	var toPrune []PrunedRow
+	var toRelink []classifiedRelink
 	for _, src := range sortedKeys(bySource) {
 		c := bySource[src]
 		if !underAvailableRoot(src, roots) {
@@ -182,32 +309,75 @@ func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Gr
 			// pass once the worker finishes or fails the item.
 			continue
 		}
-		row := PrunedRow{SourcePath: src, ScanResultIDs: c.scanResultIDs}
-		for _, w := range c.workItems {
-			row.WorkItemIDs = append(row.WorkItemIDs, w.id)
-			row.Inputs = append(row.Inputs, w.inputs)
+
+		cg, err := p.classify(ctx, idx, policy, src, c)
+		if err != nil {
+			return Result{}, err
 		}
-		res.Pruned = append(res.Pruned, row)
+		switch cg.outcome {
+		case outcomeRetain:
+			res.Retained = append(res.Retained, cg.retained)
+			if hooks.Retained != nil {
+				if err := hooks.Retained(cg.retained); err != nil {
+					return Result{}, fmt.Errorf("prune: report retained %q: %w", src, err)
+				}
+			}
+		case outcomeRelink:
+			toRelink = append(toRelink, cg.classifiedRelink)
+		case outcomePrune:
+			row := PrunedRow{SourcePath: src, ScanResultIDs: c.scanResultIDs}
+			for _, w := range c.workItems {
+				row.WorkItemIDs = append(row.WorkItemIDs, w.id)
+				row.Inputs = append(row.Inputs, w.inputs)
+			}
+			toPrune = append(toPrune, row)
+		}
+	}
+	res.Pruned = toPrune
+	for _, cg := range toRelink {
+		res.Relinked = append(res.Relinked, cg.relinked)
 	}
 
 	if dryRun {
-		// Dry-run reports the intended prune set (gather-time counts), since no
-		// delete runs to measure.
-		for _, row := range res.Pruned {
+		// Dry-run reports the intended outcome (gather-time counts), since no
+		// mutation runs to measure.
+		for _, row := range toPrune {
 			res.ScanResults += len(row.ScanResultIDs)
 			res.WorkItems += len(row.WorkItemIDs)
-			if report != nil {
-				if err := report(row); err != nil {
+			if hooks.Prune != nil {
+				if err := hooks.Prune(row); err != nil {
 					return Result{}, fmt.Errorf("prune: report: %w", err)
+				}
+			}
+		}
+		for _, cg := range toRelink {
+			if hooks.Relinked != nil {
+				if err := hooks.Relinked(cg.relinked); err != nil {
+					return Result{}, fmt.Errorf("prune: report relinked %q: %w", cg.relinked.OldPath, err)
 				}
 			}
 		}
 		return res, nil
 	}
-	if len(res.Pruned) == 0 {
+
+	if len(toRelink) > 0 {
+		applied, retainedByConflict, err := p.applyRelinks(ctx, toRelink, hooks.Relinked, hooks.Retained)
+		if err != nil {
+			return Result{}, err
+		}
+		res.Relinked = applied
+		// A candidate that failed to relink (its target is already owned by a
+		// different work_queue row) is neither pruned nor relinked, but it must
+		// still be accounted for -- appending here, not overwriting, keeps it
+		// alongside any rows classify() already retained directly (absent or
+		// ambiguous identity) so pruned+relinked+retained always equals the
+		// number of gone rows considered.
+		res.Retained = append(res.Retained, retainedByConflict...)
+	}
+	if len(toPrune) == 0 {
 		return res, nil
 	}
-	scanDeleted, workDeleted, err := p.deletePruned(ctx, res.Pruned, report)
+	scanDeleted, workDeleted, err := p.deletePruned(ctx, toPrune, hooks.Prune)
 	if err != nil {
 		return Result{}, err
 	}
@@ -216,6 +386,285 @@ func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Gr
 	res.ScanResults = scanDeleted
 	res.WorkItems = workDeleted
 	return res, nil
+}
+
+// outcome classifies what reconcile decided for one gone candidate.
+type outcome int
+
+const (
+	outcomePrune outcome = iota
+	outcomeRelink
+	outcomeRetain
+)
+
+// classifiedRelink carries both the reporting-facing RelinkedRow and the
+// internal detail applyRelinks needs to actually perform the update.
+type classifiedRelink struct {
+	src      string
+	c        *candidate
+	relinked RelinkedRow
+	target   presentRowDetail
+}
+
+type classified struct {
+	outcome  outcome
+	retained RetainedRow
+	classifiedRelink
+}
+
+// classify decides one gone candidate's fate: retain (identity absent,
+// ambiguous, or -- under PolicyRelinkOrRetain -- unresolved), relink (identity
+// resolves uniquely to an already-present file), or prune (identity present
+// but matches nothing anywhere in the library, and policy allows a genuine
+// delete).
+func (p *Pruner) classify(ctx context.Context, idx *presentIndex, policy Policy, src string, c *candidate) (classified, error) {
+	if c.mbid == "" && c.isrc == "" {
+		return classified{outcome: outcomeRetain, retained: RetainedRow{SourcePath: src, Reason: "identity absent; never deleted on a guess"}}, nil
+	}
+	pool, err := idx.pool(ctx, c.libraryID)
+	if err != nil {
+		return classified{}, err
+	}
+	verdict, ref := identity.ResolveExact(c.mbid, c.isrc, p.identityKeys, pool)
+	switch verdict {
+	case identity.VerdictUnique:
+		detail := idx.detail(c.libraryID, ref)
+		rr := RelinkedRow{OldPath: src, NewPath: ref, ScanResultIDs: c.scanResultIDs, MBID: c.mbid, ISRC: c.isrc}
+		for _, w := range c.workItems {
+			rr.WorkItemIDs = append(rr.WorkItemIDs, w.id)
+		}
+		return classified{outcome: outcomeRelink, classifiedRelink: classifiedRelink{src: src, c: c, relinked: rr, target: detail}}, nil
+	case identity.VerdictConflict:
+		return classified{outcome: outcomeRetain, retained: RetainedRow{SourcePath: src, Reason: "identity matches more than one present file; never guessed", MBID: c.mbid, ISRC: c.isrc}}, nil
+	default: // VerdictNone
+		if policy == PolicyRelinkOrRetain {
+			return classified{outcome: outcomeRetain, retained: RetainedRow{SourcePath: src, Reason: "identity present but not yet found elsewhere; reactive pass defers genuine delete to the periodic sweep", MBID: c.mbid, ISRC: c.isrc}}, nil
+		}
+		return classified{outcome: outcomePrune}, nil
+	}
+}
+
+// applyRelinks performs every relink in one transaction, updating the
+// surviving work_queue row(s)' source_path/outdir/filename to the resolved new
+// location, ensuring the work_queue_scan_results junction points at the
+// present-file scan_results row, and deleting only the stale (gone-path)
+// scan_results row -- never the work_queue row itself, so every
+// telemetry/timing/provenance column already on it survives untouched.
+//
+// A candidate whose present-file target is already junction-linked to a
+// DIFFERENT work_queue row is not silently skipped: it is accounted for as a
+// RetainedRow (see relinkOne), because #640's whole premise is keep-and-report,
+// never decide silently -- a row this package declines to touch must still
+// show up in the reconcile Result and the operator-facing summary/backup, the
+// same as an absent or ambiguous identity would.
+//
+// Both reportRelinked and reportRetained fire once per outcome, after the
+// commit, mirroring deletePruned's backup-first-on-report-time discipline: if
+// any relink in the batch errors, the whole transaction rolls back and NO
+// report fires for anything in this call, applied or retained-by-conflict
+// alike, so a report is never written for a row a rollback left untouched by
+// a different mechanism than it claims.
+func (p *Pruner) applyRelinks(ctx context.Context, targets []classifiedRelink, reportRelinked func(RelinkedRow) error, reportRetained func(RetainedRow) error) (applied []RelinkedRow, retained []RetainedRow, retErr error) {
+	tx, err := p.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("prune: begin relink tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, cg := range targets {
+		ok, conflictWorkQueueID, err := relinkOne(ctx, tx, cg.c, cg.target)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !ok {
+			// The present-file scan_results row is already owned by a DIFFERENT
+			// work_queue row than this gone candidate's own. Merging two
+			// work_queue rows is internal/identityrepair's job, not prune's, so
+			// this package declines the merge -- but the row still needs an
+			// outcome an operator can see, not a bare drop from every count.
+			retained = append(retained, RetainedRow{
+				SourcePath: cg.relinked.OldPath,
+				Reason:     fmt.Sprintf("present-file candidate already linked to work_queue row %d; merging is identityrepair's job", conflictWorkQueueID),
+				MBID:       cg.relinked.MBID,
+				ISRC:       cg.relinked.ISRC,
+			})
+			continue
+		}
+		applied = append(applied, cg.relinked)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("prune: commit relink tx: %w", err)
+	}
+	if reportRelinked != nil {
+		for _, rr := range applied {
+			if err := reportRelinked(rr); err != nil {
+				return applied, retained, fmt.Errorf("prune: report relinked %q: %w", rr.OldPath, err)
+			}
+		}
+	}
+	if reportRetained != nil {
+		for _, rr := range retained {
+			if err := reportRetained(rr); err != nil {
+				return applied, retained, fmt.Errorf("prune: report retained %q: %w", rr.SourcePath, err)
+			}
+		}
+	}
+	return applied, retained, nil
+}
+
+// relinkOne performs one candidate's relink within tx, returning ok=false
+// (with no mutation) when the present-file scan_results row is already
+// junction-linked to a work_queue row other than this candidate's own -- a
+// genuine identity conflict this package declines to auto-merge. On ok=false,
+// conflictWorkQueueID identifies the row that already owns the target, so the
+// caller can report a reason an operator can act on.
+func relinkOne(ctx context.Context, tx *sql.Tx, c *candidate, target presentRowDetail) (ok bool, conflictWorkQueueID int64, retErr error) {
+	for _, w := range c.workItems {
+		var otherID int64
+		err := tx.QueryRowContext(ctx,
+			`SELECT work_queue_id FROM work_queue_scan_results WHERE scan_result_id = ? AND work_queue_id != ?`,
+			target.scanResultID, w.id).Scan(&otherID)
+		if err == nil {
+			return false, otherID, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return false, 0, fmt.Errorf("prune: check present scan_result %d ownership: %w", target.scanResultID, err)
+		}
+	}
+	for _, w := range c.workItems {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE work_queue SET source_path = ?, outdir = ?, filename = ? WHERE id = ? AND status != 'processing'`,
+			target.filePath, target.outdir, target.filename, w.id); err != nil {
+			return false, 0, fmt.Errorf("prune: relink work_queue %d: %w", w.id, err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+			w.id, target.scanResultID); err != nil {
+			return false, 0, fmt.Errorf("prune: link work_queue %d to scan_result %d: %w", w.id, target.scanResultID, err)
+		}
+	}
+	for _, id := range c.scanResultIDs {
+		// Same in-flight guard as deletePruned: never delete a scan_results row
+		// still linked to a processing work_queue row.
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM scan_results WHERE id = ?
+             AND NOT EXISTS (
+                 SELECT 1 FROM work_queue_scan_results j
+                 JOIN work_queue wq ON wq.id = j.work_queue_id
+                 WHERE j.scan_result_id = ? AND wq.status = 'processing')`,
+			id, id); err != nil {
+			return false, 0, fmt.Errorf("prune: delete stale scan_result %d: %w", id, err)
+		}
+	}
+	return true, 0, nil
+}
+
+// presentRowDetail is the detail applyRelinks needs from the present-file
+// scan_results row an identity match resolved to.
+type presentRowDetail struct {
+	scanResultID int64
+	filePath     string
+	outdir       string
+	filename     string
+}
+
+// presentIndexGlobalKey is the map key presentIndex uses for an unscoped
+// (whole-database) candidate pool, built for a candidate whose owning library
+// is unknown (a link-less work_queue-only row with no scan_results of its own).
+const presentIndexGlobalKey = int64(-1)
+
+// presentIndex lazily builds and memoizes the library-scoped set of currently-
+// present scan_results rows carrying identity -- the candidate pool prune's
+// exact-match tier searches. Building a scope's pool costs one query plus one
+// os.Stat per identity-bearing row in that library, so a caller should build it
+// AT MOST ONCE PER LIBRARY SCOPE ENCOUNTERED during a reconcile pass (memoized
+// here), not once per gone candidate.
+type presentIndex struct {
+	db      *sql.DB
+	roots   []string
+	byScope map[int64][]identity.Candidate
+	details map[int64]map[string]presentRowDetail
+}
+
+func newPresentIndex(db *sql.DB, roots []string) *presentIndex {
+	return &presentIndex{
+		db:      db,
+		roots:   roots,
+		byScope: map[int64][]identity.Candidate{},
+		details: map[int64]map[string]presentRowDetail{},
+	}
+}
+
+// pool returns the present-file identity candidates for libraryID (or the
+// unscoped global pool when libraryID is nil), building and caching it on
+// first use.
+func (idx *presentIndex) pool(ctx context.Context, libraryID *int64) ([]identity.Candidate, error) {
+	key := presentIndexGlobalKey
+	if libraryID != nil {
+		key = *libraryID
+	}
+	if pool, ok := idx.byScope[key]; ok {
+		return pool, nil
+	}
+	// Only rows carrying identity can ever win the exact tier, so filtering at
+	// the SQL level (seekable via migration 037's partial indexes) skips the
+	// os.Stat cost for the majority of a library that has no identity at all.
+	query := `SELECT id, file_path, outdir, filename, isrc, recording_mbid FROM scan_results
+              WHERE file_path != '' AND (isrc != '' OR recording_mbid != '')`
+	var args []any
+	if libraryID != nil {
+		query += ` AND library_id = ?`
+		args = append(args, *libraryID)
+	}
+	var pool []identity.Candidate
+	details := map[string]presentRowDetail{}
+	if err := queryRows(ctx, idx.db, query, args, func(rows *sql.Rows) error {
+		var id int64
+		var path, outdir, filename, isrc, mbid string
+		if err := rows.Scan(&id, &path, &outdir, &filename, &isrc, &mbid); err != nil {
+			return err
+		}
+		// DELIBERATE, BOUNDED I/O COST -- flagged because the issue's proposed
+		// design explicitly wanted zero extra disk access, and this is the one
+		// place that constraint is not fully met. Without this os.Stat, a
+		// scan_results row whose file itself later vanished (a second, distinct
+		// gone event the periodic sweep has not yet reconciled) would offer
+		// itself as a relink target and hand a gone row's identity to another
+		// gone row -- silently trading one dangling reference for another. The
+		// cost is bounded and does not scale with library size: one os.Stat per
+		// IDENTITY-BEARING row (filtered at the SQL level above, migration 037's
+		// partial index; the common case is most rows carry no identity at all)
+		// in a library SCOPE that actually has a gone-with-identity row to
+		// resolve, and the whole pool is memoized here for the rest of the
+		// reconcile pass (built at most once per library scope encountered, never
+		// once per gone candidate). On a spun-down array this still wakes disks
+		// under the stat, so it is a real cost, just a small and bounded one --
+		// nowhere near what reading candidate durations for the heuristic tier
+		// would have cost (Design Choice 1 explicitly ruled that out).
+		if !underAvailableRoot(path, idx.roots) || !pathExists(path) {
+			return nil
+		}
+		pool = append(pool, identity.Candidate{Ref: path, MBID: mbid, ISRC: isrc})
+		details[path] = presentRowDetail{scanResultID: id, filePath: path, outdir: outdir, filename: filename}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("prune: build present-file identity index: %w", err)
+	}
+	idx.byScope[key] = pool
+	idx.details[key] = details
+	return pool, nil
+}
+
+// detail returns the present-row detail for ref within libraryID's scope,
+// populated by a prior call to pool. Callers only invoke this after pool
+// already resolved ref via identity.ResolveExact, so the lookup is expected to
+// always hit.
+func (idx *presentIndex) detail(libraryID *int64, ref string) presentRowDetail {
+	key := presentIndexGlobalKey
+	if libraryID != nil {
+		key = *libraryID
+	}
+	return idx.details[key][ref]
 }
 
 // availableRoots returns the configured library root paths that are currently
@@ -279,7 +728,7 @@ func underAvailableRoot(src string, roots []string) bool {
 func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int64) (map[string]*candidate, error) {
 	bySource := make(map[string]*candidate)
 
-	srQuery := `SELECT id, file_path FROM scan_results WHERE file_path != ''`
+	srQuery := `SELECT id, library_id, file_path, isrc, recording_mbid FROM scan_results WHERE file_path != ''`
 	var srArgs []any
 	if sc.scoped {
 		// Push the path scope into SQL so the reactive PrunePath (fired per
@@ -294,9 +743,9 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 		srArgs = append(srArgs, *libraryID)
 	}
 	if err := queryRows(ctx, p.db, srQuery, srArgs, func(rows *sql.Rows) error {
-		var id int64
-		var path string
-		if err := rows.Scan(&id, &path); err != nil {
+		var id, libID int64
+		var path, isrc, mbid string
+		if err := rows.Scan(&id, &libID, &path, &isrc, &mbid); err != nil {
 			return err
 		}
 		if !sc.matches(path) {
@@ -304,17 +753,25 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 		}
 		c := ensureCandidate(bySource, path)
 		c.scanResultIDs = append(c.scanResultIDs, id)
+		lib := libID
+		c.libraryID = &lib
+		if isrc != "" {
+			c.isrc = isrc
+		}
+		if mbid != "" {
+			c.mbid = mbid
+		}
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("prune: gather scan_results: %w", err)
 	}
 
-	wqQuery := `SELECT id, artist, title, source_path, output_paths, status FROM work_queue WHERE source_path != ''`
+	wqQuery := `SELECT id, artist, title, source_path, output_paths, status, isrc, mbid FROM work_queue WHERE source_path != ''`
 	var wqArgs []any
 	if libraryID != nil {
 		// Library-scope work_queue through the junction so a scoped sweep only
 		// prunes queue rows belonging to that library.
-		wqQuery = `SELECT DISTINCT wq.id, wq.artist, wq.title, wq.source_path, wq.output_paths, wq.status
+		wqQuery = `SELECT DISTINCT wq.id, wq.artist, wq.title, wq.source_path, wq.output_paths, wq.status, wq.isrc, wq.mbid
                    FROM work_queue wq
                    JOIN work_queue_scan_results j ON j.work_queue_id = wq.id
                    JOIN scan_results sr ON sr.id = j.scan_result_id
@@ -330,7 +787,8 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 	if err := queryRows(ctx, p.db, wqQuery, wqArgs, func(rows *sql.Rows) error {
 		var id int64
 		var artist, title, source, outputPaths, status string
-		if err := rows.Scan(&id, &artist, &title, &source, &outputPaths, &status); err != nil {
+		var isrc, mbid sql.NullString
+		if err := rows.Scan(&id, &artist, &title, &source, &outputPaths, &status, &isrc, &mbid); err != nil {
 			return err
 		}
 		if !sc.matches(source) {
@@ -355,6 +813,17 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 				OutputPaths: paths,
 			},
 		})
+		// work_queue.isrc/mbid (migration 033, the provider's resolved identity
+		// at fetch time) is only a FALLBACK: scan_results' tag-read identity is
+		// preferred because it can never be stale for a since-deleted file (it
+		// is re-read on every scan), whereas this column is a point-in-time
+		// stamp from whichever provider match won.
+		if c.isrc == "" && isrc.Valid && isrc.String != "" {
+			c.isrc = isrc.String
+		}
+		if c.mbid == "" && mbid.Valid && mbid.String != "" {
+			c.mbid = mbid.String
+		}
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("prune: gather work_queue: %w", err)

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -142,11 +142,16 @@ type SweepOptions struct {
 	Granularity Granularity
 	// DryRun computes and reports the prune set without mutating the database.
 	DryRun bool
-	// Report, when set, is invoked once per pruned source path before the delete
-	// commits, so a caller can back up or log each row.
+	// Report, when set, is invoked once per pruned source path AFTER the delete
+	// commits, so a caller can back up or log each row -- and only for a row the
+	// deletes actually removed, so a backup record never describes a row that a
+	// race into 'processing' skipped or that a rollback left in place. In
+	// dry-run it fires for every row that would be pruned.
 	Report func(PrunedRow) error
-	// ReportRelinked, when set, is invoked once per relinked source path before
-	// the update commits (or, in dry-run, for the row that would be relinked).
+	// ReportRelinked, when set, is invoked once per relinked source path AFTER
+	// the update commits (or, in dry-run, for the row that would be relinked),
+	// mirroring Report's discipline: if the relink transaction rolls back, no
+	// report fires for anything in that batch.
 	ReportRelinked func(RelinkedRow) error
 	// ReportRetained, when set, is invoked once per retained source path.
 	// Retaining never mutates the database, so this fires the same way in
@@ -471,26 +476,44 @@ func (p *Pruner) applyRelinks(ctx context.Context, targets []classifiedRelink, r
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	for _, cg := range targets {
-		ok, conflictWorkQueueID, err := relinkOne(ctx, tx, cg.c, cg.target)
+	for i, cg := range targets {
+		// Each candidate runs inside its own savepoint so a decline part-way
+		// through a multi-row candidate (the in-flight guard rejecting the
+		// second of two work items) unwinds that candidate's earlier writes
+		// instead of committing a half-relink. Savepoint names are generated,
+		// never caller-derived, so no identifier can be injected.
+		sp := fmt.Sprintf("prune_relink_%d", i)
+		if _, err := tx.ExecContext(ctx, "SAVEPOINT "+sp); err != nil { //nolint:gosec // reason: sp is a fixed prefix plus a loop index, never external input
+			return nil, nil, fmt.Errorf("prune: savepoint relink: %w", err)
+		}
+		decision, err := relinkOne(ctx, tx, cg.c, cg.target)
 		if err != nil {
 			return nil, nil, err
 		}
-		if !ok {
-			// The present-file scan_results row is already owned by a DIFFERENT
-			// work_queue row than this gone candidate's own. Merging two
-			// work_queue rows is internal/identityrepair's job, not prune's, so
-			// this package declines the merge -- but the row still needs an
-			// outcome an operator can see, not a bare drop from every count.
+		if decision.reason != "" {
+			// This candidate is declined: either the present-file scan_results
+			// row is already owned by a DIFFERENT work_queue row (merging two
+			// work_queue rows is internal/identityrepair's job, not prune's), or
+			// a work item raced into 'processing' so its relink UPDATE matched
+			// nothing. Either way the row still needs an outcome an operator can
+			// see, not a bare drop from every count -- and its partial writes are
+			// rolled back to the savepoint first, so the reported "retained" is
+			// literally true of the database.
+			if _, err := tx.ExecContext(ctx, "ROLLBACK TO "+sp); err != nil { //nolint:gosec // reason: sp is a fixed prefix plus a loop index, never external input
+				return nil, nil, fmt.Errorf("prune: rollback relink savepoint: %w", err)
+			}
 			retained = append(retained, RetainedRow{
 				SourcePath: cg.relinked.OldPath,
-				Reason:     fmt.Sprintf("present-file candidate already linked to work_queue row %d; merging is identityrepair's job", conflictWorkQueueID),
+				Reason:     decision.reason,
 				MBID:       cg.relinked.MBID,
 				ISRC:       cg.relinked.ISRC,
 			})
-			continue
+		} else {
+			applied = append(applied, cg.relinked)
 		}
-		applied = append(applied, cg.relinked)
+		if _, err := tx.ExecContext(ctx, "RELEASE "+sp); err != nil { //nolint:gosec // reason: sp is a fixed prefix plus a loop index, never external input
+			return nil, nil, fmt.Errorf("prune: release relink savepoint: %w", err)
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, nil, fmt.Errorf("prune: commit relink tx: %w", err)
@@ -512,35 +535,68 @@ func (p *Pruner) applyRelinks(ctx context.Context, targets []classifiedRelink, r
 	return applied, retained, nil
 }
 
-// relinkOne performs one candidate's relink within tx, returning ok=false
-// (with no mutation) when the present-file scan_results row is already
-// junction-linked to a work_queue row other than this candidate's own -- a
-// genuine identity conflict this package declines to auto-merge. On ok=false,
-// conflictWorkQueueID identifies the row that already owns the target, so the
-// caller can report a reason an operator can act on.
-func relinkOne(ctx context.Context, tx *sql.Tx, c *candidate, target presentRowDetail) (ok bool, conflictWorkQueueID int64, retErr error) {
+// relinkDecision is relinkOne's verdict for one candidate. A zero value means
+// the relink was performed; a non-empty reason means it was declined and the
+// caller must roll the candidate back and report it as retained.
+type relinkDecision struct {
+	reason string
+}
+
+// relinkOne performs one candidate's relink within tx, returning a non-empty
+// decision reason (and leaving the caller to roll back to its savepoint) in
+// either of two keep-and-report cases.
+//
+// FIRST, an ownership conflict: the present-file scan_results row is already
+// junction-linked to a work_queue row other than this candidate's own -- an
+// identity conflict this package declines to auto-merge, because merging two
+// work_queue rows is internal/identityrepair's job.
+//
+// "This candidate's own" means EVERY work_queue row in c.workItems, not just
+// the one being examined. gatherCandidates aggregates every work_queue row
+// sharing a source_path into ONE candidate (source_path carries no uniqueness
+// constraint -- migration 026 only indexes it), so a candidate routinely holds
+// several rows. Excluding only the current row would let a SIBLING of the same
+// candidate that already owns the target read as an ownership conflict, and the
+// row would then be retained forever on a conflict with itself.
+//
+// SECOND, a lost in-flight race: the relink UPDATE is guarded on
+// `status != 'processing'`, so a work item that raced into 'processing' between
+// gatherCandidates and this transaction updates NOTHING. Proceeding past a
+// zero-row UPDATE would junction-link and then DELETE the stale scan_results row
+// while the work_queue row still pointed at the vanished path -- silent data
+// loss reported as a successful relink, exactly the outcome #640 exists to
+// prevent. The candidate is declined whole instead.
+func relinkOne(ctx context.Context, tx *sql.Tx, c *candidate, target presentRowDetail) (relinkDecision, error) {
+	own := make(map[int64]bool, len(c.workItems))
 	for _, w := range c.workItems {
-		var otherID int64
-		err := tx.QueryRowContext(ctx,
-			`SELECT work_queue_id FROM work_queue_scan_results WHERE scan_result_id = ? AND work_queue_id != ?`,
-			target.scanResultID, w.id).Scan(&otherID)
-		if err == nil {
-			return false, otherID, nil
+		own[w.id] = true
+	}
+	if len(own) > 0 {
+		otherID, found, err := foreignOwner(ctx, tx, target.scanResultID, own)
+		if err != nil {
+			return relinkDecision{}, err
 		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return false, 0, fmt.Errorf("prune: check present scan_result %d ownership: %w", target.scanResultID, err)
+		if found {
+			return relinkDecision{reason: fmt.Sprintf("present-file candidate already linked to work_queue row %d; merging is identityrepair's job", otherID)}, nil
 		}
 	}
 	for _, w := range c.workItems {
-		if _, err := tx.ExecContext(ctx,
+		res, err := tx.ExecContext(ctx,
 			`UPDATE work_queue SET source_path = ?, outdir = ?, filename = ? WHERE id = ? AND status != 'processing'`,
-			target.filePath, target.outdir, target.filename, w.id); err != nil {
-			return false, 0, fmt.Errorf("prune: relink work_queue %d: %w", w.id, err)
+			target.filePath, target.outdir, target.filename, w.id)
+		if err != nil {
+			return relinkDecision{}, fmt.Errorf("prune: relink work_queue %d: %w", w.id, err)
+		}
+		if rowsAffected(res) == 0 {
+			// The row raced into 'processing' (or vanished) after gather. Decline
+			// the whole candidate rather than deleting its scan_results row out
+			// from under a work_queue row still pointing at the gone path.
+			return relinkDecision{reason: fmt.Sprintf("work_queue row %d became in-flight (or vanished) before the relink could apply; kept for a later pass", w.id)}, nil
 		}
 		if _, err := tx.ExecContext(ctx,
 			`INSERT OR IGNORE INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
 			w.id, target.scanResultID); err != nil {
-			return false, 0, fmt.Errorf("prune: link work_queue %d to scan_result %d: %w", w.id, target.scanResultID, err)
+			return relinkDecision{}, fmt.Errorf("prune: link work_queue %d to scan_result %d: %w", w.id, target.scanResultID, err)
 		}
 	}
 	for _, id := range c.scanResultIDs {
@@ -553,10 +609,39 @@ func relinkOne(ctx context.Context, tx *sql.Tx, c *candidate, target presentRowD
                  JOIN work_queue wq ON wq.id = j.work_queue_id
                  WHERE j.scan_result_id = ? AND wq.status = 'processing')`,
 			id, id); err != nil {
-			return false, 0, fmt.Errorf("prune: delete stale scan_result %d: %w", id, err)
+			return relinkDecision{}, fmt.Errorf("prune: delete stale scan_result %d: %w", id, err)
 		}
 	}
-	return true, 0, nil
+	return relinkDecision{}, nil
+}
+
+// foreignOwner reports whether scanResultID is junction-linked to any
+// work_queue row NOT in own -- the candidate's own set of aggregated work
+// items. Filtering in Go rather than building a variadic NOT IN keeps the
+// query a single fixed statement; the junction row count per scan_result is
+// tiny (normally one), so the scan is trivial.
+func foreignOwner(ctx context.Context, tx *sql.Tx, scanResultID int64, own map[int64]bool) (int64, bool, error) {
+	var foreignID int64
+	var found bool
+	rows, err := tx.QueryContext(ctx,
+		`SELECT work_queue_id FROM work_queue_scan_results WHERE scan_result_id = ?`, scanResultID)
+	if err != nil {
+		return 0, false, fmt.Errorf("prune: check present scan_result %d ownership: %w", scanResultID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return 0, false, fmt.Errorf("prune: check present scan_result %d ownership: %w", scanResultID, err)
+		}
+		if !own[id] && !found {
+			foreignID, found = id, true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, false, fmt.Errorf("prune: check present scan_result %d ownership: %w", scanResultID, err)
+	}
+	return foreignID, found, nil
 }
 
 // presentRowDetail is the detail applyRelinks needs from the present-file

--- a/internal/prune/prune_relink_conflict_test.go
+++ b/internal/prune/prune_relink_conflict_test.go
@@ -1,0 +1,205 @@
+package prune
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/queue"
+)
+
+// seedPresentScanResultOwnedByOtherRow inserts a present-file scan_results row
+// carrying identity, already junction-linked to its OWN separate work_queue
+// row (as if that file had already been fully scanned and enqueued under its
+// own identity, unrelated to the gone candidate this test pairs it against).
+// This is the fixture for the relink-conflict path: the gone candidate's
+// identity match resolves to this scan_results row, but relinkOne must refuse
+// to touch it because a DIFFERENT work_queue row already owns it.
+func seedPresentScanResultOwnedByOtherRow(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, mbid, isrc string) (scanResultID, workQueueID int64) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write present source: %v", err)
+	}
+	res, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid, isrc) VALUES (?, ?, ?, ?, 'done', ?, ?, ?, ?)`,
+		libraryID, filePath, "OtherArtist", "OtherTitle", filepath.Dir(filePath), filepath.Base(filePath), mbid, isrc,
+	)
+	if err != nil {
+		t.Fatalf("insert present scan_result: %v", err)
+	}
+	srID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("present scan_result id: %v", err)
+	}
+	q := queue.NewDBQueue(sqlDB)
+	q.SetRandomized(false)
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:        models.Track{ArtistName: "OtherArtist", TrackName: "OtherTitle"},
+		SourcePath:   filePath,
+		OutputPaths:  []models.OutputPath{{Outdir: filepath.Dir(filePath), Filename: filepath.Base(filePath)}},
+		ScanResultID: srID,
+	}, queue.PriorityScan)
+	if err != nil {
+		t.Fatalf("enqueue other row: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = 'done' WHERE id = ?`, item.ID); err != nil {
+		t.Fatalf("set other row done: %v", err)
+	}
+	return srID, item.ID
+}
+
+// TestSweep_RelinkConflictIsRetainedNotDropped is the regression test for the
+// silent-drop bug found while implementing #640: a gone candidate whose
+// identity match resolves uniquely to a present-file scan_results row that is
+// ALREADY junction-linked to a DIFFERENT work_queue row must not vanish from
+// every outcome count. Before the fix, applyRelinks/relinkOne's `continue` on
+// ok=false dropped such a candidate from Pruned, Relinked, AND Retained alike
+// -- this test fails against that code (verified against 215616c/b4814a8) and
+// passes once the conflict routes through RetainedRow.
+func TestSweep_RelinkConflictIsRetainedNotDropped(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+
+	// The gone candidate: its identity (mbid-shared) will resolve uniquely to
+	// the present-file row below, but that present-file row is owned by a
+	// wholly separate work_queue row.
+	goneOld := filepath.Join(root, "ArtistR", "AlbumOld", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, goneOld, "done", "done", "mbid-shared-r", "")
+	if err := os.Remove(goneOld); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+
+	// The present-file candidate: already fully owned by its OWN work_queue
+	// row (simulating a file that was independently scanned and enqueued
+	// under this identity before the gone row's reconcile pass ran).
+	present := filepath.Join(root, "ArtistR", "AlbumNew", "01. track.flac")
+	presentSrID, presentWqID := seedPresentScanResultOwnedByOtherRow(t, ctx, sqlDB, libID, present, "mbid-shared-r", "")
+
+	beforeSR, beforeWQ, beforeJ := rowCounts(t, ctx, sqlDB)
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// The conflicted candidate must not be pruned or relinked...
+	if len(res.Pruned) != 0 {
+		t.Errorf("Pruned = %d, want 0 (a relink-conflict row must never be genuinely deleted)", len(res.Pruned))
+	}
+	if len(res.Relinked) != 0 {
+		t.Errorf("Relinked = %d, want 0 (relinkOne must refuse a target owned by a different work_queue row)", len(res.Relinked))
+	}
+	// ...it must be RETAINED, with a reason naming the conflicting row -- this
+	// is the assertion that fails against the pre-fix `continue`.
+	if len(res.Retained) != 1 {
+		t.Fatalf("Retained = %d, want 1 (THE BUG: a relink-conflict candidate must not silently vanish from every outcome)", len(res.Retained))
+	}
+	if res.Retained[0].SourcePath != goneOld {
+		t.Errorf("Retained[0].SourcePath = %q, want %q", res.Retained[0].SourcePath, goneOld)
+	}
+	if res.Retained[0].Reason == "" {
+		t.Error("Retained[0].Reason is empty; want a reason naming the conflicting work_queue row")
+	}
+
+	// Nothing was mutated: neither row's data changed, and the present row's
+	// own linkage is untouched.
+	afterSR, afterWQ, afterJ := rowCounts(t, ctx, sqlDB)
+	if afterSR != beforeSR || afterWQ != beforeWQ || afterJ != beforeJ {
+		t.Errorf("row counts changed: before=(%d,%d,%d) after=(%d,%d,%d); want unchanged (retain never mutates)",
+			beforeSR, beforeWQ, beforeJ, afterSR, afterWQ, afterJ)
+	}
+	var owner int64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT work_queue_id FROM work_queue_scan_results WHERE scan_result_id = ?`, presentSrID).Scan(&owner); err != nil {
+		t.Fatalf("query present row owner: %v", err)
+	}
+	if owner != presentWqID {
+		t.Errorf("present scan_result %d owner = %d, want unchanged %d", presentSrID, owner, presentWqID)
+	}
+}
+
+// TestSweep_ThreeWayAccountingInvariant asserts, across a mixed batch
+// exercising every termination path a gone candidate can take (genuine
+// prune, clean relink, relink-conflict retain, absent-identity retain,
+// ambiguous-identity retain), that len(Pruned)+len(Relinked)+len(Retained)
+// equals the number of gone candidates considered -- the invariant #640
+// exists to establish: every row reconcile looks at gets an accounted-for
+// outcome, never a silent drop.
+func TestSweep_ThreeWayAccountingInvariant(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+
+	// 1. Genuine prune: identity present, matches nothing anywhere.
+	prunePath := filepath.Join(root, "Acct1", "01. gone.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, prunePath, "done", "done", "mbid-acct1-nomatch", "")
+	if err := os.Remove(prunePath); err != nil {
+		t.Fatalf("remove acct1: %v", err)
+	}
+
+	// 2. Clean relink: identity matches a present, unowned-elsewhere file.
+	relinkOld := filepath.Join(root, "Acct2", "AlbumOld", "02. relink.flac")
+	relinkNew := filepath.Join(root, "Acct2", "AlbumNew", "02. relink.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, relinkOld, "done", "done", "mbid-acct2-shared", "")
+	if err := os.Remove(relinkOld); err != nil {
+		t.Fatalf("remove acct2: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, relinkNew, "mbid-acct2-shared", "")
+
+	// 3. Relink-conflict retain: identity matches a present file already owned
+	// by a different work_queue row.
+	conflictOld := filepath.Join(root, "Acct3", "AlbumOld", "03. conflict.flac")
+	conflictPresent := filepath.Join(root, "Acct3", "AlbumNew", "03. conflict.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, conflictOld, "done", "done", "mbid-acct3-shared", "")
+	if err := os.Remove(conflictOld); err != nil {
+		t.Fatalf("remove acct3: %v", err)
+	}
+	seedPresentScanResultOwnedByOtherRow(t, ctx, sqlDB, libID, conflictPresent, "mbid-acct3-shared", "")
+
+	// 4. Absent-identity retain.
+	absentPath := filepath.Join(root, "Acct4", "01. gone.flac")
+	seedRow(t, ctx, sqlDB, libID, absentPath, "done", "done")
+	if err := os.Remove(absentPath); err != nil {
+		t.Fatalf("remove acct4: %v", err)
+	}
+
+	// 5. Ambiguous-identity retain: two present candidates share one identity.
+	ambigOld := filepath.Join(root, "Acct5", "AlbumOld", "05. ambig.flac")
+	ambigDupeA := filepath.Join(root, "Acct5", "Dup1", "05. ambig.flac")
+	ambigDupeB := filepath.Join(root, "Acct5", "Dup2", "05. ambig.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, ambigOld, "done", "done", "mbid-acct5-shared", "")
+	if err := os.Remove(ambigOld); err != nil {
+		t.Fatalf("remove acct5: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, ambigDupeA, "mbid-acct5-shared", "")
+	seedPresentScanResult(t, ctx, sqlDB, libID, ambigDupeB, "mbid-acct5-shared", "")
+
+	const wantConsidered = 5
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	got := len(res.Pruned) + len(res.Relinked) + len(res.Retained)
+	if got != wantConsidered {
+		t.Fatalf("pruned(%d)+relinked(%d)+retained(%d) = %d, want %d (every gone candidate must land in exactly one bucket)",
+			len(res.Pruned), len(res.Relinked), len(res.Retained), got, wantConsidered)
+	}
+	// Spot-check the expected split, so a future change that shifts a
+	// candidate into the wrong bucket (rather than dropping it) is also
+	// caught, not just the aggregate count.
+	if len(res.Pruned) != 1 {
+		t.Errorf("Pruned = %d, want 1 (acct1)", len(res.Pruned))
+	}
+	if len(res.Relinked) != 1 {
+		t.Errorf("Relinked = %d, want 1 (acct2)", len(res.Relinked))
+	}
+	if len(res.Retained) != 3 {
+		t.Errorf("Retained = %d, want 3 (acct3 conflict, acct4 absent, acct5 ambiguous)", len(res.Retained))
+	}
+}

--- a/internal/prune/prune_test.go
+++ b/internal/prune/prune_test.go
@@ -132,15 +132,15 @@ func openSeeded(t *testing.T) (context.Context, *sql.DB, int64, string) {
 	return ctx, sqlDB, lib.ID, root
 }
 
-// TestPrunePath_WedgedRowDeletedWhenSourceGone: a failed work_queue row wedged
-// against a processing scan_results row whose source file was removed, with NO
-// stored identity, is pruned across both tables and the junction even under
-// the reactive PolicyRelinkOrRetain -- absent identity has nothing to relink or
-// defer, so it stays subject to the same genuine-delete outcome relink-or-
-// retain reserves for identity-present-no-match rows. Wait: per #640 AC2,
-// identity-ABSENT rows must be retained, not deleted -- see the retain variant
-// below, which supersedes the old always-delete assumption this test name
-// predates. This test now asserts the NEW behavior: retained, not deleted.
+// TestPrunePath_RetainsWedgedRowWithNoIdentity: a failed work_queue row wedged
+// against a processing scan_results row, whose source file was removed and
+// which carries NO stored identity, is RETAINED rather than pruned (#640 AC2).
+// Absent identity has nothing to match on, and prune never deletes on a guess:
+// a wrongly-kept row is inert, while a wrongly-deleted one destroys work that
+// cannot be reconstructed. The row is kept and reported with a reason instead.
+//
+// This supersedes the pre-#640 behavior, where an identity-absent gone row was
+// deleted unconditionally.
 func TestPrunePath_RetainsWedgedRowWithNoIdentity(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	gone := filepath.Join(root, "ArtistA", "AlbumA", "01. gone.flac")
@@ -452,7 +452,13 @@ func TestSweep_RelinkOnExactMBIDMatch(t *testing.T) {
 		t.Fatalf("work_queue.source_path = %q, want %q", got, newPath)
 	}
 	// Exactly one scan_results row remains (the present one at newPath); the
-	// stale gone-path row was deleted as part of the relink.
+	// stale gone-path row was deleted as part of the relink. The COUNT is
+	// asserted first and separately: QueryRowContext silently takes the first
+	// row, so a path assertion alone would still pass if the stale row survived
+	// and merely sorted second.
+	if sr, _, _ := rowCounts(t, ctx, sqlDB); sr != 1 {
+		t.Fatalf("after relink scan_results=%d, want exactly 1 (the stale gone-path row must be deleted)", sr)
+	}
 	var remainingPath string
 	if err := sqlDB.QueryRowContext(ctx, `SELECT file_path FROM scan_results`).Scan(&remainingPath); err != nil {
 		t.Fatalf("query remaining scan_result: %v", err)

--- a/internal/prune/prune_test.go
+++ b/internal/prune/prune_test.go
@@ -16,9 +16,16 @@ import (
 // seedRow inserts a scan_results row for filePath under libraryID with the given
 // scan-side status, enqueues a linked work_queue item (writing the junction via
 // the ScanResultID link), then forces the work_queue row to wqStatus. It writes
-// a real file at filePath so os.Stat reflects presence. Returns the scan_result
-// id and work_queue id.
+// a real file at filePath so os.Stat reflects presence. No identity (mbid/isrc)
+// is stored -- use seedRowWithIdentity for the relink/retain test paths.
 func seedRow(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, srStatus, wqStatus string) {
+	t.Helper()
+	seedRowWithIdentity(t, ctx, sqlDB, libraryID, filePath, srStatus, wqStatus, "", "")
+}
+
+// seedRowWithIdentity is seedRow plus a stored mbid/isrc on the scan_results
+// row, exercising the #640 identity columns (migration 037).
+func seedRowWithIdentity(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, srStatus, wqStatus, mbid, isrc string) int64 {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -27,8 +34,8 @@ func seedRow(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, 
 		t.Fatalf("write source: %v", err)
 	}
 	res, err := sqlDB.ExecContext(ctx,
-		`INSERT INTO scan_results (library_id, file_path, artist, title, status) VALUES (?, ?, ?, ?, ?)`,
-		libraryID, filePath, "Artist", "Title", srStatus)
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid, isrc) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		libraryID, filePath, "Artist", "Title", srStatus, filepath.Dir(filePath), filepath.Base(filePath), mbid, isrc)
 	if err != nil {
 		t.Fatalf("insert scan_result: %v", err)
 	}
@@ -50,6 +57,28 @@ func seedRow(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, 
 	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = ? WHERE id = ?`, wqStatus, item.ID); err != nil {
 		t.Fatalf("set wq status: %v", err)
 	}
+	return srID
+}
+
+// seedPresentScanResult inserts a bare, unlinked scan_results row for a file
+// that already exists on disk (as if a rescan had already discovered a moved
+// file at its new location, before the worker enqueued anything for it),
+// carrying the given identity. This is the "present-file candidate" side of a
+// relink match.
+func seedPresentScanResult(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, mbid, isrc string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write present source: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid, isrc) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
+		libraryID, filePath, "Artist", "Title", filepath.Dir(filePath), filepath.Base(filePath), mbid, isrc,
+	); err != nil {
+		t.Fatalf("insert present scan_result: %v", err)
+	}
 }
 
 func rowCounts(t *testing.T, ctx context.Context, sqlDB *sql.DB) (scanResults, workQueue, junction int) {
@@ -64,6 +93,15 @@ func rowCounts(t *testing.T, ctx context.Context, sqlDB *sql.DB) (scanResults, w
 	return q(`SELECT count(*) FROM scan_results`),
 		q(`SELECT count(*) FROM work_queue`),
 		q(`SELECT count(*) FROM work_queue_scan_results`)
+}
+
+func workQueueSourcePath(t *testing.T, ctx context.Context, sqlDB *sql.DB, id int64) string {
+	t.Helper()
+	var path string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT source_path FROM work_queue WHERE id = ?`, id).Scan(&path); err != nil {
+		t.Fatalf("query source_path: %v", err)
+	}
+	return path
 }
 
 func openSeeded(t *testing.T) (context.Context, *sql.DB, int64, string) {
@@ -86,10 +124,16 @@ func openSeeded(t *testing.T) (context.Context, *sql.DB, int64, string) {
 	return ctx, sqlDB, lib.ID, root
 }
 
-// TestPrunePath_WedgedRowDeletedWhenSourceGone: the ticket's target state --
-// a failed work_queue row wedged against a processing scan_results row whose
-// source file was removed -- is pruned across both tables and the junction.
-func TestPrunePath_WedgedRowDeletedWhenSourceGone(t *testing.T) {
+// TestPrunePath_WedgedRowDeletedWhenSourceGone: a failed work_queue row wedged
+// against a processing scan_results row whose source file was removed, with NO
+// stored identity, is pruned across both tables and the junction even under
+// the reactive PolicyRelinkOrRetain -- absent identity has nothing to relink or
+// defer, so it stays subject to the same genuine-delete outcome relink-or-
+// retain reserves for identity-present-no-match rows. Wait: per #640 AC2,
+// identity-ABSENT rows must be retained, not deleted -- see the retain variant
+// below, which supersedes the old always-delete assumption this test name
+// predates. This test now asserts the NEW behavior: retained, not deleted.
+func TestPrunePath_RetainsWedgedRowWithNoIdentity(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	gone := filepath.Join(root, "ArtistA", "AlbumA", "01. gone.flac")
 	seedRow(t, ctx, sqlDB, libID, gone, "processing", "failed")
@@ -102,32 +146,36 @@ func TestPrunePath_WedgedRowDeletedWhenSourceGone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrunePath: %v", err)
 	}
-	if res.ScanResults != 1 || res.WorkItems != 1 {
-		t.Fatalf("pruned scan=%d wq=%d, want 1/1", res.ScanResults, res.WorkItems)
+	if res.ScanResults != 0 || res.WorkItems != 0 {
+		t.Fatalf("pruned scan=%d wq=%d, want 0/0 (no identity: retained, not deleted)", res.ScanResults, res.WorkItems)
+	}
+	if len(res.Retained) != 1 {
+		t.Fatalf("retained %d rows, want 1", len(res.Retained))
 	}
 	sr, wq, j := rowCounts(t, ctx, sqlDB)
-	if sr != 0 || wq != 0 || j != 0 {
-		t.Fatalf("after prune scan=%d wq=%d junction=%d, want 0/0/0", sr, wq, j)
+	if sr != 1 || wq != 1 || j != 1 {
+		t.Fatalf("after prune scan=%d wq=%d junction=%d, want 1/1/1 (row kept)", sr, wq, j)
 	}
 }
 
-// TestPrunePath_DeletesDoneRowWhenSourceGone: a moved track whose lyrics already
-// completed is 'done' on the queue side; the reconciler must delete it (and its
-// scan_results row) rather than leak the done row while orphaning scan_results.
-func TestPrunePath_DeletesDoneRowWhenSourceGone(t *testing.T) {
+// TestSweep_GenuineDeleteWhenIdentityPresentButUnmatched: AC3 -- a gone row
+// whose identity IS present but matches no candidate anywhere in the library
+// still prunes under PolicyFull (the periodic sweep / CLI), so the table does
+// not grow without bound.
+func TestSweep_GenuineDeleteWhenIdentityPresentButUnmatched(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	gone := filepath.Join(root, "ArtistDone", "01. done.flac")
-	seedRow(t, ctx, sqlDB, libID, gone, "done", "done")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "done", "mbid-nomatch", "")
 	if err := os.Remove(gone); err != nil {
 		t.Fatalf("remove source: %v", err)
 	}
 	p := New(sqlDB)
-	res, err := p.PrunePath(ctx, filepath.Dir(gone))
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
 	if err != nil {
-		t.Fatalf("PrunePath: %v", err)
+		t.Fatalf("Sweep: %v", err)
 	}
 	if res.ScanResults != 1 || res.WorkItems != 1 {
-		t.Fatalf("pruned scan=%d wq=%d, want 1/1 (done row must be deleted)", res.ScanResults, res.WorkItems)
+		t.Fatalf("pruned scan=%d wq=%d, want 1/1 (identity present, no match anywhere: genuine delete)", res.ScanResults, res.WorkItems)
 	}
 	if sr, wq, j := rowCounts(t, ctx, sqlDB); sr != 0 || wq != 0 || j != 0 {
 		t.Fatalf("after prune scan=%d wq=%d junction=%d, want 0/0/0 (no leaked done row)", sr, wq, j)
@@ -142,7 +190,7 @@ func TestPrunePath_DeletesDoneRowWhenSourceGone(t *testing.T) {
 func TestSweep_SkipsUnavailableRoot(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	gone := filepath.Join(root, "ArtistX", "01. x.flac")
-	seedRow(t, ctx, sqlDB, libID, gone, "processing", "failed")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "processing", "failed", "mbid-x", "")
 	// Remove the root's CONTENTS but keep the root directory itself, simulating an
 	// unmounted share whose mountpoint remains present but empty.
 	if err := os.RemoveAll(filepath.Join(root, "ArtistX")); err != nil {
@@ -165,7 +213,7 @@ func TestSweep_SkipsUnavailableRoot(t *testing.T) {
 }
 
 // TestPrunePath_SkipsPresentSource: a row whose source file still exists is
-// never pruned.
+// never touched.
 func TestPrunePath_SkipsPresentSource(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	present := filepath.Join(root, "ArtistB", "01. present.flac")
@@ -176,8 +224,8 @@ func TestPrunePath_SkipsPresentSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrunePath: %v", err)
 	}
-	if res.ScanResults != 0 || res.WorkItems != 0 {
-		t.Fatalf("pruned scan=%d wq=%d, want 0/0 (source present)", res.ScanResults, res.WorkItems)
+	if res.ScanResults != 0 || res.WorkItems != 0 || len(res.Retained) != 0 || len(res.Relinked) != 0 {
+		t.Fatalf("acted on scan=%d wq=%d retained=%d relinked=%d, want all 0 (source present)", res.ScanResults, res.WorkItems, len(res.Retained), len(res.Relinked))
 	}
 	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
 		t.Fatalf("rows removed despite present source: scan=%d wq=%d", sr, wq)
@@ -186,7 +234,7 @@ func TestPrunePath_SkipsPresentSource(t *testing.T) {
 
 // TestPrunePath_DefersInFlightProcessing: a gone source whose linked work_queue
 // row is still 'processing' (the worker owns it) is deferred -- neither the
-// work_queue row nor its scan_results row is deleted, avoiding a half-pruned
+// work_queue row nor its scan_results row is touched, avoiding a half-pruned
 // in-flight item.
 func TestPrunePath_DefersInFlightProcessing(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
@@ -200,8 +248,8 @@ func TestPrunePath_DefersInFlightProcessing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrunePath: %v", err)
 	}
-	if res.ScanResults != 0 || res.WorkItems != 0 {
-		t.Fatalf("pruned an in-flight item: scan=%d wq=%d, want 0/0", res.ScanResults, res.WorkItems)
+	if res.ScanResults != 0 || res.WorkItems != 0 || len(res.Retained) != 0 {
+		t.Fatalf("acted on an in-flight item: scan=%d wq=%d retained=%d, want all 0", res.ScanResults, res.WorkItems, len(res.Retained))
 	}
 	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
 		t.Fatalf("in-flight rows removed: scan=%d wq=%d", sr, wq)
@@ -210,7 +258,8 @@ func TestPrunePath_DefersInFlightProcessing(t *testing.T) {
 
 // TestSweep_DirectoryVsExact: a single-file rename inside a surviving directory
 // (the file is gone but its directory remains) is caught by Granularity: Exact
-// but not by Granularity: Directory.
+// but not by Granularity: Directory. Both rows carry no identity, so the caught
+// row is retained (not deleted) under the new #640 policy.
 func TestSweep_DirectoryVsExact(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	album := filepath.Join(root, "ArtistD", "AlbumD")
@@ -224,24 +273,25 @@ func TestSweep_DirectoryVsExact(t *testing.T) {
 	}
 
 	p := New(sqlDB)
-	// Directory granularity: album dir exists, so nothing is pruned.
+	// Directory granularity: album dir exists, so nothing is touched.
 	dirRes, err := p.Sweep(ctx, SweepOptions{Granularity: Directory})
 	if err != nil {
 		t.Fatalf("Sweep dir: %v", err)
 	}
-	if dirRes.ScanResults != 0 {
-		t.Fatalf("directory sweep pruned %d, want 0 (dir survives)", dirRes.ScanResults)
+	if dirRes.ScanResults != 0 || len(dirRes.Retained) != 0 {
+		t.Fatalf("directory sweep acted on %d/%d, want 0/0 (dir survives)", dirRes.ScanResults, len(dirRes.Retained))
 	}
-	// Exact granularity: the renamed-away file is gone, so its row is pruned.
+	// Exact granularity: the renamed-away file is gone and carries no identity,
+	// so it is retained (not pruned) under the new policy.
 	exactRes, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
 	if err != nil {
 		t.Fatalf("Sweep exact: %v", err)
 	}
-	if exactRes.ScanResults != 1 || exactRes.WorkItems != 1 {
-		t.Fatalf("exact sweep pruned scan=%d wq=%d, want 1/1", exactRes.ScanResults, exactRes.WorkItems)
+	if exactRes.ScanResults != 0 || len(exactRes.Retained) != 1 {
+		t.Fatalf("exact sweep scan=%d retained=%d, want 0/1 (no identity: retained)", exactRes.ScanResults, len(exactRes.Retained))
 	}
-	if sr, _, _ := rowCounts(t, ctx, sqlDB); sr != 1 {
-		t.Fatalf("after exact sweep scan_results=%d, want 1 (kept.flac survives)", sr)
+	if sr, _, _ := rowCounts(t, ctx, sqlDB); sr != 2 {
+		t.Fatalf("after exact sweep scan_results=%d, want 2 (both rows survive: kept.flac present, renamed-away.flac retained)", sr)
 	}
 }
 
@@ -252,8 +302,8 @@ func TestPrunePath_PrefixBoundary(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	fooGone := filepath.Join(root, "Foo", "01. a.flac")
 	barGone := filepath.Join(root, "Foobar", "01. b.flac")
-	seedRow(t, ctx, sqlDB, libID, fooGone, "processing", "failed")
-	seedRow(t, ctx, sqlDB, libID, barGone, "processing", "failed")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, fooGone, "processing", "failed", "mbid-foo", "")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, barGone, "processing", "failed", "mbid-bar", "")
 	// Both source files are gone, but Foobar keeps the root non-empty.
 	if err := os.Remove(fooGone); err != nil {
 		t.Fatalf("remove foo: %v", err)
@@ -266,12 +316,13 @@ func TestPrunePath_PrefixBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrunePath: %v", err)
 	}
-	if res.ScanResults != 1 || res.WorkItems != 1 {
-		t.Fatalf("pruned scan=%d wq=%d, want 1/1 (only Foo, not Foobar)", res.ScanResults, res.WorkItems)
+	if len(res.Retained) != 1 || res.Retained[0].SourcePath != fooGone {
+		t.Fatalf("retained %v, want exactly [%s] (only Foo, not Foobar)", res.Retained, fooGone)
 	}
-	// Foobar's row must survive.
-	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
-		t.Fatalf("sibling Foobar row touched: scan=%d wq=%d, want 1/1", sr, wq)
+	// Foobar's row must survive untouched (identity present, not yet resolved
+	// under the reactive relink-or-retain policy -- and out of scope besides).
+	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 2 || wq != 2 {
+		t.Fatalf("sibling Foobar row touched: scan=%d wq=%d, want 2/2", sr, wq)
 	}
 }
 
@@ -296,9 +347,9 @@ func TestSweep_LibraryScoped(t *testing.T) {
 	}
 	goneA := filepath.Join(rootA, "ArtistA", "01. a.flac")
 	goneB := filepath.Join(rootB, "ArtistB", "01. b.flac")
-	seedRow(t, ctx, sqlDB, libA.ID, goneA, "processing", "failed")
+	seedRowWithIdentity(t, ctx, sqlDB, libA.ID, goneA, "processing", "failed", "mbid-a", "")
 	// libB row: seed under library_id 2 (the second Add). Its file is also gone.
-	seedRow(t, ctx, sqlDB, libA.ID+1, goneB, "processing", "failed")
+	seedRowWithIdentity(t, ctx, sqlDB, libA.ID+1, goneB, "processing", "failed", "mbid-b", "")
 	if err := os.Remove(goneA); err != nil {
 		t.Fatalf("remove A: %v", err)
 	}
@@ -325,7 +376,7 @@ func TestSweep_LibraryScoped(t *testing.T) {
 func TestSweep_DryRunReportsWithoutMutating(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	gone := filepath.Join(root, "ArtistE", "01. gone.flac")
-	seedRow(t, ctx, sqlDB, libID, gone, "processing", "failed")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "processing", "failed", "mbid-e-nomatch", "")
 	if err := os.Remove(gone); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
@@ -344,5 +395,239 @@ func TestSweep_DryRunReportsWithoutMutating(t *testing.T) {
 	}
 	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
 		t.Fatalf("dry-run mutated the DB: scan=%d wq=%d, want 1/1", sr, wq)
+	}
+}
+
+// TestSweep_RelinkOnExactMBIDMatch: the ticket's core scenario -- a bulk move
+// within a library. The old row (carrying detector telemetry via
+// SetInstrumentalResult-shaped columns, simulated here via work_queue status)
+// is gone from its old path, but a file bearing the same MBID is present
+// elsewhere in the library (as a bare, unlinked scan_results row -- as if a
+// rescan had already discovered it). The exact tier relinks: work_queue's
+// source_path moves to the new location, the stale scan_results row is
+// deleted, and the work_queue row itself -- and everything on it -- survives.
+func TestSweep_RelinkOnExactMBIDMatch(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistF", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistF", "AlbumNew", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-f-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "mbid-f-shared", "")
+
+	p := New(sqlDB)
+	var relinked []RelinkedRow
+	res, err := p.Sweep(ctx, SweepOptions{
+		Granularity:    Exact,
+		ReportRelinked: func(rr RelinkedRow) error { relinked = append(relinked, rr); return nil },
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if res.ScanResults != 0 || res.WorkItems != 0 {
+		t.Fatalf("relink also pruned scan=%d wq=%d, want 0/0 (the row survives, it moves)", res.ScanResults, res.WorkItems)
+	}
+	if len(res.Relinked) != 1 || len(relinked) != 1 {
+		t.Fatalf("relinked %d rows (hook saw %d), want 1", len(res.Relinked), len(relinked))
+	}
+	if res.Relinked[0].OldPath != oldPath || res.Relinked[0].NewPath != newPath {
+		t.Fatalf("relinked %+v, want old=%s new=%s", res.Relinked[0], oldPath, newPath)
+	}
+	// The surviving work_queue row (still 'done', telemetry untouched by this
+	// package) now points at the new path.
+	var wqID int64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT id FROM work_queue WHERE status = 'done'`).Scan(&wqID); err != nil {
+		t.Fatalf("query surviving work_queue row: %v", err)
+	}
+	if got := workQueueSourcePath(t, ctx, sqlDB, wqID); got != newPath {
+		t.Fatalf("work_queue.source_path = %q, want %q", got, newPath)
+	}
+	// Exactly one scan_results row remains (the present one at newPath); the
+	// stale gone-path row was deleted as part of the relink.
+	var remainingPath string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT file_path FROM scan_results`).Scan(&remainingPath); err != nil {
+		t.Fatalf("query remaining scan_result: %v", err)
+	}
+	if remainingPath != newPath {
+		t.Fatalf("remaining scan_results.file_path = %q, want %q", remainingPath, newPath)
+	}
+}
+
+// TestSweep_RelinkOnExactISRCMatch: same as the MBID case, but the identity
+// signal is ISRC-only (no MBID on either side), covering AC1's "or ISRC" half.
+func TestSweep_RelinkOnExactISRCMatch(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistG", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistG", "AlbumNew", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "", "isrc-g-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "", "isrc-g-shared")
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Relinked) != 1 || res.Relinked[0].NewPath != newPath {
+		t.Fatalf("Relinked = %+v, want one row to %s", res.Relinked, newPath)
+	}
+	if res.ScanResults != 0 || res.WorkItems != 0 {
+		t.Fatalf("ISRC relink also pruned scan=%d wq=%d, want 0/0", res.ScanResults, res.WorkItems)
+	}
+}
+
+// TestSweep_RetainsOnAmbiguousIdentity: AC2 -- when a gone row's identity
+// matches MORE THAN ONE present candidate, it is retained and reported, never
+// guessed at.
+func TestSweep_RetainsOnAmbiguousIdentity(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistH", "AlbumOld", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-h-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	dupeA := filepath.Join(root, "ArtistH", "Dup1", "01. track.flac")
+	dupeB := filepath.Join(root, "ArtistH", "Dup2", "01. track.flac")
+	seedPresentScanResult(t, ctx, sqlDB, libID, dupeA, "mbid-h-shared", "")
+	seedPresentScanResult(t, ctx, sqlDB, libID, dupeB, "mbid-h-shared", "")
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Relinked) != 0 || res.ScanResults != 0 || res.WorkItems != 0 {
+		t.Fatalf("ambiguous identity acted on: relinked=%d scan=%d wq=%d, want 0/0/0", len(res.Relinked), res.ScanResults, res.WorkItems)
+	}
+	if len(res.Retained) != 1 || res.Retained[0].SourcePath != oldPath {
+		t.Fatalf("retained %v, want exactly [%s]", res.Retained, oldPath)
+	}
+	// Nothing was deleted: the original gone row and both duplicate candidates
+	// all survive.
+	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 3 || wq != 1 {
+		t.Fatalf("after ambiguous sweep scan=%d wq=%d, want 3/1 (nothing deleted)", sr, wq)
+	}
+}
+
+// TestPrunePath_RelinkOrRetainNeverGenuineDeletes: the reactive path (#640 AC5
+// / Design Choice 3) never performs a genuine delete even when identity is
+// present and currently unmatched -- it retains, deferring to the periodic
+// sweep, to avoid racing a rescan of the file's new location that has not yet
+// run.
+func TestPrunePath_RelinkOrRetainNeverGenuineDeletes(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistI", "01. gone.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "done", "mbid-i-nomatch-yet", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	p := New(sqlDB)
+	res, err := p.PrunePath(ctx, filepath.Dir(gone))
+	if err != nil {
+		t.Fatalf("PrunePath: %v", err)
+	}
+	if res.ScanResults != 0 || res.WorkItems != 0 {
+		t.Fatalf("reactive path genuinely deleted: scan=%d wq=%d, want 0/0", res.ScanResults, res.WorkItems)
+	}
+	if len(res.Retained) != 1 {
+		t.Fatalf("retained %d rows, want 1", len(res.Retained))
+	}
+	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
+		t.Fatalf("reactive path mutated rows: scan=%d wq=%d, want 1/1 (kept)", sr, wq)
+	}
+}
+
+// TestSweep_RelinkDryRunReportsWithoutMutating: a relink candidate under
+// DryRun is reported via ReportRelinked but the database is left untouched.
+func TestSweep_RelinkDryRunReportsWithoutMutating(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistJ", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistJ", "AlbumNew", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-j-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "mbid-j-shared", "")
+
+	var reported int
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{
+		Granularity:    Exact,
+		DryRun:         true,
+		ReportRelinked: func(RelinkedRow) error { reported++; return nil },
+	})
+	if err != nil {
+		t.Fatalf("Sweep dry-run: %v", err)
+	}
+	if len(res.Relinked) != 1 || reported != 1 {
+		t.Fatalf("dry-run relinked=%d hook=%d, want 1/1", len(res.Relinked), reported)
+	}
+	if got := workQueueSourcePath(t, ctx, sqlDB, mustWorkQueueID(t, ctx, sqlDB)); got != oldPath {
+		t.Fatalf("dry-run mutated source_path to %q, want unchanged %q", got, oldPath)
+	}
+	if sr, _, _ := rowCounts(t, ctx, sqlDB); sr != 2 {
+		t.Fatalf("dry-run mutated scan_results: %d rows, want 2 (both survive)", sr)
+	}
+}
+
+func mustWorkQueueID(t *testing.T, ctx context.Context, sqlDB *sql.DB) int64 {
+	t.Helper()
+	var id int64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT id FROM work_queue LIMIT 1`).Scan(&id); err != nil {
+		t.Fatalf("query work_queue id: %v", err)
+	}
+	return id
+}
+
+// TestSetIdentityKeys_ISRCFirstHonorsOperatorOrder: SetIdentityKeys overrides
+// the default mbid-first order, matching config.RealignConfig.IdentityKeys so
+// prune and realign can never disagree about key precedence. With isrc first
+// and a row carrying an isrc match plus an unrelated (non-matching) mbid, the
+// isrc-first order still resolves it via the earlier-checked key.
+func TestSetIdentityKeys_ISRCFirstHonorsOperatorOrder(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistK", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistK", "AlbumNew", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-k-unrelated", "isrc-k-shared")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "", "isrc-k-shared")
+
+	p := New(sqlDB)
+	p.SetIdentityKeys([]string{"isrc", "mbid"})
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Relinked) != 1 || res.Relinked[0].NewPath != newPath {
+		t.Fatalf("Relinked = %+v, want one row to %s", res.Relinked, newPath)
+	}
+}
+
+// TestSetIdentityKeys_IgnoresEmptyOrInvalidOverride: passing no valid keys
+// leaves the existing (default) order in place rather than disabling the
+// exact tier altogether.
+func TestSetIdentityKeys_IgnoresEmptyOrInvalidOverride(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistL", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistL", "AlbumNew", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-l-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "mbid-l-shared", "")
+
+	p := New(sqlDB)
+	p.SetIdentityKeys([]string{"spotify_id", "not-a-real-key"})
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Relinked) != 1 {
+		t.Fatalf("Relinked = %d rows, want 1 (default mbid/isrc order preserved)", len(res.Relinked))
 	}
 }

--- a/internal/prune/prune_test.go
+++ b/internal/prune/prune_test.go
@@ -64,8 +64,10 @@ func seedRowWithIdentity(t *testing.T, ctx context.Context, sqlDB *sql.DB, libra
 // that already exists on disk (as if a rescan had already discovered a moved
 // file at its new location, before the worker enqueued anything for it),
 // carrying the given identity. This is the "present-file candidate" side of a
-// relink match.
-func seedPresentScanResult(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, mbid, isrc string) {
+// relink match. It returns the new scan_results row's id, which the
+// ownership-conflict and in-flight-race tests need in order to wire the
+// junction table by hand.
+func seedPresentScanResult(t *testing.T, ctx context.Context, sqlDB *sql.DB, libraryID int64, filePath, mbid, isrc string) int64 {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -73,12 +75,18 @@ func seedPresentScanResult(t *testing.T, ctx context.Context, sqlDB *sql.DB, lib
 	if err := os.WriteFile(filePath, []byte("audio"), 0o600); err != nil {
 		t.Fatalf("write present source: %v", err)
 	}
-	if _, err := sqlDB.ExecContext(ctx,
+	res, err := sqlDB.ExecContext(ctx,
 		`INSERT INTO scan_results (library_id, file_path, artist, title, status, outdir, filename, recording_mbid, isrc) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
 		libraryID, filePath, "Artist", "Title", filepath.Dir(filePath), filepath.Base(filePath), mbid, isrc,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("insert present scan_result: %v", err)
 	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("present scan_result id: %v", err)
+	}
+	return id
 }
 
 func rowCounts(t *testing.T, ctx context.Context, sqlDB *sql.DB) (scanResults, workQueue, junction int) {
@@ -584,18 +592,29 @@ func mustWorkQueueID(t *testing.T, ctx context.Context, sqlDB *sql.DB) int64 {
 
 // TestSetIdentityKeys_ISRCFirstHonorsOperatorOrder: SetIdentityKeys overrides
 // the default mbid-first order, matching config.RealignConfig.IdentityKeys so
-// prune and realign can never disagree about key precedence. With isrc first
-// and a row carrying an isrc match plus an unrelated (non-matching) mbid, the
-// isrc-first order still resolves it via the earlier-checked key.
+// prune and realign can never disagree about key precedence.
+//
+// The fixture is built so key PRECEDENCE is the only thing that can decide the
+// answer: the gone row carries BOTH an mbid and an isrc, and TWO distinct
+// present files are in the pool -- one matching only on mbid, the other only on
+// isrc. mbid-first selects the mbid file; isrc-first selects the isrc file. The
+// test asserts the isrc file was chosen, so flipping the implementation's key
+// order makes it fail. (An earlier version of this test gave the present row an
+// empty mbid, which made the mbid key match nothing and the assertion pass
+// under either order -- it proved nothing about precedence.)
 func TestSetIdentityKeys_ISRCFirstHonorsOperatorOrder(t *testing.T) {
 	ctx, sqlDB, libID, root := openSeeded(t)
 	oldPath := filepath.Join(root, "ArtistK", "AlbumOld", "01. track.flac")
-	newPath := filepath.Join(root, "ArtistK", "AlbumNew", "01. track.flac")
-	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-k-unrelated", "isrc-k-shared")
+	isrcMatch := filepath.Join(root, "ArtistK", "ByISRC", "01. track.flac")
+	mbidMatch := filepath.Join(root, "ArtistK", "ByMBID", "01. track.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-k-shared", "isrc-k-shared")
 	if err := os.Remove(oldPath); err != nil {
 		t.Fatalf("remove old: %v", err)
 	}
-	seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "", "isrc-k-shared")
+	// Each present candidate matches on EXACTLY ONE key, and on a different one,
+	// so the two key orders resolve to two different files.
+	seedPresentScanResult(t, ctx, sqlDB, libID, isrcMatch, "mbid-k-other", "isrc-k-shared")
+	seedPresentScanResult(t, ctx, sqlDB, libID, mbidMatch, "mbid-k-shared", "isrc-k-other")
 
 	p := New(sqlDB)
 	p.SetIdentityKeys([]string{"isrc", "mbid"})
@@ -603,8 +622,241 @@ func TestSetIdentityKeys_ISRCFirstHonorsOperatorOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
+	if len(res.Relinked) != 1 {
+		t.Fatalf("Relinked = %+v, want exactly one row", res.Relinked)
+	}
+	if res.Relinked[0].NewPath != isrcMatch {
+		t.Fatalf("isrc-first resolved to %q, want the ISRC-matching file %q (mbid-match candidate was %q)",
+			res.Relinked[0].NewPath, isrcMatch, mbidMatch)
+	}
+	// Assert the artifact, not just the report: the surviving work_queue row
+	// actually points at the ISRC-matched file.
+	if got := workQueueSourcePath(t, ctx, sqlDB, mustWorkQueueID(t, ctx, sqlDB)); got != isrcMatch {
+		t.Fatalf("work_queue.source_path = %q, want %q", got, isrcMatch)
+	}
+}
+
+// seedExtraWorkItem inserts a SECOND work_queue row sharing sourcePath with an
+// existing candidate (source_path carries no uniqueness constraint), optionally
+// junction-linking it to linkScanResultID. artist/title must differ from the
+// first row's because idx_work_queue_artist_title_key is unique. It returns the
+// new row's id.
+func seedExtraWorkItem(t *testing.T, ctx context.Context, sqlDB *sql.DB, sourcePath, artist, title, status string, linkScanResultID int64) int64 {
+	t.Helper()
+	res, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO work_queue (artist, title, artist_key, title_key, outdir, filename, source_path, output_paths, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, '', ?)`,
+		artist, title, artist, title, filepath.Dir(sourcePath), filepath.Base(sourcePath), sourcePath, status)
+	if err != nil {
+		t.Fatalf("insert extra work_queue row: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("extra work_queue id: %v", err)
+	}
+	if linkScanResultID != 0 {
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT OR IGNORE INTO work_queue_scan_results (work_queue_id, scan_result_id) VALUES (?, ?)`,
+			id, linkScanResultID); err != nil {
+			t.Fatalf("link extra work_queue row: %v", err)
+		}
+	}
+	return id
+}
+
+func workQueueStatus(t *testing.T, ctx context.Context, sqlDB *sql.DB, id int64) string {
+	t.Helper()
+	var status string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT status FROM work_queue WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("query status: %v", err)
+	}
+	return status
+}
+
+func scanResultExists(t *testing.T, ctx context.Context, sqlDB *sql.DB, id int64) bool {
+	t.Helper()
+	var n int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM scan_results WHERE id = ?`, id).Scan(&n); err != nil {
+		t.Fatalf("count scan_results %d: %v", id, err)
+	}
+	return n > 0
+}
+
+// TestSweep_SiblingWorkItemIsNotAnOwnershipConflict: gatherCandidates
+// aggregates EVERY work_queue row sharing a source_path into ONE candidate, so
+// a candidate can hold more than one work item. When one of those SIBLINGS
+// already junction-owns the present-file target, that is not a foreign
+// ownership conflict -- it is the candidate conflicting with itself. Excluding
+// only the currently-examined row from the ownership probe made the relink
+// report a false conflict and retain the row FOREVER.
+//
+// Preconditions asserted first (the candidate really does hold 2 work items,
+// and the sibling really does own the target), then the effect: no retained
+// row, a relink applied, and both work items moved to the new path with the
+// stale scan_results row gone.
+func TestSweep_SiblingWorkItemIsNotAnOwnershipConflict(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistM", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistM", "AlbumNew", "01. track.flac")
+	staleSRID := seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-m-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	presentSRID := seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "mbid-m-shared", "")
+	// The sibling: a second work_queue row on the SAME gone source_path that
+	// ALREADY owns the present-file scan_results row (as a prior partial relink
+	// or a rescan-driven enqueue would leave it).
+	siblingID := seedExtraWorkItem(t, ctx, sqlDB, oldPath, "Artist Sibling", "Title Sibling", "done", presentSRID)
+	firstID := mustWorkQueueIDExcept(t, ctx, sqlDB, siblingID)
+
+	// PRECONDITION 1: the candidate aggregation really produces >1 work item.
+	bySource, err := New(sqlDB).gatherCandidates(ctx, scope{}, nil)
+	if err != nil {
+		t.Fatalf("gatherCandidates: %v", err)
+	}
+	c, ok := bySource[oldPath]
+	if !ok {
+		t.Fatalf("no candidate gathered for %s", oldPath)
+	}
+	if len(c.workItems) != 2 {
+		t.Fatalf("candidate holds %d work items, want 2 -- the aggregation this test depends on did not happen", len(c.workItems))
+	}
+	// PRECONDITION 2: the sibling really owns the target scan_result.
+	var owner int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT work_queue_id FROM work_queue_scan_results WHERE scan_result_id = ?`, presentSRID).Scan(&owner); err != nil {
+		t.Fatalf("query target owner: %v", err)
+	}
+	if owner != siblingID {
+		t.Fatalf("target scan_result owned by work_queue %d, want the sibling %d", owner, siblingID)
+	}
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Retained) != 0 {
+		t.Fatalf("false ownership conflict: retained %+v, want none (the owner is this candidate's own sibling)", res.Retained)
+	}
 	if len(res.Relinked) != 1 || res.Relinked[0].NewPath != newPath {
-		t.Fatalf("Relinked = %+v, want one row to %s", res.Relinked, newPath)
+		t.Fatalf("Relinked = %+v, want one row relinked to %s", res.Relinked, newPath)
+	}
+	// The artifact: BOTH work items now point at the new path, and the stale
+	// gone-path scan_results row is gone while the present one survives.
+	for _, id := range []int64{firstID, siblingID} {
+		if got := workQueueSourcePath(t, ctx, sqlDB, id); got != newPath {
+			t.Fatalf("work_queue %d source_path = %q, want %q", id, got, newPath)
+		}
+	}
+	if scanResultExists(t, ctx, sqlDB, staleSRID) {
+		t.Fatalf("stale scan_results %d survived the relink", staleSRID)
+	}
+	if !scanResultExists(t, ctx, sqlDB, presentSRID) {
+		t.Fatalf("present scan_results %d was deleted", presentSRID)
+	}
+}
+
+// mustWorkQueueIDExcept returns the single work_queue row id that is not except.
+func mustWorkQueueIDExcept(t *testing.T, ctx context.Context, sqlDB *sql.DB, except int64) int64 {
+	t.Helper()
+	var id int64
+	if err := sqlDB.QueryRowContext(ctx, `SELECT id FROM work_queue WHERE id != ? LIMIT 1`, except).Scan(&id); err != nil {
+		t.Fatalf("query other work_queue id: %v", err)
+	}
+	return id
+}
+
+// TestSweep_RelinkDeclinedWhenWorkItemRacesIntoProcessing: the relink UPDATE is
+// guarded on `status != 'processing'`. A work item that flips to 'processing'
+// between gatherCandidates and the relink transaction therefore updates ZERO
+// rows. Ignoring that result and pressing on would junction-link and then
+// DELETE the stale scan_results row while the work_queue row still pointed at
+// the vanished path -- silent data loss reported as a successful relink.
+//
+// The race window is between gatherCandidates and applyRelinks, both internal
+// to a single Sweep call with no seam in between, so the test drives the two
+// halves directly: snapshot the candidate with gatherCandidates exactly as
+// reconcile does, flip the row to 'processing', then call applyRelinks with
+// that (now stale) snapshot. That is precisely the state a real worker claim
+// produces, with no sleeps or goroutine scheduling to make it flaky.
+func TestSweep_RelinkDeclinedWhenWorkItemRacesIntoProcessing(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	oldPath := filepath.Join(root, "ArtistN", "AlbumOld", "01. track.flac")
+	newPath := filepath.Join(root, "ArtistN", "AlbumNew", "01. track.flac")
+	staleSRID := seedRowWithIdentity(t, ctx, sqlDB, libID, oldPath, "done", "done", "mbid-n-shared", "")
+	if err := os.Remove(oldPath); err != nil {
+		t.Fatalf("remove old: %v", err)
+	}
+	presentSRID := seedPresentScanResult(t, ctx, sqlDB, libID, newPath, "mbid-n-shared", "")
+
+	p := New(sqlDB)
+	// Snapshot the candidate exactly as reconcile would, BEFORE the race.
+	bySource, err := p.gatherCandidates(ctx, scope{}, nil)
+	if err != nil {
+		t.Fatalf("gatherCandidates: %v", err)
+	}
+	c, ok := bySource[oldPath]
+	if !ok {
+		t.Fatalf("no candidate gathered for %s", oldPath)
+	}
+	if len(c.workItems) != 1 {
+		t.Fatalf("candidate holds %d work items, want 1", len(c.workItems))
+	}
+	wqID := c.workItems[0].id
+
+	// THE RACE: a worker claims the row after gather, before the relink applies.
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE work_queue SET status = 'processing' WHERE id = ?`, wqID); err != nil {
+		t.Fatalf("simulate race into processing: %v", err)
+	}
+
+	var retainedSeen []RetainedRow
+	var relinkedSeen []RelinkedRow
+	applied, retained, err := p.applyRelinks(ctx, []classifiedRelink{{
+		src:      oldPath,
+		c:        c,
+		relinked: RelinkedRow{OldPath: oldPath, NewPath: newPath, ScanResultIDs: c.scanResultIDs, WorkItemIDs: []int64{wqID}, MBID: "mbid-n-shared"},
+		target:   presentRowDetail{scanResultID: presentSRID, filePath: newPath, outdir: filepath.Dir(newPath), filename: filepath.Base(newPath)},
+	}},
+		func(rr RelinkedRow) error { relinkedSeen = append(relinkedSeen, rr); return nil },
+		func(rr RetainedRow) error { retainedSeen = append(retainedSeen, rr); return nil },
+	)
+	if err != nil {
+		t.Fatalf("applyRelinks: %v", err)
+	}
+
+	// NOT reported as a successful relink.
+	if len(applied) != 0 || len(relinkedSeen) != 0 {
+		t.Fatalf("a zero-row UPDATE was reported as a relink: applied=%+v hook=%+v", applied, relinkedSeen)
+	}
+	// Reported as retained, under the keep-and-report principle.
+	if len(retained) != 1 || len(retainedSeen) != 1 || retained[0].SourcePath != oldPath {
+		t.Fatalf("retained = %+v (hook %+v), want exactly one row for %s", retained, retainedSeen, oldPath)
+	}
+	// THE ARTIFACT that matters: the stale scan_results row SURVIVED. Deleting
+	// it here would strand a work_queue row pointing at a path that no longer
+	// exists, with nothing left to reconstruct it from.
+	if !scanResultExists(t, ctx, sqlDB, staleSRID) {
+		t.Fatalf("stale scan_results %d was deleted despite the relink not applying -- silent data loss", staleSRID)
+	}
+	if !scanResultExists(t, ctx, sqlDB, presentSRID) {
+		t.Fatalf("present scan_results %d disappeared", presentSRID)
+	}
+	// The work_queue row is untouched: still processing, still on the old path.
+	if got := workQueueSourcePath(t, ctx, sqlDB, wqID); got != oldPath {
+		t.Fatalf("work_queue %d source_path = %q, want unchanged %q", wqID, got, oldPath)
+	}
+	if got := workQueueStatus(t, ctx, sqlDB, wqID); got != "processing" {
+		t.Fatalf("work_queue %d status = %q, want processing", wqID, got)
+	}
+	// No junction row to the present-file target was left behind.
+	var links int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT count(*) FROM work_queue_scan_results WHERE scan_result_id = ?`, presentSRID).Scan(&links); err != nil {
+		t.Fatalf("count junction rows: %v", err)
+	}
+	if links != 0 {
+		t.Fatalf("junction row(s) to the present target survived a declined relink: %d", links)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `prune` now consults the shared identity resolver before deleting a row whose source file has vanished. On a unique MBID/ISRC match the row is **relinked** to the file's new path; when identity is absent or ambiguous the row is **kept and reported**, never deleted on a guess.
- Fixes the destructive case in #640: a bulk move previously destroyed detector telemetry (each row costing a YAMNet inference run), timing verdicts, and completion provenance, because `os.Stat` was the sole authority and a move is indistinguishable from a deletion by path alone.
- A file with no identity match anywhere still prunes, so the table cannot grow without bound.

## Linked issue

Closes #640

## Stacked PR

**Base is `feat/640a-identity-extraction` (#656), not `main`.** This consumes the `internal/identity` package that PR adds. Merge #656 first; this diff shows only the prune/CLI changes.

## Why keep-and-report is the default

The costs are asymmetric. A wrongly-KEPT row is inert -- it matches no file, costs a few KB, and the next scan re-enqueues the track normally. A wrongly-DELETED row destroys a GPU-class inference result that is expensive or impossible to regain.

## Reactive vs periodic

The reactive `PrunePath` (fired the moment a watcher reports a path gone) never performs a genuine delete -- only relink-or-retain. At that instant a rescan of the file's new location almost certainly has not happened, so a "no match anywhere" verdict would be a false positive. Genuine deletion is reserved for the periodic sweep and the CLI, which run after rescans settle.

## Three-way accounting invariant

Every gone candidate must land in exactly one of pruned / relinked / retained. Adding that invariant as a test exposed a silent drop: a relink target already owned by a different `work_queue` row fell through a bare `continue` and vanished from all three counts. Not data loss -- nothing in the DB was touched -- but a row disappearing from every count with no reason contradicts the keep-and-report principle this feature exists to establish. It now routes through `RetainedRow` with a reason naming the conflict.

Both new tests were verified to FAIL when the fix is reverted, so they are regression locks rather than tautologies.

## Test plan

- [x] `make gate` green
- [x] Patch coverage 81.30% (326/401); reconcile_paths.go 81.5%, prune.go 75.0%
- [x] Bulk move preserves telemetry for MBID-carrying and ISRC-only files
- [x] Absent identity and ambiguous identity both retained + reported
- [x] Genuinely deleted file with no match anywhere still prunes
- [x] Dry-run default with fsynced JSONL backup across all three outcomes
- [x] golangci-lint 0 issues, actionlint, govulncheck clean
- [ ] Reviewer follow-ups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciles missing files by relinking them when a unique identity match is found.
  * Retains unresolved or ambiguous files instead of deleting them.
  * Supports configurable identity-key precedence for reconciliation.
  * Adds detailed reconciliation reporting and JSONL backups for pruned, relinked, and retained records.
  * Displays relinked and retained counts in command results.

* **Bug Fixes**
  * Prevents relink conflicts and unresolved identities from being silently discarded.
  * Applies consistent identity settings across reactive and periodic cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->