### PR TITLE
feat(cache): add Invalidate to repudiate a cached lyrics entry

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -78,6 +78,55 @@ func (r *CacheRepo) Lookup(ctx context.Context, artist, title string, durationBu
 	return lyrics, nil
 }
 
+// Execer is the subset of *sql.DB / *sql.Tx that Invalidate needs, so a caller
+// holding an open transaction can invalidate inside it rather than on its own
+// connection.
+type Execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// Invalidate deletes every cached entry for (artist, title) across ALL duration
+// buckets and returns the number of rows removed.
+//
+// Deleting every bucket -- not just the caller's -- is deliberate and load-bearing.
+// Lookup falls back to the bucket-0 unknown-duration sentinel row whenever an
+// exact-bucket lookup misses, so removing only one bucket can leave a sibling row
+// that still satisfies the very lookup the caller is trying to defeat. The cache
+// key carries no provenance, so a caller that has repudiated a track's lyrics
+// (purge-provenance, #474) cannot distinguish "the entry I purged" from "some
+// other bucket's copy of the same purged fetch": the honest invalidation is all of
+// them. Over-deleting costs at most one re-fetch; under-deleting silently defeats
+// the caller.
+//
+// Keys are normalized exactly as Store and Lookup normalize them, so the deleted
+// key is the same key a subsequent Lookup would probe. Empty artist/title are not
+// special-cased -- an identity-less row is looked up under ("", "") and so is
+// invalidated under ("", "").
+func Invalidate(ctx context.Context, ex Execer, artist, title string) (int, error) {
+	res, err := ex.ExecContext(ctx,
+		`DELETE FROM lyrics_cache WHERE artist=? AND title=?`,
+		normalize.NormalizeKey(artist),
+		normalize.NormalizeKey(title),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("cache: invalidate: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		// The delete committed; only the count is unavailable. Report success with
+		// an unknown count rather than making the caller treat this as a failure.
+		return 0, nil
+	}
+	return int(n), nil
+}
+
+// Invalidate deletes every cached entry for (artist, title) across all duration
+// buckets on the repository's own connection. See the package-level Invalidate
+// for why every bucket is removed.
+func (r *CacheRepo) Invalidate(ctx context.Context, artist, title string) (int, error) {
+	return Invalidate(ctx, r.db, artist, title)
+}
+
 // CacheStats returns the process-lifetime cache hit and lookup counts. hits is
 // the number of Lookup calls served from cache (either the exact bucket or the
 // bucket-0 fallback); lookups is the total number of Lookup calls. Both are

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -286,3 +286,176 @@ func TestCacheStats_ConcurrentLookupsRace(t *testing.T) {
 		t.Errorf("hits = %d, want %d (every concurrent lookup is a hit)", hits, want)
 	}
 }
+
+// TestInvalidate_RemovesEveryDurationBucket is the load-bearing property:
+// Lookup falls back to the bucket-0 sentinel on an exact-bucket miss, so an
+// invalidation that spares any bucket can still be satisfied by a sibling row.
+func TestInvalidate_RemovesEveryDurationBucket(t *testing.T) {
+	ctx := context.Background()
+	repo := cache.New(openTestDB(t))
+
+	for _, bucket := range []int{0, 36, 42} {
+		if err := repo.Store(ctx, "Artist", "Song", bucket, "lyrics"); err != nil {
+			t.Fatalf("Store bucket %d: %v", bucket, err)
+		}
+	}
+	n, err := repo.Invalidate(ctx, "Artist", "Song")
+	if err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("Invalidate removed %d rows, want 3", n)
+	}
+	for _, bucket := range []int{0, 36, 42, 99} {
+		if _, lerr := repo.Lookup(ctx, "Artist", "Song", bucket); !errors.Is(lerr, sql.ErrNoRows) {
+			t.Errorf("Lookup bucket %d after Invalidate: err = %v, want sql.ErrNoRows", bucket, lerr)
+		}
+	}
+}
+
+// TestInvalidate_ScopedToKey verifies invalidation does not spill onto other
+// tracks, which would trigger a library-wide re-fetch wave.
+func TestInvalidate_ScopedToKey(t *testing.T) {
+	ctx := context.Background()
+	repo := cache.New(openTestDB(t))
+
+	if err := repo.Store(ctx, "Artist", "Song", 0, "target"); err != nil {
+		t.Fatalf("Store target: %v", err)
+	}
+	if err := repo.Store(ctx, "Artist", "Other Song", 0, "keep"); err != nil {
+		t.Fatalf("Store sibling title: %v", err)
+	}
+	if err := repo.Store(ctx, "Other Artist", "Song", 0, "keep"); err != nil {
+		t.Fatalf("Store sibling artist: %v", err)
+	}
+	n, err := repo.Invalidate(ctx, "Artist", "Song")
+	if err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Invalidate removed %d rows, want 1", n)
+	}
+	if _, lerr := repo.Lookup(ctx, "Artist", "Other Song", 0); lerr != nil {
+		t.Errorf("sibling title destroyed: %v", lerr)
+	}
+	if _, lerr := repo.Lookup(ctx, "Other Artist", "Song", 0); lerr != nil {
+		t.Errorf("sibling artist destroyed: %v", lerr)
+	}
+}
+
+// TestInvalidate_NormalizesKeys verifies Invalidate normalizes its key exactly
+// as Store and Lookup do, so a differently-cased caller still clears the entry
+// a later Lookup would find.
+func TestInvalidate_NormalizesKeys(t *testing.T) {
+	ctx := context.Background()
+	repo := cache.New(openTestDB(t))
+
+	if err := repo.Store(ctx, "The Artist", "Song Title", 0, "lyrics"); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	n, err := repo.Invalidate(ctx, "  THE ARTIST  ", "song title")
+	if err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Invalidate removed %d rows, want 1 (keys must normalize)", n)
+	}
+	if _, lerr := repo.Lookup(ctx, "The Artist", "Song Title", 0); !errors.Is(lerr, sql.ErrNoRows) {
+		t.Errorf("entry survived a normalized invalidate: %v", lerr)
+	}
+}
+
+// TestInvalidate_MissIsNotAnError verifies invalidating an absent key succeeds
+// with a zero count, so a caller purging a track that was never cached is not
+// forced to treat the no-op as a failure.
+func TestInvalidate_MissIsNotAnError(t *testing.T) {
+	ctx := context.Background()
+	repo := cache.New(openTestDB(t))
+
+	n, err := repo.Invalidate(ctx, "Nobody", "Nothing")
+	if err != nil {
+		t.Fatalf("Invalidate on a miss: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Invalidate removed %d rows, want 0", n)
+	}
+}
+
+// TestInvalidate_InsideTransactionRollsBack verifies the Execer seam: an
+// invalidation performed inside a caller's transaction is undone when that
+// transaction rolls back, which is what lets purge-provenance commit the row
+// reset and the invalidation atomically.
+func TestInvalidate_InsideTransactionRollsBack(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := cache.New(sqlDB)
+
+	if err := repo.Store(ctx, "Artist", "Song", 0, "lyrics"); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if _, ierr := cache.Invalidate(ctx, tx, "Artist", "Song"); ierr != nil {
+		t.Fatalf("Invalidate in tx: %v", ierr)
+	}
+	if rerr := tx.Rollback(); rerr != nil {
+		t.Fatalf("Rollback: %v", rerr)
+	}
+	if _, lerr := repo.Lookup(ctx, "Artist", "Song", 0); lerr != nil {
+		t.Errorf("rolled-back invalidation still removed the entry: %v", lerr)
+	}
+}
+
+// TestInvalidate_ReportsExecFailure verifies a failed invalidation surfaces as
+// an error rather than a silent zero-count no-op. A caller that deletes a user's
+// file on the strength of "the cache is now clear" must be told when it is not.
+func TestInvalidate_ReportsExecFailure(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := cache.New(sqlDB)
+
+	if _, err := sqlDB.ExecContext(ctx, `DROP TABLE lyrics_cache`); err != nil {
+		t.Fatalf("drop lyrics_cache: %v", err)
+	}
+	if _, err := repo.Invalidate(ctx, "Artist", "Song"); err == nil {
+		t.Error("Invalidate against a missing table returned nil error")
+	}
+}
+
+// TestStore_ReportsExecFailure verifies a failed Store surfaces as an error.
+// The worker treats a Store failure as non-fatal, so this is the only place the
+// error is actually asserted to exist.
+func TestStore_ReportsExecFailure(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := cache.New(sqlDB)
+
+	if _, err := sqlDB.ExecContext(ctx, `DROP TABLE lyrics_cache`); err != nil {
+		t.Fatalf("drop lyrics_cache: %v", err)
+	}
+	if err := repo.Store(ctx, "Artist", "Song", 0, "lyrics"); err == nil {
+		t.Error("Store against a missing table returned nil error")
+	}
+}
+
+// TestLookup_ReportsExecFailure verifies a Lookup failure that is not
+// sql.ErrNoRows propagates, so a caller cannot mistake a broken database for a
+// clean cache miss and act on it.
+func TestLookup_ReportsExecFailure(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := cache.New(sqlDB)
+
+	if _, err := sqlDB.ExecContext(ctx, `DROP TABLE lyrics_cache`); err != nil {
+		t.Fatalf("drop lyrics_cache: %v", err)
+	}
+	_, err := repo.Lookup(ctx, "Artist", "Song", 0)
+	if err == nil {
+		t.Fatal("Lookup against a missing table returned nil error")
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		t.Error("a broken database must not be reported as a clean cache miss")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cache.Invalidate`, so a caller that deliberately discards a track's lyrics can drop the corresponding `lyrics_cache` row.
- **No caller yet.** The first one (`scan purge-provenance`) lands in a follow-up PR, kept separate so this reasoning gets read on its own.

## Linked issue

Part of #474

## Why it deletes every duration bucket, not just the matching one

This is the load-bearing decision and the reason the PR exists on its own.

`Lookup` falls back to the **bucket-0 unknown-duration sentinel** row on an exact-bucket miss. So invalidating only the exact bucket leaves a sibling row that still satisfies the very lookup being defeated -- the invalidation silently does nothing in exactly the case it matters.

The cache key also carries no provenance, so a caller repudiating a track cannot distinguish its own entry from another bucket's copy of the same track. Deleting every bucket costs at most one re-fetch; deleting some silently fails.

## Why two entry points

Exposed as both a repo method and a package function over an `Execer` seam, so a caller can invalidate **inside its own transaction** rather than committing the two halves separately. The follow-up PR needs exactly that: a row reset that commits without its invalidation is the data-loss defect this exists to prevent.

## Test plan

- [x] `make gate` green; patch coverage 72.22%
- [x] `TestInvalidate_RemovesEveryDurationBucket` -- the bucket-0 fallback case
- [x] `TestInvalidate_ScopedToKey` -- other tracks untouched
- [x] `TestInvalidate_NormalizesKeys` -- same NFKC normalization as `Store`/`Lookup`
- [x] `TestInvalidate_MissIsNotAnError`
- [x] `TestInvalidate_InsideTransactionRollsBack` -- the `Execer` seam under rollback
- [x] `TestInvalidate_ReportsExecFailure`
- [x] golangci-lint 0 issues, actionlint, govulncheck clean
- [ ] Reviewer follow-ups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache invalidation for specific artist and title combinations across all stored duration variants.
  * Invalidation consistently normalizes artist and title values.
  * Reports the number of removed cache entries and safely handles missing entries.

* **Bug Fixes**
  * Improved error reporting for cache storage, lookup, and invalidation failures.
  * Prevented database lookup errors from being incorrectly reported as missing entries.

* **Tests**
  * Added coverage for scoped invalidation, transaction rollback, normalization, and database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->