### PR TITLE
ci: run the gate workflows on stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter: a stacked PR targets its parent branch, not main,
+  # and a base filter would silently skip CI on it -- a PR with no checks looks
+  # much like a PR whose checks passed. A glob (e.g. 'feat/**') has the same
+  # failure mode for any branch outside the pattern. This repo is single-trunk,
+  # so every PR reaches main eventually and the filter only ever excludes work
+  # that should have been tested.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,13 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # No base-branch filter: a stacked PR targets its parent branch, not main,
+  # and a base filter would silently skip CI on it -- a PR with no checks looks
+  # much like a PR whose checks passed. A glob (e.g. 'feat/**') has the same
+  # failure mode for any branch outside the pattern. This repo is single-trunk,
+  # so every PR reaches main eventually and the filter only ever excludes work
+  # that should have been tested.
   pull_request:
-    branches: [main]
   schedule:
     - cron: "17 4 * * 1"
   workflow_dispatch:

--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -13,8 +13,13 @@ on:
     branches: [main]
     tags:
       - 'v*.*.*'
+  # No base-branch filter: a stacked PR targets its parent branch, not main,
+  # and a base filter would silently skip CI on it -- a PR with no checks looks
+  # much like a PR whose checks passed. A glob (e.g. 'feat/**') has the same
+  # failure mode for any branch outside the pattern. This repo is single-trunk,
+  # so every PR reaches main eventually and the filter only ever excludes work
+  # that should have been tested.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- `ci.yml`, `codeql.yml` and `yamnet.yml` filtered `pull_request` by base branch (`branches: [main]`). That filter matches the **base**, so a stacked PR -- one targeting its parent's branch rather than `main` -- triggered **nothing at all**.
- Observed live on #657 and #661: zero workflow runs, and `mergeStateStatus` reporting `CLEAN`, because a PR with no checks looks much like a PR whose checks passed.
- Removes the base filter from those three. Four other PR-triggered workflows keep theirs, deliberately; the commit message records all seven with reasoning.

## Linked issue

None -- found while shipping the two stacks (#656 -> #657, #660 -> #661).

## Why drop the filter rather than glob it

A glob such as `feat/**` has the identical failure mode for any branch outside the pattern, just rarer and harder to notice. This repo is single-trunk, so every PR reaches `main` eventually and the base filter only ever excluded work that should have been tested.

## Not a path for untested code to reach main

Worth stating plainly, since "CI never ran" sounds worse than it is: ruleset 13896557 applies to `~DEFAULT_BRANCH` only. A child merges into its parent's *branch*, and the parent PR still carries the combined change through the full required-check gate (`Analyze Go`, `Build`, `Coverage Floor`, `Lint`, `Test`, `strict_required_status_checks_policy=true`, `bypass_actors=[]`). What was missing is CI signal **during** a stacked PR's review -- which is when it is most useful.

## Hostile review

No CodeRabbit budget for this one, so it had a full adversarial pass instead. It found one real defect: my enumeration stopped at five workflow files out of fourteen, missing `pr-labels.yml` and `pr-milestone.yml`. Both are now recorded in the commit message with the reasoning for keeping them filtered -- they use `pull_request_target`, which runs privileged with repository secrets, and widening a privileged trigger to buy label metadata on stacked PRs is the wrong trade. Stacked PRs consequently get no auto-label and no milestone: a known, accepted cost.

The review also verified and could not break:

- **Concurrency**: `github.ref` resolves to `refs/pull/<number>/merge` for PR events, so the group key already contains the PR number -- two siblings sharing a base cannot cancel each other.
- **Fork PRs**: all three widened workflows use `pull_request`, not `pull_request_target`, so they run unprivileged with no secrets. `yamnet.yml`'s publish job is separately gated on `github.event_name != 'pull_request'`, so a fork PR cannot reach it on any base.
- **Cost**: bounded. `yamnet.yml` is gated by a paths filter on `deploy/yamnet-detector/**`, so the container build only fires when the sidecar actually changed.
- All three factual claims in the commit message, checked against the live ruleset API.

Stated limit: a workflow could not be executed to observe a stacked-PR trigger directly without pushing, so the fix rests on documented `on.pull_request.branches` semantics plus the #656-vs-#657 contrast. **Merging this and re-running the stacked PRs is the empirical confirmation.**

## Test plan

- [x] `actionlint` clean on all three changed files
- [x] Every trigger block parsed with a YAML parser to confirm the dangling `pull_request:` key resolves to unfiltered
- [x] All 14 workflow files enumerated; the 7 with a PR-family trigger classified and recorded
- [x] Pre-push gate green
- [ ] **After merge**: `gh pr update-branch` on #657 and #661, then confirm Actions runs actually appear on both -- do not assume the retrigger fired
- [ ] Reviewer follow-ups

## Follow-up, out of scope

`sydlexius/audioduration`'s `ci.yml` carries the identical pattern. Latent rather than active (no stacked PRs there today), and a different repo, so it needs its own change.
