### PR TITLE
fix(commands): deflake TestIndexMetadataInterruptStillPrintsSummary

### DIFF
--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -20,6 +20,17 @@ import (
 	"github.com/sydlexius/canticle/internal/scanner"
 )
 
+// indexMetadataRowCommitted, when non-nil, is invoked synchronously
+// immediately after walkIndexMetadata successfully commits a row to
+// audio_metadata (--yes runs only). It is a test-only synchronization seam
+// (default nil = no-op in production, the same pattern as
+// watcher.Watcher.armed) that lets a test observe "a row has just landed in
+// the DB" deterministically -- via a channel send -- instead of polling
+// countAudioMetadataRows on a 1ms sleep loop, which raced the DB's
+// single-connection WAL setup on every db.Open and made the observed timing
+// depend on scheduler luck rather than an actual ordering guarantee.
+var indexMetadataRowCommitted func()
+
 // runIndexMetadata walks a library's audio files and records the full tag set
 // into audio_metadata (#646). Dry-run by default; --yes writes. A file whose
 // (path, mtime, size) still matches its row is skipped without being opened,
@@ -282,6 +293,9 @@ func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string,
 		if args.Yes {
 			if rerr := store.Record(ctx, canonPath, facts); rerr != nil {
 				return fmt.Errorf("index-metadata: record %q: %w", canonPath, rerr)
+			}
+			if indexMetadataRowCommitted != nil {
+				indexMetadataRowCommitted()
 			}
 		}
 		*indexed++

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -305,6 +305,25 @@ func TestIndexMetadataInterruptStillPrintsSummary(t *testing.T) {
 
 	ctx := newCancelDuringWalkCtx()
 
+	// committed is signaled synchronously, from inside the walk goroutine,
+	// immediately after each row commits -- see indexMetadataRowCommitted.
+	// This replaces a 1ms-sleep polling loop that re-opened the (single-
+	// connection) test DB on every iteration via countAudioMetadataRows,
+	// which raced the walk goroutine's own db.Open for the WAL-mode pragma
+	// and intermittently failed with "database is locked" well inside the
+	// deadline, aborting the test outright rather than just mistiming the
+	// interrupt. The channel also removes the interleaving gap the polling
+	// loop left between "observed a row" and "called arm()", during which
+	// the walk could make arbitrary further progress under load.
+	committed := make(chan struct{}, 1)
+	indexMetadataRowCommitted = func() {
+		select {
+		case committed <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() { indexMetadataRowCommitted = nil })
+
 	var out bytes.Buffer
 	done := make(chan int, 1)
 	go func() {
@@ -315,12 +334,10 @@ func TestIndexMetadataInterruptStillPrintsSummary(t *testing.T) {
 	// least one file has actually been committed, so the interrupt genuinely
 	// lands mid-walk with real partial work behind it, not before the walk
 	// even starts.
-	deadline := time.Now().Add(5 * time.Second)
-	for countAudioMetadataRows(t, dbPath) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the first row to be committed")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-committed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first row to be committed")
 	}
 	ctx.arm()
 


### PR DESCRIPTION
## Summary

- Makes `TestIndexMetadataInterruptStillPrintsSummary` deterministic. It failed intermittently in
  full-package runs (and twice during unrelated pre-push gates this session), which is corrosive
  well beyond its own package: an intermittently-red gate teaches you to re-run rather than
  investigate, which is how a genuine regression gets waved through.
- The fix replaces the test's timing-based coordination with an explicit synchronization seam. No
  sleeps, no retries, no widened timeouts, and no weakened assertions -- in particular the
  assertion that the printed coverage number matches the rows actually committed is untouched,
  since that is the behavior the test exists to protect.
- **No production defect.** `runIndexMetadata`'s interrupt handling (the `context.WithoutCancel`
  used for the post-interrupt coverage query) was already correct. This was purely a test bug.

## Linked issue

Closes #658

## Root cause

The issue suspected cross-test interference or CPU contention. The dominant mechanism turned out
to be more specific, and self-inflicted: the test polled `countAudioMetadataRows` in a 1ms sleep
loop, and that helper calls `db.Open` on **every** iteration. `db.Open` re-runs
`PRAGMA journal_mode=WAL` against a database opened with `SetMaxOpenConns(1)`, so the poll raced
the walk goroutine's own `db.Open` for the same file and intermittently hit:

```
db.Open count: db: set WAL mode: database is locked (261)
```

That is a `t.Fatalf`, not a soft retry, so the test aborted immediately and reported "timed out
waiting for the first row to be committed" -- well inside its 5s deadline. The error message
pointed at a timeout that never actually occurred, which is much of why this was hard to read.

In short, the probe perturbed the system it was measuring: each poll opened a second connection to
a single-connection database. That also explains the issue's observation that adding `-v` flipped
the outcome -- it shifted timing enough to change how often the two opens collided.

Secondarily, the original hypothesis about goroutine interleaving was also real but not what
usually flipped the result: even on iterations that avoided the lock error, nothing constrained
how far the walk progressed between "the poll observed a row" and "`arm()` took effect".

## The fix

Adds `indexMetadataRowCommitted func()`, a nil-by-default test-only hook invoked synchronously in
`walkIndexMetadata` right after `store.Record` commits a row (inside the `--yes` branch only). It
follows the pattern already established by `watcher.Watcher.armed`.

The test now sets that hook to send on a buffered channel and blocks on the channel instead of
polling. No repeated `db.Open`, so no lock race, and the interrupt lands deterministically right
after the first real commit with no interleaving gap. Production cost is a single nil check on the
commit path.

## Scope check

Grepped for `cancelDuringWalkCtx` and the poll-then-arm shape across `internal/commands/*_test.go`:
this pattern is unique to this one test, so no sibling test carries the same latent defect.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
- [x] Label set on `gh pr create --label ...` (no CI gate enforces this, but it keeps the tracker usable).
- [x] UAT performed for user-visible changes (run the binary, not just the test suite).
- [x] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD.
- [x] `make ui` re-run if any `.templ` or CSS source changed.
- [x] Migration added under `internal/db/migrations/` if this is a one-time data correction.

No user-visible change (test-only synchronization plus a nil-default hook), so no UAT or
screenshot applies. No `.templ`/CSS source changed and no migration is needed.

## Test plan

- [x] `make gate` passes locally. Clean run, exit 0; `internal/commands` ok at 94.9s.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written.
      The pre-fix failure was captured verbatim (the `database is locked (261)` abort above)
      rather than inferred.
- [x] Patch coverage meets the Codecov threshold.
- [x] Which **surface** this change fixes is stated explicitly: the `internal/commands` test
      suite's determinism. No runtime surface changes.
- [x] Manual UAT steps (list the specific flows exercised):
  - [x] Repetition, since a deflake is only proven by repetition and never by one green run:
        60/60 passes isolated; 30/30 under `-race -shuffle=on`; 40/40 under deliberate CPU
        contention; plus the full gate run above, which is the context it used to fail in.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] `indexMetadataRowCommitted` is a package-level mutable var. It is reset via `t.Cleanup`
        and no test in the file calls `t.Parallel()`, so it is safe today, but it would need
        revisiting if these tests are ever parallelized.

## Not covered

- The seam only signals row commits under `--yes`; the dry-run path is unchanged and untested by
  this hook, which matches the existing test's scope.
- A separate pre-existing issue surfaced while stress-testing this package and is deliberately not
  addressed here: `TestRunScanResults_EmptyDBPrintsHeaderOnly` hung for 10 minutes inside a goose
  migration under `-race -shuffle=on -count=20`. It did not reproduce in normal gate runs. Filed
  as #666, since a plausible shared mechanism (concurrent `db.Open` against a single-connection
  SQLite file) connects it to this one.
