### PR TITLE
EXPERIMENT (do not merge): measure the Go Cache Primer's cost (#677)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     # keeps requiring ONE context instead of enumerating every shard.
     name: Test Shard
     runs-on: ubuntu-latest
-    needs: [changes, go-cache-primer]
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
     # Pure correctness gate: no external-network calls, so a third-party outage
     # (e.g. Codecov) can never fail this required check. Coverage is shipped to
@@ -711,12 +711,12 @@ jobs:
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
-    needs: [changes, lint, test, coverage-floor]
+    needs: [changes, lint]
     # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
     # named with the literal, unexpanded ${{ matrix.* }} template. Non-code PRs get
     # a single placeholder leg (skip='true', see the `changes` job) whose steps
     # no-op, so the check name still interpolates to a concrete goos/goarch.
-    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' && needs.coverage-floor.result != 'failure' }}
+    if: ${{ !cancelled() && needs.lint.result != 'failure' }}
     strategy:
       matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,25 @@ jobs:
       - name: Generate web UI assets (make generate)
         run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
 
+      # Validate the freshly generated CSS (sentinel classes + size band).
+      # Replaces the removed committed-drift "UI Assets" job: nothing is
+      # committed to drift now, but a broken Tailwind run must still fail CI.
+      # Lives here rather than in the Go cache primer (#677): the primer no
+      # longer runs on pull_request, and this gate must run on EVERY code PR.
+      # `lint` already checks out, installs Go and runs `make generate`, so the
+      # gate costs only its own runtime and adds no new serial dependency.
+      - name: Validate generated web UI assets (make ui-validate)
+        run: make ui-validate
+
+      # Assert the test-shard split has not drifted: every package in
+      # `go list ./...` lands in exactly one shard, and each partitioned
+      # package's buckets are complete and disjoint. This guard exists because
+      # the drift failure mode is SILENT -- an unclaimed package is simply never
+      # tested and nothing turns red. Also formerly on the primer (#677); `Lint`
+      # is a required check, so a drifted split still blocks the merge.
+      - name: Verify test-shard split integrity
+        run: bash scripts/ci-shards.sh verify
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -126,8 +145,21 @@ jobs:
   #      cold-compile -race on each run -- N times the compile the unsharded
   #      job paid once, which would eat the entire sharding win.
   #
-  # Shards restore this entry READ-ONLY (actions/cache/restore, no post-job
-  # save), so ten concurrent shards never race to write the same key.
+  # PUSH-ONLY (#677). Measured on run 30227016700, where a no-primer shard
+  # matrix ran CONCURRENTLY with the primer on one commit and one runner pool:
+  # the primer does NOT pay for itself on a pull_request. It is a serial prefix
+  # (shards wait for it) whose own duration swings 44s-138s, while the shards it
+  # unblocks save only ~30-45s each versus warming themselves from restore-keys.
+  # Since shards run concurrently, that per-shard saving is paid once in
+  # wall-clock and never exceeds the prefix it costs.
+  #
+  # It still runs on push-to-main, where it is NOT on anyone's critical path and
+  # publishes a warm, race-instrumented entry that later PRs pick up through
+  # restore-keys. That is the case where a primer genuinely earns its keep.
+  #
+  # Shards no longer `needs` this job; they restore whatever entry exists via
+  # the same key + restore-keys, read-only (no post-job save), so ten concurrent
+  # shards never race to write the same key.
   #
   # This job also owns `make ui-validate` (the generated-CSS correctness gate,
   # formerly on the Test job). It runs exactly once instead of once per shard,
@@ -138,7 +170,8 @@ jobs:
     name: Go Cache Primer
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # push-only: see the header above. On a PR the shards warm themselves.
+    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
     steps:
@@ -186,22 +219,6 @@ jobs:
       - name: Generate web UI assets (make generate)
         run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
 
-      # Validate the freshly generated CSS (sentinel classes + size band).
-      # Replaces the removed committed-drift "UI Assets" job: nothing is
-      # committed to drift now, but a broken Tailwind run must still fail CI.
-      # Runs here, once, rather than in all ten shards.
-      - name: Validate generated web UI assets (make ui-validate)
-        run: make ui-validate
-
-      # Fail the pipeline BEFORE any shard runs if the split has drifted: assert
-      # every package in `go list ./...` lands in exactly one shard, and that
-      # each partitioned package's buckets are complete and disjoint. This guard
-      # exists because the drift failure mode is silent -- an unclaimed package
-      # is simply never tested and nothing turns red. Every shard `needs` this
-      # job, so a failure here stops the whole Test matrix.
-      - name: Verify test-shard split integrity
-        run: bash scripts/ci-shards.sh verify
-
       - name: Warm Go module cache
         run: go mod download
 
@@ -243,9 +260,15 @@ jobs:
           # never write it, so there are no save races between shards.
           cache: false
 
-      # Key/restore-keys are byte-identical to the primer's save step, so the
-      # per-commit ${{ github.sha }} suffix scores an EXACT hit on the entry the
-      # primer published earlier in this same workflow run.
+      # Key/restore-keys are byte-identical to the primer's save step. The
+      # primer is push-only now (#677), so the two cases differ:
+      #   - re-run of a push commit: the ${{ github.sha }} suffix is an EXACT
+      #     hit on the entry that commit's primer published.
+      #   - pull_request (the common case): the exact key MISSES and the first
+      #     restore-key warms from the last entry built against the same
+      #     go.mod/go.sum -- normally the one push-to-main last published.
+      # Restore-only (no post-job save), so ten concurrent shards never race to
+      # write the same key.
       - name: Restore Go module + build cache (read-only)
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -339,127 +362,6 @@ jobs:
           name: coverage-${{ matrix.shard }}
           path: coverage.out
           retention-days: 1
-
-  # ===== TEMPORARY EXPERIMENT (#677) -- DELETE BEFORE MERGE =====
-  # Identical matrix to `test:` above, but WITHOUT the primer dependency:
-  # setup-go's own cache + restore-keys instead. Runs in the SAME workflow
-  # run as the primed shards, so cold-start cost is measured on one commit,
-  # one runner pool, one moment -- not across two runs.
-  test-noprimer:
-    # Per-shard display names render as "Test Shard (commands-1)",
-    # "Test Shard (web)", etc. The bare required check name "Test" is owned by
-    # the always-running `test-gate` job further down, so branch protection
-    # keeps requiring ONE context instead of enumerating every shard.
-    name: NoPrimer Shard
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: needs.changes.outputs.code == 'true'
-    # Pure correctness gate: no external-network calls, so a third-party outage
-    # (e.g. Codecov) can never fail this required check. Coverage is shipped to
-    # Codecov by the separate, non-required `coverage-upload` job.
-    permissions:
-      contents: read
-    strategy:
-      # One shard's failure must not cancel the others: with fail-fast a flake
-      # in one shard hides real failures in every other shard.
-      fail-fast: false
-      matrix: ${{ fromJson(needs.changes.outputs.test_matrix) }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          # EXPERIMENT (#677): use setup-go's own cache instead of the primer.
-          # The primer job owns the cache SAVE; shards only read that key and
-          # never write it, so there are no save races between shards.
-          cache: true
-
-      # Generated web UI assets are regenerated per shard rather than passed
-      # between jobs as an artifact. Measured on CI (run 30222557570): the
-      # Tailwind install is 1s and `make generate` is 5s, so ~6s -- and because
-      # shards run concurrently that 6s is paid once in wall-clock. An artifact
-      # upload+download round-trip costs about the same per shard AND adds a
-      # cross-job dependency, so regenerating is strictly simpler. Every shard
-      # needs them: internal/web go:embed's the generated CSS and templ output,
-      # so a shard without them fails to build even when it runs no web test.
-      # `make ui-validate` deliberately does NOT run here -- the primer owns it.
-      - name: Install Tailwind standalone CLI (v4.2.0)
-        run: bash scripts/install-tailwind.sh "$RUNNER_TEMP/tailwindcss"
-
-      - name: Generate web UI assets (make generate)
-        run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
-
-      # Resolve this shard's package list, and for a partitioned shard its -run
-      # bucket regex. Both come from scripts/ci-shards.sh, which is the SINGLE
-      # SOURCE OF TRUTH for the split: the same script generated the matrix in
-      # the `changes` job above, so the shard names and the package map cannot
-      # drift apart. See that script's header for the measured per-package CI
-      # times the split is balanced against, and for why internal/commands and
-      # internal/queue are partitioned by test name rather than merely given
-      # their own shards.
-      #
-      # `rest` is the DYNAMIC remainder: its package list is derived by
-      # excluding every named shard's packages from `go list ./...`, so a newly
-      # added package automatically lands in a shard and can never be silently
-      # untested.
-      - name: Resolve shard package list
-        id: shard
-        env:
-          SHARD: ${{ matrix.shard }}
-        run: |
-          set -euo pipefail
-          packages=$(bash scripts/ci-shards.sh packages "$SHARD")
-          run=$(bash scripts/ci-shards.sh run "$SHARD")
-          echo "shard=$SHARD packages=$packages"
-          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
-          # The -run regex can be large; use the heredoc form of GITHUB_OUTPUT.
-          {
-            echo "run<<__RUN_EOF__"
-            echo "${run}"
-            echo "__RUN_EOF__"
-          } >> "$GITHUB_OUTPUT"
-
-      # NOTE: deliberately NO -coverpkg. The unsharded job did not use it
-      # either, so each package is instrumented only in its own test binary.
-      # Two consequences, both wanted:
-      #   1. Per-package coverage keeps meaning "covered by this package's own
-      #      tests", so the coverage-floor numbers and the Codecov baseline are
-      #      byte-for-byte what they were before sharding.
-      #   2. Shard profiles are disjoint by package (the only overlap is the
-      #      partitioned shards of a single package, whose counts gocovmerge
-      #      sums), which makes the merge exact rather than approximate.
-      # Adding -coverpkg=./... would make every shard emit a full-module profile
-      # and would credit a package's coverage from other shards' tests, moving
-      # every floor.
-      - name: Run tests
-        # RUN and PACKAGES go through env, not template interpolation, so a
-        # large regex cannot break shell quoting. PACKAGES stays UNQUOTED at the
-        # use site: it is a space-separated list the shell must word-split into
-        # separate `go test` arguments.
-        env:
-          RUN: ${{ steps.shard.outputs.run }}
-          PACKAGES: ${{ steps.shard.outputs.packages }}
-        run: |
-          if [ -n "$RUN" ]; then
-            # shellcheck disable=SC2086 # deliberate word-splitting of the package list
-            go test -v -race -count=1 -coverprofile=coverage.out -run "$RUN" $PACKAGES
-          else
-            # shellcheck disable=SC2086 # deliberate word-splitting of the package list
-            go test -v -race -count=1 -coverprofile=coverage.out $PACKAGES
-          fi
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          # Unique name per shard so all artifacts survive side by side and the
-          # consumer jobs can download them all with `pattern: coverage-*`.
-          name: noprimer-coverage-${{ matrix.shard }}
-          path: coverage.out
-          retention-days: 1
-
 
   scan:
     name: Image Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,127 @@ jobs:
           path: coverage.out
           retention-days: 1
 
+  # ===== TEMPORARY EXPERIMENT (#677) -- DELETE BEFORE MERGE =====
+  # Identical matrix to `test:` above, but WITHOUT the primer dependency:
+  # setup-go's own cache + restore-keys instead. Runs in the SAME workflow
+  # run as the primed shards, so cold-start cost is measured on one commit,
+  # one runner pool, one moment -- not across two runs.
+  test-noprimer:
+    # Per-shard display names render as "Test Shard (commands-1)",
+    # "Test Shard (web)", etc. The bare required check name "Test" is owned by
+    # the always-running `test-gate` job further down, so branch protection
+    # keeps requiring ONE context instead of enumerating every shard.
+    name: NoPrimer Shard
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    # Pure correctness gate: no external-network calls, so a third-party outage
+    # (e.g. Codecov) can never fail this required check. Coverage is shipped to
+    # Codecov by the separate, non-required `coverage-upload` job.
+    permissions:
+      contents: read
+    strategy:
+      # One shard's failure must not cancel the others: with fail-fast a flake
+      # in one shard hides real failures in every other shard.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.changes.outputs.test_matrix) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          # EXPERIMENT (#677): use setup-go's own cache instead of the primer.
+          # The primer job owns the cache SAVE; shards only read that key and
+          # never write it, so there are no save races between shards.
+          cache: true
+
+      # Generated web UI assets are regenerated per shard rather than passed
+      # between jobs as an artifact. Measured on CI (run 30222557570): the
+      # Tailwind install is 1s and `make generate` is 5s, so ~6s -- and because
+      # shards run concurrently that 6s is paid once in wall-clock. An artifact
+      # upload+download round-trip costs about the same per shard AND adds a
+      # cross-job dependency, so regenerating is strictly simpler. Every shard
+      # needs them: internal/web go:embed's the generated CSS and templ output,
+      # so a shard without them fails to build even when it runs no web test.
+      # `make ui-validate` deliberately does NOT run here -- the primer owns it.
+      - name: Install Tailwind standalone CLI (v4.2.0)
+        run: bash scripts/install-tailwind.sh "$RUNNER_TEMP/tailwindcss"
+
+      - name: Generate web UI assets (make generate)
+        run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
+
+      # Resolve this shard's package list, and for a partitioned shard its -run
+      # bucket regex. Both come from scripts/ci-shards.sh, which is the SINGLE
+      # SOURCE OF TRUTH for the split: the same script generated the matrix in
+      # the `changes` job above, so the shard names and the package map cannot
+      # drift apart. See that script's header for the measured per-package CI
+      # times the split is balanced against, and for why internal/commands and
+      # internal/queue are partitioned by test name rather than merely given
+      # their own shards.
+      #
+      # `rest` is the DYNAMIC remainder: its package list is derived by
+      # excluding every named shard's packages from `go list ./...`, so a newly
+      # added package automatically lands in a shard and can never be silently
+      # untested.
+      - name: Resolve shard package list
+        id: shard
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          packages=$(bash scripts/ci-shards.sh packages "$SHARD")
+          run=$(bash scripts/ci-shards.sh run "$SHARD")
+          echo "shard=$SHARD packages=$packages"
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+          # The -run regex can be large; use the heredoc form of GITHUB_OUTPUT.
+          {
+            echo "run<<__RUN_EOF__"
+            echo "${run}"
+            echo "__RUN_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      # NOTE: deliberately NO -coverpkg. The unsharded job did not use it
+      # either, so each package is instrumented only in its own test binary.
+      # Two consequences, both wanted:
+      #   1. Per-package coverage keeps meaning "covered by this package's own
+      #      tests", so the coverage-floor numbers and the Codecov baseline are
+      #      byte-for-byte what they were before sharding.
+      #   2. Shard profiles are disjoint by package (the only overlap is the
+      #      partitioned shards of a single package, whose counts gocovmerge
+      #      sums), which makes the merge exact rather than approximate.
+      # Adding -coverpkg=./... would make every shard emit a full-module profile
+      # and would credit a package's coverage from other shards' tests, moving
+      # every floor.
+      - name: Run tests
+        # RUN and PACKAGES go through env, not template interpolation, so a
+        # large regex cannot break shell quoting. PACKAGES stays UNQUOTED at the
+        # use site: it is a space-separated list the shell must word-split into
+        # separate `go test` arguments.
+        env:
+          RUN: ${{ steps.shard.outputs.run }}
+          PACKAGES: ${{ steps.shard.outputs.packages }}
+        run: |
+          if [ -n "$RUN" ]; then
+            # shellcheck disable=SC2086 # deliberate word-splitting of the package list
+            go test -v -race -count=1 -coverprofile=coverage.out -run "$RUN" $PACKAGES
+          else
+            # shellcheck disable=SC2086 # deliberate word-splitting of the package list
+            go test -v -race -count=1 -coverprofile=coverage.out $PACKAGES
+          fi
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Unique name per shard so all artifacts survive side by side and the
+          # consumer jobs can download them all with `pattern: coverage-*`.
+          name: noprimer-coverage-${{ matrix.shard }}
+          path: coverage.out
+          retention-days: 1
+
+
   scan:
     name: Image Scan
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -53,3 +53,5 @@ tool (
 	github.com/a-h/templ/cmd/templ
 	github.com/wadey/gocovmerge
 )
+
+// #677 cold-cache experiment: perturb the go.mod hash to force a cache miss. REVERT.

--- a/go.mod
+++ b/go.mod
@@ -53,5 +53,3 @@ tool (
 	github.com/a-h/templ/cmd/templ
 	github.com/wadey/gocovmerge
 )
-
-// #677 cold-cache experiment: perturb the go.mod hash to force a cache miss. REVERT.


### PR DESCRIPTION
# EXPERIMENT (do not merge): CI critical-path measurements (#677)

Throwaway scaffolding for measuring CI latency. **Do not merge as-is** -- the
final config wants to land as its own reviewed PR against #677.

## Measured results (all warm-cache unless noted)

| Run | Config | Wall | Critical path |
|---|---|---|---|
| 30226091502 (`main`) | primer + build after test | **320s** | primer 138s -> shards 90s -> cov 14s -> build 53s |
| 30227342602 | A+B, primer still running | 176s | Image Scan 169s |
| 30227572065 a1 | + primer push-only, guards -> lint | **155s** | Image Scan 145s |
| 30227572065 a2 | same commit, re-run (variance) | **156s** | Image Scan 145s |
| 30228246011 | same, **degraded cache** (go.mod hash perturbed) | 161s | Image Scan 154s |
| 30228588389 | final (perturbation reverted) | **123s** | Image Scan 97s |

`main` 320s -> 155s steady-state. **~165s (52%) off the wall clock.**

## What changed

1. **`go-cache-primer` is push-only.** On a PR it was a serial prefix whose own
   duration swings 44s-138s, while the shards it unblocks save only ~30-45s each
   -- and since shards are concurrent that saving is paid once in wall-clock, so
   it never repaid its own prefix. It still runs on push-to-main, off the
   critical path, publishing the entry PRs restore from.
2. **Shards dropped `needs: go-cache-primer`**, so the test phase starts at t=0
   beside lint and the image scan.
3. **`build-matrix` gates on `[changes, lint]`** instead of the full test chain.
   Test only runs linux/amd64; the matrix cross-compiles darwin/arm64,
   windows/amd64, linux/arm64, so it catches a failure class Test structurally
   cannot. Serializing disjoint checks bought latency and nothing else.
4. **`make ui-validate` + `scripts/ci-shards.sh verify` moved from the primer to
   `lint`.** Both are correctness gates that must run on EVERY code PR, and the
   primer no longer does. This is a correctness fix, not an optimization -- see
   below.

## Two things worth flagging

**The primer owned two correctness gates.** Making it push-only would have
silently dropped `ui-validate` (broken-Tailwind gate) and `ci-shards.sh verify`
(the guard whose failure mode is a package silently never being tested) from
every PR. Re-homed to `lint`, which already runs `make generate`, so they cost
+7s and add no serial dependency; `Lint` is required, so a drifted split still
blocks the merge. Verified as executed steps 6 and 7 of the Lint job in run
30227572065, not assumed.

**The bottleneck moved.** The test phase is no longer the ceiling -- `Image Scan`
is, at 97-169s across five runs, and it is now the sole determinant of wall
clock. Further test-side tuning buys ~nothing until the scan is addressed.

## Cold-cache case

The primer's value peaks when the fallback is cold, so the go.mod hash was
perturbed to force a miss. Confirmed from the logs: primary key moved to
`Linux-go-4db5c33e...`, the go.sum-specific restore-key missed, and it degraded
to the bare `Linux-go-` prefix. Cost: 161s vs 155s warm. Even fully degraded,
the no-primer config beats `main`'s 320s by a wide margin. The perturbation is
reverted; HEAD is byte-identical to the measured config.
