### PR TITLE
ci: run the cache primer on push only and unblock build from test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,25 @@ jobs:
       - name: Generate web UI assets (make generate)
         run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
 
+      # Validate the freshly generated CSS (sentinel classes + size band).
+      # Replaces the removed committed-drift "UI Assets" job: nothing is
+      # committed to drift now, but a broken Tailwind run must still fail CI.
+      # Lives here rather than in the Go cache primer (#677): the primer no
+      # longer runs on pull_request, and this gate must run on EVERY code PR.
+      # `lint` already checks out, installs Go and runs `make generate`, so the
+      # gate costs only its own runtime and adds no new serial dependency.
+      - name: Validate generated web UI assets (make ui-validate)
+        run: make ui-validate
+
+      # Assert the test-shard split has not drifted: every package in
+      # `go list ./...` lands in exactly one shard, and each partitioned
+      # package's buckets are complete and disjoint. This guard exists because
+      # the drift failure mode is SILENT -- an unclaimed package is simply never
+      # tested and nothing turns red. Also formerly on the primer (#677); `Lint`
+      # is a required check, so a drifted split still blocks the merge.
+      - name: Verify test-shard split integrity
+        run: bash scripts/ci-shards.sh verify
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -126,8 +145,21 @@ jobs:
   #      cold-compile -race on each run -- N times the compile the unsharded
   #      job paid once, which would eat the entire sharding win.
   #
-  # Shards restore this entry READ-ONLY (actions/cache/restore, no post-job
-  # save), so ten concurrent shards never race to write the same key.
+  # PUSH-ONLY (#677). Measured on run 30227016700, where a no-primer shard
+  # matrix ran CONCURRENTLY with the primer on one commit and one runner pool:
+  # the primer does NOT pay for itself on a pull_request. It is a serial prefix
+  # (shards wait for it) whose own duration swings 44s-138s, while the shards it
+  # unblocks save only ~30-45s each versus warming themselves from restore-keys.
+  # Since shards run concurrently, that per-shard saving is paid once in
+  # wall-clock and never exceeds the prefix it costs.
+  #
+  # It still runs on push-to-main, where it is NOT on anyone's critical path and
+  # publishes a warm, race-instrumented entry that later PRs pick up through
+  # restore-keys. That is the case where a primer genuinely earns its keep.
+  #
+  # Shards no longer `needs` this job; they restore whatever entry exists via
+  # the same key + restore-keys, read-only (no post-job save), so ten concurrent
+  # shards never race to write the same key.
   #
   # This job also owns `make ui-validate` (the generated-CSS correctness gate,
   # formerly on the Test job). It runs exactly once instead of once per shard,
@@ -138,7 +170,8 @@ jobs:
     name: Go Cache Primer
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # push-only: see the header above. On a PR the shards warm themselves.
+    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
     steps:
@@ -186,22 +219,6 @@ jobs:
       - name: Generate web UI assets (make generate)
         run: make generate TAILWIND="$RUNNER_TEMP/tailwindcss"
 
-      # Validate the freshly generated CSS (sentinel classes + size band).
-      # Replaces the removed committed-drift "UI Assets" job: nothing is
-      # committed to drift now, but a broken Tailwind run must still fail CI.
-      # Runs here, once, rather than in all ten shards.
-      - name: Validate generated web UI assets (make ui-validate)
-        run: make ui-validate
-
-      # Fail the pipeline BEFORE any shard runs if the split has drifted: assert
-      # every package in `go list ./...` lands in exactly one shard, and that
-      # each partitioned package's buckets are complete and disjoint. This guard
-      # exists because the drift failure mode is silent -- an unclaimed package
-      # is simply never tested and nothing turns red. Every shard `needs` this
-      # job, so a failure here stops the whole Test matrix.
-      - name: Verify test-shard split integrity
-        run: bash scripts/ci-shards.sh verify
-
       - name: Warm Go module cache
         run: go mod download
 
@@ -218,7 +235,7 @@ jobs:
     # keeps requiring ONE context instead of enumerating every shard.
     name: Test Shard
     runs-on: ubuntu-latest
-    needs: [changes, go-cache-primer]
+    needs: [changes]
     if: needs.changes.outputs.code == 'true'
     # Pure correctness gate: no external-network calls, so a third-party outage
     # (e.g. Codecov) can never fail this required check. Coverage is shipped to
@@ -243,9 +260,15 @@ jobs:
           # never write it, so there are no save races between shards.
           cache: false
 
-      # Key/restore-keys are byte-identical to the primer's save step, so the
-      # per-commit ${{ github.sha }} suffix scores an EXACT hit on the entry the
-      # primer published earlier in this same workflow run.
+      # Key/restore-keys are byte-identical to the primer's save step. The
+      # primer is push-only now (#677), so the two cases differ:
+      #   - re-run of a push commit: the ${{ github.sha }} suffix is an EXACT
+      #     hit on the entry that commit's primer published.
+      #   - pull_request (the common case): the exact key MISSES and the first
+      #     restore-key warms from the last entry built against the same
+      #     go.mod/go.sum -- normally the one push-to-main last published.
+      # Restore-only (no post-job save), so ten concurrent shards never race to
+      # write the same key.
       - name: Restore Go module + build cache (read-only)
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -590,12 +613,12 @@ jobs:
   build-matrix:
     name: Build (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
-    needs: [changes, lint, test, coverage-floor]
+    needs: [changes, lint]
     # Avoid a job-level `if: code == 'true'`: a skipped matrix job surfaces a check
     # named with the literal, unexpanded ${{ matrix.* }} template. Non-code PRs get
     # a single placeholder leg (skip='true', see the `changes` job) whose steps
     # no-op, so the check name still interpolates to a concrete goos/goarch.
-    if: ${{ !cancelled() && needs.lint.result != 'failure' && needs.test.result != 'failure' && needs.coverage-floor.result != 'failure' }}
+    if: ${{ !cancelled() && needs.lint.result != 'failure' }}
     strategy:
       matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:


### PR DESCRIPTION
## Summary

- Measured **324s -> 126-164s** total CI wall-clock, from two changes to job ordering. No test, no gate, and no correctness check is weakened.
- The cache primer now runs on `push` only. It is not useless -- it is wrongly **placed**: publishing a warm Go build cache is valuable, making every PR run *block* on the publishing is not. `main` still publishes an entry that later PR runs restore from via `restore-keys`.
- Build no longer waits on the whole test phase.

Refs #677. Measurements come from the throwaway experiment branch behind draft PR #678, which will be closed.

## The measurements

Four configurations, each a real CI run on the same branch:

| config | total | note |
|---|---|---|
| baseline (`main`) | **324s** | primer 138s serial, then a 90s pole, then build |
| primer deleted from shards | 180s | worse than gating it |
| **primer push-only + build parallel** | **160s** | this PR's shape |
| same, cold cache | 164s | `go.mod` hash deliberately perturbed |
| same, warm (later run) | 126s | run-to-run variance on shared runners |

**The cold-cache row is the one that settled the design.** I had argued the primer's value peaks exactly when `restore-keys` cannot help, and that a warm-only measurement would overstate the case for changing it. Cold measured **164s against 160s warm** -- four seconds. Go's build cache is content-addressed, so `restore-keys` recovers nearly everything even across a dependency change. The primer was insuring against a cost that barely exists. That hypothesis was mine and the experiment disproved it.

## Why build can run parallel to test

Test runs on `ubuntu-latest` only, i.e. linux/amd64. The build matrix cross-compiles darwin/amd64, darwin/arm64, windows/amd64 and linux/arm64. A `GOOS`-specific compile break -- build tags, syscall differences, a `//go:build` guard -- is invisible to the test job and surfaces *only* in Build.

The two jobs therefore cover **disjoint** failure classes, and serializing disjoint checks buys latency and nothing else. Gating Build behind Test delayed the signal for the one failure class Test cannot detect, by the full length of the test phase.

Cost: ~225 wasted runner-seconds when tests are red, and two red checks instead of one on a broken commit. Worth it for ~79s off every run plus earlier cross-compile signal.

## Not a precedent from stillwater

Worth stating since it came up: `sydlexius/stillwater` does **not** run build parallel to test. Its `build-matrix` needs `coverage-floor`, which needs `test` -- the same transitive chain canticle had. This is a canticle-specific call, made on canticle's numbers.

## What this does not change

- `-race` retained.
- The coverage merge (`go tool gocovmerge`), `scripts/coverage-floor.sh`, and `scripts/ci-shards.sh verify` are untouched.
- Required check names (`Lint` / `Test` / `Build` / `Analyze Go` / `Coverage Floor`) are unchanged; the always-running gate jobs still own them.
- Actions stay SHA-pinned; `persist-credentials: false` intact.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), including `actionlint`.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes.
- [x] `make ui` re-run if any `.templ` or CSS source changed.
- [x] Migration added if this is a one-time data correction.

CI-only change: no user-visible behavior, no templ/CSS, no migration. The UAT here *is* the four measured runs above.

## Test plan

- [x] `make gate` passes locally (verified by reading the log's pass marker, not a wrapper exit code).
- [x] `actionlint` clean.
- [x] Four real CI runs measured per-job from the API rather than the UI, with each number's cache state labelled.
- [ ] Reviewer follow-ups:
  - [ ] **`Image Scan` at 97s is now the wall-clock ceiling.** It was concurrent-and-invisible while the test phase dominated. Worth its own issue rather than pre-emptive work here.

## Not covered

- Whether the same change helps `sydlexius/stillwater`. Its primer costs the same ~139s but sits ahead of a 223s pole rather than a 90s one, so the amortization differs materially and the answer may be different. Filed there as sydlexius/stillwater#2829 and being measured separately; the verdict belongs to that repo's lead.
- The ~225 runner-seconds spent building a red commit are a real cost, accepted deliberately rather than measured against an alternative.