### PR TITLE
feat(lyrics): add the disk-to-Song LRC seam for timing revalidation

### DIFF
--- a/internal/lyrics/lrcfile.go
+++ b/internal/lyrics/lrcfile.go
@@ -1,0 +1,79 @@
+package lyrics
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sydlexius/canticle/internal/lrcnormalize"
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/timing"
+)
+
+// ReadSyncedLRC reads the .lrc file at path and returns its cues as the
+// models.Synced that internal/timing judges.
+//
+// THIS IS THE DISK-TO-VERDICT SEAM. Everything downstream of a fetch already
+// speaks models.Song: timing.Evaluate takes one, DecidePromotion takes one. What
+// nothing did was go the other way -- take a .lrc that is ALREADY on disk and
+// hand it back in that form -- so the backlog remediation pass (#442) and the
+// serve sweep (#443) had no way to re-judge an existing file with the same
+// predicate that judged it at accept time.
+//
+// The parse is DELEGATED to lrcnormalize.ParseBody rather than written here.
+// That is the point: ParseBody already expands stacked [t1][t2]text lines into
+// one cue per timestamp and classifies [key:value] header tags OUT of the cue
+// list, so a canticle-written header can never be mistaken for a lyric line. A
+// third LRC parser in this repo would be a third thing to keep in agreement with
+// the writer, and the one it would disagree with first is the timing verdict.
+//
+// A file with no recognizable cue yields an empty Synced and a nil error: an
+// unparsable or plain-text sidecar is a real state, not a failure, and it must
+// reach timing.Evaluate as "no timing evidence" so the caller fails open on it.
+func ReadSyncedLRC(path string) (models.Synced, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // G304: path comes from the caller's own library-root walk, not untrusted input
+	if err != nil {
+		return models.Synced{}, fmt.Errorf("read lrc %q: %w", path, err)
+	}
+	doc := lrcnormalize.ParseBody(strings.TrimPrefix(string(b), utf8BOM))
+	return models.Synced{Lines: doc.Cues}, nil
+}
+
+// EvaluateLRCFile reads the .lrc at path and classifies its timing against
+// durationSeconds, returning the verdict, its magnitude, and how many cues were
+// judged.
+//
+// It owns NO comparison logic: the verdict is timing.Evaluate's, computed over
+// the corrected max (text-bearing lines only). That delegation is the whole
+// reason this function exists rather than a bespoke max-timestamp check --
+// roughly a third of naively-flagged files are perfectly-synced lyrics whose
+// only past-duration timestamp is a trailing decorative marker, and only
+// timing.Evaluate filters those out. A duration of 0 (unknown) yields
+// timing.UnknownDuration, which every caller must treat as "do not remediate".
+func EvaluateLRCFile(path string, durationSeconds int) (timing.TimingOutcome, timing.Magnitude, int, error) {
+	synced, err := ReadSyncedLRC(path)
+	if err != nil {
+		return "", timing.Magnitude{}, 0, err
+	}
+	outcome, mag := timing.Evaluate(models.Song{Subtitles: synced}, durationSeconds)
+	return outcome, mag, len(synced.Lines), nil
+}
+
+// PlainBody flattens synced cues to the plain words a demotion persists as
+// .txt, dropping decorative cues via timing.IsDecorative.
+//
+// Exported so the backlog remediation pass demotes a file to exactly the body
+// the accept-time guard would have written for the same lyric, rather than a
+// near-copy that drifts. An empty result means there is nothing worth writing.
+func PlainBody(synced models.Synced) string {
+	var b strings.Builder
+	for _, l := range synced.Lines {
+		text := strings.TrimSpace(l.Text)
+		if timing.IsDecorative(text) {
+			continue
+		}
+		b.WriteString(text)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/lyrics/lrcfile.go
+++ b/internal/lyrics/lrcfile.go
@@ -31,7 +31,7 @@ import (
 // unparsable or plain-text sidecar is a real state, not a failure, and it must
 // reach timing.Evaluate as "no timing evidence" so the caller fails open on it.
 func ReadSyncedLRC(path string) (models.Synced, error) {
-	b, err := os.ReadFile(path) //nolint:gosec // G304: path comes from the caller's own library-root walk, not untrusted input
+	b, err := os.ReadFile(path) //nolint:gosec // reason: G304: path comes from the caller's own library-root walk, not untrusted input
 	if err != nil {
 		return models.Synced{}, fmt.Errorf("read lrc %q: %w", path, err)
 	}

--- a/internal/lyrics/lrcfile_test.go
+++ b/internal/lyrics/lrcfile_test.go
@@ -1,0 +1,164 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/timing"
+)
+
+// writeLRCFixture writes body to a temp .lrc and returns its path.
+func writeLRCFixture(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "fixture.lrc")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return p
+}
+
+// TestReadSyncedLRC_HeaderTagsAreNotCues is the seam's core contract: a
+// canticle-written header must never reach the verdict as lyric timing.
+func TestReadSyncedLRC_HeaderTagsAreNotCues(t *testing.T) {
+	p := writeLRCFixture(t, "[ar:Placeholder Artist]\n[ti:Placeholder Title]\n[source:testlane]\n\n[00:01.00]alpha\n[00:02.00]beta\n")
+	synced, err := ReadSyncedLRC(p)
+	if err != nil {
+		t.Fatalf("ReadSyncedLRC: %v", err)
+	}
+	if len(synced.Lines) != 2 {
+		t.Fatalf("cue count = %d, want 2 (header tags must not be cues): %+v", len(synced.Lines), synced.Lines)
+	}
+	if synced.Lines[0].Time.Total != 1 || synced.Lines[1].Time.Total != 2 {
+		t.Errorf("cue times = %v/%v, want 1/2", synced.Lines[0].Time.Total, synced.Lines[1].Time.Total)
+	}
+}
+
+// TestReadSyncedLRC_ExpandsStackedTimestamps proves the seam reuses
+// lrcnormalize rather than a second parser: a stacked line yields one cue per
+// timestamp.
+func TestReadSyncedLRC_ExpandsStackedTimestamps(t *testing.T) {
+	p := writeLRCFixture(t, "[00:05.00][01:10.00]refrain\n")
+	synced, err := ReadSyncedLRC(p)
+	if err != nil {
+		t.Fatalf("ReadSyncedLRC: %v", err)
+	}
+	if len(synced.Lines) != 2 {
+		t.Fatalf("cue count = %d, want 2 expanded cues", len(synced.Lines))
+	}
+	if synced.Lines[1].Time.Total != 70 {
+		t.Errorf("second cue = %v, want 70", synced.Lines[1].Time.Total)
+	}
+}
+
+// TestReadSyncedLRC_BOMStripped: a BOM must not blind the first line.
+func TestReadSyncedLRC_BOMStripped(t *testing.T) {
+	p := writeLRCFixture(t, "\ufeff[00:01.00]alpha\n")
+	synced, err := ReadSyncedLRC(p)
+	if err != nil {
+		t.Fatalf("ReadSyncedLRC: %v", err)
+	}
+	if len(synced.Lines) != 1 {
+		t.Fatalf("cue count = %d, want 1", len(synced.Lines))
+	}
+}
+
+// TestReadSyncedLRC_NoCuesIsNotAnError: an unparsable sidecar is a state, not a
+// failure, and must reach the predicate as "no timing evidence".
+func TestReadSyncedLRC_NoCuesIsNotAnError(t *testing.T) {
+	p := writeLRCFixture(t, "just some plain words\nand more of them\n")
+	synced, err := ReadSyncedLRC(p)
+	if err != nil {
+		t.Fatalf("ReadSyncedLRC: %v", err)
+	}
+	if len(synced.Lines) != 0 {
+		t.Fatalf("cue count = %d, want 0", len(synced.Lines))
+	}
+	outcome, _, _, err := EvaluateLRCFile(p, 180)
+	if err != nil {
+		t.Fatalf("EvaluateLRCFile: %v", err)
+	}
+	if outcome != timing.Ok {
+		t.Errorf("outcome = %q, want %q (no timing evidence must fail open)", outcome, timing.Ok)
+	}
+}
+
+func TestReadSyncedLRC_MissingFileErrors(t *testing.T) {
+	if _, err := ReadSyncedLRC(filepath.Join(t.TempDir(), "absent.lrc")); err == nil {
+		t.Fatal("want an error for a missing file")
+	}
+}
+
+// TestEvaluateLRCFile_Outcomes walks the seam end-to-end for each verdict.
+func TestEvaluateLRCFile_Outcomes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		duration int
+		want     timing.TimingOutcome
+	}{
+		{"ok", "[00:10.00]alpha\n[01:00.00]beta\n", 120, timing.Ok},
+		{"mis_synced", "[00:10.00]alpha\n[02:30.00]beta\n", 120, timing.MisSynced},
+		{"categorical", "[00:10.00]alpha\n[05:00.00]beta\n", 120, timing.Categorical},
+		{"unknown_duration", "[00:10.00]alpha\n[05:00.00]beta\n", 0, timing.UnknownDuration},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeLRCFixture(t, tc.body)
+			got, _, cues, err := EvaluateLRCFile(p, tc.duration)
+			if err != nil {
+				t.Fatalf("EvaluateLRCFile: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("outcome = %q, want %q", got, tc.want)
+			}
+			if cues != 2 {
+				t.Errorf("cues = %d, want 2", cues)
+			}
+		})
+	}
+}
+
+// TestEvaluateLRCFile_TrailingDecorativeMarkerIsNotFlagged is the ~33% case from
+// Investigation-0 on #438: a perfectly-synced lyric whose ONLY past-duration
+// timestamp is a trailing decorative music-note marker. A naive max-timestamp
+// check calls this MisSynced and destroys a good file. The seam must consume
+// timing.Evaluate's corrected max, so the verdict is Ok.
+func TestEvaluateLRCFile_TrailingDecorativeMarkerIsNotFlagged(t *testing.T) {
+	// Last SUNG line at 1:50 against a 120s track (fine); a decorative marker
+	// parked at 3:00, which is both past Tolerance and past CategoricalRatio.
+	for _, marker := range []string{"♪", "♫ ♫", "♪ Instrumental ♪", "\U0001F3B5"} {
+		p := writeLRCFixture(t, "[00:10.00]alpha\n[01:50.00]beta\n[03:00.00]"+marker+"\n")
+		got, mag, _, err := EvaluateLRCFile(p, 120)
+		if err != nil {
+			t.Fatalf("EvaluateLRCFile: %v", err)
+		}
+		if got != timing.Ok {
+			t.Errorf("marker %q: outcome = %q, want %q -- a trailing decorative marker must NOT be remediated", marker, got, timing.Ok)
+		}
+		if mag.Measured && mag.OverrunSeconds > timing.Tolerance {
+			t.Errorf("marker %q: magnitude %v came from the RAW max, not the corrected one", marker, mag.OverrunSeconds)
+		}
+	}
+}
+
+// TestPlainBody_DropsDecorativeCues: a demoted .txt gains no stray marker lines.
+func TestPlainBody_DropsDecorativeCues(t *testing.T) {
+	synced := models.Synced{Lines: []models.Lines{
+		{Text: "alpha", Time: models.Time{Total: 1}},
+		{Text: "♪", Time: models.Time{Total: 2}},
+		{Text: "  ", Time: models.Time{Total: 3}},
+		{Text: "beta", Time: models.Time{Total: 4}},
+	}}
+	if got, want := PlainBody(synced), "alpha\nbeta\n"; got != want {
+		t.Errorf("PlainBody = %q, want %q", got, want)
+	}
+}
+
+func TestPlainBody_AllDecorativeIsEmpty(t *testing.T) {
+	synced := models.Synced{Lines: []models.Lines{{Text: "♪", Time: models.Time{Total: 1}}}}
+	if got := PlainBody(synced); got != "" {
+		t.Errorf("PlainBody = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/lyrics/lrcfile.go`: the disk-to-`models.Song` seam that lets an `.lrc` ALREADY on
  disk be re-judged by the same predicate that judged it at accept time.
- Three functions, no new logic: `ReadSyncedLRC` (parse), `EvaluateLRCFile` (verdict),
  `PlainBody` (demotion body). Each delegates to an existing owner rather than reimplementing it.
- **Reviewers look here first:** the delegation boundaries. This package deliberately owns no LRC
  parsing and no timing comparison; if it did, that would be the defect.

## Linked issue

Part of #442. Split out ahead of it -- see below.

## Why this is its own PR

#442 as a whole came to 817 hand-written LOC across 12 files, over both PR size gates (800 / 10).
This seam is the natural cut: it is self-contained, it introduces no migration and no new predicate,
and it reviews on its own terms. What remains for #442 proper -- the `revalidate` command, the new
`realign` action kinds, and the demote-path atomic-write fix -- lands under both gates once this is
out.

**This is 243 LOC across 2 files.**

The honest cost of splitting this way: PR 1 adds a seam whose only caller arrives in PR 2. That is a
real reviewability trade, and the reason it is acceptable here is that the seam's contract is
verifiable without its caller -- every behavior below is pinned by a test in this PR.

## What each function delegates to, and why that matters

| function | delegates to | what would go wrong if it did not |
|---|---|---|
| `ReadSyncedLRC` | `lrcnormalize.ParseBody` | A third LRC parser in this repo, and the first thing it would disagree with the writer about is the timing verdict. `ParseBody` already expands stacked `[t1][t2]text` into one cue per timestamp and classifies `[key:value]` header tags OUT of the cue list, so a canticle-written header cannot be mistaken for a lyric line. |
| `EvaluateLRCFile` | `timing.Evaluate` | A bespoke max-timestamp check would falsely condemn roughly a third of flagged files -- per #438's investigation, that share are correctly-synced lyrics whose only past-duration timestamp is a trailing decorative marker. Only `timing.Evaluate` filters those, because it takes the max over text-bearing lines only. |
| `PlainBody` | `timing.IsDecorative` | A demoted file would get a near-copy of the accept-time body rather than the same body, and the two would drift. |

## Two deliberate fail-open decisions

Both are load-bearing for the remediation pass that consumes this, and both are pinned by tests:

1. **An unparsable or plain-text sidecar yields an empty `Synced` and a NIL error.** It is a real
   state, not a failure. It must reach `timing.Evaluate` as "no timing evidence" so the caller fails
   open rather than treating a read as a condemnation.
2. **A duration of 0 yields `timing.UnknownDuration`**, which every caller must treat as "do not
   remediate". Unknown duration never justifies touching a file.

A UTF-8 BOM is stripped before parsing, so a BOM-prefixed sidecar does not silently parse as
zero-cue (which, under decision 1, would look like a legitimately unparsable file rather than a bug).

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`) -- verified by reading the log for
      `OK: all pre-push checks passed`, not by trusting a wrapper exit code.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push.
- [ ] UAT performed for user-visible changes -- N/A, this PR adds no user-visible surface. The
      command that exposes it arrives in #442.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- no such change.
- [x] Migration added if this is a one-time data correction -- none needed; this PR is read-only
      with respect to both disk and database.

## Test plan

- [x] `make gate` passes locally.
- [x] Both fail-open behaviors above are covered by tests, not just asserted in doc comments.
- [x] Which surface this change adds is stated explicitly: a read path from disk to `models.Song`.
      It writes nothing.
- [ ] Manual UAT: not run, and not applicable -- there is no caller yet by design.

## Note on a gate re-run

The first `make gate` on this branch reported 7 lint findings, all citing a file in a SIBLING
worktree that does not exist in this branch. That is the stale-cache phantom tracked as #669;
`golangci-lint cache clean` cleared it and the same commit then passed with zero findings. Recorded
here because the failing run and the passing run are byte-identical code, and a reviewer who sees
only one of them should know which is real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and interpreting synchronized LRC lyrics files.
  * Handles common metadata, UTF-8 BOMs, and multiple timestamps on a single line.
  * Added timing evaluation with outcomes, severity details, and cue counts.
  * Added plain-text lyric extraction that excludes decorative music markers.

* **Bug Fixes**
  * Empty lyric files are handled successfully.
  * Missing or invalid files now return clear errors.
  * Decorative trailing markers no longer trigger incorrect timing warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->