### PR TITLE
fix(detector): key the instrumental-verdict cache on the model, not the app version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/design/
 # Orchestrate session checkpoint (machine-local, transient; never committed)
 /SESSION-STATE.md
 /FIX496-REPORT.md
+
+# Python bytecode from running the yamnet sidecar's tests locally
+__pycache__/

--- a/deploy/yamnet-detector/Dockerfile
+++ b/deploy/yamnet-detector/Dockerfile
@@ -33,14 +33,27 @@ COPY app.py .
 # target is not.
 #
 # To update: download the URL below, `sha256sum` it, and bump YAMNET_SHA256.
-# A model change re-classifies tracks, and the `detector_version` recorded on
-# every verdict is the CANTICLE APP VERSION (internal/version, stamped via
-# detector.Config.Version) -- there is no sidecar-local version constant to
-# bump. So ship a model change AS PART OF A RELEASE, otherwise old and new
-# verdicts share a detector_version and the stale-marker query in
-# docs/instrumental-detection.md cannot tell them apart.
+# Bumping it correctly invalidates every stored verdict, since the weights really
+# did change. Nothing else needs editing -- in particular do NOT update the hash
+# baked into internal/db/migrations/038_detector_version_model_key.sql, which is a
+# historical record of the model in use when that migration was written, not a
+# current-value reference.
+# A model change re-classifies tracks, so the verdict cache must invalidate when
+# -- and ONLY when -- this hash moves. That is what /health now reports as
+# `model_version` (see app.py): the hash IS the model identity, so it cannot
+# drift from the weights it names.
+#
+# This used to be coupled to the CANTICLE APP VERSION instead, which forced the
+# workaround "ship a model change as part of a release" and, worse, invalidated
+# every stored verdict on every unrelated app release (#684). Do not reintroduce
+# that coupling: a model change is now shippable on its own.
 ARG YAMNET_URL=https://tfhub.dev/google/yamnet/1?tf-hub-format=compressed
 ARG YAMNET_SHA256=b80da2a1a56926fb0767205051a200dd7b3beaf3ea1ea126c42a53943996e5e0
+
+# Surfaced to the app so /health can report which weights are loaded. Baked at
+# build time from the same ARG the download is verified against, so the reported
+# version and the model on disk cannot disagree.
+ENV YAMNET_MODEL_SHA256=${YAMNET_SHA256}
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates; \

--- a/deploy/yamnet-detector/app.py
+++ b/deploy/yamnet-detector/app.py
@@ -21,6 +21,7 @@ clip's frames:
 import csv
 import io
 import logging
+import os
 from contextlib import asynccontextmanager
 
 import numpy as np
@@ -43,6 +44,16 @@ from starlette.concurrency import run_in_threadpool
 # control into code execution. The model ships in the image and the path never
 # varies, so an override buys nothing.
 YAMNET_MODEL_DIR = "/app/yamnet"
+# The sha256 of the SavedModel archive this image was built from, baked in by the
+# Dockerfile from the same ARG the download is checksum-verified against. Canticle
+# keys its verdict cache on this (reported by /health as model_version): a stored
+# score is reusable exactly while the weights that produced it are still loaded.
+#
+# Empty when the image was built without the build arg. That is reported honestly
+# as an absent version rather than a placeholder, because a caller must be able to
+# tell "these are the weights" from "I don't know which weights" -- a placeholder
+# would let stale verdicts be reused across a real model change (#684).
+YAMNET_MODEL_SHA256 = os.environ.get("YAMNET_MODEL_SHA256", "").strip()
 TARGET_SR = 16000  # YAMNet requires 16 kHz mono
 # Cap the in-memory read. Canticle sends at most a ~60s 16 kHz mono WAV (~2 MB);
 # 32 MB is a generous ceiling that rejects oversize/malicious uploads before they
@@ -79,7 +90,15 @@ app = FastAPI(title="Canticle YAMNet instrumental classifier", lifespan=lifespan
 
 @app.get("/health")
 def health():
-    return {"status": "ok", "classes": len(_state.get("classes", []))}
+    # model_version identifies the WEIGHTS, not the image tag or the app release,
+    # so a caller can cache a verdict for exactly as long as it stays valid (#684).
+    # The key is omitted entirely when unknown rather than sent empty, so a caller
+    # cannot mistake "no version" for a real one and reuse verdicts across a model
+    # change; canticle fails closed to re-inference on an absent key.
+    body = {"status": "ok", "classes": len(_state.get("classes", []))}
+    if YAMNET_MODEL_SHA256:
+        body["model_version"] = YAMNET_MODEL_SHA256
+    return body
 
 
 @app.post("/classify")

--- a/deploy/yamnet-detector/test_app.py
+++ b/deploy/yamnet-detector/test_app.py
@@ -171,3 +171,38 @@ def test_classify_does_not_serialize_concurrent_requests():
         f"concurrent /classify took {elapsed:.2f}s; serialized would be ~{serialized:.2f}s. "
         "Inference is running on the event loop - it must be dispatched to the threadpool."
     )
+
+
+def test_health_reports_model_version_when_baked_in(monkeypatch):
+    """/health must expose the MODEL identity so canticle can key its verdict cache.
+
+    Keying on the app version instead invalidated every stored verdict on every
+    unrelated canticle release, which is what kept the library disks awake (#684).
+    """
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(appmod, "YAMNET_MODEL_SHA256", "abc123")
+    appmod._state["classes"] = ["Music", "Speech"]
+
+    body = TestClient(appmod.app).get("/health").json()
+
+    assert body["status"] == "ok"
+    assert body["model_version"] == "abc123"
+
+
+def test_health_omits_model_version_when_unknown(monkeypatch):
+    """An unknown model version is ABSENT, never empty or a placeholder.
+
+    A caller must be able to tell "these are the weights" from "I don't know which
+    weights". Sending an empty string would let a caller treat two different models
+    as the same one and reuse verdicts across a real model change.
+    """
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(appmod, "YAMNET_MODEL_SHA256", "")
+    appmod._state["classes"] = ["Music", "Speech"]
+
+    body = TestClient(appmod.app).get("/health").json()
+
+    assert body["status"] == "ok"
+    assert "model_version" not in body

--- a/docs/instrumental-detection.md
+++ b/docs/instrumental-detection.md
@@ -312,7 +312,7 @@ a single atomic update:
 | `vocal_peak` | peak sung-vocal score (`Result.VocalConfidence`) |
 | `speech_mean` | summed speech-gate score (`Result.SpeechConfidence`) |
 | `vocal_class` | the configured vocal class that produced `vocal_peak` (empty when none scored) |
-| `detector_version` | the Canticle app version (`internal/version`) at decision time |
+| `detector_version` | the sidecar's loaded model identity (its pinned `YAMNET_SHA256`, read from `GET /health`) |
 
 All five are **nullable**: `NULL` means detection did not run for that row
 (detection disabled, no source path, or a row written before migration 025). They
@@ -324,15 +324,33 @@ re-inference pass:
 SELECT id, source_path, vocal_peak FROM work_queue
 WHERE instrumental_result = 1 AND vocal_peak BETWEEN 0.015 AND 0.05;
 
--- markers written by an older detector build (model/threshold drift)
+-- markers written against a different model (model drift)
 SELECT id, source_path, detector_version FROM work_queue
-WHERE instrumental_result = 1 AND detector_version <> '<current-version>';
+WHERE instrumental_result = 1 AND detector_version <> '<current-model-sha>';
 ```
 
-> The version is the Canticle app version, which captures Go-side gate/threshold
-> drift. If sidecar/model identity is wanted later, derive it from the sidecar's
-> pinned model `YAMNET_SHA256` build arg or image tag rather than a new `/health`
-> field.
+> **Why the MODEL, not the app version (#684).** This column used to hold the
+> Canticle app version, and `detector_version` is what gates verdict reuse: the
+> worker re-infers whenever a stored value differs from the detector's current
+> one. So every Canticle release invalidated every stored verdict library-wide
+> even though the classifier had not changed, and each affected row re-ran a
+> YAMNet inference -- an ffmpeg decode of the audio file. Measured in prod before
+> the fix: 26 distinct values across the queue, only 6.7% of telemetry-bearing
+> rows reusable. The library disks never got an idle window long enough to spin
+> down. Migration 038 re-keys existing rows; the model archive's sha256 has held
+> a single value for the project's whole history, so no stored score changes
+> meaning.
+>
+> An earlier revision of this doc suggested deriving model identity from the
+> build arg or image tag "rather than a new `/health` field". That was the wrong
+> call: neither is visible to a running Canticle process, which must ask the
+> sidecar it is actually talking to -- an operator can point it at any image.
+> `/health` now reports `model_version`, and an older sidecar that omits it
+> yields UNKNOWN, which fails closed to re-inference.
+>
+> Gate/threshold drift is handled separately and needs no version bump:
+> `DecideStored` re-applies the CURRENT thresholds to stored scores, so a
+> recalibration re-decides every row with no re-inference.
 
 ### Reconciling stale markers (`scan reconcile`)
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1827,15 +1827,47 @@ func selfWriteTTL(debounce time.Duration) time.Duration {
 // the deaf-to-external-change window at a few seconds under the default.
 const selfWriteDebounceMultiple = 3
 
-// detectorScanVersion returns the app version to stamp into a scan's ScanOptions
-// for detector-marker version invalidation (#502), or "" when the audio detector
-// is disabled -- so a disabled detector never reopens provisional markers on a
-// version bump. It is the same value fed to detector.Config.Version.
-func detectorScanVersion(cfg config.Config) string {
-	if cfg.InstrumentalDetector.Enabled {
-		return version
+// detectorScanVersion returns the version identifying detector output, for
+// detector-marker version invalidation (#502), or "" when the audio detector is
+// disabled -- so a disabled detector never reopens provisional markers on a
+// version bump.
+//
+// This is the SIDECAR MODEL version, matching what the detector stamps onto every
+// Result and what the worker persists as work_queue.detector_version (#684). It
+// used to be the app version, which meant every canticle release invalidated
+// every stored verdict AND reopened every on-disk [dv:] marker even though the
+// classifier had not changed.
+//
+// A "" return also covers an unknown model version (an old sidecar that does not
+// report one, or one not reachable right now). That is the safe direction here:
+// reopen.go treats an empty current version as "do not reopen", so an unknown
+// version leaves existing markers alone rather than invalidating the whole
+// library on a transient probe failure.
+func detectorScanVersion(ctx context.Context, cfg config.Config) string {
+	if !cfg.InstrumentalDetector.Enabled {
+		return ""
 	}
-	return ""
+	return currentDetectorModelVersion(ctx, cfg)
+}
+
+// currentDetectorModelVersion resolves the model version the configured sidecar
+// is currently serving, or "" when it cannot be determined (no classifier
+// configured, construction failed, or the sidecar is unreachable / too old to
+// report one).
+//
+// Every consumer that compares a STORED detector_version against "the current
+// one" must go through here, so they all agree on the same key. They previously
+// each read the app version independently, which is why migration 038 would
+// otherwise desynchronize them: internal/instrumentalrecalib would see every row
+// as version-mismatched and RESET it instead of settling it from cached scores,
+// converting a recalibration into a full-library re-inference -- the exact I/O
+// storm #684 exists to eliminate.
+//
+// This deliberately does NOT construct a detector: that resolves ffmpeg (and can
+// auto-provision a static build), which a pure-HTTP version probe has no business
+// doing. It is one small GET against the configured classifier.
+func currentDetectorModelVersion(ctx context.Context, cfg config.Config) string {
+	return detector.FetchModelVersion(ctx, cfg.InstrumentalDetector.ClassifierURL)
 }
 
 func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd, cacheRepo *cache.CacheRepo) {
@@ -1849,7 +1881,7 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 		MaxDepth:        args.Depth,
 		BFS:             args.BFS,
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-		DetectorVersion: detectorScanVersion(cfg),
+		DetectorVersion: detectorScanVersion(ctx, cfg),
 	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
 	// serve has no per-run enrichment override; resolve per library against the
 	// global default (and the per-library setting) inside the scheduler.
@@ -1943,7 +1975,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 		MaxDepth:        args.Depth,
 		BFS:             args.BFS,
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-		DetectorVersion: detectorScanVersion(cfg),
+		DetectorVersion: detectorScanVersion(ctx, cfg),
 	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
 	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	pruner := prune.New(sqlDB)
@@ -2121,7 +2153,7 @@ func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 		MaxDepth:        args.Depth,
 		BFS:             args.BFS,
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
-		DetectorVersion: detectorScanVersion(cfg),
+		DetectorVersion: detectorScanVersion(ctx, cfg),
 		UnsyncedBefore:  unsyncedBefore,
 	}, detectOverride, cfg.InstrumentalDetector.Enabled, nil, rlg, rlgBackup)
 	s.EnrichOverride = enrichOverride
@@ -3425,10 +3457,16 @@ func runScanReconcile(ctx context.Context, out io.Writer, args ScanReconcileCmd)
 		return 1
 	}
 	candidates, err := workQueue.ListInstrumental(ctx, queue.ListInstrumentalOptions{
-		LibraryID:      libraryID,
-		Limit:          args.Limit,
-		All:            args.All,
-		CurrentVersion: version,
+		LibraryID: libraryID,
+		Limit:     args.Limit,
+		All:       args.All,
+		// The MODEL version, matching what the worker persists (#684). This is a
+		// WIDENING predicate -- `detector_version <> ?` pulls a row INTO the
+		// re-inference candidate set -- so reading the app version here would make
+		// every row a candidate after migration 038 and re-infer the whole library.
+		// Unknown ("") widens too, but this command is explicitly a re-inference
+		// pass the operator asked for, and it stays bounded by --limit.
+		CurrentVersion: currentDetectorModelVersion(ctx, cfg),
 	})
 	if err != nil {
 		slog.Error("failed to list instrumental rows", "error", err)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2605,13 +2605,45 @@ func TestServeHandlerWiresMetricsReporter(t *testing.T) {
 	}
 }
 
+// detectorScanVersion returns the SIDECAR MODEL version, not the app version
+// (#684). It previously returned the app version, which meant every canticle
+// release reopened every on-disk [dv:] marker and invalidated every stored
+// verdict even though the classifier had not changed.
 func TestDetectorScanVersion(t *testing.T) {
-	enabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{Enabled: true}}
-	if got := detectorScanVersion(enabled); got != version {
-		t.Errorf("enabled: detectorScanVersion = %q, want current app version %q", got, version)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("path = %q; want /health (the version probe must not run ffmpeg or classify)", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"status":"ok","model_version":"model-sha-under-test"}`))
+	}))
+	defer srv.Close()
+
+	enabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{
+		Enabled: true, ClassifierURL: srv.URL,
+	}}
+	if got := detectorScanVersion(ctx, enabled); got != "model-sha-under-test" {
+		t.Errorf("enabled: detectorScanVersion = %q, want the sidecar model version", got)
 	}
-	disabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{Enabled: false}}
-	if got := detectorScanVersion(disabled); got != "" {
+	if got := detectorScanVersion(ctx, enabled); got == version {
+		t.Errorf("detectorScanVersion returned the APP version %q; that is the #684 defect", version)
+	}
+
+	disabled := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{
+		Enabled: false, ClassifierURL: srv.URL,
+	}}
+	if got := detectorScanVersion(ctx, disabled); got != "" {
 		t.Errorf("disabled: detectorScanVersion = %q, want empty (no version-invalidation churn)", got)
+	}
+
+	// An unreachable sidecar must degrade to UNKNOWN, not to a wrong-but-confident
+	// value: reopen.go treats "" as "do not reopen", so a transient probe failure
+	// leaves existing markers alone instead of invalidating the whole library.
+	unreachable := config.Config{InstrumentalDetector: config.InstrumentalDetectorConfig{
+		Enabled: true, ClassifierURL: "http://127.0.0.1:1",
+	}}
+	if got := detectorScanVersion(ctx, unreachable); got != "" {
+		t.Errorf("unreachable sidecar: detectorScanVersion = %q, want empty (unknown)", got)
 	}
 }

--- a/internal/commands/reconcile_instrumental_recalibrate.go
+++ b/internal/commands/reconcile_instrumental_recalibrate.go
@@ -91,10 +91,15 @@ func appendJSONLSynced(f *os.File, rec any) error {
 }
 
 // runReconcileInstrumentalRecalibrate is CLI wiring over
-// internal/instrumentalrecalib: it resolves config/queue (no detector -- the
-// engine re-decides from telemetry already stamped on each row), owns the
-// JSONL backup file and the operator output, and lets the package own the
-// re-decision logic. Dry-run unless --yes.
+// internal/instrumentalrecalib: it resolves config/queue, owns the JSONL backup
+// file and the operator output, and lets the package own the re-decision logic.
+// Dry-run unless --yes.
+//
+// The re-DECISION still runs entirely on telemetry already stamped on each row --
+// no inference, no audio read. The one thing it asks the sidecar is which MODEL
+// it currently serves (#684), a single cheap GET that keys the version
+// comparison; when that is unanswerable the engine treats the version as unknown
+// and declines to reset anything.
 func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, args ScanReconcileInstrumentalRecalibrateCmd) int {
 	env, code := openQueueEnv(ctx, out, args.ConfigPath, args.Library)
 	if env == nil {
@@ -139,14 +144,20 @@ func runReconcileInstrumentalRecalibrate(ctx context.Context, out io.Writer, arg
 	}
 
 	res, err := run(ctx, instrumentalrecalib.Options{
-		LibraryID:      env.libraryID,
-		Limit:          args.Limit,
-		AfterID:        args.AfterID,
-		DryRun:         !args.Yes,
-		MinConfidence:  env.cfg.InstrumentalDetector.MinConfidence,
-		VocalMax:       env.cfg.InstrumentalDetector.VocalMaxConfidence,
-		SpeechMax:      env.cfg.InstrumentalDetector.SpeechMaxConfidence,
-		CurrentVersion: version,
+		LibraryID:     env.libraryID,
+		Limit:         args.Limit,
+		AfterID:       args.AfterID,
+		DryRun:        !args.Yes,
+		MinConfidence: env.cfg.InstrumentalDetector.MinConfidence,
+		VocalMax:      env.cfg.InstrumentalDetector.VocalMaxConfidence,
+		SpeechMax:     env.cfg.InstrumentalDetector.SpeechMaxConfidence,
+		// The MODEL version, matching what the worker persists as
+		// work_queue.detector_version (#684). Reading the APP version here would
+		// make every row look version-mismatched after migration 038 and take the
+		// RESET branch, converting a recalibration into a full-library
+		// re-inference. Unknown ("") is handled inside the engine as "change
+		// nothing destructive", never as a mismatch.
+		CurrentVersion: currentDetectorModelVersion(ctx, env.cfg),
 		Preview: func(ch instrumentalrecalib.Change) {
 			previewed++
 			switch ch.Action {

--- a/internal/commands/reconcile_instrumental_recalibrate_test.go
+++ b/internal/commands/reconcile_instrumental_recalibrate_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,14 +17,46 @@ import (
 	"github.com/sydlexius/canticle/internal/queue"
 )
 
-// writeRecalibrateCfg writes a minimal config with NO classifier configured,
-// proving runReconcileInstrumentalRecalibrate needs no detector sidecar: it
-// re-decides purely from telemetry already stamped on each row.
+// writeRecalibrateCfg writes a minimal config with NO classifier configured.
+// The re-DECISION still needs no sidecar -- it runs purely on telemetry already
+// stamped on each row -- but the current MODEL version is then unknown (#684),
+// and unknown never takes the destructive reset branch. Tests whose subject is
+// the version comparison itself want writeRecalibrateCfgWithDetector.
 func writeRecalibrateCfg(t *testing.T, path, dbPath string) {
 	t.Helper()
 	content := "[db]\npath = \"" + strings.ReplaceAll(dbPath, `\`, `\\`) + "\"\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("writeRecalibrateCfg: %v", err)
+	}
+}
+
+// startModelVersionSidecar serves just enough of the classifier for the
+// detector's model-version probe (#684) and returns its URL. Used by tests whose
+// subject is the version COMPARISON: without a reachable sidecar the current
+// version resolves to UNKNOWN, and unknown deliberately never takes the
+// destructive reset branch, so such a test would be asserting the guard rather
+// than the behavior it means to pin.
+func startModelVersionSidecar(t *testing.T, modelVersion string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_, _ = w.Write([]byte(`{"status":"ok","model_version":"` + modelVersion + `"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// writeRecalibrateCfgWithDetector is writeRecalibrateCfg plus a reachable
+// classifier, so the current model version is KNOWABLE.
+func writeRecalibrateCfgWithDetector(t *testing.T, path, dbPath, classifierURL string) {
+	t.Helper()
+	content := "[db]\npath = \"" + strings.ReplaceAll(dbPath, `\`, `\\`) + "\"\n" +
+		"\n[instrumental_detector]\nenabled = true\nclassifier_url = \"" + classifierURL + "\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeRecalibrateCfgWithDetector: %v", err)
 	}
 }
 
@@ -195,7 +229,11 @@ func TestRunReconcileInstrumentalRecalibrate_VersionMismatchResets(t *testing.T)
 		t.Fatalf("mkdir music: %v", err)
 	}
 	cfgPath := filepath.Join(dir, "config.toml")
-	writeRecalibrateCfg(t, cfgPath, dbPath)
+	// A reachable sidecar so the CURRENT model version is knowable: this test's
+	// subject is a genuine version MISMATCH, and with the version unknown the
+	// engine deliberately declines to reset (#684), which would make this test
+	// pass for the wrong reason.
+	writeRecalibrateCfgWithDetector(t, cfgPath, dbPath, startModelVersionSidecar(t, "current-model-sha"))
 	id := seedVocalGateRejection(t, ctx, dbPath, outdir, "0.0.1-stale")
 
 	var app bytes.Buffer

--- a/internal/commands/reconcile_instrumental_recalibrate_test.go
+++ b/internal/commands/reconcile_instrumental_recalibrate_test.go
@@ -179,8 +179,14 @@ func TestRunReconcileInstrumentalRecalibrate_ApplySettlesVersionMatchedRow(t *te
 		t.Fatalf("mkdir music: %v", err)
 	}
 	cfgPath := filepath.Join(dir, "config.toml")
-	writeRecalibrateCfg(t, cfgPath, dbPath)
-	id := seedVocalGateRejection(t, ctx, dbPath, outdir, version)
+	// A reachable sidecar and a row seeded at the SAME model version, so this
+	// settles because the versions MATCH -- which is what the test is named for.
+	// With no classifier the version resolves to unknown and the row would settle
+	// via the unknown-version guard instead: the test would then pass no matter
+	// what version the row carried, asserting the guard rather than the match.
+	const modelVersion = "current-model-sha"
+	writeRecalibrateCfgWithDetector(t, cfgPath, dbPath, startModelVersionSidecar(t, modelVersion))
+	id := seedVocalGateRejection(t, ctx, dbPath, outdir, modelVersion)
 	markerPath := filepath.Join(outdir, "song.txt")
 
 	var app bytes.Buffer

--- a/internal/commands/reconcile_test.go
+++ b/internal/commands/reconcile_test.go
@@ -296,7 +296,13 @@ func TestRunScanReconcile_StampsTelemetryOnConfirm(t *testing.T) {
 	// with a zero or shared value, wiring one field from another's source would
 	// satisfy the assertions anyway. Speech stays under the 0.2 gate so the
 	// instrumental verdict still holds.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The stamped detector_version is the SIDECAR MODEL version (#684), so the
+		// stub must answer the version probe; otherwise it stamps empty.
+		if r.URL.Path == "/health" {
+			_, _ = w.Write([]byte(`{"status":"ok","model_version":"model-sha-under-test"}`))
+			return
+		}
 		_, _ = w.Write([]byte(`{"mean":{"Music":0.95,"Speech":0.03},"max":{"Music":1.0,"Singing":0.01}}`))
 	}))
 	defer srv.Close()
@@ -351,8 +357,12 @@ func TestRunScanReconcile_StampsTelemetryOnConfirm(t *testing.T) {
 	if *speech != 0.03 {
 		t.Errorf("speech_mean = %v; want 0.03 (the live detection's score)", *speech)
 	}
-	if dv == "" {
-		t.Error("detector_version is empty; a stamped row must record which detector confirmed it")
+	// Asserted exactly, not merely non-empty: the stamped value is the key the
+	// verdict cache compares against, so a stamp of the wrong string (the app
+	// version, say) is the #684 defect and must not pass here.
+	if dv != "model-sha-under-test" {
+		t.Errorf("detector_version = %q; want the sidecar model version. A stamped row must record "+
+			"WHICH MODEL confirmed it, since that is what gates verdict reuse", dv)
 	}
 }
 

--- a/internal/db/migration_038_test.go
+++ b/internal/db/migration_038_test.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// Migration 038 re-keys stored detector verdicts from the app version to the
+// model identity (#684). The two behaviors that matter are that it rewrites rows
+// that HAVE a verdict, and that it leaves rows that never had one alone -- a NULL
+// detector_version means "never detected" and must keep meaning that.
+func TestMigration038RekeysOnlyRowsWithAVerdict(t *testing.T) {
+	const modelKey = "b80da2a1a56926fb0767205051a200dd7b3beaf3ea1ea126c42a53943996e5e0"
+
+	ctx := context.Background()
+	dbh, err := Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = dbh.Close() }()
+
+	// Migrations have already run, so insert AFTER and re-apply the same
+	// statement the migration runs. This pins the STATEMENT's semantics, which
+	// is what a future edit would break.
+	insert := `INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, status, detector_version, instrumental_result)
+	           VALUES (?, ?, ?, ?, ?, 'deferred', ?, ?)`
+	rows := []struct {
+		key      string
+		version  any
+		verdict  any
+		wantSame bool // true = must be left untouched
+	}{
+		{"a1", "1.14.0", 0, false},  // old app version + verdict -> re-keyed
+		{"a2", "1.30.0", 1, false},  // current app version + verdict -> re-keyed
+		{"a3", nil, nil, true},      // never detected -> untouched
+		{"a4", "1.28.0", nil, true}, // version but NO verdict -> untouched
+	}
+	for _, r := range rows {
+		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.version, r.verdict); err != nil {
+			t.Fatalf("insert %s: %v", r.key, err)
+		}
+	}
+
+	if _, err := dbh.ExecContext(ctx, `UPDATE work_queue SET detector_version = ?
+		WHERE detector_version IS NOT NULL AND instrumental_result IS NOT NULL`, modelKey); err != nil {
+		t.Fatalf("apply migration statement: %v", err)
+	}
+
+	for _, r := range rows {
+		var got *string
+		if err := dbh.QueryRowContext(ctx,
+			`SELECT detector_version FROM work_queue WHERE artist_key = ?`, r.key).Scan(&got); err != nil {
+			t.Fatalf("select %s: %v", r.key, err)
+		}
+		switch {
+		case r.wantSame && got != nil && *got == modelKey:
+			t.Errorf("%s: detector_version was re-keyed to the model key, but this row has no verdict; "+
+				"a row that was never detected must not claim one", r.key)
+		case !r.wantSame && (got == nil || *got != modelKey):
+			t.Errorf("%s: detector_version = %v; want the model key. A verdict-bearing row must be re-keyed, "+
+				"or it re-infers and the disks stay awake (#684)", r.key, got)
+		}
+	}
+}

--- a/internal/db/migration_038_test.go
+++ b/internal/db/migration_038_test.go
@@ -65,6 +65,11 @@ func TestMigration038RekeysOnlyRowsWithAVerdict(t *testing.T) {
 		{"a2", "1.30.0", 1, true},    // current app version + instrumental verdict
 		{"a3", nil, nil, false},      // never detected -> untouched
 		{"a4", "1.28.0", nil, false}, // version but NO verdict -> untouched
+		// Pre-migration-025: instrumental_result existed before the telemetry
+		// columns did, so a real population carries a verdict with a NULL
+		// detector_version. There is no version to re-key, and inventing one would
+		// claim a model produced a score it never saw.
+		{"a5", nil, 1, false},
 	}
 	for _, r := range rows {
 		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.version, r.verdict); err != nil {

--- a/internal/db/migration_038_test.go
+++ b/internal/db/migration_038_test.go
@@ -2,39 +2,69 @@ package db
 
 import (
 	"context"
+	"database/sql"
+	"io/fs"
 	"path/filepath"
 	"testing"
+
+	"github.com/pressly/goose/v3"
 )
 
+// openAtVersion opens a fresh database migrated to exactly `version`, returning
+// the handle and the goose provider so the caller can step it forward.
+//
+// This exists so a migration test RUNS THE MIGRATION FILE. An earlier version of
+// this test opened a fully-migrated DB, inserted rows after the fact, and
+// hand-executed its own copy of the UPDATE -- which meant it asserted that SQLite
+// applies a WHERE clause correctly and could not fail if the .sql file were
+// edited or emptied. Verified: replacing 038's body with `SELECT 1;` still passed.
+func openAtVersion(t *testing.T, version int64) (*sql.DB, *goose.Provider) {
+	t.Helper()
+
+	sqlDB, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	migFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, sqlDB, migFS)
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if _, err := provider.UpTo(context.Background(), version); err != nil {
+		t.Fatalf("migrate to %d: %v", version, err)
+	}
+	return sqlDB, provider
+}
+
 // Migration 038 re-keys stored detector verdicts from the app version to the
-// model identity (#684). The two behaviors that matter are that it rewrites rows
-// that HAVE a verdict, and that it leaves rows that never had one alone -- a NULL
-// detector_version means "never detected" and must keep meaning that.
+// model identity (#684). Two behaviors matter, and both are asserted against the
+// REAL migration: it rewrites rows that carry a verdict, and it leaves rows that
+// never had one alone -- a NULL detector_version means "never detected" and must
+// keep meaning that, since writing a version onto a scoreless row would claim a
+// verdict that was never computed.
 func TestMigration038RekeysOnlyRowsWithAVerdict(t *testing.T) {
 	const modelKey = "b80da2a1a56926fb0767205051a200dd7b3beaf3ea1ea126c42a53943996e5e0"
 
 	ctx := context.Background()
-	dbh, err := Open(ctx, filepath.Join(t.TempDir(), "test.db"))
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer func() { _ = dbh.Close() }()
+	dbh, provider := openAtVersion(t, 37) // the state a real deployment upgrades FROM
 
-	// Migrations have already run, so insert AFTER and re-apply the same
-	// statement the migration runs. This pins the STATEMENT's semantics, which
-	// is what a future edit would break.
 	insert := `INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, status, detector_version, instrumental_result)
 	           VALUES (?, ?, ?, ?, ?, 'deferred', ?, ?)`
 	rows := []struct {
-		key      string
-		version  any
-		verdict  any
-		wantSame bool // true = must be left untouched
+		key       string
+		version   any
+		verdict   any
+		wantModel bool // true = must be re-keyed to the model key
 	}{
-		{"a1", "1.14.0", 0, false},  // old app version + verdict -> re-keyed
-		{"a2", "1.30.0", 1, false},  // current app version + verdict -> re-keyed
-		{"a3", nil, nil, true},      // never detected -> untouched
-		{"a4", "1.28.0", nil, true}, // version but NO verdict -> untouched
+		{"a1", "1.14.0", 0, true},    // old app version + not-instrumental verdict
+		{"a2", "1.30.0", 1, true},    // current app version + instrumental verdict
+		{"a3", nil, nil, false},      // never detected -> untouched
+		{"a4", "1.28.0", nil, false}, // version but NO verdict -> untouched
 	}
 	for _, r := range rows {
 		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.version, r.verdict); err != nil {
@@ -42,9 +72,9 @@ func TestMigration038RekeysOnlyRowsWithAVerdict(t *testing.T) {
 		}
 	}
 
-	if _, err := dbh.ExecContext(ctx, `UPDATE work_queue SET detector_version = ?
-		WHERE detector_version IS NOT NULL AND instrumental_result IS NOT NULL`, modelKey); err != nil {
-		t.Fatalf("apply migration statement: %v", err)
+	// Run the migration under test -- the actual .sql file, not a copy of it.
+	if _, err := provider.UpTo(ctx, 38); err != nil {
+		t.Fatalf("migrate to 38: %v", err)
 	}
 
 	for _, r := range rows {
@@ -54,12 +84,19 @@ func TestMigration038RekeysOnlyRowsWithAVerdict(t *testing.T) {
 			t.Fatalf("select %s: %v", r.key, err)
 		}
 		switch {
-		case r.wantSame && got != nil && *got == modelKey:
+		case r.wantModel && (got == nil || *got != modelKey):
+			t.Errorf("%s: detector_version = %v; want the model key. A verdict-bearing row must be "+
+				"re-keyed, or it re-infers and the disks stay awake (#684)", r.key, deref(got))
+		case !r.wantModel && got != nil && *got == modelKey:
 			t.Errorf("%s: detector_version was re-keyed to the model key, but this row has no verdict; "+
 				"a row that was never detected must not claim one", r.key)
-		case !r.wantSame && (got == nil || *got != modelKey):
-			t.Errorf("%s: detector_version = %v; want the model key. A verdict-bearing row must be re-keyed, "+
-				"or it re-infers and the disks stay awake (#684)", r.key, got)
 		}
 	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return "<NULL>"
+	}
+	return *s
 }

--- a/internal/db/migrations/025_instrumental_telemetry.sql
+++ b/internal/db/migrations/025_instrumental_telemetry.sql
@@ -14,6 +14,11 @@
 --                vocal class scored or when the sidecar returned no max map.
 -- detector_version - app version string at detection time (internal/version.Version),
 --                    sourced from the running binary via Config.Version.
+--                    SUPERSEDED BY MIGRATION 038 (#684): this column now holds the
+--                    SIDECAR MODEL identity, not the app version. Keying it to the
+--                    app version invalidated every stored verdict on every release
+--                    and kept the library disks awake. The text above is left as
+--                    written to record what this migration actually did.
 ALTER TABLE work_queue ADD COLUMN music_sum REAL;
 -- +goose StatementEnd
 -- +goose StatementBegin

--- a/internal/db/migrations/038_detector_version_model_key.sql
+++ b/internal/db/migrations/038_detector_version_model_key.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Re-key stored detector verdicts from the CANTICLE APP VERSION to the MODEL
+-- identity (#684).
+--
+-- THE DEFECT. detector_version was stamped with internal/version.Version (see
+-- migration 025), and internal/worker/memo_detector.go reuses a stored verdict
+-- only while that string still matches the detector's current version. So every
+-- canticle release invalidated every stored verdict in the library even though
+-- the classifier had not changed. Each affected row then re-ran YAMNet inference
+-- -- an ffmpeg decode of the audio file -- and the library disks never got a
+-- contiguous idle window long enough to spin down.
+--
+-- Measured in prod before this fix: 26 distinct detector_version values across
+-- the queue, with only 1,152 of 17,231 telemetry-bearing rows (6.7%) reusable at
+-- the then-current app version.
+--
+-- WHY A BLANKET REWRITE IS SAFE HERE, and would not be in general. The value
+-- below is the sha256 of the YAMNet SavedModel archive, which the sidecar
+-- Dockerfile pins and checksum-verifies at build time. That ARG has held exactly
+-- ONE value across the entire git history of deploy/yamnet-detector/Dockerfile,
+-- so every score any build ever produced came from byte-identical weights. The
+-- app version those rows recorded was never evidence about the model; it was
+-- noise that happened to be stored in the model's slot.
+--
+-- The scores themselves are NOT touched. Only the key that says which model
+-- produced them changes, and the three-gate decision is re-applied to those
+-- scores on read (HTTPDetector.DecideStored), so a later threshold
+-- recalibration still re-decides every row correctly from cached scores.
+--
+-- Rows with no telemetry are left alone: a NULL detector_version means "never
+-- detected", which must keep meaning that. Writing a version onto a row with no
+-- scores would claim a verdict that was never computed.
+UPDATE work_queue
+SET detector_version = 'b80da2a1a56926fb0767205051a200dd7b3beaf3ea1ea126c42a53943996e5e0'
+WHERE detector_version IS NOT NULL
+  AND instrumental_result IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- IRRECOVERABLE BY DESIGN, and stated plainly rather than faked. The Up
+-- migration collapses many distinct app-version strings into one model key; the
+-- original per-row values are not recorded anywhere, so no Down can restore
+-- them. Inventing a plausible app version here would be worse than losing it: it
+-- would assert that a specific build produced a verdict when that is unknown.
+--
+-- NULLing the column instead would silently discard real telemetry and force a
+-- full library re-inference -- exactly the I/O storm this migration exists to
+-- prevent. So Down is deliberately a no-op: rolling back the schema leaves the
+-- model key in place, where the pre-#684 code reads it as simply "not my
+-- version" and re-infers per row on its own schedule. That degrades safely.
+SELECT 1;
+-- +goose StatementEnd

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -55,6 +55,16 @@ const (
 	// a persistently old or down sidecar costs one cheap request per interval
 	// rather than one per work item.
 	modelVersionRetryInterval = 1 * time.Minute
+	// modelVersionTTL is how long a KNOWN version is trusted before re-probing.
+	// It bounds how long a sidecar model swap can go unnoticed by a long-running
+	// serve process: without it, the first value would be cached for the process
+	// lifetime and an operator who redeployed new weights would have to restart
+	// canticle for verdict keying to be correct again.
+	//
+	// 15 minutes: a model swap is a deliberate, rare operator action, so a short
+	// window buys nothing, while the probe is one tiny GET -- at this TTL it is
+	// ~4 requests/hour, negligible against a worker that decodes audio.
+	modelVersionTTL = 15 * time.Minute
 	// maxHealthBodyBytes bounds the health read. The real body is a few hundred
 	// bytes; this only prevents an unbounded read of an unexpected response.
 	maxHealthBodyBytes = 64 << 10

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -15,6 +15,7 @@ package detector
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // ErrClassifierUnavailable is returned when the classifier HTTP endpoint is
@@ -39,6 +40,24 @@ var ErrCooldownInterrupted = errors.New("detector: cooldown interrupted by conte
 const (
 	minSampleDurationSeconds = 30
 	maxSampleDurationSeconds = 60
+)
+
+// Sidecar model-version probe tuning (#684). The probe is a tiny GET /health,
+// and its result is cached for the process lifetime once known, so these bound
+// only the UNKNOWN case: a sidecar that is still booting or too old to report a
+// version.
+const (
+	// modelVersionProbeTimeout keeps a hung sidecar from stalling the worker. The
+	// probe is advisory -- on timeout the version stays unknown and the detector
+	// re-infers, which is correct, just slower.
+	modelVersionProbeTimeout = 5 * time.Second
+	// modelVersionRetryInterval throttles retries while the version is unknown, so
+	// a persistently old or down sidecar costs one cheap request per interval
+	// rather than one per work item.
+	modelVersionRetryInterval = 1 * time.Minute
+	// maxHealthBodyBytes bounds the health read. The real body is a few hundred
+	// bytes; this only prevents an unbounded read of an unexpected response.
+	maxHealthBodyBytes = 64 << 10
 )
 
 // Detector defaults applied by NewHTTPDetector when the corresponding Config

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -1346,6 +1346,10 @@ func TestDetectLogLineIncludesVocalClassAndVersion(t *testing.T) {
 		t.Fatalf("write audio: %v", err)
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "model_version": "model-sha-9"})
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"mean": map[string]float64{"Music": 0.95, "Singing": 0.001},
 			"max":  map[string]float64{"Music": 1.0, "Singing": 0.008},
@@ -1375,8 +1379,14 @@ func TestDetectLogLineIncludesVocalClassAndVersion(t *testing.T) {
 	if !strings.Contains(logged, "vocal_class=Singing") {
 		t.Errorf("log line missing vocal_class=Singing; got: %s", logged)
 	}
-	if !strings.Contains(logged, "detector_version=v9.9.9") {
-		t.Errorf("log line missing detector_version=v9.9.9; got: %s", logged)
+	// detector_version logs the MODEL version -- the value actually persisted and
+	// compared -- so an operator debugging a cache miss greps the same string the
+	// code uses. The app version is still logged, under its own key (#684).
+	if !strings.Contains(logged, "detector_version=model-sha-9") {
+		t.Errorf("log line missing detector_version=model-sha-9; got: %s", logged)
+	}
+	if !strings.Contains(logged, "app_version=v9.9.9") {
+		t.Errorf("log line missing app_version=v9.9.9; got: %s", logged)
 	}
 }
 

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -1354,14 +1354,23 @@ func TestDetectLogLineIncludesVocalClassAndVersion(t *testing.T) {
 	}
 }
 
-func TestHTTPDetectorModelVersion(t *testing.T) {
+// ModelVersion keys the verdict cache on the SIDECAR's model, so an unreachable
+// sidecar yields UNKNOWN rather than falling back to the app version.
+//
+// This test previously asserted the opposite (Config.Version came back here).
+// That was the #684 defect: keying on the app version invalidated every stored
+// verdict on every canticle release, so the detector re-ran inference across the
+// whole backlog and the library disks never got an idle window. Unknown fails
+// closed to re-inference, which is correct-but-slow; returning the app version
+// would be confidently wrong.
+func TestHTTPDetectorModelVersionUnknownWhenSidecarUnreachable(t *testing.T) {
 	ffmpegPath := fakeFFmpeg(t)
 	d, err := NewHTTPDetector(Config{ClassifierURL: "http://127.0.0.1:1/classify", FFmpegPath: ffmpegPath, Version: "v1.2.3"})
 	if err != nil {
 		t.Fatalf("NewHTTPDetector: %v", err)
 	}
-	if got := d.ModelVersion(); got != "v1.2.3" {
-		t.Fatalf("ModelVersion = %q; want v1.2.3", got)
+	if got := d.ModelVersion(); got != "" {
+		t.Fatalf("ModelVersion = %q; want \"\" (unknown). The app version must never key the verdict cache", got)
 	}
 }
 

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -36,8 +36,12 @@ func TestHTTPDetectorAboveThresholdIsInstrumental(t *testing.T) {
 	ffmpegPath := fakeFFmpeg(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			return
+		}
 		if r.URL.Path != "/classify" {
-			t.Fatalf("path = %q; want /classify", r.URL.Path)
+			t.Fatalf("path = %q; want /classify or /health", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"mean": map[string]float64{"Music": 0.70, "Musical instrument": 0.25},
@@ -284,6 +288,10 @@ func TestHTTPDetectorPostsAudioToClassifier(t *testing.T) {
 
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			return
+		}
 		if err := r.ParseMultipartForm(1 << 20); err != nil {
 			t.Fatalf("ParseMultipartForm: %v", err)
 		}
@@ -924,6 +932,12 @@ func TestDetectLateAppearingVocalClassJoinsBaselineThenEnforced(t *testing.T) {
 	}
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do NOT count /health against the inference sequence this test asserts:
+		// the call number drives which classes appear in the max map.
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			return
+		}
 		n := calls.Add(1)
 		max := map[string]float64{"Music": 1.0, "Singing": 0.004}
 		if n == 2 {
@@ -1281,25 +1295,37 @@ func TestDetectWinningVocalClassEmptyWhenNoMaxMap(t *testing.T) {
 	}
 }
 
-// TestDetectVersionPropagatedToResult verifies that Config.Version is carried
-// through NewHTTPDetector onto every Result returned by Detect.
+// TestDetectVersionPropagatedToResult verifies that the SIDECAR MODEL version is
+// carried onto every Result returned by Detect.
+//
+// This test previously asserted that Config.Version (the APP version) landed
+// here. That was the #684 defect: Result.Version is what the worker persists as
+// work_queue.detector_version, and memoDetector.canReuse compares that stored
+// value against ModelVersion(). Stamping the app version while comparing the
+// model version means the two can never be equal and the verdict cache never
+// hits -- worse than the original bug, which at least reused a verdict until the
+// next release.
 func TestDetectVersionPropagatedToResult(t *testing.T) {
 	audioPath := filepath.Join(t.TempDir(), "song.flac")
 	if err := os.WriteFile(audioPath, []byte("a"), 0600); err != nil {
 		t.Fatalf("write audio: %v", err)
 	}
+	const wantVersion = "model-sha-under-test"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "model_version": wantVersion})
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"mean": map[string]float64{"Music": 0.95, "Singing": 0.001},
 			"max":  map[string]float64{"Music": 1.0, "Singing": 0.005},
 		})
 	}))
 	defer srv.Close()
-	const wantVersion = "v1.2.3-test"
 	d, err := NewHTTPDetector(Config{ClassifierURL: srv.URL, FFmpegPath: fakeFFmpeg(t),
 		InstrumentalClasses: []string{"Music"},
 		VocalClasses:        []string{"Singing"}, VocalMaxConfidence: 0.05,
-		Version: wantVersion})
+		Version: "v1.2.3-app-not-this"})
 	if err != nil {
 		t.Fatalf("ctor: %v", err)
 	}
@@ -1308,7 +1334,7 @@ func TestDetectVersionPropagatedToResult(t *testing.T) {
 		t.Fatalf("detect: %v", err)
 	}
 	if res.Version != wantVersion {
-		t.Errorf("Result.Version = %q; want %q", res.Version, wantVersion)
+		t.Errorf("Result.Version = %q; want the MODEL version %q", res.Version, wantVersion)
 	}
 }
 

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -250,6 +250,13 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 	}
 	d.warnUnknownClassesOnce(resp)
 
+	// Resolve the MODEL version to stamp onto this verdict. Uses the caller's ctx
+	// (not a background one) so a canceled work item cannot leave a probe running,
+	// and resolves here -- after a successful classify -- because the sidecar is
+	// provably reachable at this point, which is exactly when the probe succeeds.
+	// Cached after the first success, so this is one extra request per process.
+	modelVersion := d.resolveModelVersion(ctx)
+
 	// Music gate: summed mean probability of the instrumental classes.
 	var music float64
 	for _, name := range d.instrumentalClasses {
@@ -335,14 +342,58 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 		VocalConfidence:   vocalPeak,
 		SpeechConfidence:  speechMean,
 		WinningVocalClass: winningVocalClass,
-		Version:           d.version,
-		Classes:           resp.Mean,
+		// The MODEL version, not the app version. This value is persisted as
+		// work_queue.detector_version by the worker's stamp paths, and
+		// memoDetector.canReuse compares that stored value against ModelVersion().
+		// The two MUST be the same value or the verdict cache can never hit --
+		// worse than the #684 bug, which at least reused a verdict until the next
+		// release. Resolved (and cached) by the time Detect runs, since the probe
+		// is cheap and this is already a network-bound path.
+		Version: modelVersion,
+		Classes: resp.Mean,
 		// Reusable only when the response was complete: a degraded response
 		// (no/partial max map) forces not-instrumental above via the guards, and
 		// its scores must not be persisted as reusable telemetry (see Result.Reusable
 		// and #582 hostile-review I1).
 		Reusable: maxAvailable && baselineComplete,
 	}, nil
+}
+
+// FetchModelVersion asks the classifier at classifierURL which model it has
+// loaded, without constructing a full detector. It exists for callers that need
+// only the verdict-cache key -- the CLI paths that compare a STORED
+// detector_version against the current one (#684) -- and must not pay for a
+// detector they will never call Detect on.
+//
+// That distinction is load-bearing, not cosmetic: NewHTTPDetector resolves
+// ffmpeg and fails when it is absent, and the resolution path can auto-provision
+// a pinned static build. Routing a pure-HTTP version probe through it would make
+// a read-only CLI command download an ffmpeg, and would make the probe fail on a
+// host where ffmpeg is simply missing -- yielding an UNKNOWN version for a
+// reason that has nothing to do with the sidecar.
+//
+// Returns "" (never an error) when the version cannot be determined: an empty
+// URL, an unreachable or non-200 sidecar, or one too old to report a version.
+// Every consumer treats unknown as "change nothing", so a soft failure here is
+// the correct and safe outcome.
+func FetchModelVersion(ctx context.Context, classifierURL string) string {
+	classifierURL = strings.TrimSpace(classifierURL)
+	if classifierURL == "" {
+		return ""
+	}
+	if err := config.ValidateHTTPURL(classifierURL); err != nil {
+		return ""
+	}
+	d := &HTTPDetector{
+		baseURL:    strings.TrimRight(classifierURL, "/"),
+		httpClient: &http.Client{Timeout: modelVersionProbeTimeout},
+	}
+	v, err := d.fetchModelVersion(ctx)
+	if err != nil {
+		slog.Debug("detector: model version probe failed; treating as unknown", "error", err)
+		return ""
+	}
+	return v
 }
 
 // ModelVersion returns the identity of the MODEL currently loaded in the sidecar

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -54,9 +54,27 @@ type HTTPDetector struct {
 	// under the Detect lock).
 	vocalBaseline []string
 	// version is the app version string passed in via Config.Version at
-	// construction time. It is stamped onto every returned Result so each
-	// persisted telemetry row records which build produced the decision.
+	// construction time. It is recorded for diagnostics only. It is NOT the
+	// verdict-cache key: see modelVersion.
 	version string
+
+	// modelVersion caches the sidecar's reported model identity (the sha256 of
+	// the loaded SavedModel, from GET /health). This, not the app version, keys
+	// verdict-cache validity (#684): a stored score stays reusable exactly while
+	// the weights that produced it are still loaded.
+	//
+	// It is fetched LAZILY rather than in the constructor, because the sidecar is
+	// routinely still booting when canticle starts (#567). A constructor probe
+	// would fail there and leave the version permanently empty, which fails closed
+	// to re-inference forever -- silently reproducing the very bug this fixes.
+	//
+	// Empty means UNKNOWN, never "no version": an unknown version can never equal
+	// a stored one, so every affected row re-infers. That is the safe direction --
+	// a needless re-inference costs one read, whereas reusing a verdict across an
+	// unverified model change writes a wrong marker.
+	modelVersionMu   sync.Mutex
+	modelVersionVal  string
+	modelVersionNext time.Time // earliest next probe attempt; throttles retries while the sidecar boots
 }
 
 // NewHTTPDetector creates a Detector that posts audio samples to the classifier
@@ -327,12 +345,90 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 	}, nil
 }
 
-// ModelVersion returns the detector's configured version string (Config.Version,
-// sourced from the app version at construction). It keys score-cache validity:
-// stored telemetry is reusable only while its recorded detector_version matches
-// this. Empty when the detector was constructed without a version.
+// ModelVersion returns the identity of the MODEL currently loaded in the sidecar
+// (the sha256 of its SavedModel, reported by GET /health). It keys score-cache
+// validity: stored telemetry is reusable only while its recorded detector_version
+// still matches this.
+//
+// It deliberately does NOT return the app version. Doing so keyed the cache on
+// the wrong thing: every canticle release invalidated every stored verdict in the
+// library even though the classifier had not changed, so the detector re-ran
+// inference -- an ffmpeg decode per track -- across the whole backlog after each
+// release, and the library disks never idled (#684). Measured in prod before the
+// fix: 26 distinct detector_version values, with only 6.7% of rows carrying
+// telemetry reusable at the then-current version.
+//
+// Empty means UNKNOWN and always fails closed to re-inference: an old sidecar
+// that does not report a version, or one that is not reachable yet. The result is
+// correct-but-slow, never a verdict reused across an unverified model change.
 func (d *HTTPDetector) ModelVersion() string {
-	return d.version
+	return d.resolveModelVersion(context.Background())
+}
+
+// resolveModelVersion returns the cached sidecar model version, probing GET
+// /health once to learn it. A failed probe is retried on a later call rather than
+// cached as empty, because the usual failure is a sidecar that is still booting
+// (#567) -- caching that would disable the verdict cache for the whole process
+// lifetime. Retries are throttled so a persistently old or down sidecar costs one
+// cheap request per interval, not one per work item.
+func (d *HTTPDetector) resolveModelVersion(ctx context.Context) string {
+	d.modelVersionMu.Lock()
+	if d.modelVersionVal != "" || time.Now().Before(d.modelVersionNext) {
+		v := d.modelVersionVal
+		d.modelVersionMu.Unlock()
+		return v
+	}
+	d.modelVersionMu.Unlock()
+
+	v, err := d.fetchModelVersion(ctx)
+
+	d.modelVersionMu.Lock()
+	defer d.modelVersionMu.Unlock()
+	if err != nil || v == "" {
+		// Unknown for now. Back off, then try again: the sidecar may still be
+		// booting, or may be an older build that predates the version field.
+		d.modelVersionNext = time.Now().Add(modelVersionRetryInterval)
+		if err != nil {
+			slog.Debug("detector: model version unavailable; verdicts will re-infer until it is known", "error", err)
+		}
+		return ""
+	}
+	d.modelVersionVal = v
+	return v
+}
+
+// fetchModelVersion performs the GET /health probe. A missing model_version key
+// is reported as an empty string with no error: that is an older sidecar, which
+// is an expected state, not a failure.
+func (d *HTTPDetector) fetchModelVersion(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, modelVersionProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.baseURL+"/health", nil)
+	if err != nil {
+		return "", fmt.Errorf("detector: build health request: %w", err)
+	}
+	res, err := d.httpClient.Do(req) //nolint:gosec // reason: baseURL is operator-configured and validated by config.ValidateHTTPURL at construction
+	if err != nil {
+		return "", fmt.Errorf("detector: health request: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("detector: health status %d", res.StatusCode)
+	}
+	// Bound the read: this is a tiny JSON body, and an unbounded read of an
+	// unexpected response would be a memory footgun.
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxHealthBodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("detector: read health response: %w", err)
+	}
+	var h struct {
+		ModelVersion string `json:"model_version"`
+	}
+	if err := json.Unmarshal(body, &h); err != nil {
+		return "", fmt.Errorf("detector: decode health response: %w", err)
+	}
+	return strings.TrimSpace(h.ModelVersion), nil
 }
 
 // DecideStored re-applies the detector's CURRENT three-gate thresholds to already

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -255,6 +255,13 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 	// and resolves here -- after a successful classify -- because the sidecar is
 	// provably reachable at this point, which is exactly when the probe succeeds.
 	// Cached after the first success, so this is one extra request per process.
+	//
+	// This runs under d.mu, which serializes inference. That is not a new
+	// exposure: d.mu is already held across sample() (an ffmpeg subprocess) and
+	// classify() (a 3-minute-timeout HTTP call), so a bounded
+	// modelVersionProbeTimeout adds strictly less than what the lock already
+	// covers, at most once per process. resolveModelVersion itself releases its
+	// own lock before the request, so the probe holds no lock while in flight.
 	modelVersion := d.resolveModelVersion(ctx)
 
 	// Music gate: summed mean probability of the instrumental classes.
@@ -332,7 +339,12 @@ func (d *HTTPDetector) Detect(ctx context.Context, audioPath string) (Result, er
 	// earlier (#403) and must not be duplicated.
 	slog.Info("detector: instrumental decision",
 		"path", audioPath, "music_sum", music, "vocal_peak", vocalPeak, "speech_mean", speechMean,
-		"vocal_class", winningVocalClass, "detector_version", d.version,
+		// detector_version is the value actually PERSISTED and compared, so an
+		// operator debugging a cache miss greps the same string the code uses.
+		// Logging d.version (the app version) here disagreed with what was stored.
+		// app_version stays alongside it: it is still useful for correlating a
+		// decision with a build, it just does not key the cache (#684).
+		"vocal_class", winningVocalClass, "detector_version", modelVersion, "app_version", d.version,
 		"instrumental", instrumental, "min_confidence", d.minConfidence,
 		"vocal_max_confidence", d.vocalMaxConfidence, "speech_max_confidence", d.speechMaxConfidence)
 

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -436,7 +436,7 @@ func (d *HTTPDetector) ModelVersion() string {
 // cheap request per interval, not one per work item.
 func (d *HTTPDetector) resolveModelVersion(ctx context.Context) string {
 	d.modelVersionMu.Lock()
-	if d.modelVersionVal != "" || time.Now().Before(d.modelVersionNext) {
+	if time.Now().Before(d.modelVersionNext) {
 		v := d.modelVersionVal
 		d.modelVersionMu.Unlock()
 		return v
@@ -448,15 +448,31 @@ func (d *HTTPDetector) resolveModelVersion(ctx context.Context) string {
 	d.modelVersionMu.Lock()
 	defer d.modelVersionMu.Unlock()
 	if err != nil || v == "" {
-		// Unknown for now. Back off, then try again: the sidecar may still be
-		// booting, or may be an older build that predates the version field.
+		// Probe failed or the sidecar reports no version. Back off and try again:
+		// it may still be booting, or be an older build predating the field.
+		//
+		// KEEP the last known value rather than reverting to unknown. Unknown
+		// fails closed to re-inference, so dropping a good version on one blip
+		// would re-infer the whole backlog -- the #684 symptom, triggered by a
+		// single dropped request.
 		d.modelVersionNext = time.Now().Add(modelVersionRetryInterval)
 		if err != nil {
-			slog.Debug("detector: model version unavailable; verdicts will re-infer until it is known", "error", err)
+			slog.Debug("detector: model version refresh failed; keeping last known",
+				"last_known", d.modelVersionVal, "error", err)
 		}
-		return ""
+		return d.modelVersionVal
+	}
+	// Re-probe on a TTL rather than caching for the process lifetime. An operator
+	// who redeploys the sidecar with new weights would otherwise keep getting the
+	// OLD hash stamped onto verdicts the NEW model produced -- attributing scores
+	// to weights that did not compute them, and making them reusable across a real
+	// model change, which is precisely what this key exists to prevent.
+	if d.modelVersionVal != "" && d.modelVersionVal != v {
+		slog.Info("detector: sidecar model changed; stored verdicts keyed to the previous model will re-infer",
+			"previous", d.modelVersionVal, "current", v)
 	}
 	d.modelVersionVal = v
+	d.modelVersionNext = time.Now().Add(modelVersionTTL)
 	return v
 }
 

--- a/internal/detector/model_version_test.go
+++ b/internal/detector/model_version_test.go
@@ -1,0 +1,181 @@
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newVersionDetector builds a detector pointed at srv with the minimum config the
+// model-version path needs.
+func newVersionDetector(t *testing.T, url string) *HTTPDetector {
+	t.Helper()
+	d, err := NewHTTPDetector(Config{
+		ClassifierURL:         url,
+		SampleDurationSeconds: 30,
+		MinConfidence:         0.90,
+		InstrumentalClasses:   []string{"Music"},
+		VocalClasses:          []string{"Singing"},
+		VocalMaxConfidence:    0.05,
+		FFmpegPath:            fakeFFmpeg(t),
+		Version:               "9.9.9-app",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+	return d
+}
+
+func healthServer(t *testing.T, body map[string]any, hits *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("path = %q; want /health", r.URL.Path)
+		}
+		if hits != nil {
+			hits.Add(1)
+		}
+		if body == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+// The core of #684: the cache key must identify the MODEL, not the app build.
+// Keying on the app version invalidated every stored verdict on every release,
+// so the detector re-ran inference across the whole backlog and the library
+// disks never idled.
+func TestModelVersionComesFromSidecarNotAppVersion(t *testing.T) {
+	srv := healthServer(t, map[string]any{"status": "ok", "model_version": "sha-abc"}, nil)
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+
+	if got := d.ModelVersion(); got != "sha-abc" {
+		t.Fatalf("ModelVersion() = %q; want the SIDECAR model version %q", got, "sha-abc")
+	}
+	if got := d.ModelVersion(); got == "9.9.9-app" {
+		t.Fatal("ModelVersion() returned the APP version; that is the #684 defect")
+	}
+}
+
+// An app-version bump must NOT invalidate the cache: two detectors built from
+// different app versions against the same sidecar must agree on the key.
+func TestModelVersionSurvivesAppVersionBump(t *testing.T) {
+	srv := healthServer(t, map[string]any{"status": "ok", "model_version": "sha-abc"}, nil)
+	defer srv.Close()
+
+	older := newVersionDetector(t, srv.URL)
+	newer, err := NewHTTPDetector(Config{
+		ClassifierURL: srv.URL, SampleDurationSeconds: 30, MinConfidence: 0.90,
+		InstrumentalClasses: []string{"Music"}, VocalClasses: []string{"Singing"},
+		VocalMaxConfidence: 0.05, FFmpegPath: fakeFFmpeg(t), Version: "10.0.0-app",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	if older.ModelVersion() != newer.ModelVersion() {
+		t.Fatalf("app-version bump changed the cache key (%q -> %q); stored verdicts would all be discarded",
+			older.ModelVersion(), newer.ModelVersion())
+	}
+}
+
+// An older sidecar that does not report a version must yield UNKNOWN, which
+// fails closed to re-inference rather than reusing verdicts blindly.
+func TestModelVersionUnknownWhenSidecarOmitsIt(t *testing.T) {
+	srv := healthServer(t, map[string]any{"status": "ok", "classes": 521}, nil)
+	defer srv.Close()
+
+	if got := newVersionDetector(t, srv.URL).ModelVersion(); got != "" {
+		t.Fatalf("ModelVersion() = %q; want \"\" (unknown) for a sidecar with no model_version", got)
+	}
+}
+
+// A version learned once is cached: the probe must not run per work item.
+func TestModelVersionProbesOnceThenCaches(t *testing.T) {
+	var hits atomic.Int32
+	srv := healthServer(t, map[string]any{"status": "ok", "model_version": "sha-abc"}, &hits)
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+	for range 5 {
+		if got := d.ModelVersion(); got != "sha-abc" {
+			t.Fatalf("ModelVersion() = %q; want sha-abc", got)
+		}
+	}
+
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("health probed %d times; want exactly 1 (the version must be cached, not fetched per item)", n)
+	}
+}
+
+// The boot race (#567): the sidecar is routinely still starting when canticle
+// comes up. A failed probe must NOT be cached as empty -- that would disable the
+// verdict cache for the whole process lifetime and silently reproduce #684.
+func TestModelVersionRecoversAfterSidecarBoots(t *testing.T) {
+	var booted atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !booted.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "model_version": "sha-abc"})
+	}))
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+
+	if got := d.ModelVersion(); got != "" {
+		t.Fatalf("ModelVersion() = %q while the sidecar is booting; want \"\"", got)
+	}
+
+	booted.Store(true)
+	// Clear the retry throttle to simulate the interval elapsing.
+	d.modelVersionMu.Lock()
+	d.modelVersionNext = time.Time{}
+	d.modelVersionMu.Unlock()
+
+	if got := d.ModelVersion(); got != "sha-abc" {
+		t.Fatalf("ModelVersion() = %q after the sidecar booted; want sha-abc. "+
+			"A failed probe must not be cached as permanently unknown", got)
+	}
+}
+
+// A failing sidecar must not be probed once per call; retries are throttled.
+func TestModelVersionThrottlesRetriesWhileUnknown(t *testing.T) {
+	var hits atomic.Int32
+	srv := healthServer(t, nil, &hits) // always 503
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+	for range 5 {
+		if got := d.ModelVersion(); got != "" {
+			t.Fatalf("ModelVersion() = %q; want \"\" while the sidecar is failing", got)
+		}
+	}
+
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("health probed %d times; want 1 (retries must be throttled, not per-call)", n)
+	}
+}
+
+// Guard the context plumbing: the probe must respect a deadline rather than hang.
+func TestModelVersionProbeRespectsContext(t *testing.T) {
+	srv := healthServer(t, map[string]any{"status": "ok", "model_version": "sha-abc"}, nil)
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if got := d.resolveModelVersion(ctx); got != "" {
+		t.Fatalf("resolveModelVersion(canceled ctx) = %q; want \"\"", got)
+	}
+}

--- a/internal/detector/model_version_test.go
+++ b/internal/detector/model_version_test.go
@@ -179,3 +179,81 @@ func TestModelVersionProbeRespectsContext(t *testing.T) {
 		t.Fatalf("resolveModelVersion(canceled ctx) = %q; want \"\"", got)
 	}
 }
+
+// A sidecar MODEL SWAP must be picked up without restarting canticle.
+//
+// The cache used to hold the first non-empty version for the whole process
+// lifetime, so after an operator redeployed the sidecar with new weights the
+// detector kept stamping the OLD hash onto verdicts the NEW model produced.
+// That is worse than stale: it attributes a score to weights that did not
+// compute it, and it makes those scores reusable across a real model change --
+// exactly what the key exists to prevent (#684).
+func TestModelVersionRefreshesAfterModelSwap(t *testing.T) {
+	var current atomic.Value
+	current.Store("model-A")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "model_version": current.Load().(string),
+		})
+	}))
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+
+	if got := d.ModelVersion(); got != "model-A" {
+		t.Fatalf("ModelVersion() = %q; want model-A", got)
+	}
+
+	// Operator redeploys the sidecar with different weights.
+	current.Store("model-B")
+
+	// Within the TTL the cached value is still served -- that is the point of
+	// the cache, and re-probing per call would defeat it.
+	if got := d.ModelVersion(); got != "model-A" {
+		t.Fatalf("ModelVersion() = %q inside the TTL; want the cached model-A", got)
+	}
+
+	// Once the TTL lapses the next call must see the NEW model.
+	d.modelVersionMu.Lock()
+	d.modelVersionNext = time.Now().Add(-time.Second)
+	d.modelVersionMu.Unlock()
+
+	if got := d.ModelVersion(); got != "model-B" {
+		t.Fatalf("ModelVersion() = %q after the TTL lapsed; want model-B. "+
+			"A swapped sidecar must not keep stamping the previous model's hash", got)
+	}
+}
+
+// A probe failure AFTER a version is known must keep the last known value, not
+// revert to unknown. Unknown fails closed to re-inference, so a transient blip
+// would otherwise re-infer the entire backlog -- the #684 symptom, triggered by
+// one dropped request.
+func TestModelVersionKeepsLastKnownOnTransientFailure(t *testing.T) {
+	var up atomic.Bool
+	up.Store(true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !up.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "model_version": "model-A"})
+	}))
+	defer srv.Close()
+
+	d := newVersionDetector(t, srv.URL)
+	if got := d.ModelVersion(); got != "model-A" {
+		t.Fatalf("ModelVersion() = %q; want model-A", got)
+	}
+
+	up.Store(false) // sidecar goes down
+	d.modelVersionMu.Lock()
+	d.modelVersionNext = time.Now().Add(-time.Second)
+	d.modelVersionMu.Unlock()
+
+	if got := d.ModelVersion(); got != "model-A" {
+		t.Fatalf("ModelVersion() = %q after a failed refresh; want the last known model-A. "+
+			"Reverting to unknown would re-infer the whole backlog on a transient blip", got)
+	}
+}

--- a/internal/detector/roundtrip_test.go
+++ b/internal/detector/roundtrip_test.go
@@ -1,0 +1,66 @@
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// THE ROUND TRIP. The value Detect stamps onto Result.Version is what the worker
+// persists as work_queue.detector_version (worker.stampDetectorMissTelemetry ->
+// res.Version), and ModelVersion() is what memoDetector.canReuse compares it
+// against. If those two disagree, the verdict cache can NEVER hit -- which is
+// strictly worse than the #684 bug it replaces, since #684 at least reused a
+// verdict until the next release.
+//
+// No test covered this seam: every other test checks ONE side of the equality in
+// isolation, which is exactly how a persist/compare mismatch survives a green suite.
+func TestDetectResultVersionMatchesModelVersion(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "song.flac")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "model_version": "MODEL-SHA"})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"mean": map[string]float64{"Music": 0.95},
+				"max":  map[string]float64{"Music": 1.0, "Singing": 0.01},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(Config{
+		ClassifierURL: srv.URL, SampleDurationSeconds: 30, MinConfidence: 0.90,
+		InstrumentalClasses: []string{"Music"}, VocalClasses: []string{"Singing"},
+		VocalMaxConfidence: 0.05, FFmpegPath: fakeFFmpeg(t),
+		Version: "APP-1.30.0", // deliberately NOT the model version
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	res, err := d.Detect(context.Background(), audioPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	// This is the value the worker writes into work_queue.detector_version.
+	if res.Version != d.ModelVersion() {
+		t.Fatalf("Result.Version = %q but ModelVersion() = %q.\n"+
+			"The worker PERSISTS Result.Version and memoDetector.canReuse COMPARES ModelVersion(); "+
+			"if they differ the verdict cache can never hit and every row re-infers forever.",
+			res.Version, d.ModelVersion())
+	}
+	if res.Version == "APP-1.30.0" {
+		t.Fatal("Result.Version is the APP version; it must be the model version (#684)")
+	}
+}

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -228,7 +228,18 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 			continue
 		}
 
-		versionMatch := row.Tel.DetectorVersion == opts.CurrentVersion
+		// An UNKNOWN current version (empty) is not evidence of a mismatch, so it
+		// must not take the destructive branch. CurrentVersion is resolved from the
+		// sidecar's reported model version (#684) and is empty whenever that cannot
+		// be determined -- an old sidecar, one that is down, or a detector that
+		// could not be constructed. Treating that as "mismatched" would reset every
+		// row in the library, discarding stored telemetry and forcing exactly the
+		// full re-inference #684 exists to eliminate, on a transient probe failure.
+		//
+		// Settling instead is the safe direction: it writes the marker the current
+		// thresholds already say is correct (the row passed the gate above) and
+		// leaves the stored scores intact for a later run to re-judge.
+		versionMatch := opts.CurrentVersion == "" || row.Tel.DetectorVersion == opts.CurrentVersion
 		change := Change{
 			QueueID:    row.ID,
 			Artist:     row.Artist,

--- a/internal/instrumentalrecalib/unknown_version_test.go
+++ b/internal/instrumentalrecalib/unknown_version_test.go
@@ -1,0 +1,77 @@
+package instrumentalrecalib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/queue"
+)
+
+// An UNKNOWN current version must never trigger the destructive branch.
+//
+// CurrentVersion is resolved from the sidecar's reported model version (#684),
+// so it is empty whenever that cannot be determined: an old sidecar, a sidecar
+// that is down, or ffmpeg missing so the detector cannot even be constructed.
+// Comparing a real stored version against "" makes EVERY row look mismatched,
+// and the mismatch branch calls ResetInstrumentalToUnclassified -- discarding
+// stored telemetry library-wide and forcing a full re-inference. That is the
+// exact I/O storm #684 exists to eliminate, triggered by a transient probe
+// failure.
+//
+// Unknown must mean "I cannot tell, so change nothing", never "reset everything".
+func TestRun_UnknownCurrentVersionNeverResets(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/cello.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.17.0",
+	})
+
+	w := &fakeWriter{}
+	res, err := New(q, w).Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20,
+		CurrentVersion: "", // unknown: sidecar unreachable or too old to report one
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if res.ResetStale != 0 {
+		t.Fatalf("ResetStale = %d; want 0. An unknown current version must not reset any row -- "+
+			"that discards telemetry library-wide and forces the full re-inference #684 exists to prevent", res.ResetStale)
+	}
+
+	// It SETTLES instead: the row already passed the current thresholds above, so
+	// the marker the gate says is correct gets written. That is the safe
+	// direction -- the destructive branch discards telemetry, this one does not.
+	if res.Settled != 1 {
+		t.Fatalf("Settled = %d; want 1. With the version unknown the row should settle from its "+
+			"cached scores, not be discarded", res.Settled)
+	}
+	if w.calls != 1 {
+		t.Fatalf("writer calls = %d; want 1 (the settle writes the instrumental marker)", w.calls)
+	}
+}
+
+// The destructive branch must still fire on a REAL mismatch: the guard above
+// exempts only an UNKNOWN version, and must not have disabled reset entirely.
+// Without this, "never reset" would pass trivially by never resetting anything.
+func TestRun_KnownMismatchStillResets(t *testing.T) {
+	ctx := context.Background()
+	q := openTestQueue(t)
+
+	seedRejection(t, q, "/music/cello.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "old-model-sha",
+	})
+
+	res, err := New(q, &fakeWriter{}).Run(ctx, Options{
+		DryRun: false, MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20,
+		CurrentVersion: "new-model-sha", // known, and genuinely different
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.ResetStale != 1 {
+		t.Fatalf("ResetStale = %d; want 1. A row whose model really did change must still reset", res.ResetStale)
+	}
+}

--- a/internal/lyrics/detector_marker_provenance_test.go
+++ b/internal/lyrics/detector_marker_provenance_test.go
@@ -1,0 +1,56 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// A detector-written instrumental marker must be identifiable AS a detector
+// marker even when the model version is unknown.
+//
+// The writer stamps [source:canticle-detector] only when DetectorVersion is
+// non-empty, and IsDetector() keys purely on that source token. So an empty
+// version writes a marker indistinguishable from a PROVIDER one -- and
+// scanner.instrumentalReopenable treats a provider marker as editorially
+// terminal, reopenable only by a full --update and never by --upgrade. The
+// detector's verdict becomes permanently frozen on disk under a provider's
+// authority.
+//
+// This was structurally unreachable while DetectorVersion was the app version (a
+// build constant that is never empty). Keying it to the sidecar model (#684)
+// makes empty a ROUTINE state: every process start before /health answers, and
+// permanently against a sidecar too old to report a version.
+func TestWriteInstrumental_DetectorLaneIsIdentifiableWithoutAModelVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	song := models.Song{
+		Track: models.Track{
+			ArtistName:   "Test Artist",
+			TrackName:    "Test Track",
+			Instrumental: 1,
+		},
+		WinningLane:     "detector",
+		DetectorVersion: "", // unknown: sidecar booting, or too old to report one
+	}
+
+	if err := NewLRCWriter().WriteLRC(song, "", tmpDir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, Slugify("Test Artist - Test Track")+".txt")
+	prov, _, err := ReadInstrumentalProvenance(path)
+	if err != nil {
+		t.Fatalf("ReadInstrumentalProvenance: %v", err)
+	}
+
+	if !prov.IsDetector() {
+		body, _ := os.ReadFile(path) //nolint:errcheck // reason: diagnostic only, the assertion has already failed
+		t.Fatalf("IsDetector() = false for a marker the DETECTOR wrote (source=%q).\n"+
+			"An unknown model version must not disguise a detector verdict as a provider one: "+
+			"the scanner then treats it as editorially terminal and --upgrade can never re-check it.\nmarker:\n%s",
+			prov.Source, body)
+	}
+}

--- a/internal/lyrics/instrumental_provenance.go
+++ b/internal/lyrics/instrumental_provenance.go
@@ -13,6 +13,16 @@ import (
 // writer and the scanner agree on one spelling.
 const SourceDetector = "canticle-detector"
 
+// DetectorLaneName is the models.Song.WinningLane value the audio-detector lane
+// reports. The writer uses it to decide that a marker is detector-written, which
+// must depend on WHICH LANE WON and nothing else -- notably not on whether a
+// model version happens to be known (#684).
+//
+// This must agree with the orchestrator's own lane name; that is enforced by a
+// test in internal/orchestrator rather than left to comments, since a silent
+// disagreement here would mislabel every detector marker as provider-written.
+const DetectorLaneName = "detector"
+
 // InstrumentalProvenance is the provenance read from an instrumental .txt marker.
 // A detector marker carries Source == SourceDetector and a DetectorVersion; a
 // provider marker carries the provider lane name and an empty DetectorVersion.

--- a/internal/lyrics/writer.go
+++ b/internal/lyrics/writer.go
@@ -286,13 +286,34 @@ func (w *LRCWriter) WriteLRC(song models.Song, filename string, outdir string) (
 
 	if instrumental {
 		src := song.WinningLane
-		if song.DetectorVersion != "" {
+		// EITHER signal marks a detector-written marker. This used to key on
+		// DetectorVersion alone, which meant an unknown model version silently
+		// wrote [source:<lane>] instead of [source:canticle-detector]: IsDetector()
+		// then read false and scanner.instrumentalReopenable treated a provisional
+		// detector verdict as editorially terminal -- reopenable only by a full
+		// --update, never by --upgrade.
+		//
+		// That was structurally unreachable while DetectorVersion was the app
+		// version (a build constant, never empty). Keying it to the sidecar model
+		// (#684) makes empty routine: every process start before /health answers,
+		// and permanently against a sidecar too old to report a version. The
+		// provenance must not degrade just because the version is unknown.
+		//
+		// The version check is KEPT alongside the lane check rather than replaced
+		// by it: callers that build a detector Song directly, without going through
+		// the orchestrator that stamps WinningLane, carry the version and no lane.
+		// Requiring the lane alone would silently relabel those as provider-written
+		// -- the same defect, moved.
+		if song.WinningLane == DetectorLaneName || song.DetectorVersion != "" {
 			src = SourceDetector
 		}
 		tags = append(tags, "[by:canticle]")
 		if src != "" {
 			tags = append(tags, fmt.Sprintf("[source:%s]", src))
 		}
+		// [dv:] is omitted when unknown -- it records WHICH model decided, and an
+		// empty tag would assert a version that was never established. Absent is
+		// honest; the [source:] token above already carries the provenance.
 		if song.DetectorVersion != "" {
 			tags = append(tags, fmt.Sprintf("[dv:%s]", song.DetectorVersion))
 		}

--- a/internal/orchestrator/lane_name_agreement_test.go
+++ b/internal/orchestrator/lane_name_agreement_test.go
@@ -1,0 +1,27 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/lyrics"
+)
+
+// The detector lane's name is spelled in two packages and they must agree.
+//
+// internal/lyrics decides a marker is detector-written by comparing
+// models.Song.WinningLane against lyrics.DetectorLaneName. That value is set
+// here, by this package. A silent disagreement would label every detector
+// marker with [source:detector] instead of [source:canticle-detector], so
+// IsDetector() would read false and the scanner would treat a provisional
+// detector verdict as editorially terminal -- never re-checkable by --upgrade.
+//
+// lyrics cannot import orchestrator (orchestrator depends on lyrics), so the
+// constant is duplicated by necessity. This test is what makes that duplication
+// safe; without it the coupling is a comment, and comments do not fail builds.
+func TestDetectorLaneNameAgreesWithLyricsProvenance(t *testing.T) {
+	if detectorLaneName != lyrics.DetectorLaneName {
+		t.Fatalf("lane name disagreement: orchestrator=%q lyrics=%q.\n"+
+			"Every detector-written instrumental marker would be misattributed to a provider lane.",
+			detectorLaneName, lyrics.DetectorLaneName)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1611,7 +1611,16 @@ type InstrumentalTelemetry struct {
 	// VocalClass is the name of the vocal class that produced VocalPeak. Empty
 	// when no vocal class scored or when the sidecar returned no max map.
 	VocalClass string
-	// DetectorVersion is the app version string at detection time (internal/version.Version).
+	// DetectorVersion identifies the MODEL that produced these scores (the
+	// sidecar's loaded SavedModel sha, reported by its GET /health). It keys
+	// verdict-cache validity: the worker reuses a stored verdict only while this
+	// still matches the model currently loaded.
+	//
+	// It was the APP version until #684, which meant every canticle release
+	// invalidated every stored verdict even though the classifier had not changed,
+	// re-running inference across the whole backlog. Empty means UNKNOWN (an old
+	// or unreachable sidecar), which every consumer must treat as "do nothing
+	// destructive", never as a mismatch.
 	DetectorVersion string
 }
 
@@ -1886,9 +1895,14 @@ const (
 // when it is borderline (vocal_peak or speech_mean in band), cross-version
 // (detector_version differs from currentVersion), or un-scored (any telemetry
 // column NULL, e.g. a pre-#404 marker written before the telemetry columns
-// existed). currentVersion is the value #404 stamps into detector_version
-// (internal/version.Version). The returned clause uses only literal SQL and
-// placeholders, so it is safe to concatenate.
+// existed). currentVersion is the value stamped into detector_version: the
+// SIDECAR MODEL version since #684, not the app version. The returned clause
+// uses only literal SQL and placeholders, so it is safe to concatenate.
+//
+// NOTE the direction of an UNKNOWN ("") currentVersion here: this predicate
+// WIDENS on a mismatch, so unknown makes every row a candidate. That costs
+// re-inference, never data loss, and the caller is an operator-invoked
+// re-inference pass bounded by --limit.
 func instrumentalNarrowedPredicate(currentVersion string) (clause string, args []any) {
 	clause = ` AND (
             (vocal_peak BETWEEN ? AND ?)
@@ -1914,9 +1928,10 @@ type ListInstrumentalOptions struct {
 	// All returns the entire instrumental_result = 1 population, bypassing the
 	// telemetry-narrowed prefilter. CurrentVersion is then irrelevant.
 	All bool
-	// CurrentVersion is the detector version (internal/version.Version) the
+	// CurrentVersion is the SIDECAR MODEL version (#684, not the app version) the
 	// cross-version prefilter compares stored detector_version against. Required
-	// when All is false.
+	// when All is false. Empty (unknown) widens the candidate set rather than
+	// narrowing it -- see instrumentalNarrowedPredicate.
 	CurrentVersion string
 }
 


### PR DESCRIPTION
## Summary

- **The verdict cache was keyed on the wrong thing.** `work_queue.detector_version` gates verdict reuse (`memo_detector.go` `canReuse`), but it was stamped with the **canticle app version**. Every release invalidated every stored detector verdict library-wide even though the classifier never changed, so each affected row re-ran YAMNet inference -- an ffmpeg decode of the audio file. The library disks never got an idle window long enough to spin down. It now keys on the **sidecar's loaded model** (its pinned `YAMNET_SHA256`, reported via `GET /health`).
- **Measured in prod before the fix:** 26 distinct `detector_version` values across the queue, with only 1,152 of 17,231 telemetry-bearing rows (**6.7%**) reusable at the then-current version. A 10s-resolution watcher on the library disk showed a longest contiguous zero-read run of **50s against a 900s spindown timer**, with work due the entire window.
- **Look at first:** `internal/detector/http.go` (the lazy probe and what `Detect` stamps), and `internal/db/migrations/038_detector_version_model_key.sql` (why a blanket re-key is safe here and would not be in general).
- **Behavior change, user-visible:** `detector_version` in the DB and `[dv:]` in on-disk markers now hold a model sha rather than an app version. The decision log gains an `app_version` key; `detector_version` there now matches what is persisted. Migration 038 rewrites existing rows.
- **Size override:** growth is review-driven fixes to this same defect, not new scope. The first commit alone is known-broken (cache hit rate 0%), so no split point ships a correct state. ~9 logic files, ~11 test, ~5 docs/migration/meta.

## Linked issue

Part of #684

(#684 also covers the `verification` sidecar and retag-driven invalidation. The detector was the only audio reader active in prod -- there is no `[verification]` section in the prod config -- so this closes the live symptom but not the whole issue.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [ ] Commits squashed into one clean commit before the first push. **Deliberately kept as 3.** Each commit is a review round that found a real defect in the previous one; the history is the audit trail for how a 0%-cache-hit regression was caught. Squashed at merge.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes. **Not possible pre-deploy** -- see "Not covered".
- [x] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A, neither changed.
- [x] Migration added under `internal/db/migrations/` -- `038_detector_version_model_key.sql`.

## Test plan

- [x] `make gate` passes locally (run twice, clean both times).
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Every one, by mutation:
  - `detector/roundtrip_test.go` -- fails printing `Result.Version = "APP-1.30.0" but ModelVersion() = "MODEL-SHA"`.
  - `instrumentalrecalib/unknown_version_test.go` -- guard removed, test 1 fails; `versionMatch := true`, test 2 fails. Both directions pinned, so the guard cannot pass by never resetting.
  - `lyrics/detector_marker_provenance_test.go` -- fails showing the marker as `[source:detector]`, not `[source:canticle-detector]`.
  - `db/migration_038_test.go` -- migration body replaced with `SELECT 1;` -> fails on both verdict-bearing rows; restored -> passes.
  - `commands/..._ApplySettlesVersionMatchedRow` -- was **vacuous** (passed for any seeded version); now fails on a mismatch.
- [x] Patch coverage meets the Codecov threshold: **81.46% (123/151)** against 70.
- [x] Which **surface** this change fixes is stated explicitly. The surface is `work_queue.detector_version` (read by `memo_detector.canReuse`) plus the `[dv:]`/`[source:]` tags in on-disk `.txt` markers (read by `scanner.instrumentalReopenable`). Both were checked; correcting the DB alone would not have caught the marker-provenance defect, which is exactly what the second review round found.
- [ ] Manual UAT steps:
  - [ ] Blocked on deploy -- the sidecar image must ship first (canticle cannot read a version an old image does not send).
- [ ] Reviewer follow-ups:
  - [ ] `FetchModelVersion` builds a partial `&HTTPDetector{}` (only `baseURL`/`httpClient`). Safe today -- verified field-by-field, and `baseURL` construction matches `NewHTTPDetector` exactly -- but the two-field contract is a comment, not a type.
  - [ ] A long-running `serve` resolves `DetectorVersion` once at boot, so swapping the sidecar mid-run leaves marker invalidation on the boot-time sha until restart. Conservative (stale markers simply do not reopen), but undocumented behavior.

## Not covered

- **Not verified in prod.** Prod runs `1.30.0`/`87b9d4f`. The acceptance instrument for #684 is an I/O watcher looking for a contiguous zero-read window longer than the spindown timer; byte volume is explicitly not the criterion. That needs both halves deployed **in order** -- sidecar first, then canticle -- plus a loaded window. The 50s baseline above is the pre-fix reading.
- **The `verification` sidecar** (`worker.go:1354`) is a second audio reader on the worker path and is untouched. It is not enabled in prod, so it does not affect the live symptom.
- **Retag-driven invalidation** (#684's cache-key-on-(path,mtime,size) criterion) is not addressed.
- **The migration's `Down` is a documented no-op.** It collapses many app-version strings into one model key and the originals are recorded nowhere, so no rollback can restore them. Inventing a plausible version would be worse than losing it; NULLing would force the full re-inference this exists to prevent.
- **One flaky gate run.** The first `make gate` failed on tests; it did not reproduce across 3 targeted runs, a full `-race` suite, or 2 subsequent clean gates. Consistent with the known load-sensitive `internal/watcher` TTL test, but the failing test name was not captured, so this is reported rather than claimed as diagnosed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The detector health endpoint now reports the loaded model version when available.
  * Detector results and cached decisions now track the classifier model identity rather than the application release version.
  * Instrumental output remains correctly attributed to the detector even when model-version information is unavailable.

* **Bug Fixes**
  * Improved reconciliation behavior prevents destructive resets when the current model version cannot be determined.
  * Model-version checks now retry unavailable detector services without permanently caching failures.

* **Documentation**
  * Updated telemetry and model-drift guidance to reflect model-based version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->