### PR TITLE
ci(yamnet): hash-pin the smoke-test pip install

### DIFF
--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -126,10 +126,17 @@ jobs:
           set -euo pipefail
           # --user root: the image drops to appuser (uid 1000), but installing
           # pytest into system site-packages for this throwaway run needs root.
+          #
+          # --require-hashes against a generated lockfile, not a bare `pip install
+          # pytest httpx`: an unpinned install resolves to whatever PyPI serves at
+          # run time, which is an unverified dependency executing in CI (Scorecard
+          # alert #81, issue #636). Version pins alone do NOT clear the check --
+          # hashes are what make the install verifiable.
           docker run --rm --user root \
             -v "$PWD/deploy/yamnet-detector/test_app.py:/app/test_app.py:ro" \
+            -v "$PWD/deploy/yamnet-detector/requirements-test.txt:/app/requirements-test.txt:ro" \
             --entrypoint sh canticle-yamnet:smoke -c \
-            'pip install --no-cache-dir --quiet pytest httpx && pytest test_app.py -q'
+            'pip install --no-cache-dir --quiet --require-hashes -r requirements-test.txt && pytest test_app.py -q'
 
   publish:
     name: Publish to GHCR

--- a/deploy/yamnet-detector/requirements-test.in
+++ b/deploy/yamnet-detector/requirements-test.in
@@ -1,0 +1,14 @@
+# TEST-only tools for the sidecar shape test, installed into a THROWAWAY
+# container in CI (.github/workflows/yamnet.yml) -- never into the shipped image.
+# Runtime deps live in requirements.in and are baked in by the Dockerfile.
+#
+# Deliberately minimal: fastapi, numpy, and soundfile are already present in the
+# image from requirements.txt, and re-pinning them here would let the two lists
+# drift to different resolved versions of the same package inside one container.
+#
+# httpx is not a direct import of test_app.py -- it is what
+# starlette.testclient.TestClient requires, and the async concurrency test uses
+# httpx.ASGITransport directly. Named here because pip cannot install an optional
+# transitive dependency of an already-installed package on its own.
+pytest==8.3.4
+httpx==0.28.1

--- a/deploy/yamnet-detector/requirements-test.txt
+++ b/deploy/yamnet-detector/requirements-test.txt
@@ -1,0 +1,63 @@
+# GENERATED -- do not edit by hand. Top-level pins live in requirements-test.in.
+# Fully pinned + hash-pinned so `pip install --require-hashes` (see the smoke-test
+# step in .github/workflows/yamnet.yml) satisfies the Scorecard Pinned-Dependencies
+# check (alert #81: pipCommand not pinned by hash). Hashes cover all wheels + sdist
+# per version, so the lock is platform-portable.
+#
+# TEST-only. These tools are installed into a THROWAWAY container in CI, never
+# into the shipped image -- the runtime lock is requirements.txt.
+#
+# Regenerate after editing requirements-test.in (resolved in the runtime image,
+# linux/amd64, for a faithful transitive closure):
+#   docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w python:3.11-slim \
+#     bash -c 'pip install -q uv==0.5.31 && uv pip compile --generate-hashes \
+#       --no-header --no-emit-index-url requirements-test.in -o requirements-test.txt'
+#   (then re-add this header block)
+anyio==4.14.2 \
+    --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494 \
+    --hash=sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f
+    # via httpx
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
+    # via
+    #   httpcore
+    #   httpx
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via httpcore
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
+    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
+    # via httpx
+httpx==0.28.1 \
+    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+    # via -r requirements-test.in
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
+    # via
+    #   anyio
+    #   httpx
+iniconfig==2.3.0 \
+    --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+    # via pytest
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via pytest
+pluggy==1.6.0 \
+    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+    # via pytest
+pytest==8.3.4 \
+    --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 \
+    --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761
+    # via -r requirements-test.in
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
+    --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
+    # via anyio

--- a/deploy/yamnet-detector/test_app.py
+++ b/deploy/yamnet-detector/test_app.py
@@ -6,8 +6,14 @@ runs, and the stubbed _state is what the handler reads.
 
 Runs in CI inside the built image (.github/workflows/yamnet.yml, #498) and
 locally:
-    pip install -r requirements.txt pytest
+    pip install -r requirements.txt
+    pip install --require-hashes -r requirements-test.txt
     pytest test_app.py -q
+
+Two files, two installs: requirements.txt is the runtime lock the image bakes
+in, requirements-test.txt is the hash-pinned test-tool lock CI mounts into a
+throwaway container (#636). They cannot be combined -- pip rejects a
+--require-hashes run if ANY requirement in the invocation lacks a hash.
 """
 
 import io


### PR DESCRIPTION
## Summary

- The sidecar shape test installed its tools with a bare `pip install pytest httpx`, so CI executed **whatever PyPI served at run time** — an unverified dependency running inside the build. Scorecard flags it as alert #81 (`pipCommand not pinned by hash`).
- Version pins alone would not clear the check, and would not close the hole: a republished artifact at the same version still changes what runs. **Hashes** are what make the install verifiable. This follows the convention the runtime deps already use — a `.in` source compiled to a fully hash-pinned `.txt` — and installs with `--require-hashes`.
- **Look at first:** `requirements-test.txt` is generated, not hand-written. It came from the same pinned toolchain the runtime lock documents (`uv==0.5.31` inside `python:3.11-slim`, linux/amd64), so the hashes are real and the transitive closure is faithful. 11 packages, 22 hashes.
- No user-visible behavior change; CI-only.

## Linked issue

Closes #636

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — N/A (CI-only), but the install itself was exercised; see Test plan.
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A, no data change.

## Test plan

- [x] `make gate` passes locally (the Go gates self-skip — this diff has no `.go` files; `actionlint` covers the workflow change and is clean).
- [x] New tests were confirmed to **fail against unfixed code** — see the enforcement proof below. There are no new unit tests here; the change is a CI install path, so it was verified by execution instead.
- [x] Patch coverage meets the Codecov threshold — N/A, no Go source in the diff.
- [x] Which **surface** this change fixes is stated explicitly: the `Run sidecar shape test (inside the image)` step in `.github/workflows/yamnet.yml`, which is what Scorecard alert #81 points at. Verified against that step, not merely against the lockfile existing.
- [x] Manual UAT steps:
  - [x] The pinned install resolves and imports inside the target platform image: `docker run --platform linux/amd64 python:3.11-slim` → `pip install --require-hashes -r requirements-test.txt` → `pytest 8.3.4 httpx 0.28.1`.
  - [x] **Enforcement is real, not assumed.** Corrupting **both** of pytest's hashes fails the install: `ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE`, exit 1.
  - [x] `actionlint .github/workflows/yamnet.yml` clean.
- [ ] Reviewer follow-ups:
  - [ ] The lock is regenerated by hand from a documented command (the repo's existing convention for `requirements.txt`). There is no freshness check tying `.in` to `.txt`, so an edit to the `.in` without a regen would go unnoticed. Pre-existing for the runtime lock; this adds a second file with the same property.

## Not covered

- **A single-hash tamper test proves nothing here, and would have been a false green.** Corrupting only pytest's *wheel* hash still **succeeded** — pip fell back to the sdist, whose hash matched, and built from source. Only corrupting both hashes produced the refusal. Any future re-verification of this lock must tamper every hash for a package, not just the first.
- **One deviation from the issue's coding plan:** it suggested adding the new files to the workflow's `paths:` filter. That filter is already `deploy/yamnet-detector/**`, which covers both, so the change would be redundant. Everything else in the plan was adopted.
- The alert is only confirmed closed once Scorecard re-runs against `main` after merge; this PR fixes the flagged command but the alert state is not something the PR itself can assert.
