### PR TITLE
ci(yamnet): publish a :latest sidecar tag, bump pytest past PYSEC-2026-1845

### DIFF
--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -172,9 +172,29 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}-yamnet
-          # latest=false: a version-pinned sidecar should not have `latest` drift
-          # under it on each release (deployments pin X.Y.Z to match Canticle).
-          flavor: latest=false
+          # `latest` IS published (metadata-action's default latest=auto: applied
+          # only to a non-prerelease semver tag, never to a main push, since those
+          # emit only the type=raw tags below).
+          #
+          # This previously set latest=false, reasoning that a version-pinned
+          # sidecar should not have `latest` drifting under it. That rationale was
+          # circular -- deployments pinned X.Y.Z because no `latest` existed to
+          # track, and the pin was then read back as evidence that pinning was the
+          # intent.
+          #
+          # The real hazard it guarded against was a silent model swap: new weights
+          # arriving under a running deployment would re-classify tracks with
+          # nothing recording that the classifier had changed. #684 removed that.
+          # The loaded model's identity is now the verdict-cache key, read from the
+          # sidecar's GET /health: a swap is detected within the cache TTL, logged
+          # at INFO with both hashes, and correctly invalidates exactly the verdicts
+          # that the previous model produced so they re-infer against the new one.
+          # An unknown or too-old sidecar fails closed to re-inference and never to
+          # a wrong verdict.
+          #
+          # So drift is now observable and self-correcting rather than silent, and
+          # an operator who wants a frozen classifier can still pin X.Y.Z -- by
+          # choice, not for want of an alternative.
           tags: |
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Two related CI/deps fixes that both fell out of getting into position for the next release.

**1. Publish a `:latest` tag for the sidecar image.** The sidecar had none, so a deployment must pin an explicit `X.Y.Z` while the app image floats on `latest`. That asymmetry makes an upgrade apply to only half the pair — prod today runs `canticle:latest` alongside `canticle-yamnet:1.29.1`, so cutting a release moves the app and strands the sidecar. It matters more now: #684 keys the verdict cache on the model the sidecar reports via `GET /health`, and a sidecar too old to report one leaves canticle failing closed to re-inference, which would look exactly like the #684 fix not working.

**2. Bump pytest past PYSEC-2026-1845, and add the missing `pip` dependabot ecosystem.** Scorecard alert #13 fired seconds after #703 merged, and #703 caused it: it hash-pinned `pytest==8.3.4`, which is vulnerable (fixed in 9.0.3). The bare `pip install pytest` it replaced floated to a **patched** release — so hash-pinning to a version chosen without checking its advisory record traded a floating-but-safe dependency for a pinned-and-vulnerable one.

The deeper finding is why that could happen at all, and why the alert appeared to come and go rather than stay fixed: **`.github/dependabot.yml` had no `pip` ecosystem.** `gomod`, `github-actions`, and `docker` (×2) were all covered; every pinned Python dep aged silently with Scorecard as the only detector — after the fact, on main, with no PR to review.

**Look at first:** the removed `flavor: latest=false` and its replacement comment (the change is one line; the reasoning is the reviewable part), and the new `pip` ecosystem block.

## Linked issue

None directly. Follows from #684's deploy path and repairs a regression introduced by #703 (issue #636).

## Pre-flight checklist

- [x] Pre-push gate green locally — `actionlint` clean, `dependabot.yml` YAML-validated; Go gates self-skip (no `.go` files).
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [ ] Commits squashed into one clean commit — **deliberately kept as 2.** They are independent changes with separate rationales; squashing would bury the security fix under a CI-tagging title. Squashed at merge.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — the pytest install was exercised; the tag is not observable pre-merge (see "Not covered").
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A.

## Test plan

- [x] `actionlint .github/workflows/yamnet.yml` clean.
- [x] `.github/dependabot.yml` parses (`yaml.safe_load`).
- [x] New tests confirmed to fail against unfixed code — N/A, no new tests. Neither change has a unit-testable surface; both load-bearing claims are verified by execution or documentation instead (below).
- [x] Patch coverage meets the Codecov threshold — N/A, no Go source.
- [x] Which **surface** each change affects, stated explicitly: (1) the `Docker metadata` step's emitted tag set in the `publish` job of `yamnet.yml` — nothing else reads that flavor; (2) the pinned pytest version installed by the smoke-test step, which is what Scorecard's Vulnerabilities check reads.
- [x] Manual UAT steps:
  - [x] **The `latest=auto` claim was verified, not assumed.** Removing the override restores metadata-action's default. Per the action's documentation, `auto` emits `latest` only for `type=semver` / `type=pep440` / `type=match` / `type=ref,event=tag` — **never** for a branch push carrying only `type=raw` tags. A push to `main` therefore still publishes exactly `dev` + `nightly` + `nightly-DATE`, unchanged.
  - [x] The new pinned install resolves and imports inside the target platform image: `pytest 9.1.1 httpx 0.28.1`.
  - [x] The lock was regenerated with the documented toolchain (`uv==0.5.31` inside `python:3.11-slim`, linux/amd64), not hand-edited.
- [ ] Reviewer follow-ups:
  - [ ] Worth a sanity check that you *want* `latest` on the sidecar — this reverses a deliberate earlier decision, and the argument for reversing it lives in the commit body rather than in any test.

## Not covered

- **The `latest` tag cannot be observed until a release tag is pushed.** CI here exercises build + smoke test but not the `publish` job, which is gated to `main` pushes and tags. First real evidence is the tag list on the next `vX.Y.Z`.
- **Neither change updates any deployment.** Prod still pins `canticle-yamnet:1.29.1`; moving it to `latest` is a compose edit on the host, and per the ops runbook that needs `down` → `build` → `up` (a plain `up` silently keeps the old container).
- **Alert #13 is only confirmed cleared once Scorecard re-runs on `main` after merge.** This PR removes the flagged version but cannot assert the alert's state.
- **A pre-push vulnerability scan would not have caught this**, and is deliberately not part of this PR. Scorecard's Vulnerabilities check reads the advisory database, which moves independently of the repo: `pytest==8.3.4` was clean when pinned and became vulnerable later, with no commit in between. Only a scheduled scan plus an update mechanism catches that — hence the dependabot ecosystem rather than a gate.
- **Why the old `latest=false` rationale was dropped,** in case a future reader disagrees: the comment said "deployments pin X.Y.Z to match Canticle", but deployments pinned a version *because no `latest` existed to track*, and the pin was then read back as evidence that pinning was the intent. The genuine hazard behind it was a silent model swap re-classifying tracks with nothing recording the change; #684 closed that (swap detected within the cache TTL, logged at INFO with both hashes, exactly the previous model's verdicts invalidated). If that reasoning is wrong, the change is wrong.
