### PR TITLE
fix(deps): bump pytest past PYSEC-2026-1845, add the missing pip ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,34 @@ updates:
       - dependencies
       - docker
     open-pull-requests-limit: 5
+
+  # The YAMNet sidecar's Python deps. This ecosystem was MISSING while gomod,
+  # github-actions, and docker were all covered, so every pinned Python
+  # dependency aged silently and Scorecard's Vulnerabilities alert was the only
+  # thing that noticed -- after the fact, on main.
+  #
+  # It is not a hypothetical gap: pinning pytest==8.3.4 (issue #636) landed a
+  # version carrying PYSEC-2026-1845, and the pin made it permanent where the
+  # previous unpinned install had floated to a patched release. Hash pinning
+  # removes the drift that used to accidentally paper over an aging pin, so the
+  # pins now REQUIRE an update mechanism rather than merely benefiting from one.
+  #
+  # Dependabot regenerates the --require-hashes hashes on a bump, so both the
+  # runtime lock and the test lock stay installable.
+  - package-ecosystem: pip
+    directory: /deploy/yamnet-detector
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+    groups:
+      # The test tools move together and are never load-bearing at runtime, so a
+      # single PR per week beats three that each re-trigger the sidecar build.
+      yamnet-test-deps:
+        patterns:
+          - "pytest*"
+          - "httpx"

--- a/deploy/yamnet-detector/requirements-test.in
+++ b/deploy/yamnet-detector/requirements-test.in
@@ -10,5 +10,5 @@
 # starlette.testclient.TestClient requires, and the async concurrency test uses
 # httpx.ASGITransport directly. Named here because pip cannot install an optional
 # transitive dependency of an already-installed package on its own.
-pytest==8.3.4
+pytest==9.1.1
 httpx==0.28.1

--- a/deploy/yamnet-detector/requirements-test.txt
+++ b/deploy/yamnet-detector/requirements-test.txt
@@ -53,9 +53,13 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
-pytest==8.3.4 \
-    --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 \
-    --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via pytest
+pytest==9.1.1 \
+    --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     # via -r requirements-test.in
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \


### PR DESCRIPTION
## Summary

- **Scorecard alert #13 (`Vulnerabilities`) flags PYSEC-2026-1845 = pytest, fixed in 9.0.3.** #703 hash-pinned `pytest==8.3.4`, which is vulnerable. This bumps it to 9.1.1 and regenerates the lock.
- **#703 caused the current instance, and the shape is worth naming:** the bare `pip install pytest` it replaced floated to the *latest* release, which is **not** vulnerable. Hash-pinning to a version chosen without checking its advisory record traded a floating-but-patched dependency for a pinned-and-vulnerable one. Pinning is still correct — an unpinned CI install executes whatever PyPI serves — but a pin is only as good as the mechanism that ages it forward, and there was none.
- **That missing mechanism is the real fix here, and it explains the flapping** the maintainer observed (the alert leaving and reappearing): `.github/dependabot.yml` covered `gomod`, `github-actions`, and `docker` (×2), but had **no `pip` ecosystem**. Every pinned Python dep in the sidecar aged silently, with Scorecard as the only detector — after the fact, on `main`, with no PR to review. So the alert tracked whatever the latest scan happened to resolve rather than a managed pin.
- **Look at first:** the new `pip` ecosystem block in `dependabot.yml`. The version bump is mechanical; the ecosystem gap is the finding.

## Linked issue

None directly — repairs a regression introduced by #703 (issue #636) and clears code-scanning alert #13.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate` via `safe-push`; Go gates self-skip — no `.go` files in the diff).
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — the pinned install was exercised; see Test plan.
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A.

## Test plan

- [x] `.github/dependabot.yml` parses (`yaml.safe_load`).
- [x] New tests confirmed to fail against unfixed code — N/A, no new tests. A dependency pin has no unit-testable surface; verified by execution instead (below).
- [x] Patch coverage meets the Codecov threshold — N/A, no Go source in the diff.
- [x] Which **surface** this fixes is stated explicitly: the pinned pytest version installed by the smoke-test step in `yamnet.yml`, which is what Scorecard's `Vulnerabilities` check reads. Verified against the lockfile contents, not merely against the `.in`.
- [x] Manual UAT steps:
  - [x] The new pinned install resolves and imports inside the target platform image: `pytest 9.1.1 httpx 0.28.1`.
  - [x] The lock was regenerated with the documented toolchain (`uv==0.5.31` inside `python:3.11-slim`, linux/amd64), **not** hand-edited — so the hashes are real and the transitive closure is faithful.
- [ ] Reviewer follow-ups:
  - [ ] The test-tool group (`pytest*`, `httpx`) is a judgment call: one weekly PR instead of three that each re-trigger the sidecar build. Split it if you would rather see them individually.

## Not covered

- **A pre-push vulnerability scan would not have caught this**, which is why this PR adds an update mechanism rather than a gate. Scorecard's `Vulnerabilities` check reads the advisory database, which moves independently of the repo: `pytest==8.3.4` was clean when it was pinned and became vulnerable later, with no commit in between. Only a scheduled scan plus an aging mechanism catches that class.
- **Alert #13 is only confirmed cleared once Scorecard re-runs on `main` after merge.** This removes the flagged version but cannot assert the alert's state.
- **Dependabot's `pip` support for hash-pinned files is taken on documentation, not demonstrated here.** It regenerates `--require-hashes` hashes on a bump; the first real evidence will be the first bump PR it opens. If it were to produce a hash-less bump, the smoke-test step would fail loudly rather than silently install something unverified.
- **The runtime lock (`requirements.txt`) is unchanged.** It is now covered by the new ecosystem going forward, but this PR does not audit its current pins — that is a separate sweep if wanted.
