### PR TITLE
feat(yamnet): publish model provenance as OCI labels

### DIFF
--- a/.claude/release.toml
+++ b/.claude/release.toml
@@ -21,6 +21,43 @@ pre_checks = [
 # This governs GROUPING only. The surrounding structure -- the `### Highlights`
 # prose for a minor release, and the Docker-pull / full-changelog footer -- is not
 # expressible here; follow the previous release (`gh release view <prev-tag>`).
+#
+# ---------------------------------------------------------------------------
+# THE DETECTOR SIDECAR MUST BE ADDRESSED IN EVERY RELEASE (#682)
+# ---------------------------------------------------------------------------
+# Every release publishes a `canticle-yamnet` image tagged with CANTICLE's
+# version, whether or not the sidecar changed. So the tag records WHEN it was
+# built, not WHAT changed in it, and two functionally identical tags look exactly
+# like two different ones. State which it is, explicitly:
+#
+#   - Sidecar UNCHANGED -> say so, in the upgrade notes:
+#       "No detector-sidecar changes in this release; `X.Y.Z` is identical in
+#        substance to `X.Y.(Z-1)`."
+#     That one sentence is the entire point: it is what lets an operator skip a
+#     ~1.56GB pull.
+#
+#   - Sidecar CHANGED -> say what changed, and whether the BAKED MODEL moved.
+#     A model change is the case that actually matters: the three-gate detector
+#     thresholds are calibrated against a specific model, and a swap invalidates
+#     stored verdicts (they re-infer -- correct, but a real I/O cost). Never ship
+#     a model change silently.
+#
+# Check it mechanically rather than from memory:
+#   git diff --stat <prev-tag>..HEAD -- deploy/yamnet-detector/
+#   git diff <prev-tag>..HEAD -- deploy/yamnet-detector/Dockerfile | grep YAMNET_SHA256
+# An empty first result means UNCHANGED; a hit on the second means THE MODEL MOVED.
+#
+# The published image also carries the model identity as OCI labels, so a reader
+# can verify any claim here without pulling:
+#   docker buildx imagetools inspect ghcr.io/sydlexius/canticle-yamnet:X.Y.Z \
+#     --format '{{json .Image.Config.Labels}}'
+#
+# WORD CHOICE: "sidecar" is ambiguous in this project and has already misled a
+# reader. It means BOTH the lyric sidecar files (.lrc/.txt written next to audio)
+# and the detector container. v1.29.0's notes contained seven hits for "sidecar",
+# every one about lyric files, in a release that published a detector image that
+# had not changed. Always qualify: "lyric sidecar" or "detector sidecar", never
+# bare "sidecar". Same for "detector", which also names telemetry rows in the DB.
 [release_notes]
 default_group = "Maintenance"
 

--- a/.github/workflows/yamnet.yml
+++ b/.github/workflows/yamnet.yml
@@ -104,6 +104,37 @@ jobs:
           test "$status" = "ok" || { echo "expected status=ok, got $status" >&2; exit 1; }
           test "$classes" = "521" || { echo "expected classes=521, got $classes" >&2; exit 1; }
           echo "smoke test passed: status=$status classes=$classes"
+
+          # The provenance labels (#682) exist so an operator can answer "did this
+          # tag actually change?" from the registry alone, without pulling 1.56GB.
+          # That is only worth anything if the labels are TRUE, so verify them
+          # against the image that just started rather than trusting the values
+          # baked into the Dockerfile.
+          #
+          # The class-count label is the drift-prone one: it is a literal in the
+          # Dockerfile while the real count comes from the SavedModel's own asset
+          # map at load time. Checking it against /health closes that loop -- a
+          # model swap that changes the map now fails here instead of shipping a
+          # label that quietly lies.
+          label_classes=$(docker image inspect canticle-yamnet:smoke \
+            --format '{{index .Config.Labels "net.sydlexius.canticle.yamnet.model.class-count"}}')
+          test "$label_classes" = "$classes" || {
+            echo "class-count label ($label_classes) disagrees with /health ($classes)" >&2
+            echo "the model changed but the label did not -- update the Dockerfile label" >&2
+            exit 1
+          }
+
+          # The model sha label must match what the service reports, or the label
+          # names weights other than the ones loaded.
+          label_sha=$(docker image inspect canticle-yamnet:smoke \
+            --format '{{index .Config.Labels "net.sydlexius.canticle.yamnet.model.sha256"}}')
+          health_sha=$(jq -r '.model_version // ""' /tmp/health.json)
+          test -n "$label_sha" || { echo "model.sha256 label is empty" >&2; exit 1; }
+          test "$label_sha" = "$health_sha" || {
+            echo "model.sha256 label ($label_sha) disagrees with /health ($health_sha)" >&2
+            exit 1
+          }
+          echo "provenance labels verified against the running image: classes=$label_classes sha=${label_sha:0:12}..."
         # Always dump logs on failure so a broken start is diagnosable in CI.
       - name: Sidecar logs on failure
         if: failure()

--- a/deploy/yamnet-detector/Dockerfile
+++ b/deploy/yamnet-detector/Dockerfile
@@ -54,6 +54,33 @@ ARG YAMNET_SHA256=b80da2a1a56926fb0767205051a200dd7b3beaf3ea1ea126c42a53943996e5
 # build time from the same ARG the download is verified against, so the reported
 # version and the model on disk cannot disagree.
 ENV YAMNET_MODEL_SHA256=${YAMNET_SHA256}
+
+# Image provenance, readable WITHOUT pulling the image (#682):
+#   docker buildx imagetools inspect ghcr.io/sydlexius/canticle-yamnet:latest \
+#     --format '{{json .Image.Config.Labels}}'
+#
+# The problem this solves: the image is tagged with CANTICLE's version, so its
+# tag says when it was built, not what changed in it. Two tags can be
+# byte-identical in substance with nothing to tell an operator that, and -- the
+# case that actually matters -- a tag whose MODEL changed looks exactly the same.
+# The detector's three-gate thresholds are calibrated against a specific model,
+# so a silent model swap is precisely what must not be silent.
+#
+# model.sha256 is the same ARG the download is checksum-verified against and the
+# same value /health reports, so the label, the running service, and the bytes on
+# disk cannot disagree. Comparing this label across two tags answers "did this
+# actually change?" without pulling 1.56GB.
+#
+# class-count is the second half of the model's identity: app.py loads the class
+# map from the SavedModel's own assets and the CI smoke test asserts 521, so a
+# drifted model that kept the same hash (impossible) or a repacked one with a
+# different map would show up here.
+LABEL org.opencontainers.image.source="https://github.com/sydlexius/canticle" \
+      org.opencontainers.image.description="YAMNet AudioSet classifier sidecar for canticle instrumental detection" \
+      org.opencontainers.image.licenses="GPL-3.0" \
+      net.sydlexius.canticle.yamnet.model.sha256="${YAMNET_SHA256}" \
+      net.sydlexius.canticle.yamnet.model.source="${YAMNET_URL}" \
+      net.sydlexius.canticle.yamnet.model.class-count="521"
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates; \

--- a/deploy/yamnet-detector/README.md
+++ b/deploy/yamnet-detector/README.md
@@ -27,7 +27,31 @@ with `tf.saved_model.load` -- `tensorflow-hub` is deliberately not a dependency
   in the max (see issue #384). `np.max` is free on the same forward pass as
   `np.mean`.
 
-- `GET /health` returns `{"status": "ok", "classes": <N>}`.
+- `GET /health` returns `{"status": "ok", "classes": <N>, "model_version": "<sha256>"}`.
+  `model_version` is the sha256 of the baked SavedModel archive and is omitted
+  entirely when unknown (an image built without the build arg) rather than sent
+  empty -- a caller must be able to tell "these are the weights" from "I don't
+  know which weights". Canticle keys its instrumental-verdict cache on it, so a
+  stored verdict is reused exactly while the weights that produced it are loaded
+  (#684).
+
+## Which image am I running?
+
+The image is tagged with **canticle's** version, so the tag records when it was
+built rather than what changed in it. The model identity is published as OCI
+labels, readable from the registry without pulling ~1.56GB:
+
+```sh
+docker buildx imagetools inspect ghcr.io/sydlexius/canticle-yamnet:latest \
+  --format '{{json .Image.Config.Labels}}'
+```
+
+`net.sydlexius.canticle.yamnet.model.sha256` is the authoritative answer to "did
+this tag actually change?" -- compare it across two tags. If it matches, the
+classifier is identical no matter what the version numbers say. `model.source`
+and `model.class-count` complete the identity. CI verifies both labels against
+what the running container reports on `/health`, so a label cannot drift from the
+weights it names (#682).
 
 ## Deployment contract: pull the published image
 


### PR DESCRIPTION
## Summary

- **The detector-sidecar image is tagged with canticle's version, so its tag records *when* it was built, not *what* changed in it.** Two functionally identical tags look exactly like two different ones — and the case that matters looks the same too: a tag whose baked **model** changed is indistinguishable from one that did not. The three-gate detector thresholds are calibrated against a specific model, so a silent model swap is precisely what must not be silent.
- **The model identity is now published as OCI labels**, readable from the registry without pulling ~1.56GB. `model.sha256` answers "did this tag actually change?" — compare it across two tags, and a match means the classifier is identical whatever the version numbers say.
- **The release process gains the other half** (`.claude/release.toml`): every release must state whether the detector sidecar changed, with the mechanical check to determine it, and "sidecar" must be qualified at each use.
- **Look at first:** the CI shell block in `yamnet.yml`. The Dockerfile change is `LABEL` lines; the assertions are the only real logic here.

## Linked issue

Part of #682

(#682's fifth AC — settle the `latest` policy deliberately — was already satisfied by #704 and verified live on v1.30.1; see the status comment on the issue. This PR covers the remaining four. Leaving the issue open until the release-notes convention has actually been exercised on a real release.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`safe-push`; Go gates self-skip — no `.go` files in the diff).
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — built the real image and inspected the labels; see Test plan.
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A.

## Test plan

- [x] `actionlint .github/workflows/yamnet.yml` clean.
- [x] `.claude/release.toml` still parses (`tomllib`), 8 group labels intact.
- [x] New tests confirmed to fail against unfixed code — N/A in the unit sense; the new assertions live in CI. What they guard is stated below.
- [x] Patch coverage meets the Codecov threshold — N/A, no Go source.
- [x] Which **surface** this changes is stated explicitly: the OCI label set on the published `canticle-yamnet` image, and the `Smoke test (/health)` step that verifies it. Verified against a real built image, not just the Dockerfile text.
- [x] Manual UAT steps:
  - [x] Built the real image on `linux/amd64` and confirmed **all six labels interpolate to real values**, not literal `${...}` — the failure mode a Dockerfile-only read cannot catch.
  - [x] Ran CI's exact `docker image inspect --format '{{index .Config.Labels "…"}}'` extraction against that image; `model.sha256` matches the checksum-verified `YAMNET_SHA256` ARG and `class-count` matches the existing smoke assertion.
- [ ] Reviewer follow-ups:
  - [ ] The `label_classes` assertion relies on comparing against `$classes` to catch an absent label (an empty `--format` result), where `label_sha` gets an explicit `test -n`. Both fail correctly, but asymmetrically — worth a look if you'd rather they were uniform.

## Not covered

- **The `/health` cross-check could not be exercised locally.** TensorFlow requires AVX, which is exactly why this image is amd64-only, so the container will not start on Apple Silicon (`The TensorFlow library was compiled to use AVX instructions, but these aren't available on your machine`). The label-vs-`/health` assertions get their first real run in CI. The label *extraction* half was verified locally against the real image; the comparison half was not.
- **The `class-count` label is a literal in the Dockerfile** while the true count comes from the SavedModel's own asset map at load time. That is the drift risk this PR is most exposed to, and it is why the CI check exists — but the check is the only thing keeping them honest. A model swap that changes the map fails the build rather than shipping a lying label.
- **The release-notes convention is documentation, not enforcement.** Nothing mechanically blocks a release that omits the detector-sidecar section; it relies on the checklist being read. Making it a gate would be a separate change.
- **This does not decouple the sidecar's version from canticle's** (option 1 in the issue). The labels make the coupling *legible* rather than removing it — an operator can now tell that two differently-numbered tags are substantively identical, which was the practical complaint.
