### PR TITLE
fix(scan): stop re-enqueueing tracks quarantined by a categorical verdict

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1191,7 +1191,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		}()
 		go func() {
 			defer wg.Done()
-			runScheduler(runCtx, sqlDB, cfg, args, cacheRepo)
+			runScheduler(runCtx, sqlDB, cfg, args, cacheRepo, gen)
 		}()
 	}
 	// Build the watcher config from the central config (TOML + env, env > file)
@@ -1202,7 +1202,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runWatcher(runCtx, sqlDB, args, watchCfg, cfg, cacheRepo, selfWrites)
+			runWatcher(runCtx, sqlDB, args, watchCfg, cfg, cacheRepo, selfWrites, gen)
 		}()
 	}
 	// Periodic path-reconciliation sweep (#453): deletes queue/scan rows whose
@@ -1870,7 +1870,7 @@ func currentDetectorModelVersion(ctx context.Context, cfg config.Config) string 
 	return detector.FetchModelVersion(ctx, cfg.InstrumentalDetector.ClassifierURL)
 }
 
-func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd, cacheRepo *cache.CacheRepo) {
+func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args ServeCmd, cacheRepo *cache.CacheRepo, providersVersion int) {
 	// serve has no per-run detect override; resolve per library against the global
 	// default (and the per-library setting) at enqueue time.
 	// Periodic scans realign only when realign.enabled AND realign.on_scan.
@@ -1882,7 +1882,7 @@ func runScheduler(ctx context.Context, sqlDB *sql.DB, cfg config.Config, args Se
 		BFS:             args.BFS,
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 		DetectorVersion: detectorScanVersion(ctx, cfg),
-	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
+	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup, providersVersion)
 	// serve has no per-run enrichment override; resolve per library against the
 	// global default (and the per-library setting) inside the scheduler.
 	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
@@ -1964,7 +1964,7 @@ func watcherConfigFromCentral(cfg config.Config) watcher.Config {
 	}
 }
 
-func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watcher.Config, cfg config.Config, cacheRepo *cache.CacheRepo, selfWrites *selfwrite.Registry) {
+func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watcher.Config, cfg config.Config, cacheRepo *cache.CacheRepo, selfWrites *selfwrite.Registry, providersVersion int) {
 	// The watcher's ScanFunc is a subtree (RunOnceForPath) scan, so realign is
 	// scoped to the changed directory. It is gated by realign.enabled alone (not
 	// on_scan, which governs full periodic/manual scans).
@@ -1976,7 +1976,7 @@ func runWatcher(ctx context.Context, sqlDB *sql.DB, args ServeCmd, watchCfg watc
 		BFS:             args.BFS,
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 		DetectorVersion: detectorScanVersion(ctx, cfg),
-	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup)
+	}, nil, cfg.InstrumentalDetector.Enabled, cacheRepo, rlg, rlgBackup, providersVersion)
 	sched.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	pruner := prune.New(sqlDB)
 	pruner.SetIdentityKeys(cfg.Realign.IdentityKeys)
@@ -2155,7 +2155,10 @@ func runScan(ctx context.Context, out io.Writer, args ScanCmd) int {
 		EmbeddedLyrics:  embeddedLyricsMode(args.EmbeddedLyrics, cfg.Output.EmbeddedLyrics),
 		DetectorVersion: detectorScanVersion(ctx, cfg),
 		UnsyncedBefore:  unsyncedBefore,
-	}, detectOverride, cfg.InstrumentalDetector.Enabled, nil, rlg, rlgBackup)
+		// providersVersion 0: a one-shot `scan` constructs no provider set, so it
+		// has no generation to compare a stored verdict against. Zero never
+		// suppresses, so the CLI keeps its pre-#679 behavior exactly.
+	}, detectOverride, cfg.InstrumentalDetector.Enabled, nil, rlg, rlgBackup, 0)
 	s.EnrichOverride = enrichOverride
 	s.GlobalEnrichDefault = cfg.Enrichment.Enabled
 	if len(args.Libraries) > 0 {
@@ -2238,18 +2241,26 @@ func resolveDetectOverride(detect, noDetect bool) (*bool, error) {
 // already-cached tracks at enqueue time; pass the worker's shared repo in serve
 // mode so the /metrics hit-rate covers scheduler lookups too (#308),
 // or nil for a one-shot scan (a fresh, uncounted repo is created).
-func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, globalDetectDefault bool, cacheRepo *cache.CacheRepo, realigner *realign.Realigner, realignBackupPath string) scan.Scheduler {
+func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, globalDetectDefault bool, cacheRepo *cache.CacheRepo, realigner *realign.Realigner, realignBackupPath string, providersVersion int) scan.Scheduler {
 	results := scan.New(sqlDB)
 	if cacheRepo == nil {
 		cacheRepo = cache.New(sqlDB)
 	}
+	workQueue := queue.NewDBQueue(sqlDB)
 	enq := scan.Enqueuer{
 		Results:             results,
 		Cache:               cacheRepo,
-		Queue:               queue.NewDBQueue(sqlDB),
+		Queue:               workQueue,
 		Priority:            queue.PriorityScan,
 		DetectOverride:      detectOverride,
 		GlobalDetectDefault: globalDetectDefault,
+		// Consult the durable timing verdict so a Categorical track -- which
+		// writes no sidecar and is therefore indistinguishable on disk from one
+		// never fetched -- is not re-enqueued and re-fetched on every scan (#679).
+		// providersVersion 0 (a one-shot CLI scan, which has no provider set
+		// constructed) never suppresses, matching pre-#679 behavior exactly.
+		Timing:           scan.TimingVerdicts{Reader: workQueue},
+		ProvidersVersion: providersVersion,
 	}
 	return scan.Scheduler{
 		Libraries: library.New(sqlDB),

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -2247,6 +2247,14 @@ func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, gl
 		cacheRepo = cache.New(sqlDB)
 	}
 	workQueue := queue.NewDBQueue(sqlDB)
+	// The generation must be set on the queue that WRITES rows, not only handed
+	// to the enqueuer that reads them back. Enqueue stamps q.providersVersion
+	// onto every new row, so without this the scheduler's queue writes generation
+	// 0 while shouldSuppress compares against the live generation -- the two can
+	// never match and the #679 suppression is a silent no-op in exactly the mode
+	// (serve) that has a generation at all. A one-shot CLI scan passes 0 here,
+	// which is the pre-existing default and changes nothing.
+	workQueue.SetProvidersVersion(providersVersion)
 	enq := scan.Enqueuer{
 		Results:             results,
 		Cache:               cacheRepo,

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -550,7 +550,7 @@ func TestSchedulerBuildsScanEnqueuer(t *testing.T) {
 		t.Fatalf("Upsert scan result: %v", err)
 	}
 
-	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7}, nil, false, nil, nil, "")
+	got := scheduler(sqlDB, scanner.ScanOptions{MaxDepth: 7}, nil, false, nil, nil, "", 0)
 	if got.OnScanComplete == nil {
 		t.Fatal("scheduler OnScanComplete = nil; want enqueue callback")
 	}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2647,3 +2647,56 @@ func TestDetectorScanVersion(t *testing.T) {
 		t.Errorf("unreachable sidecar: detectorScanVersion = %q, want empty (unknown)", got)
 	}
 }
+
+// The scheduler's work queue must be stamped with the provider generation.
+//
+// Enqueue writes q.providersVersion onto every new row, and the #679
+// suppression compares that STORED value against the live generation. If the
+// queue scheduler() builds is left at the default 0 while the enqueuer is handed
+// a real generation, the two can never match: every row is written as
+// generation 0, read back as 0, compared against N, and the suppression is a
+// silent no-op in serve mode -- the only mode that has a generation at all.
+//
+// CodeRabbit caught this on #707; nothing in the suite did, because every
+// suppression test constructed the Enqueuer directly and never exercised
+// scheduler()'s wiring. This drives OnScanComplete -- the real callback, over
+// the real queue -- rather than a queue the test built itself, which would
+// verify the fixture instead of the code.
+func TestSchedulerStampsProvidersVersionOnItsQueue(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	lib, err := library.New(sqlDB).Add(ctx, "/music", "Music", models.LibrarySettings{})
+	if err != nil {
+		t.Fatalf("Add library: %v", err)
+	}
+	if err := scan.New(sqlDB).Upsert(ctx, lib.ID, []models.ScanResult{{
+		FilePath: "/music/a.mp3",
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:   "/music",
+		Filename: "a.lrc",
+		Status:   scan.StatusPending,
+	}}, scan.UpsertOptions{}); err != nil {
+		t.Fatalf("Upsert scan result: %v", err)
+	}
+
+	const gen = 42
+	s := scheduler(sqlDB, scanner.ScanOptions{}, nil, false, nil, nil, "", gen)
+	if err := s.OnScanComplete(ctx, models.Library{ID: lib.ID}, nil, lib.Path, scan.TriggerScheduler); err != nil {
+		t.Fatalf("OnScanComplete: %v", err)
+	}
+
+	var stored int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT providers_version FROM work_queue`).Scan(&stored); err != nil {
+		t.Fatalf("read providers_version: %v", err)
+	}
+	if stored != gen {
+		t.Fatalf("providers_version = %d; want %d -- a row stamped 0 can never match the live generation, "+
+			"so the #679 suppression would silently never fire", stored, gen)
+	}
+}

--- a/internal/queue/lookup_timing_test.go
+++ b/internal/queue/lookup_timing_test.go
@@ -1,0 +1,115 @@
+package queue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// LookupTiming is the READ side migration 034's columns never had: the worker
+// has stamped timing_outcome since #440, but nothing consumed it, so a
+// Categorical verdict (which writes no sidecar) was re-enqueued and re-fetched
+// on every scan (#679). These exercise it against a real SQLite database rather
+// than a fake, since the lookup is a query and its keying is the thing at risk.
+func TestLookupTimingReturnsStoredVerdict(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetProvidersVersion(7)
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Song"},
+		Outdir:   "out",
+		Filename: "a.lrc",
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := q.SetTimingOutcome(ctx, item.ID, TimingRecord{Outcome: "categorical"}); err != nil {
+		t.Fatalf("SetTimingOutcome: %v", err)
+	}
+
+	outcome, version, found, err := q.LookupTiming(ctx, "Artist", "Song")
+	if err != nil {
+		t.Fatalf("LookupTiming: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false; want true for a row carrying a verdict")
+	}
+	if outcome != "categorical" {
+		t.Errorf("outcome = %q; want categorical", outcome)
+	}
+	if version != 7 {
+		t.Errorf("providersVersion = %d; want 7 -- losing it would break expiry", version)
+	}
+}
+
+// The lookup keys on the NORMALIZED artist/title, exactly as work_queue itself
+// is keyed. A caller passes the raw tag values, so a lookup that did not
+// normalize would miss every row whose tags differ in case, spacing, or
+// Unicode form -- silently disabling the suppression for those tracks.
+func TestLookupTimingNormalizesTheKey(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "Hello", TrackName: "World"},
+		Outdir:   "out",
+		Filename: "a.lrc",
+	}, 1)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := q.SetTimingOutcome(ctx, item.ID, TimingRecord{Outcome: "categorical"}); err != nil {
+		t.Fatalf("SetTimingOutcome: %v", err)
+	}
+
+	// Same track, differently spelled by the caller.
+	outcome, _, found, err := q.LookupTiming(ctx, "  HELLO  ", " world ")
+	if err != nil {
+		t.Fatalf("LookupTiming: %v", err)
+	}
+	if !found || outcome != "categorical" {
+		t.Fatalf("found=%v outcome=%q; want the verdict to be found through normalization", found, outcome)
+	}
+}
+
+// A row with no verdict yet reports NOT FOUND, identically to no row at all: to
+// a caller both mean "no verdict on record", and collapsing them keeps the
+// caller from distinguishing two states it treats alike.
+func TestLookupTimingRowWithoutVerdictIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	if _, err := q.Enqueue(ctx, models.Inputs{
+		Track:    models.Track{ArtistName: "Artist", TrackName: "Unjudged"},
+		Outdir:   "out",
+		Filename: "a.lrc",
+	}, 1); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	_, _, found, err := q.LookupTiming(ctx, "Artist", "Unjudged")
+	if err != nil {
+		t.Fatalf("LookupTiming: %v", err)
+	}
+	if found {
+		t.Fatal("found = true for a row that has never been judged; want false")
+	}
+}
+
+// An absent track is the ordinary never-fetched case: not found, and NOT an
+// error. Returning an error here would make the caller fail open on every
+// unqueued track, which is every track on a first scan.
+func TestLookupTimingAbsentTrackIsNotAnError(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	_, _, found, err := q.LookupTiming(ctx, "Nobody", "Nothing")
+	if err != nil {
+		t.Fatalf("LookupTiming on an absent track returned an error: %v", err)
+	}
+	if found {
+		t.Fatal("found = true for a track that was never enqueued; want false")
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1740,6 +1740,44 @@ func (q *DBQueue) SetTimingOutcome(ctx context.Context, id int64, rec TimingReco
 	return nil
 }
 
+// LookupTiming returns the timing verdict recorded for a track, keyed the same
+// way work_queue itself is keyed -- normalized (artist_key, title_key), which is
+// uniquely indexed, so this reads at most one row.
+//
+// This is the READ side migration 034's columns never had. The worker has
+// stamped timing_outcome since #440, but nothing consumed it, so the pipeline
+// had no memory of having already rejected a track and a Categorical verdict
+// (which writes no sidecar) was re-enqueued and re-fetched on every scan (#679).
+//
+// found is false when the row exists but has no verdict, exactly as when no row
+// exists at all: to a caller both mean "no verdict on record", and collapsing
+// them keeps the caller from having to distinguish two states it treats alike.
+// providers_version is returned alongside so the caller can decide whether the
+// verdict still speaks for the current provider set.
+func (q *DBQueue) LookupTiming(ctx context.Context, artist, title string) (outcome string, providersVersion int, found bool, err error) {
+	var (
+		storedOutcome sql.NullString
+		storedVersion sql.NullInt64
+	)
+	row := q.db.QueryRowContext(ctx,
+		`SELECT timing_outcome, providers_version
+         FROM work_queue
+         WHERE artist_key = ? AND title_key = ?`,
+		normalize.NormalizeKey(artist),
+		normalize.NormalizeKey(title),
+	)
+	switch err := row.Scan(&storedOutcome, &storedVersion); {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", 0, false, nil
+	case err != nil:
+		return "", 0, false, fmt.Errorf("queue: lookup timing verdict: %w", err)
+	}
+	if !storedOutcome.Valid || storedOutcome.String == "" {
+		return "", 0, false, nil
+	}
+	return storedOutcome.String, int(storedVersion.Int64), true, nil
+}
+
 // CompletionProvenance carries the identifiers and writer version a work_queue
 // row was settled with (#620). Every field is optional: an empty string or zero
 // time leaves the corresponding column NULL, which means "not recorded" and

--- a/internal/scan/categorical_suppression_test.go
+++ b/internal/scan/categorical_suppression_test.go
@@ -1,0 +1,290 @@
+package scan_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/scan"
+	"github.com/sydlexius/canticle/internal/timing"
+)
+
+// fakeTimingVerdicts stands in for the durable timing_outcome record (#440).
+// Keyed by the same (artist, title) the enqueuer already has from a scan result.
+type fakeTimingVerdicts struct {
+	verdicts map[string]scan.TimingVerdict
+	err      error
+	lookups  int
+}
+
+func (f *fakeTimingVerdicts) LookupTiming(_ context.Context, artist, title string) (scan.TimingVerdict, bool, error) {
+	f.lookups++
+	if f.err != nil {
+		return scan.TimingVerdict{}, false, f.err
+	}
+	v, ok := f.verdicts[artist+"\x00"+title]
+	return v, ok, nil
+}
+
+// A Categorical verdict writes NO sidecar, so nothing on disk suppresses the
+// next attempt: the row looks exactly like a track that was never fetched and is
+// re-enqueued, re-fetched, re-judged and re-rejected on every single scan,
+// forever. That is a self-inflicted read loop against the library disks (#679).
+func TestEnqueuePendingSuppressesCategorical(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/quarantined.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Quarantined"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Quarantined": {Outcome: timing.Categorical, ProvidersVersion: 3},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 3,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 0 || len(work.inputs) != 0 {
+		t.Fatalf("enqueued=%d items=%d; want 0 -- a Categorical row must not be re-fetched on every scan",
+			enqueued, len(work.inputs))
+	}
+}
+
+// MisSynced is already safe: it WRITES a .txt, and #439's settled-sidecar check
+// makes a later re-fetch a no-op. Suppressing it too would be scope creep that
+// hides a recoverable track, so the suppression must be Categorical-only.
+func TestEnqueuePendingSuppressesOnlyCategorical(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/mistimed.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Mistimed"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Mistimed": {Outcome: timing.MisSynced, ProvidersVersion: 3},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 3,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- MisSynced writes a .txt and is already safe, do not suppress it", enqueued)
+	}
+}
+
+// Suppression EXPIRES with the provider generation. A Categorical verdict is a
+// statement about what the providers served at ONE MOMENT; if the provider set
+// changes, the track deserves another look. Tying expiry to the existing
+// providers_version counter reuses the mechanism that already retires stale
+// cache entries rather than inventing a parallel one.
+func TestEnqueuePendingRetriesCategoricalAfterProviderGenerationChange(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/quarantined.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Quarantined"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Quarantined": {Outcome: timing.Categorical, ProvidersVersion: 3},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 4, // provider set changed since the verdict
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- a new provider generation must re-examine a quarantined track", enqueued)
+	}
+}
+
+// A nil Timing seam must preserve pre-#679 behavior exactly, so every non-serve
+// caller (and any construction that predates this) keeps working unchanged.
+func TestEnqueuePendingNilTimingSeamEnqueuesNormally(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/song.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Song"},
+	}}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{Results: store, Cache: fakeLyricsCache{}, Queue: work}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 with no Timing seam wired", enqueued)
+	}
+}
+
+// A lookup error must FAIL OPEN (enqueue anyway). Suppression is an
+// optimization: a failed read of the verdict must never silently drop work,
+// which would look exactly like a track that was fetched and lose it.
+func TestEnqueuePendingFailsOpenOnTimingLookupError(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/song.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Song"},
+	}}}
+	verdicts := &fakeTimingVerdicts{err: context.DeadlineExceeded}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 3,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- a failed verdict lookup must not drop work", enqueued)
+	}
+}
+
+// fakeVerdictReader is the raw primitive-shaped queue read the adapter wraps.
+type fakeVerdictReader struct {
+	outcome string
+	version int
+	found   bool
+	err     error
+	artist  string
+	title   string
+	lookups int
+}
+
+func (f *fakeVerdictReader) LookupTiming(_ context.Context, artist, title string) (string, int, bool, error) {
+	f.lookups++
+	f.artist, f.title = artist, title
+	return f.outcome, f.version, f.found, f.err
+}
+
+// The adapter exists so internal/queue never has to import internal/scan (scan
+// imports queue, and reversing that would be a cycle). It must convert the
+// stored outcome STRING into the typed verdict without losing the generation.
+func TestTimingVerdictsAdaptsStoredOutcome(t *testing.T) {
+	r := &fakeVerdictReader{outcome: string(timing.Categorical), version: 9, found: true}
+
+	v, found, err := scan.TimingVerdicts{Reader: r}.LookupTiming(context.Background(), "A", "T")
+	if err != nil {
+		t.Fatalf("LookupTiming: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false; want true when the reader reports a verdict")
+	}
+	if v.Outcome != timing.Categorical {
+		t.Errorf("Outcome = %q; want %q", v.Outcome, timing.Categorical)
+	}
+	if v.ProvidersVersion != 9 {
+		t.Errorf("ProvidersVersion = %d; want 9 -- losing it would break expiry", v.ProvidersVersion)
+	}
+	if r.artist != "A" || r.title != "T" {
+		t.Errorf("reader saw (%q,%q); want the caller's artist/title verbatim", r.artist, r.title)
+	}
+}
+
+// A nil Reader must be inert rather than panic: the adapter is constructed from
+// wiring that a non-serve caller may legitimately leave unset.
+func TestTimingVerdictsNilReaderIsInert(t *testing.T) {
+	v, found, err := scan.TimingVerdicts{}.LookupTiming(context.Background(), "A", "T")
+	if err != nil || found || v.Outcome != "" {
+		t.Fatalf("nil reader = (%+v, %v, %v); want a zero verdict, not found, no error", v, found, err)
+	}
+}
+
+// A reader error propagates rather than being reported as "no verdict". The
+// caller distinguishes them: an error fails open (enqueue anyway), while
+// not-found is the ordinary never-fetched case.
+func TestTimingVerdictsPropagatesReaderError(t *testing.T) {
+	r := &fakeVerdictReader{err: context.DeadlineExceeded}
+
+	_, found, err := scan.TimingVerdicts{Reader: r}.LookupTiming(context.Background(), "A", "T")
+	if err == nil {
+		t.Fatal("err = nil; want the reader's error surfaced so the caller can fail open deliberately")
+	}
+	if found {
+		t.Error("found = true on an errored lookup; want false")
+	}
+}
+
+// An unrecognized stored value must not suppress. The column holds a verbatim
+// timing.TimingOutcome, but a future value (or a hand-edited row) must degrade
+// to "not Categorical" rather than matching something by accident.
+func TestTimingVerdictsUnknownOutcomeDoesNotSuppress(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/song.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Song"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Song": {Outcome: timing.TimingOutcome("something_else"), ProvidersVersion: 3},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 3,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- only Categorical suppresses", enqueued)
+	}
+}
+
+// A zero current generation (an unknown provider set, as in a one-shot CLI scan)
+// must never suppress: without a trustworthy comparison the safe direction is to
+// re-examine, since the cost is one refetch versus losing the track indefinitely.
+func TestEnqueuePendingUnknownGenerationNeverSuppresses(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/quarantined.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Quarantined"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Quarantined": {Outcome: timing.Categorical, ProvidersVersion: 0},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 0,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- an unknown generation must not suppress", enqueued)
+	}
+}

--- a/internal/scan/enqueuer.go
+++ b/internal/scan/enqueuer.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/normalize"
 	"github.com/sydlexius/canticle/internal/queue"
+	"github.com/sydlexius/canticle/internal/timing"
 )
 
 // PendingResultStore reads and updates scan results eligible for queuing.
@@ -32,6 +34,60 @@ type WorkQueue interface {
 	Enqueue(ctx context.Context, inputs models.Inputs, priority int) (queue.WorkItem, error)
 }
 
+// TimingVerdict is a track's persisted accept-time timing decision, together
+// with the provider generation that produced it.
+type TimingVerdict struct {
+	// Outcome is the stored work_queue.timing_outcome value (#440).
+	Outcome timing.TimingOutcome
+	// ProvidersVersion is the provider-set generation in effect when the verdict
+	// was reached. It is what makes the suppression expire: see shouldSuppress.
+	ProvidersVersion int
+}
+
+// TimingVerdictStore reads the durable timing verdict recorded for a track.
+//
+// This is the consumer that migration 034's columns never had: the worker has
+// stamped timing_outcome since #440, but nothing read it back, so the pipeline
+// had no memory of having already rejected a track (#679).
+//
+// found is false when no verdict was ever recorded, which is the normal case for
+// a track that has simply not been fetched yet.
+type TimingVerdictStore interface {
+	LookupTiming(ctx context.Context, artist, title string) (TimingVerdict, bool, error)
+}
+
+// TimingVerdictReader is the raw queue-side read, in primitives.
+//
+// *queue.DBQueue satisfies it directly. Keeping the queue package free of a
+// scan-package type preserves the existing dependency direction (scan imports
+// queue, never the reverse); TimingVerdicts bridges the two shapes.
+type TimingVerdictReader interface {
+	LookupTiming(ctx context.Context, artist, title string) (outcome string, providersVersion int, found bool, err error)
+}
+
+// TimingVerdicts adapts a TimingVerdictReader to TimingVerdictStore.
+type TimingVerdicts struct {
+	Reader TimingVerdictReader
+}
+
+// LookupTiming converts the stored outcome string into a typed verdict. The
+// column holds an internal/timing TimingOutcome verbatim (see migration 034), so
+// the conversion is a cast rather than a parse; an unrecognized value simply
+// never matches Categorical and therefore never suppresses.
+func (t TimingVerdicts) LookupTiming(ctx context.Context, artist, title string) (TimingVerdict, bool, error) {
+	if t.Reader == nil {
+		return TimingVerdict{}, false, nil
+	}
+	outcome, version, found, err := t.Reader.LookupTiming(ctx, artist, title)
+	if err != nil || !found {
+		return TimingVerdict{}, false, err
+	}
+	return TimingVerdict{
+		Outcome:          timing.TimingOutcome(outcome),
+		ProvidersVersion: version,
+	}, true, nil
+}
+
 // Enqueuer bridges pending scan results to the durable work queue.
 type Enqueuer struct {
 	Results  PendingResultStore
@@ -46,6 +102,48 @@ type Enqueuer struct {
 	// enqueued item (stamp-on-insert; the worker reads it back later).
 	DetectOverride      *bool
 	GlobalDetectDefault bool
+	// Timing reads the durable timing verdict so a Categorical track is not
+	// re-fetched on every scan (#679). Optional: a nil Timing disables the
+	// suppression entirely and preserves the pre-#679 behavior, so a caller that
+	// does not wire it enqueues exactly as before.
+	Timing TimingVerdictStore
+	// ProvidersVersion is the CURRENT provider-set generation, compared against
+	// the generation stored with a verdict to decide whether the verdict still
+	// speaks for today's provider set. Zero means unknown, which never suppresses.
+	ProvidersVersion int
+}
+
+// shouldSuppress reports whether a track's stored timing verdict means this scan
+// must not re-enqueue it.
+//
+// ONLY Categorical suppresses. That verdict means the lyric was timed to a
+// different, longer recording -- the words themselves are suspect -- so the
+// accept-time guard (#439) deliberately writes NOTHING. With no sidecar on disk,
+// the row is indistinguishable from a track that was never fetched, so it is
+// re-enqueued, re-fetched, re-judged and re-rejected on every scan forever.
+//
+// MisSynced is deliberately NOT suppressed. It writes a .txt, and #439's
+// settled-sidecar check makes a later re-fetch a no-op: wasteful, never
+// destructive. Suppressing it would hide a recoverable track for no gain.
+//
+// THE SUPPRESSION EXPIRES WITH THE PROVIDER GENERATION, and that is a deliberate
+// choice rather than a default. A Categorical verdict is a statement about what
+// the providers served at ONE MOMENT; permanent suppression would mean never
+// finding correctly-timed lyrics that a provider starts serving later. Tying
+// expiry to providers_version reuses the generation counter that already retires
+// stale cache entries, instead of inventing a second, parallel expiry scheme.
+//
+// A zero current generation (unknown) never suppresses: without a trustworthy
+// comparison the safe direction is to re-examine, since the cost is one refetch
+// while the cost of wrongly suppressing is losing the track indefinitely.
+func (e *Enqueuer) shouldSuppress(v TimingVerdict) bool {
+	if v.Outcome != timing.Categorical {
+		return false
+	}
+	if e.ProvidersVersion == 0 {
+		return false
+	}
+	return v.ProvidersVersion == e.ProvidersVersion
 }
 
 // EnqueuePending reads pending scan results for libraryID, skips cache hits,
@@ -77,6 +175,13 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, lib models.Library) (enqu
 		return 0, 0, fmt.Errorf("scan: list pending for enqueue: %w", err)
 	}
 
+	// Tracks skipped this pass because a Categorical verdict quarantined them.
+	// Logged once at the end rather than returned: a per-track line would be
+	// noise on a library where the count is stable across scans, and the full
+	// operator surface (listing and re-examining quarantined tracks) belongs to
+	// #629 rather than a second mechanism built here.
+	suppressed := 0
+
 	for _, res := range results {
 		if err := ctx.Err(); err != nil {
 			return enqueued, cacheHits, err
@@ -92,6 +197,29 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, lib models.Library) (enqu
 		case errors.Is(err, sql.ErrNoRows):
 		default:
 			return enqueued, cacheHits, fmt.Errorf("scan: cache lookup %d: %w", res.ID, err)
+		}
+
+		// A Categorical verdict wrote no sidecar, so nothing on disk stops this
+		// track being re-fetched forever. Consult the durable verdict instead
+		// (#679), placed here -- after the cache check, before the row is reserved
+		// -- so a suppressed track stays pending and is re-examined the moment the
+		// provider generation moves, rather than being consumed by this scan.
+		//
+		// FAILS OPEN by construction: a lookup error is logged and ignored, since
+		// suppression is an optimization and a failed read must never silently
+		// drop work. Losing a track looks identical to having fetched it.
+		if e.Timing != nil {
+			verdict, found, terr := e.Timing.LookupTiming(ctx, res.Track.ArtistName, res.Track.TrackName)
+			switch {
+			case terr != nil:
+				slog.Debug("scan: timing verdict lookup failed; enqueueing anyway",
+					"result_id", res.ID, "error", terr)
+			case found && e.shouldSuppress(verdict):
+				slog.Debug("scan: skipping track quarantined by a categorical timing verdict",
+					"result_id", res.ID, "providers_version", verdict.ProvidersVersion)
+				suppressed++
+				continue
+			}
 		}
 
 		if err := e.Results.SetStatus(ctx, []int64{res.ID}, StatusProcessing); err != nil {
@@ -112,6 +240,14 @@ func (e *Enqueuer) EnqueuePending(ctx context.Context, lib models.Library) (enqu
 			return enqueued, cacheHits, fmt.Errorf("scan: enqueue result %d: %w", res.ID, err)
 		}
 		enqueued++
+	}
+	// Never leave the suppression silent: a track skipped here produces no work
+	// item, no sidecar and no queue row, so without this line an operator has no
+	// way to tell "nothing left to fetch" from "N tracks are quarantined".
+	if suppressed > 0 {
+		slog.Info("scan: skipped tracks quarantined by a categorical timing verdict",
+			"library_id", libraryID, "suppressed", suppressed,
+			"providers_version", e.ProvidersVersion)
 	}
 	return enqueued, cacheHits, nil
 }

--- a/internal/watcher/selfwrite_test.go
+++ b/internal/watcher/selfwrite_test.go
@@ -283,10 +283,19 @@ func TestExpiredSelfWriteNoLongerSuppresses(t *testing.T) {
 
 	target := filepath.Join(root, "aged.flac")
 	reg.Record(target)
-	// Poll the exact predicate the assertion below depends on, rather than
-	// sleeping a constant tuned against the TTL. This proceeds the instant the
-	// entry actually ages out, on any machine and at any TTL, and it cannot drift
-	// out of step with the constant above the way a fixed sleep silently would.
+	// Assert the entry is suppressed BEFORE polling for it to stop being
+	// suppressed. Without this the expiry poll is satisfied instantly by a broken
+	// or ineffective Record -- the predicate would already be true, the write
+	// would trigger a scan, and the test would pass while proving nothing about
+	// expiry. Establishing the starting state is what makes the transition
+	// meaningful.
+	if !reg.Suppress(target) {
+		t.Fatal("a just-recorded path is not suppressed; the expiry assertion below would pass vacuously")
+	}
+	// Poll the exact predicate the assertion depends on, rather than sleeping a
+	// constant tuned against the TTL. This proceeds the instant the entry
+	// actually ages out, on any machine and at any TTL, and it cannot drift out
+	// of step with the constant above the way a fixed sleep silently would.
 	waitFor(t, func() bool { return !reg.Suppress(target) }, "the recorded entry to age out")
 
 	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {

--- a/internal/watcher/selfwrite_test.go
+++ b/internal/watcher/selfwrite_test.go
@@ -245,7 +245,27 @@ func TestFullWriteCycleTriggersNoRescan(t *testing.T) {
 // permanently invisible to the watcher.
 func TestExpiredSelfWriteNoLongerSuppresses(t *testing.T) {
 	root := tempRoot(t)
-	reg := selfwrite.New(30 * time.Millisecond)
+	// 750ms, not 30ms. The sentinel step below races the TTL against FSEvents
+	// DELIVERY LATENCY, which is bounded by the OS scheduler rather than by
+	// anything this test controls: measured at ~11-14ms typical but 80ms at p99
+	// under CPU oversubscription. A 30ms TTL is a ~1.5x margin, so under load the
+	// entry expired before its own event arrived, the watcher correctly treated
+	// the event as external, and the test failed on the SETUP step reporting "the
+	// sentinel event to be suppressed" -- a false negative that says nothing about
+	// the expiry behavior it exists to pin. Reproduced at 17/40 under load; 40/40
+	// clean at this value.
+	//
+	// Widening is sufficient here rather than papering over a race, because the
+	// two racing quantities are INDEPENDENT: worst-case delivery is a property of
+	// the scheduler, and the TTL is a free test constant. This is a ~9x margin
+	// against the worst latency observed.
+	//
+	// Note an injected clock does NOT help. selfwrite.Registry already has one
+	// (r.now), and internal/selfwrite covers expiry deterministically with it. The
+	// uncontrolled variable here is kernel event delivery, which no clock
+	// injection reaches, so faking time would leave this race untouched.
+	const ttl = 750 * time.Millisecond
+	reg := selfwrite.New(ttl)
 	scanned, drops := startWatcher(t, root, reg)
 
 	// Prove notify delivery works HERE before the timeout below is allowed to
@@ -263,11 +283,11 @@ func TestExpiredSelfWriteNoLongerSuppresses(t *testing.T) {
 
 	target := filepath.Join(root, "aged.flac")
 	reg.Record(target)
-	// Let the entry age out before the change lands.
-	time.Sleep(60 * time.Millisecond)
-	if reg.Suppress(target) {
-		t.Fatal("entry did not expire; the rest of this test would prove nothing")
-	}
+	// Poll the exact predicate the assertion below depends on, rather than
+	// sleeping a constant tuned against the TTL. This proceeds the instant the
+	// entry actually ages out, on any machine and at any TTL, and it cannot drift
+	// out of step with the constant above the way a fixed sleep silently would.
+	waitFor(t, func() bool { return !reg.Suppress(target) }, "the recorded entry to age out")
 
 	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)


### PR DESCRIPTION
## Summary

- **A `Categorical` timing verdict writes no sidecar, so the track is re-fetched on every scan, forever.** The accept-time guard (#439) deliberately writes nothing — the lyric was timed to a different, longer recording, so the words themselves are suspect. With nothing on disk, the row is indistinguishable from a track that was never fetched, so it is re-enqueued, re-fetched, re-judged and re-rejected indefinitely. That is a self-inflicted read loop against the library disks.
- **The durable record already existed and had no consumer.** Migration 034 added `timing_outcome` and the worker has stamped it since #440. Nothing ever read it back. This adds the missing read.
- **Look at first:** `shouldSuppress` in `internal/scan/enqueuer.go` — the expiry rule and the two fail-open paths are where the risk is. The SQL read is mechanical.
- Also carries an unrelated fix for a flake that blocked three pushes tonight (second commit; see below).

## Linked issue

Part of #679

(Leaving the issue open until the operator-visibility AC is genuinely satisfied — it is deferred to #629 with a written justification, which the issue permits, but the deferral should be confirmed rather than assumed closed by me.)

## Design decisions, settled by evidence

The issue is `[mode: plan]` and asked for three decisions before coding.

**1. Where suppression belongs → `scan.Enqueuer`, not `reopenClassesFor`.** Not a preference. `reopenClassesFor` decides from `ScanOptions` flags, and `instrumentalReopenable` reads provenance off the *sidecar file*. A `Categorical` row has **no sidecar** — that is the entire defect — so the reopen path is structurally incapable of seeing this case. `EnqueuePending` already consults the cache and `continue`s past tracks it should not enqueue; this is a second predicate in that existing loop.

**2. Whether suppression expires → yes, tied to `providers_version`.** A `Categorical` verdict describes what the providers served at *one moment*. Permanent suppression would mean never finding correctly-timed lyrics a provider starts serving later. `providers_version` is the generation counter that already retires stale cache entries, so expiry reuses it rather than inventing a parallel backoff or a new column. Change the provider set and quarantined tracks become eligible again automatically.

**3. Operator visibility → deferred to #629, with justification.** #629 (same milestone) is scoped to exactly this: expose timing outcome on `/metrics` and as a review-queue report. The issue explicitly warns against building a second surface here. What this PR does add is a summary log line, because a suppressed track produces no work item, no sidecar and no queue row — without it an operator cannot distinguish "nothing left to fetch" from "N tracks are quarantined".

## Safety properties

- **Only `Categorical` suppresses.** The merely-mistimed verdict writes a `.txt`, and #439's settled-sidecar check makes a later re-fetch a no-op: wasteful, never destructive. Suppressing it would hide a recoverable track for no gain.
- **Fails open on a lookup error** — suppression is an optimization, and a failed read must never silently drop work, which would look exactly like having fetched it.
- **An unknown generation never suppresses.** Without a trustworthy comparison the safe direction is to re-examine: the cost is one refetch, versus losing the track indefinitely.
- **A nil `Timing` seam disables the feature entirely**, so the one-shot CLI `scan` — which constructs no provider set — keeps its pre-#679 behavior exactly.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate` via `safe-push`).
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [ ] Commits squashed into one — **deliberately kept as 3.** The third is an unrelated flake fix that would be buried under a `fix(scan):` title. Squashed at merge.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes — no user-visible surface; behavior is verified by test, including against a real database.
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added under `internal/db/migrations/` — N/A, the columns exist (migration 034); this adds the reader.

## Test plan

- [x] `make gate` passes locally.
- [x] **New tests confirmed to fail against unfixed code.** The issue's AC requires this explicitly. Neutering `shouldSuppress` makes `TestEnqueuePendingSuppressesCategorical` fail with its precise message; it passes restored.
- [x] Patch coverage **93.67%** (74/79), threshold 70. `internal/scan/enqueuer.go` is at 100%.
- [x] Which **surface** this fixes is stated explicitly: `scan.Enqueuer.EnqueuePending`, the path that decides what enters `work_queue`. Verified there, and the SQL read is verified against a real SQLite database rather than a fake — the fake would not have caught a keying error.
- [x] 14 tests: suppression, the exemption for a merely-mistimed verdict, generation expiry, both fail-open paths, the nil seam, the queue→scan adapter, an unrecognized stored outcome, and four SQL tests covering round-trip, key normalization, a verdict-less row, and an absent track.
- [ ] Reviewer follow-ups:
  - [ ] `providersVersion` is threaded through `scheduler()` and both serve entry points. Worth a look that the plumbing is where you would want it rather than passed further down.

## Not covered

- **Not exercised against production data.** The suppression is proven by test, including against a real database, but no prod scan has yet skipped a real quarantined track. Prod currently has 3,123 never-detected rows and the timing backlog is separate; this will show up in the scan log's `suppressed=N` line when it does.
- **The operator-visibility AC is deferred, not met.** There is still no way to *list* quarantined tracks or re-examine them on demand — only a count in the log. That is #629's scope, and the issue permits the deferral with a written reason, but it means #679 is not fully closed by this PR.
- **Second commit is unrelated.** `TestExpiredSelfWriteNoLongerSuppresses` blocked three pushes tonight on diffs containing no Go code. The failure was never in the expiry logic: it was the sentinel setup racing FSEvents delivery (30ms TTL vs ~11-14ms typical, 80ms p99 under load), and the reported message was a false negative. Reproduced 17/40 under CPU load; **20/20 clean after the fix under the same load.** An injected clock is deliberately not the fix — `selfwrite.Registry` already has one, but the uncontrolled variable is kernel event delivery, which no clock injection reaches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated reprocessing of tracks with unchanged categorical timing results.
  * Reprocessing resumes automatically when the active provider configuration changes.
  * Preserved normal scan behavior when provider information is unavailable.
  * Improved filesystem watcher reliability by reducing timing-sensitive event suppression.

* **Tests**
  * Added coverage for timing-result lookups, normalization, missing data, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->