### PR TITLE
fix(reports): unify the detector-instrumental settle and repair its attribution

### DIFF
--- a/internal/db/migration_039_test.go
+++ b/internal/db/migration_039_test.go
@@ -51,6 +51,16 @@ func TestMigration039AttributesOnlyDetectorEvidencedRows(t *testing.T) {
 		// on detector_version alone credits the detector with a provider's find.
 		// Measured on a live install as 26 real rows.
 		{"b5", "done", "instrumental", "v1", 0, nil, "<NULL>"},
+		// The INVERSE repair: a detector settle that a tightened vocal gate later
+		// REVERSED. UnsettleInstrumental cleared the verdict, the outcome type and
+		// the completion but left provider_lane behind, so the row asserted a
+		// completion that no longer exists. Measured on a live install as 43 rows.
+		{"b6", "deferred", nil, "v1", 0, "detector", "<NULL>"},
+		// The scoping guard for that repair: a row a PROVIDER completed and that was
+		// re-deferred for an --upgrade re-fetch keeps its lane. That is correct
+		// history, and a broader "clear the lane on any non-done row" would destroy
+		// it.
+		{"b7", "deferred", nil, nil, nil, "musixmatch", "musixmatch"},
 	}
 	for _, r := range rows {
 		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.status, r.outcome, r.version, r.verdict, r.lane); err != nil {

--- a/internal/db/migration_039_test.go
+++ b/internal/db/migration_039_test.go
@@ -20,31 +20,40 @@ func TestMigration039AttributesOnlyDetectorEvidencedRows(t *testing.T) {
 	ctx := context.Background()
 	dbh, provider := openAtVersion(t, 38) // the state a real deployment upgrades FROM
 
-	insert := `INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, status, outcome_type, detector_version, provider_lane)
-	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	insert := `INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, status, outcome_type, detector_version, instrumental_result, provider_lane)
+	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	rows := []struct {
 		key      string
 		status   string
 		outcome  any
 		version  any
+		verdict  any
 		lane     any
 		wantLane string
 	}{
 		// The defect's population: settled by the backfill, detector evidence
 		// present, never attributed.
-		{"b1", "done", "instrumental", "v1", nil, "detector"},
+		{"b1", "done", "instrumental", "v1", 1, nil, "detector"},
 		// No detector evidence. Must stay NULL rather than gain a fabricated lane.
-		{"b2", "done", "instrumental", nil, nil, "<NULL>"},
+		{"b2", "done", "instrumental", nil, nil, nil, "<NULL>"},
 		// Already attributed elsewhere: recorded history outranks reconstruction,
 		// so the migration must not overwrite it.
-		{"b3", "done", "instrumental", "v1", "musixmatch", "musixmatch"},
+		{"b3", "done", "instrumental", "v1", 1, "musixmatch", "musixmatch"},
 		// Detector ran and said NOT instrumental: the row stays deferred and was
 		// never completed by any lane, so claiming one would assert a completion
 		// that never happened.
-		{"b4", "deferred", nil, "v1", nil, "<NULL>"},
+		{"b4", "deferred", nil, "v1", 0, nil, "<NULL>"},
+		// THE TRAP. The detector judged this NOT instrumental (result=0) and stamped
+		// its telemetry, leaving the row deferred; a PROVIDER then found it and
+		// flagged it instrumental, setting outcome_type while provider_lane stayed
+		// NULL (that stamp is advisory on the provider path and can fail). So the row
+		// carries detector_version from a verdict that said the opposite, and gating
+		// on detector_version alone credits the detector with a provider's find.
+		// Measured on a live install as 26 real rows.
+		{"b5", "done", "instrumental", "v1", 0, nil, "<NULL>"},
 	}
 	for _, r := range rows {
-		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.status, r.outcome, r.version, r.lane); err != nil {
+		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.status, r.outcome, r.version, r.verdict, r.lane); err != nil {
 			t.Fatalf("insert %s: %v", r.key, err)
 		}
 	}

--- a/internal/db/migration_039_test.go
+++ b/internal/db/migration_039_test.go
@@ -83,4 +83,42 @@ func TestMigration039AttributesOnlyDetectorEvidencedRows(t *testing.T) {
 			t.Errorf("%s: provider_lane = %q; want %q", r.key, deref(got), r.wantLane)
 		}
 	}
+
+	// The clear is the one destructive statement here -- it overwrites a real
+	// stored value, and Down cannot reconstruct which rows held 'detector'. So the
+	// pre-mutation value must be recoverable, and the backup must cover EXACTLY the
+	// rows that changed: a backup whose predicate drifts from the UPDATE's is worse
+	// than none, because it reads as a safety net that is not there.
+	var backedUp int
+	var oldValue string
+	if err := dbh.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(MAX(old_value), '') FROM provenance_repair_backup
+		  WHERE migration = '039' AND table_name = 'work_queue' AND column_name = 'provider_lane'`,
+	).Scan(&backedUp, &oldValue); err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if backedUp != 1 {
+		t.Errorf("backed-up rows = %d; want exactly 1 (only b6's lane is cleared)", backedUp)
+	}
+	if oldValue != "detector" {
+		t.Errorf("backed-up old_value = %q; want %q -- the PRE-mutation value, or the record cannot restore", oldValue, "detector")
+	}
+	// Restoring from the backup must reproduce the original value exactly.
+	if _, err := dbh.ExecContext(ctx, `
+		UPDATE work_queue SET provider_lane = (
+			SELECT old_value FROM provenance_repair_backup b
+			 WHERE b.migration = '039' AND b.table_name = 'work_queue'
+			   AND b.column_name = 'provider_lane' AND b.row_id = work_queue.id)
+		WHERE id IN (SELECT row_id FROM provenance_repair_backup
+		              WHERE migration = '039' AND table_name = 'work_queue')`); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	var restored *string
+	if err := dbh.QueryRowContext(ctx,
+		`SELECT provider_lane FROM work_queue WHERE artist_key = 'b6'`).Scan(&restored); err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if deref(restored) != "detector" {
+		t.Errorf("restored provider_lane = %q; want %q -- the backup is not actually restorable", deref(restored), "detector")
+	}
 }

--- a/internal/db/migration_039_test.go
+++ b/internal/db/migration_039_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// Migration 039 backfills work_queue.provider_lane for detector-settled rows the
+// old SettleInstrumental left unattributed (#708). Three behaviors matter, and
+// all are asserted against the REAL migration via openAtVersion (see the comment
+// on that helper in migration_038_test.go: an earlier test hand-executed its own
+// copy of the UPDATE and still passed with the .sql file emptied).
+//
+// The interesting case is the unevidenced row. A blanket
+// "outcome_type='instrumental' AND provider_lane IS NULL" would sweep in rows
+// with no detector_version, fabricating provenance for a settle nothing recorded
+// the detector producing -- worse than the blank cell being fixed, since a blank
+// cell is visibly missing while a wrong lane is silently believed.
+func TestMigration039AttributesOnlyDetectorEvidencedRows(t *testing.T) {
+	ctx := context.Background()
+	dbh, provider := openAtVersion(t, 38) // the state a real deployment upgrades FROM
+
+	insert := `INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, status, outcome_type, detector_version, provider_lane)
+	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	rows := []struct {
+		key      string
+		status   string
+		outcome  any
+		version  any
+		lane     any
+		wantLane string
+	}{
+		// The defect's population: settled by the backfill, detector evidence
+		// present, never attributed.
+		{"b1", "done", "instrumental", "v1", nil, "detector"},
+		// No detector evidence. Must stay NULL rather than gain a fabricated lane.
+		{"b2", "done", "instrumental", nil, nil, "<NULL>"},
+		// Already attributed elsewhere: recorded history outranks reconstruction,
+		// so the migration must not overwrite it.
+		{"b3", "done", "instrumental", "v1", "musixmatch", "musixmatch"},
+		// Detector ran and said NOT instrumental: the row stays deferred and was
+		// never completed by any lane, so claiming one would assert a completion
+		// that never happened.
+		{"b4", "deferred", nil, "v1", nil, "<NULL>"},
+	}
+	for _, r := range rows {
+		if _, err := dbh.ExecContext(ctx, insert, r.key, r.key, r.key, r.key, "/m/"+r.key, r.status, r.outcome, r.version, r.lane); err != nil {
+			t.Fatalf("insert %s: %v", r.key, err)
+		}
+	}
+
+	// Run the migration under test -- the actual .sql file, not a copy of it.
+	if _, err := provider.UpTo(ctx, 39); err != nil {
+		t.Fatalf("migrate to 39: %v", err)
+	}
+
+	for _, r := range rows {
+		var got *string
+		if err := dbh.QueryRowContext(ctx,
+			`SELECT provider_lane FROM work_queue WHERE artist_key = ?`, r.key).Scan(&got); err != nil {
+			t.Fatalf("select %s: %v", r.key, err)
+		}
+		if deref(got) != r.wantLane {
+			t.Errorf("%s: provider_lane = %q; want %q", r.key, deref(got), r.wantLane)
+		}
+	}
+}

--- a/internal/db/migration_040_test.go
+++ b/internal/db/migration_040_test.go
@@ -1,0 +1,94 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// Migration 040 fills lane_attempts for detector verdicts the offline backfill
+// paths recorded without ever writing the table (#282). Asserted against the
+// REAL migration via openAtVersion -- see the comment on that helper in
+// migration_038_test.go for why a hand-executed copy of the UPDATE proves
+// nothing.
+//
+// The two cases that matter are the ones a careless fill gets wrong: a row whose
+// attempt was already recorded must keep the RECORDED value (reconstruction must
+// never overwrite observation, including the recalibration correction the code
+// fix introduces), and a not-instrumental verdict must be filled as a MISS rather
+// than skipped -- the report renders a hit RATE, so a hits-only fill inflates it.
+func TestMigration040FillsGapsWithoutOverwritingRecordedAttempts(t *testing.T) {
+	ctx := context.Background()
+	dbh, provider := openAtVersion(t, 39) // the state a real deployment upgrades FROM
+
+	insert := `INSERT INTO work_queue (id, artist_key, title_key, artist, title, source_path, status, instrumental_result, updated_at)
+	           VALUES (?, ?, ?, ?, ?, ?, ?, ?, '2026-07-27T00:00:00Z')`
+	rows := []struct {
+		id      int64
+		key     string
+		verdict any
+		// preRecorded, when non-nil, is an attempt already in the table before the
+		// migration runs.
+		preRecorded *int
+		wantHit     int // -1 = no attempt row expected
+	}{
+		// The defect's population: a verdict the backfill produced, never recorded.
+		{901, "c1", 1, nil, 1},
+		// A miss must be filled as hit=0, not skipped: the tile is a RATE.
+		{902, "c2", 0, nil, 0},
+		// Already recorded live (or corrected by a recalibration flip). The stored
+		// verdict disagrees with the recorded attempt on purpose: the RECORDED value
+		// must survive, or the migration would silently revert a correction.
+		{903, "c3", 0, intPtr(1), 1},
+		// Never detected -- no verdict, so nothing to attribute.
+		{904, "c4", nil, nil, -1},
+	}
+	for _, r := range rows {
+		if _, err := dbh.ExecContext(ctx, insert, r.id, r.key, r.key, r.key, r.key, "/m/"+r.key, "deferred", r.verdict); err != nil {
+			t.Fatalf("insert %s: %v", r.key, err)
+		}
+		if r.preRecorded != nil {
+			if _, err := dbh.ExecContext(ctx,
+				`INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at) VALUES (?, 'detector', ?, '2026-07-26T00:00:00Z')`,
+				r.id, *r.preRecorded); err != nil {
+				t.Fatalf("seed attempt %s: %v", r.key, err)
+			}
+		}
+	}
+
+	// Run the migration under test -- the actual .sql file, not a copy of it.
+	if _, err := provider.UpTo(ctx, 40); err != nil {
+		t.Fatalf("migrate to 40: %v", err)
+	}
+
+	for _, r := range rows {
+		var hit *int
+		var n int
+		if err := dbh.QueryRowContext(ctx,
+			`SELECT MAX(hit), COUNT(*) FROM lane_attempts WHERE queue_id = ? AND lane = 'detector'`,
+			r.id).Scan(&hit, &n); err != nil {
+			t.Fatalf("select %s: %v", r.key, err)
+		}
+		if r.wantHit == -1 {
+			if n != 0 {
+				t.Errorf("%s: got %d attempt rows; a row that was never detected must not claim one", r.key, n)
+			}
+			continue
+		}
+		if n != 1 {
+			t.Errorf("%s: got %d attempt rows; want exactly 1 (UNIQUE(queue_id, lane) must collapse, never duplicate)", r.key, n)
+			continue
+		}
+		if hit == nil || *hit != r.wantHit {
+			t.Errorf("%s: hit = %v; want %d", r.key, deref2(hit), r.wantHit)
+		}
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func deref2(i *int) string {
+	if i == nil {
+		return "<NULL>"
+	}
+	return string(rune('0' + *i))
+}

--- a/internal/db/migration_040_test.go
+++ b/internal/db/migration_040_test.go
@@ -35,12 +35,22 @@ func TestMigration040FillsGapsWithoutOverwritingRecordedAttempts(t *testing.T) {
 		{901, "c1", 1, nil, 1},
 		// A miss must be filled as hit=0, not skipped: the tile is a RATE.
 		{902, "c2", 0, nil, 0},
-		// Already recorded live (or corrected by a recalibration flip). The stored
-		// verdict disagrees with the recorded attempt on purpose: the RECORDED value
-		// must survive, or the migration would silently revert a correction.
+		// Already recorded live, and corrected by a recalibration flip: the attempt
+		// says hit while the row says 0. The RECORDED value must survive, or the
+		// migration silently reverts that correction. This is the AMBIGUOUS
+		// direction the repair below deliberately does not touch -- a first draft
+		// used a symmetric "make the attempt match the row" UPDATE and broke exactly
+		// this case, which is why the statement is one-directional.
 		{903, "c3", 0, intPtr(1), 1},
 		// Never detected -- no verdict, so nothing to attribute.
 		{904, "c4", nil, nil, -1},
+		// The UNAMBIGUOUS direction: the attempt says miss, the row says
+		// instrumental. Settling requires instrumental_result=1 AND a completion, so
+		// the row is the later, stronger evidence and the attempt is stale. Both
+		// real rows measured on a live install are this shape. The gap-fill cannot
+		// reach it -- the row already has an attempt, so DO NOTHING skips it -- which
+		// is why the repair statement exists at all.
+		{905, "c5", 1, intPtr(0), 1},
 	}
 	for _, r := range rows {
 		if _, err := dbh.ExecContext(ctx, insert, r.id, r.key, r.key, r.key, r.key, "/m/"+r.key, "deferred", r.verdict); err != nil {

--- a/internal/db/migration_040_test.go
+++ b/internal/db/migration_040_test.go
@@ -92,6 +92,26 @@ func TestMigration040FillsGapsWithoutOverwritingRecordedAttempts(t *testing.T) {
 			t.Errorf("%s: hit = %v; want %d", r.key, deref2(hit), r.wantHit)
 		}
 	}
+
+	// The repair OVERWRITES a recorded hit value, which Down cannot recover, so the
+	// pre-mutation value must be restorable and the backup must cover exactly the
+	// overwritten rows -- c5 only. c3 is deliberately absent: it is never touched,
+	// so backing it up would misrepresent what this migration changed.
+	var backedUp, restoredRow int
+	var oldValue string
+	if err := dbh.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(MAX(row_id), -1), COALESCE(MAX(old_value), '')
+		   FROM provenance_repair_backup
+		  WHERE migration = '040' AND table_name = 'lane_attempts' AND column_name = 'hit'`,
+	).Scan(&backedUp, &restoredRow, &oldValue); err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if backedUp != 1 || restoredRow != 905 {
+		t.Errorf("backup = %d row(s), row_id %d; want exactly 1 for queue_id 905 (only c5 is overwritten)", backedUp, restoredRow)
+	}
+	if oldValue != "0" {
+		t.Errorf("backed-up old_value = %q; want %q -- the PRE-mutation hit, or the record cannot restore", oldValue, "0")
+	}
 }
 
 func intPtr(i int) *int { return &i }

--- a/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
+++ b/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Backfill work_queue.provider_lane for detector-settled rows that were never
+-- attributed (issue #708), so the reports UI stops rendering them with a blank
+-- lane column.
+--
+-- WHY THE ROWS EXIST. queue.SettleInstrumental is the only completion path the
+-- backfill callers have (instrumentalbackfill, instrumentalrecalib), and until
+-- the accompanying fix it stamped outcome_type='instrumental' without ever
+-- stamping provider_lane. The worker's own detector path attributes its settles
+-- via SetProviderLane, so two rows identical in every other respect rendered
+-- differently depending on which path produced them -- the worker's as
+-- "Instrumental Detector", the backfill's as blank. The code fix closes it going
+-- forward; this pass corrects the rows already on disk, for the same reason 028
+-- and 029 are migrations rather than a CLI pass: it must correct every upgrading
+-- deployment, not one box an operator remembers to run a command on.
+--
+-- GATED ON detector_version, NOT ON outcome_type ALONE. A blanket
+-- "outcome_type='instrumental' AND provider_lane IS NULL" would be wrong: on the
+-- deployment this was diagnosed against, a minority of such rows carry NO
+-- detector_version at all, meaning nothing recorded that the detector produced
+-- them. Attributing those to the detector lane would FABRICATE provenance --
+-- inventing evidence is worse than the blank cell this fixes, because a blank
+-- cell is visibly missing while a wrong lane is silently believed. Rows without
+-- detector evidence are left NULL on purpose.
+--
+-- ONLY WHERE provider_lane IS NULL. An already-attributed row is left untouched,
+-- including one attributed to a provider lane: recorded history outranks
+-- reconstruction (the same rule migration 029 states). That also makes this
+-- statement idempotent independently of goose -- re-running it is a no-op.
+--
+-- outcome_type IS STILL REQUIRED alongside detector_version. detector_version is
+-- also set on rows the detector judged NOT instrumental (instrumental_result=0),
+-- which stay deferred and were never completed by any lane; provider_lane means
+-- "which lane completed this row", so stamping a still-deferred row would assert
+-- a completion that never happened.
+UPDATE work_queue
+SET provider_lane = 'detector'
+WHERE provider_lane IS NULL
+  AND outcome_type = 'instrumental'
+  AND detector_version IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Irreversible by design, matching 028 and 029: once these rows carry the lane
+-- string nothing distinguishes a backfilled attribution from one stamped live at
+-- settle time, so a Down would have to guess which to clear and would blank
+-- correctly-attributed rows. Restore from backup if this must be undone.
+SELECT 1;
+-- +goose StatementEnd

--- a/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
+++ b/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
@@ -29,16 +29,29 @@
 -- reconstruction (the same rule migration 029 states). That also makes this
 -- statement idempotent independently of goose -- re-running it is a no-op.
 --
--- outcome_type IS STILL REQUIRED alongside detector_version. detector_version is
--- also set on rows the detector judged NOT instrumental (instrumental_result=0),
--- which stay deferred and were never completed by any lane; provider_lane means
--- "which lane completed this row", so stamping a still-deferred row would assert
--- a completion that never happened.
+-- instrumental_result = 1 IS REQUIRED, AND detector_version ALONE IS NOT ENOUGH.
+-- This is the subtle one, and gating on detector_version by itself gets it WRONG.
+-- The worker ALSO writes detector_version on a NOT-instrumental verdict
+-- (stampDetectorMissTelemetry, internal/worker/worker.go: SetInstrumentalResult
+-- with result=0), leaving the row deferred. A provider can then find that track
+-- and flag it instrumental, which sets outcome_type='instrumental' while
+-- provider_lane stays NULL -- SetProviderLane is advisory on that path and can
+-- fail, which is one of the defects this very migration series exists to repair.
+-- Such a row carries detector telemetry from a verdict that said NOT
+-- instrumental, so attributing it to the detector credits the detector with a
+-- provider's find. Measured on a live install: 26 rows matched exactly that
+-- shape. instrumental_result = 1 is the only column that says the DETECTOR is
+-- what concluded instrumental, which is why migrations 028 and 029 both key on
+-- it rather than on detector_version.
+--
+-- outcome_type is still required alongside it: provider_lane means "which lane
+-- COMPLETED this row", so a row carrying a positive verdict but not yet completed
+-- would assert a completion that never happened.
 UPDATE work_queue
 SET provider_lane = 'detector'
 WHERE provider_lane IS NULL
   AND outcome_type = 'instrumental'
-  AND detector_version IS NOT NULL;
+  AND instrumental_result = 1;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
+++ b/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
@@ -15,14 +15,14 @@
 -- and 029 are migrations rather than a CLI pass: it must correct every upgrading
 -- deployment, not one box an operator remembers to run a command on.
 --
--- GATED ON detector_version, NOT ON outcome_type ALONE. A blanket
--- "outcome_type='instrumental' AND provider_lane IS NULL" would be wrong: on the
--- deployment this was diagnosed against, a minority of such rows carry NO
--- detector_version at all, meaning nothing recorded that the detector produced
+-- NEVER GATED ON outcome_type ALONE. A blanket "outcome_type='instrumental' AND
+-- provider_lane IS NULL" would be wrong: a minority of such rows carry no
+-- detector evidence at all, meaning nothing recorded that the detector produced
 -- them. Attributing those to the detector lane would FABRICATE provenance --
 -- inventing evidence is worse than the blank cell this fixes, because a blank
 -- cell is visibly missing while a wrong lane is silently believed. Rows without
--- detector evidence are left NULL on purpose.
+-- detector evidence are left NULL on purpose. (See the instrumental_result note
+-- below for why detector_version is NOT the right evidence column either.)
 --
 -- ONLY WHERE provider_lane IS NULL. An already-attributed row is left untouched,
 -- including one attributed to a provider lane: recorded history outranks
@@ -52,6 +52,31 @@ SET provider_lane = 'detector'
 WHERE provider_lane IS NULL
   AND outcome_type = 'instrumental'
   AND instrumental_result = 1;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The INVERSE repair, for the same column: clear a detector attribution that a
+-- REVERSAL left behind.
+--
+-- queue.UnsettleInstrumental un-does a detector settle when a tightened vocal
+-- gate overturns it -- clearing instrumental_result, outcome_type, and the
+-- completion -- but it did not clear provider_lane. The reverted row therefore
+-- kept asserting that the detector COMPLETED it, attribution for a completion
+-- that no longer exists. Measured on a live install: 43 rows. The accompanying
+-- change adds provider_lane = NULL to that statement; this repairs the rows it
+-- already produced, so the code fix and its data repair ship together.
+--
+-- SCOPED TIGHTLY, ON PURPOSE. All three conditions are required because they
+-- jointly describe a REVERTED detector row and nothing else: the lane says
+-- detector, the verdict was overturned to 0, and the outcome type was cleared. A
+-- broader predicate -- "clear the lane on any row that is not done" -- would
+-- destroy legitimate history, because a row a PROVIDER completed and that was
+-- later re-deferred for an --upgrade re-fetch correctly keeps its lane.
+UPDATE work_queue
+SET provider_lane = NULL
+WHERE provider_lane = 'detector'
+  AND instrumental_result = 0
+  AND outcome_type IS NULL;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
+++ b/internal/db/migrations/039_work_queue_detector_lane_backfill.sql
@@ -72,6 +72,50 @@ WHERE provider_lane IS NULL
 -- broader predicate -- "clear the lane on any row that is not done" -- would
 -- destroy legitimate history, because a row a PROVIDER completed and that was
 -- later re-deferred for an --upgrade re-fetch correctly keeps its lane.
+-- BACKUP FIRST. The clear below is the one genuinely DESTRUCTIVE statement in
+-- this migration -- the fill above only writes into NULLs, but this overwrites a
+-- real stored value, and Down cannot recover it (it has no way to know which rows
+-- held 'detector' beforehand).
+--
+-- A goose SQL migration cannot write and fsync a JSONL file, so the restorable
+-- record is a TABLE written inside the migration's own transaction. That is
+-- strictly stronger than the JSONL trail the CLI paths use: the backup and the
+-- mutation commit or roll back together, so there is no window where the change
+-- exists without its record, and no file to be orphaned or lost.
+--
+-- Restore is a direct join:
+--   UPDATE work_queue SET provider_lane = (
+--     SELECT old_value FROM provenance_repair_backup b
+--      WHERE b.table_name = 'work_queue' AND b.column_name = 'provider_lane'
+--        AND b.row_id = work_queue.id AND b.migration = '039')
+--   WHERE id IN (SELECT row_id FROM provenance_repair_backup
+--                 WHERE migration = '039' AND table_name = 'work_queue');
+CREATE TABLE IF NOT EXISTS provenance_repair_backup (
+    migration    TEXT    NOT NULL,
+    table_name   TEXT    NOT NULL,
+    row_id       INTEGER NOT NULL,
+    column_name  TEXT    NOT NULL,
+    old_value    TEXT,
+    backed_up_at TEXT    NOT NULL,
+    UNIQUE(migration, table_name, row_id, column_name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The predicate MUST match the UPDATE's exactly, or the backup covers a different
+-- set than the change. ON CONFLICT DO NOTHING keeps a re-run idempotent and, more
+-- importantly, preserves the FIRST recorded value: a second application must never
+-- overwrite the original with the already-cleared one.
+INSERT INTO provenance_repair_backup (migration, table_name, row_id, column_name, old_value, backed_up_at)
+SELECT '039', 'work_queue', id, 'provider_lane', provider_lane, datetime('now')
+FROM work_queue
+WHERE provider_lane = 'detector'
+  AND instrumental_result = 0
+  AND outcome_type IS NULL
+ON CONFLICT(migration, table_name, row_id, column_name) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 UPDATE work_queue
 SET provider_lane = NULL
 WHERE provider_lane = 'detector'

--- a/internal/db/migrations/040_lane_attempts_backfill_gap.sql
+++ b/internal/db/migrations/040_lane_attempts_backfill_gap.sql
@@ -88,6 +88,52 @@ ON CONFLICT(queue_id, lane) DO NOTHING;
 --
 -- A symmetric "make the attempt match the row" UPDATE was written first and
 -- rejected for precisely that reason: it silently reverted the protected case.
+-- BACKUP FIRST, for the same reason as 039's clear: the INSERT above only fills
+-- gaps, but this OVERWRITES a recorded hit value, and Down cannot recover it.
+-- The backup table is created by 039 (which always runs first); CREATE TABLE IF
+-- NOT EXISTS is repeated here so this file is not silently dependent on that
+-- ordering. Both the backup and the mutation are in this migration's own
+-- transaction, so neither can exist without the other.
+--
+-- Restore is a direct join:
+--   UPDATE lane_attempts SET hit = (
+--     SELECT CAST(old_value AS INTEGER) FROM provenance_repair_backup b
+--      WHERE b.table_name = 'lane_attempts' AND b.column_name = 'hit'
+--        AND b.row_id = lane_attempts.queue_id AND b.migration = '040')
+--   WHERE lane = 'detector' AND queue_id IN (
+--     SELECT row_id FROM provenance_repair_backup WHERE migration = '040');
+--
+-- row_id is queue_id: lane_attempts has no surrogate key, and UNIQUE(queue_id,
+-- lane) plus the lane = 'detector' filter identifies exactly one row.
+CREATE TABLE IF NOT EXISTS provenance_repair_backup (
+    migration    TEXT    NOT NULL,
+    table_name   TEXT    NOT NULL,
+    row_id       INTEGER NOT NULL,
+    column_name  TEXT    NOT NULL,
+    old_value    TEXT,
+    backed_up_at TEXT    NOT NULL,
+    UNIQUE(migration, table_name, row_id, column_name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Predicate identical to the UPDATE's, so the backup covers exactly the rows that
+-- change. DO NOTHING preserves the FIRST recorded value on a re-run.
+INSERT INTO provenance_repair_backup (migration, table_name, row_id, column_name, old_value, backed_up_at)
+SELECT '040', 'lane_attempts', la.queue_id, 'hit', CAST(la.hit AS TEXT), datetime('now')
+FROM lane_attempts la
+WHERE la.lane = 'detector'
+  AND la.hit = 0
+  AND EXISTS (
+        SELECT 1
+        FROM work_queue wq
+        WHERE wq.id = la.queue_id
+          AND wq.instrumental_result = 1
+    )
+ON CONFLICT(migration, table_name, row_id, column_name) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 UPDATE lane_attempts
 SET hit = 1
 WHERE lane = 'detector'

--- a/internal/db/migrations/040_lane_attempts_backfill_gap.sql
+++ b/internal/db/migrations/040_lane_attempts_backfill_gap.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Fill lane_attempts for detector verdicts recorded by the OFFLINE BACKFILL
+-- paths, which never wrote the table at all (issue #282, #708).
+--
+-- WHY A SECOND PASS AFTER 029. Migration 029 already reconstructed the detector's
+-- history once, but it ran at ONE point in time and only covered rows that
+-- existed then. The accompanying code fix makes instrumentalbackfill and
+-- instrumentalrecalib record their attempts going forward; it does nothing for
+-- rows they already classified. On the deployment this was diagnosed against,
+-- 2,564 rows carried a detector verdict with no lane_attempts row, and that count
+-- was GROWING during an in-flight backfill drain -- every track it classified
+-- landed a verdict the report could not see. Without this pass the report's
+-- detector tile stays frozen for all of that work, which is the exact symptom
+-- being fixed.
+--
+-- THE STATEMENT IS 029'S, DELIBERATELY UNCHANGED. It was written to be
+-- re-runnable: ON CONFLICT(queue_id, lane) DO NOTHING means rows recorded live by
+-- queue.RecordLaneAttempts -- or by 029 itself -- are left exactly as they are,
+-- and only the genuine gaps are filled. Re-applying it is a no-op independently
+-- of goose, so this is a gap-fill rather than a rewrite.
+--
+-- BOTH VERDICTS, NOT HITS-ONLY. instrumental_result = 1 becomes hit=1 and 0
+-- becomes hit=0, for the reason 029 states and the code fix repeats: the tile
+-- renders a per-track hit RATE, so inserting only the wins inflates it toward a
+-- meaningless 100%. Rows with NULL instrumental_result carry no verdict at all --
+-- detection never ran for them -- so there is nothing to attribute and they are
+-- excluded.
+--
+-- RECORDED HISTORY OUTRANKS RECONSTRUCTION. DO NOTHING, never DO UPDATE: an
+-- attempt observed at the time it happened is always better evidence than one
+-- inferred later from a stored verdict. That also protects the recalibration
+-- correction the code fix introduces -- a flip that already updated its attempt
+-- must not be overwritten by a reconstruction keyed on the same row.
+--
+-- attempted_at IS A PROXY, NOT AN OBSERVATION, exactly as in 029: the true
+-- detection time was never recorded, so work_queue.updated_at stands in as an
+-- upper bound. completed_at is deliberately NOT used -- it correlates with the
+-- verdict (a hit is promoted to 'done' and stamped; a miss stays deferred and
+-- untimestamped), so keying on it would drop misses at a higher rate than hits
+-- and reintroduce the very rate skew the both-verdicts rule prevents.
+INSERT INTO lane_attempts (queue_id, lane, hit, attempted_at)
+SELECT id,
+       'detector',
+       CASE WHEN instrumental_result = 1 THEN 1 ELSE 0 END,
+       updated_at
+FROM work_queue
+WHERE instrumental_result IN (0, 1)
+ON CONFLICT(queue_id, lane) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Irreversible by design, for the same reason as 028 and 029: once these rows are
+-- in lane_attempts nothing distinguishes a backfilled attempt from one recorded
+-- live, so a Down would have to guess which to delete and would destroy real
+-- history. Restore from backup if this must be undone.
+SELECT 1;
+-- +goose StatementEnd

--- a/internal/db/migrations/040_lane_attempts_backfill_gap.sql
+++ b/internal/db/migrations/040_lane_attempts_backfill_gap.sql
@@ -27,11 +27,15 @@
 -- detection never ran for them -- so there is nothing to attribute and they are
 -- excluded.
 --
--- RECORDED HISTORY OUTRANKS RECONSTRUCTION. DO NOTHING, never DO UPDATE: an
--- attempt observed at the time it happened is always better evidence than one
--- inferred later from a stored verdict. That also protects the recalibration
+-- RECORDED HISTORY OUTRANKS RECONSTRUCTION. DO NOTHING, not DO UPDATE, in THIS
+-- statement: an attempt observed at the time it happened is better evidence than
+-- one inferred later from a stored verdict. That also protects the recalibration
 -- correction the code fix introduces -- a flip that already updated its attempt
 -- must not be overwritten by a reconstruction keyed on the same row.
+--
+-- The second statement below DOES update, but only for the one case this rule
+-- does not cover: an attempt its own row now CONTRADICTS, in the single direction
+-- where the row is unambiguously the later evidence. See its comment.
 --
 -- attempted_at IS A PROXY, NOT AN OBSERVATION, exactly as in 029: the true
 -- detection time was never recorded, so work_queue.updated_at stands in as an
@@ -47,6 +51,53 @@ SELECT id,
 FROM work_queue
 WHERE instrumental_result IN (0, 1)
 ON CONFLICT(queue_id, lane) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Correct attempts that CONTRADICT the verdict now stored on their row.
+--
+-- The gap-fill above cannot reach these: they already HAVE an attempt row, so
+-- ON CONFLICT DO NOTHING deliberately leaves them alone. They exist because a
+-- re-decision (instrumentalrecalib) or a later settle overturned a verdict while
+-- the recorded attempt kept the ORIGINAL outcome -- the drift the accompanying
+-- code change stops from recurring. Measured on a live install: 2 rows, both
+-- reporting a miss for a row since settled instrumental.
+--
+-- WHY THIS IS AN UPDATE WHERE THE FILL IS DO NOTHING, WHICH LOOKS CONTRADICTORY.
+-- "Recorded history outranks reconstruction" governs an attempt whose row STILL
+-- AGREES with it -- there, the observation is better evidence than anything
+-- inferred later. It does not license keeping an attempt its own row now
+-- CONTRADICTS: that is not history, it is a stale record of a verdict that was
+-- explicitly overturned, and the report reads the rate as if it were current.
+--
+-- ONE DIRECTION ONLY: hit 0 -> 1, never 1 -> 0. This is deliberate and it is the
+-- whole reason the statement is safe. Both directions of disagreement are
+-- describable, but only ONE of them is unambiguous:
+--
+--   attempt=0, row=1  ->  the row was SETTLED instrumental after the attempt was
+--                         recorded. Settling requires instrumental_result=1 and a
+--                         completion, so the row is the later, stronger evidence.
+--                         All 2 real rows measured on a live install are this
+--                         shape.
+--   attempt=1, row=0  ->  AMBIGUOUS, and deliberately NOT touched. It is equally
+--                         consistent with a stale attempt AND with a recalib
+--                         reversal that already corrected the attempt while the
+--                         row moved on. Rewriting it could destroy exactly the
+--                         correction the accompanying code change introduces, so
+--                         this statement leaves it to the code path that owns it.
+--
+-- A symmetric "make the attempt match the row" UPDATE was written first and
+-- rejected for precisely that reason: it silently reverted the protected case.
+UPDATE lane_attempts
+SET hit = 1
+WHERE lane = 'detector'
+  AND hit = 0
+  AND EXISTS (
+        SELECT 1
+        FROM work_queue wq
+        WHERE wq.id = lane_attempts.queue_id
+          AND wq.instrumental_result = 1
+    );
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/instrumentalbackfill/instrumentalbackfill.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill.go
@@ -38,7 +38,7 @@ import (
 type Store interface {
 	CountUnclassified(ctx context.Context, libraryID *int64, globalDetectDefault bool) (int, error)
 	ListUnclassified(ctx context.Context, opts queue.ListUnclassifiedOptions) ([]queue.WorkItem, error)
-	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error)
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error)
 	StampUnclassifiedMiss(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
 }
 
@@ -314,7 +314,7 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 
 		// One guarded transaction: verdict, telemetry, outcome, and completion all
 		// land together or not at all.
-		outcome, err := b.store.SettleInstrumental(ctx, item.ID, tel)
+		outcome, err := b.store.SettleInstrumental(ctx, item.ID, tel, queue.OwnedByBackfill)
 		if err != nil {
 			// AMBIGUOUS: the error may have come from Commit itself, so the settle may
 			// or may not have landed. Deleting the marker could destroy a committed

--- a/internal/instrumentalbackfill/instrumentalbackfill.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/sydlexius/canticle/internal/detector"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -40,6 +41,10 @@ type Store interface {
 	ListUnclassified(ctx context.Context, opts queue.ListUnclassifiedOptions) ([]queue.WorkItem, error)
 	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error)
 	StampUnclassifiedMiss(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (bool, error)
+	// RecordLaneAttempts persists the per-track detector attempt that produced the
+	// verdict, so the backfill's work appears in the per-track hit-rate report
+	// (#282) the same way the worker's does. Idempotent per (queue_id, lane).
+	RecordLaneAttempts(ctx context.Context, queueID int64, attempts []models.LaneAttempt) error
 }
 
 // Detector classifies a track from its audio. Satisfied by detector.Detector.
@@ -274,6 +279,10 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 				continue
 			}
 			res.RowsStamped++
+			// Recorded only after the stamp APPLIED: a row a worker claimed mid-flight
+			// was not classified by this run, so attributing an attempt to it would
+			// credit the detector with work it did not land.
+			b.recordAttempt(ctx, item.ID, false)
 			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeApplied})
 			continue
 		}
@@ -331,6 +340,11 @@ func (b *Backfiller) Run(ctx context.Context, opts Options) (Result, error) {
 		switch outcome {
 		case queue.Settled:
 			res.RowsSettled++
+			// Only on Settled. SettleAlreadyInstrumental means a PEER settled the row
+			// and recorded its own attempt, so recording one here would attribute the
+			// same track to the detector twice -- harmless for the (idempotent) row
+			// itself, but it is the peer's classification, not this run's.
+			b.recordAttempt(ctx, item.ID, true)
 			b.reportOutcome(opts, Outcome{QueueID: item.ID, Status: OutcomeApplied})
 		case queue.SettleAlreadyInstrumental:
 			// A PEER BACKFILL settled this row first with the same verdict. The marker
@@ -374,6 +388,39 @@ func (b *Backfiller) reportOutcome(opts Options, o Outcome) {
 	if err := opts.Outcome(o); err != nil {
 		slog.Warn("instrumentalbackfill: could not record change outcome to the backup trail",
 			"id", o.QueueID, "status", o.Status, "error", err)
+	}
+}
+
+// recordAttempt persists the detector attempt that produced a verdict, so the
+// backfill's classifications appear in the per-track hit-rate report (#282).
+//
+// WHY THIS EXISTS. lane_attempts is written by the worker via recordLaneAttempts
+// on every dispatch, but the backfill reaches its verdict through an entirely
+// different path and recorded nothing at all. The report's detector tile
+// therefore counted ONLY worker-side detections and sat frozen while a backfill
+// classified thousands of tracks -- the numerator and denominator both stalled,
+// so the tile did not merely undercount, it looked broken.
+//
+// BOTH VERDICTS, NOT HITS-ONLY. hit=1 for instrumental, hit=0 for
+// not-instrumental. The tile renders a hit RATE, so recording only the positives
+// would drive the detector toward a meaningless 100%. This is the same rule
+// migration 029 states for the historical backfill, and it is easy to get wrong
+// in the opposite direction here because only the positive path feels like a
+// "result".
+//
+// BEST-EFFORT. A failure is logged and swallowed: the verdict is already durably
+// recorded on the row, and losing a reporting attempt must not fail a row whose
+// mutation succeeded. Idempotent per (queue_id, lane), so a later re-run
+// upserts rather than double-counting.
+func (b *Backfiller) recordAttempt(ctx context.Context, queueID int64, instrumental bool) {
+	if err := b.store.RecordLaneAttempts(ctx, queueID, []models.LaneAttempt{{
+		Lane: detectorbackfill.LaneName,
+		Hit:  instrumental,
+		// The detector resolves a track with no outbound provider request.
+		Local: true,
+	}}); err != nil {
+		slog.Warn("instrumentalbackfill: could not record the detector lane attempt; the per-track hit-rate report will undercount this row",
+			"id", queueID, "error", err)
 	}
 }
 

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/detector"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -39,6 +40,11 @@ type fakeStore struct {
 	settled     []int64
 	stampCalls  int
 	settleCalls int
+	// laneAttempts is the LAST attempt recorded per queue id, mirroring the real
+	// table's UNIQUE(queue_id, lane) upsert.
+	laneAttempts     map[int64]models.LaneAttempt
+	laneAttemptCalls int
+	laneAttemptErr   error
 	// t reports a wrong-ownership call. The fake asserts the argument rather than
 	// ignoring it, because ownership is the one parameter that silently no-ops in
 	// production when it is wrong.
@@ -103,6 +109,25 @@ func (s *fakeStore) StampUnclassifiedMiss(_ context.Context, id int64, _ queue.I
 	}
 	s.stamped[id] = 0
 	return true, nil
+}
+
+// RecordLaneAttempts records the attempts the backfill reports, keyed by queue
+// id, so a test can assert BOTH that an attempt was recorded and which verdict
+// it carried. It models the real UNIQUE(queue_id, lane) upsert by overwriting
+// rather than appending: a fake that appended would hide a double-record bug the
+// real schema silently collapses.
+func (s *fakeStore) RecordLaneAttempts(_ context.Context, queueID int64, attempts []models.LaneAttempt) error {
+	s.laneAttemptCalls++
+	if s.laneAttemptErr != nil {
+		return s.laneAttemptErr
+	}
+	if s.laneAttempts == nil {
+		s.laneAttempts = map[int64]models.LaneAttempt{}
+	}
+	for _, a := range attempts {
+		s.laneAttempts[queueID] = a
+	}
+	return nil
 }
 
 type fakeDetector struct {
@@ -335,6 +360,87 @@ func TestRun_NotInstrumentalStampsZeroAndDoesNotWrite(t *testing.T) {
 	}
 	if got, ok := store.stamped[1]; !ok || got != 0 {
 		t.Errorf("stamped = %v (present=%v); want 0 so it is distinguishable from never-detected", got, ok)
+	}
+}
+
+// TestRun_RecordsDetectorLaneAttemptForBothVerdicts pins the per-track hit-rate
+// reporting the backfill owes.
+//
+// The backfill reaches its verdict through a different path than the worker and
+// recorded NO lane_attempts at all, so the report's detector tile counted only
+// worker-side detections. On a live install that tile sat frozen at a fixed
+// numerator AND denominator while a backfill classified thousands of tracks --
+// not merely undercounting, but looking broken.
+//
+// BOTH verdicts are asserted because the tile renders a hit RATE: recording only
+// the instrumental settles would drive the detector toward a meaningless 100%,
+// the same trap migration 029 calls out for the historical backfill. A test that
+// checked only the positive path would pass against exactly that bug.
+func TestRun_RecordsDetectorLaneAttemptForBothVerdicts(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		instrumental bool
+	}{
+		{"instrumental settle records a hit", true},
+		{"not-instrumental stamp records a miss", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeStore(t, item(1, "/music/a.flac"))
+			res, err := New(store, fakeDetector{res: detector.Result{Instrumental: tc.instrumental, Version: "v1"}}, &fakeWriter{}).Run(
+				context.Background(), Options{GlobalDetectDefault: true})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if res.Errors != 0 {
+				t.Fatalf("res = %+v; want no errors", res)
+			}
+			got, ok := store.laneAttempts[1]
+			if !ok {
+				t.Fatal("no lane attempt recorded; the detector tile cannot see this row's classification and stays frozen while the backfill runs")
+			}
+			if got.Hit != tc.instrumental {
+				t.Errorf("attempt Hit = %v; want %v. The tile renders a hit RATE, so a wrong or missing verdict skews it", got.Hit, tc.instrumental)
+			}
+			if got.Lane != detectorbackfill.LaneName {
+				t.Errorf("attempt Lane = %q; want %q so it aggregates with the worker's detector attempts", got.Lane, detectorbackfill.LaneName)
+			}
+			if !got.Local {
+				t.Error("attempt Local = false; the detector resolves a track with no outbound provider request")
+			}
+		})
+	}
+}
+
+// TestRun_RecordsNoLaneAttemptWhenTheRowWasClaimed: a row a worker claimed
+// mid-classification was not settled by this run, so crediting the detector with
+// an attempt on it would report work that never landed.
+func TestRun_RecordsNoLaneAttemptWhenTheRowWasClaimed(t *testing.T) {
+	store := newFakeStore(t, item(1, "/music/a.flac"))
+	store.settleOutcome = queue.SettleClaimed
+
+	if _, err := New(store, fakeDetector{res: detector.Result{Instrumental: true, Version: "v1"}}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, ok := store.laneAttempts[1]; ok {
+		t.Error("recorded a lane attempt for a row a worker claimed; the settle never applied, so the detector did not resolve this track")
+	}
+}
+
+// TestRun_LaneAttemptFailureDoesNotFailTheRow: the verdict is already durably
+// recorded by the time the attempt is reported, so losing the report must not
+// turn a successful settle into an error.
+func TestRun_LaneAttemptFailureDoesNotFailTheRow(t *testing.T) {
+	store := newFakeStore(t, item(1, "/music/a.flac"))
+	store.laneAttemptErr = errors.New("db is busy")
+
+	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: true, Version: "v1"}}, &fakeWriter{}).Run(
+		context.Background(), Options{GlobalDetectDefault: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.RowsSettled != 1 || res.Errors != 0 {
+		t.Errorf("res = %+v; want settled=1 errors=0: a reporting failure must not fail a row whose settle committed", res)
 	}
 }
 

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -39,14 +39,20 @@ type fakeStore struct {
 	settled     []int64
 	stampCalls  int
 	settleCalls int
+	// t reports a wrong-ownership call. The fake asserts the argument rather than
+	// ignoring it, because ownership is the one parameter that silently no-ops in
+	// production when it is wrong.
+	t *testing.T
 }
 
-func newFakeStore(items ...queue.WorkItem) *fakeStore {
+func newFakeStore(t *testing.T, items ...queue.WorkItem) *fakeStore {
+	t.Helper()
 	return &fakeStore{
 		items:         items,
 		total:         len(items),
 		stamped:       map[int64]int{},
 		settleOutcome: queue.Settled,
+		t:             t,
 	}
 }
 
@@ -66,7 +72,12 @@ func (s *fakeStore) ListUnclassified(_ context.Context, opts queue.ListUnclassif
 	return items, nil
 }
 
-func (s *fakeStore) SettleInstrumental(_ context.Context, id int64, _ queue.InstrumentalTelemetry) (queue.SettleOutcome, error) {
+func (s *fakeStore) SettleInstrumental(_ context.Context, id int64, _ queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error) {
+	// The backfill does not own its rows; passing OwnedByWorker would guard on the
+	// wrong status and settle nothing in production, so assert it here.
+	if owner != queue.OwnedByBackfill {
+		s.t.Errorf("SettleInstrumental owner = %v; want OwnedByBackfill", owner)
+	}
 	s.settleCalls++
 	if s.order != nil {
 		*s.order = append(*s.order, "settle")
@@ -151,7 +162,7 @@ func instrumentalVerdict() detector.Result {
 
 func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
 	var order []string
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.order = &order
 	w := &fakeWriter{order: &order}
 
@@ -191,7 +202,7 @@ func TestRun_SettlesInstrumentalRowBackupFirst(t *testing.T) {
 // just intent (#515).
 func TestRun_OutcomeReportsAppliedAfterSettle(t *testing.T) {
 	var order []string
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.order = &order
 	w := &fakeWriter{order: &order}
 
@@ -227,7 +238,7 @@ func TestRun_OutcomeReportsAppliedAfterSettle(t *testing.T) {
 // fires skipped (nothing landed), and TestRun_OutcomeReportsAmbiguous the
 // ambiguous-settle failed case (#515).
 func TestRun_OutcomeReportsSkippedOnClaim(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.stampClaimed = true // negative verdict, but a worker claimed the row
 
 	var outcomes []Outcome
@@ -244,7 +255,7 @@ func TestRun_OutcomeReportsSkippedOnClaim(t *testing.T) {
 }
 
 func TestRun_OutcomeReportsAmbiguousOnSettleError(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.settleErr = errors.New("commit failed")
 
 	var outcomes []Outcome
@@ -263,7 +274,7 @@ func TestRun_OutcomeReportsAmbiguousOnSettleError(t *testing.T) {
 // A Report failure must abort that row's mutation entirely: the whole point of
 // backup-first is that a change never exists without its restorable record.
 func TestRun_ReportFailureAbortsRowMutation(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	w := &fakeWriter{}
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
@@ -287,7 +298,7 @@ func TestRun_ReportFailureAbortsRowMutation(t *testing.T) {
 // A failed marker write must leave the row unstamped: a row claiming
 // instrumental with nothing on disk is worse than an unexamined row.
 func TestRun_MarkerWriteFailureLeavesRowUnstamped(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	w := &fakeWriter{err: errors.New("read-only filesystem")}
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
@@ -308,7 +319,7 @@ func TestRun_MarkerWriteFailureLeavesRowUnstamped(t *testing.T) {
 }
 
 func TestRun_NotInstrumentalStampsZeroAndDoesNotWrite(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	w := &fakeWriter{}
 
 	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, w).Run(
@@ -328,7 +339,7 @@ func TestRun_NotInstrumentalStampsZeroAndDoesNotWrite(t *testing.T) {
 }
 
 func TestRun_DryRunPreviewsAndMutatesNothing(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	w := &fakeWriter{}
 	var previewed []int64
 
@@ -356,7 +367,7 @@ func TestRun_HonorsPerItemOptOutOverGlobalDefault(t *testing.T) {
 	optOut := false
 	it := item(1, "/music/a.flac")
 	it.DetectInstrumental = &optOut
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 	w := &fakeWriter{}
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, w).Run(context.Background(), Options{
@@ -379,7 +390,7 @@ func TestRun_PerItemOptInOverridesGlobalOff(t *testing.T) {
 	optIn := true
 	it := item(1, "/music/a.flac")
 	it.DetectInstrumental = &optIn
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(context.Background(), Options{
 		GlobalDetectDefault: false,
@@ -393,7 +404,7 @@ func TestRun_PerItemOptInOverridesGlobalOff(t *testing.T) {
 }
 
 func TestRun_DetectorFailureIsNonFatalAndLeavesRowAlone(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"), item(2, "/music/b.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"), item(2, "/music/b.flac"))
 	w := &fakeWriter{}
 
 	res, err := New(store, fakeDetector{err: errors.New("sidecar down")}, w).Run(context.Background(), Options{
@@ -411,7 +422,7 @@ func TestRun_DetectorFailureIsNonFatalAndLeavesRowAlone(t *testing.T) {
 }
 
 func TestRun_SkipsRowWithNoSourcePath(t *testing.T) {
-	store := newFakeStore(item(1, "   "))
+	store := newFakeStore(t, item(1, "   "))
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
 		context.Background(), Options{GlobalDetectDefault: true})
 	if err != nil {
@@ -426,7 +437,7 @@ func TestRun_SkipsRowWithNoSourcePath(t *testing.T) {
 // set, so a capped run can say what it left behind rather than reading as full
 // coverage.
 func TestRun_LimitCapsCandidatesButTotalReportsBacklog(t *testing.T) {
-	store := newFakeStore(item(1, "/a.flac"), item(2, "/b.flac"), item(3, "/c.flac"))
+	store := newFakeStore(t, item(1, "/a.flac"), item(2, "/b.flac"), item(3, "/c.flac"))
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
 		context.Background(), Options{GlobalDetectDefault: true, Limit: 1})
 	if err != nil {
@@ -445,7 +456,7 @@ func TestRun_LimitCapsCandidatesButTotalReportsBacklog(t *testing.T) {
 
 // The miss path's stamp failure must be counted, not swallowed.
 func TestRun_MissStampFailureIsCounted(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.stampErr = errors.New("db locked")
 
 	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(
@@ -459,7 +470,7 @@ func TestRun_MissStampFailureIsCounted(t *testing.T) {
 }
 
 func TestRun_SettleFailureCountsErrorAndDoesNotClaimSuccess(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	store.settleErr = errors.New("row owned by a worker")
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, &fakeWriter{}).Run(
@@ -473,7 +484,7 @@ func TestRun_SettleFailureCountsErrorAndDoesNotClaimSuccess(t *testing.T) {
 }
 
 func TestRun_CountFailureAborts(t *testing.T) {
-	store := newFakeStore()
+	store := newFakeStore(t)
 	store.countErr = errors.New("db gone")
 	if _, err := New(store, fakeDetector{}, &fakeWriter{}).Run(context.Background(), Options{}); err == nil {
 		t.Fatal("Run must abort when the backlog cannot be enumerated")
@@ -481,7 +492,7 @@ func TestRun_CountFailureAborts(t *testing.T) {
 }
 
 func TestRun_ListFailureAborts(t *testing.T) {
-	store := newFakeStore()
+	store := newFakeStore(t)
 	store.listErr = errors.New("db gone")
 	if _, err := New(store, fakeDetector{}, &fakeWriter{}).Run(context.Background(), Options{}); err == nil {
 		t.Fatal("Run must abort when candidates cannot be listed")
@@ -489,7 +500,7 @@ func TestRun_ListFailureAborts(t *testing.T) {
 }
 
 func TestRun_CancelledContextStopsWithoutMutating(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -547,7 +558,7 @@ func TestRun_WorkerClaimedRowLeavesNoOrphanMarker(t *testing.T) {
 		Filename:   "song.lrc",
 		SourcePath: "/music/a.flac",
 	}}
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 	store.settleOutcome = queue.SettleClaimed // a worker took the row mid-classification
 
 	// A real writer, so a real file lands on disk and must really be removed.
@@ -586,7 +597,7 @@ func TestRun_PeerSettledRowKeepsItsMarker(t *testing.T) {
 		Filename:   "song.lrc",
 		SourcePath: "/music/a.flac",
 	}}
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 	store.settleOutcome = queue.SettleAlreadyInstrumental // a peer got there first
 
 	var outcomes []Outcome
@@ -630,7 +641,7 @@ func TestRun_AmbiguousSettleErrorKeepsMarker(t *testing.T) {
 		Filename:   "song.lrc",
 		SourcePath: "/music/a.flac",
 	}}
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 	store.settleErr = errors.New("commit failed: outcome unknown")
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
@@ -659,7 +670,7 @@ func TestRun_VerdictCountsSurviveAWorkerClaim(t *testing.T) {
 		Filename:   "song.lrc",
 		SourcePath: "/music/a.flac",
 	}}
-	store := newFakeStore(it)
+	store := newFakeStore(t, it)
 	store.settleOutcome = queue.SettleClaimed
 
 	res, err := New(store, fakeDetector{res: instrumentalVerdict()}, lyrics.NewLRCWriter()).Run(
@@ -681,7 +692,7 @@ func TestRun_VerdictCountsSurviveAWorkerClaim(t *testing.T) {
 // A negative verdict is a mutation too -- it stamps instrumental_result=0, which
 // retires the row from every future backfill. It must be backed up first.
 func TestRun_NegativeVerdictIsBackedUpBeforeStamping(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 	var order []string
 	store.order = &order
 
@@ -709,7 +720,7 @@ func TestRun_NegativeVerdictIsBackedUpBeforeStamping(t *testing.T) {
 
 // A Report failure on the negative path must abort the stamp: no record, no change.
 func TestRun_NegativeVerdictReportFailureAbortsStamp(t *testing.T) {
-	store := newFakeStore(item(1, "/music/a.flac"))
+	store := newFakeStore(t, item(1, "/music/a.flac"))
 
 	res, err := New(store, fakeDetector{res: detector.Result{Instrumental: false, Version: "v1"}}, &fakeWriter{}).Run(
 		context.Background(), Options{

--- a/internal/instrumentalbackfill/instrumentalbackfill_test.go
+++ b/internal/instrumentalbackfill/instrumentalbackfill_test.go
@@ -733,6 +733,14 @@ func TestRun_PeerSettledRowKeepsItsMarker(t *testing.T) {
 	if res.MarkersWritten != 1 {
 		t.Errorf("MarkersWritten = %d; want 1 (the marker stands, it is simply the peer's)", res.MarkersWritten)
 	}
+	// The peer recorded its OWN attempt when it settled, so recording one here
+	// would attribute the same track to the detector twice. The engine skips it
+	// deliberately (only queue.Settled records); this pins that, since a double
+	// count is invisible in the report -- it just makes the rate quietly wrong.
+	if _, ok := store.laneAttempts[1]; ok {
+		t.Error("recorded a lane attempt for a PEER-settled row; the peer already recorded its own, " +
+			"so this double-attributes the track and skews the per-track hit rate")
+	}
 }
 
 // A settle ERROR is ambiguous -- the failure may have come from Commit itself, so

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -46,7 +46,7 @@ type Resetter interface {
 type Store interface {
 	Resetter
 	ListVocalGateRejections(ctx context.Context, opts queue.ListVocalGateRejectionsOptions) ([]queue.StampedRejection, error)
-	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error)
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error)
 	// The tightening direction (Reverse): enumerate confirmed instrumentals and
 	// revert the ones a lowered threshold now rejects.
 	ListVocalGateConfirmations(ctx context.Context, opts queue.ListVocalGateConfirmationsOptions) ([]queue.StampedRejection, error)
@@ -302,7 +302,7 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 			continue
 		}
 
-		outcome, err := r.store.SettleInstrumental(ctx, row.ID, row.Tel)
+		outcome, err := r.store.SettleInstrumental(ctx, row.ID, row.Tel, queue.OwnedByBackfill)
 		if err != nil {
 			// AMBIGUOUS: the error may have come from Commit itself, so the settle
 			// may or may not have landed. Keep the marker and report the error --

--- a/internal/instrumentalrecalib/instrumentalrecalib.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/sydlexius/canticle/internal/detector"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -51,6 +52,11 @@ type Store interface {
 	// revert the ones a lowered threshold now rejects.
 	ListVocalGateConfirmations(ctx context.Context, opts queue.ListVocalGateConfirmationsOptions) ([]queue.StampedRejection, error)
 	UnsettleInstrumental(ctx context.Context, id int64) (bool, error)
+	// RecordLaneAttempts updates the detector's recorded attempt when a
+	// re-decision flips the verdict, so the per-track hit-rate report (#282) does
+	// not keep reporting the outcome this run just overturned. Idempotent per
+	// (queue_id, lane), so it UPDATES the existing attempt rather than adding one.
+	RecordLaneAttempts(ctx context.Context, queueID int64, attempts []models.LaneAttempt) error
 }
 
 // Writer writes the instrumental marker sidecar. Satisfied by lyrics.Writer.
@@ -318,6 +324,14 @@ func (r *Recalibrator) Run(ctx context.Context, opts Options) (Result, error) {
 		switch outcome {
 		case queue.Settled:
 			res.Settled++
+			// The stored attempt still says hit=0, from the ORIGINAL detection pass
+			// whose verdict this run just overturned. Leaving it would keep the
+			// per-track hit-rate report (#282) reporting a miss for a row now settled
+			// instrumental -- the same verdict/report drift measured on a live
+			// install. This UPDATES that attempt rather than adding one
+			// (UNIQUE(queue_id, lane)); no new detection happened, the re-decision is
+			// pure arithmetic over the stored telemetry.
+			r.recordAttempt(ctx, row.ID, true)
 			r.reportOutcome(opts, Outcome{QueueID: row.ID, Status: OutcomeApplied})
 		case queue.SettleAlreadyInstrumental:
 			// A PEER settled this row first with the same verdict; the marker on
@@ -400,6 +414,30 @@ func (r *Recalibrator) reportOutcome(opts Options, o Outcome) {
 	if err := opts.Outcome(o); err != nil {
 		slog.Warn("instrumentalrecalib: could not record change outcome to the backup trail",
 			"id", o.QueueID, "status", o.Status, "error", err)
+	}
+}
+
+// recordAttempt updates the detector's recorded lane attempt after a
+// re-decision flips a row's verdict, so the per-track hit-rate report (#282)
+// reflects the verdict that now stands rather than the one this run overturned.
+//
+// It UPDATES rather than adds: UNIQUE(queue_id, lane) makes the write an upsert,
+// and every row here already carries an attempt from the original detection pass
+// (that pass is what produced the stored telemetry this package re-decides). No
+// new detection happened -- the re-decision is pure arithmetic over those stored
+// scores -- so this corrects an existing record instead of claiming a new one.
+//
+// Best-effort: the verdict is already durably recorded on the row, so a failed
+// report write must not fail a flip that succeeded.
+func (r *Recalibrator) recordAttempt(ctx context.Context, queueID int64, instrumental bool) {
+	if err := r.store.RecordLaneAttempts(ctx, queueID, []models.LaneAttempt{{
+		Lane: detectorbackfill.LaneName,
+		Hit:  instrumental,
+		// The detector resolves a track with no outbound provider request.
+		Local: true,
+	}}); err != nil {
+		slog.Warn("instrumentalrecalib: could not update the detector lane attempt; the per-track hit-rate report will keep showing the overturned verdict",
+			"id", queueID, "error", err)
 	}
 }
 
@@ -530,6 +568,12 @@ func (r *Recalibrator) Reverse(ctx context.Context, opts Options) (Result, error
 			continue
 		}
 		res.Reversed++
+		// Mirror of the forward direction: the stored attempt says hit=1 from the
+		// original pass, and this run just reverted that verdict. Recorded right
+		// after the revert applied, before the marker cleanup below, because the DB
+		// verdict is what the report reads -- a marker that fails to unlink is
+		// self-healing residue and must not hold back the correction.
+		r.recordAttempt(ctx, row.ID, false)
 
 		if marker == "" {
 			continue

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -69,14 +69,14 @@ func (f *fakeStore) ListVocalGateRejections(ctx context.Context, opts queue.List
 	return f.DBQueue.ListVocalGateRejections(ctx, opts)
 }
 
-func (f *fakeStore) SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry) (queue.SettleOutcome, error) {
+func (f *fakeStore) SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error) {
 	if f.settleErr != nil {
 		return queue.SettleFailed, f.settleErr
 	}
 	if f.settleOutcome != nil {
 		return *f.settleOutcome, nil
 	}
-	return f.DBQueue.SettleInstrumental(ctx, id, tel)
+	return f.DBQueue.SettleInstrumental(ctx, id, tel, owner)
 }
 
 func (f *fakeStore) ResetInstrumentalToUnclassified(ctx context.Context, id int64) (bool, error) {
@@ -776,7 +776,7 @@ func seedConfirmation(t *testing.T, q *queue.DBQueue, sourcePath string, tel que
 	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
 		t.Fatalf("defer: %v", err)
 	}
-	if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+	if _, err := q.SettleInstrumental(ctx, item.ID, tel, queue.OwnedByBackfill); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
 	name, err := lyrics.SidecarName("Artist", "Title", filepath.Base(sourcePath), false)
@@ -921,7 +921,7 @@ func TestReverse_ReversesLegacyBareMarker(t *testing.T) {
 		if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
 			return 0, err
 		}
-		if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+		if _, err := q.SettleInstrumental(ctx, item.ID, tel, queue.OwnedByBackfill); err != nil {
 			return 0, err
 		}
 		return item.ID, nil

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -882,6 +882,54 @@ func TestReverse_RevertsRowThatNowFailsTheVocalGate(t *testing.T) {
 	}
 }
 
+// TestReverse_UpdatesDetectorLaneAttemptOnRevert is the reverse direction's
+// counterpart to TestRun_UpdatesDetectorLaneAttemptOnFlip.
+//
+// It is asserted separately because the two directions are separate call sites
+// and the forward test does not cover this one: verified by mutation that making
+// Reverse's recordAttempt a no-op leaves the whole package green. Reverse is also
+// the direction that DEFLATES the rate (a recorded hit becomes a miss), so a gap
+// here reports the detector as better than it is -- the same failure mode as a
+// hits-only fill, arrived at from the other side.
+func TestReverse_UpdatesDetectorLaneAttemptOnRevert(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+	src := filepath.Join(t.TempDir(), "a.flac")
+	tel := queue.InstrumentalTelemetry{MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1"}
+	id, _ := seedConfirmation(t, q, src, tel, lyrics.SourceDetector)
+
+	// The attempt the original detection pass recorded: a hit.
+	if err := q.RecordLaneAttempts(ctx, id, []models.LaneAttempt{
+		{Lane: detectorbackfill.LaneName, Hit: true, Local: true},
+	}); err != nil {
+		t.Fatalf("seed lane attempt: %v", err)
+	}
+
+	res, err := New(q, &fakeWriter{}).Reverse(ctx, Options{
+		MinConfidence: 0.9, VocalMax: 0.015, SpeechMax: 0.2, CurrentVersion: "v1",
+	})
+	if err != nil {
+		t.Fatalf("Reverse: %v", err)
+	}
+	if res.Reversed != 1 {
+		t.Fatalf("res = %+v; want 1 reversed", res)
+	}
+
+	var hit, n int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(hit), -1), COUNT(*) FROM lane_attempts WHERE queue_id = ? AND lane = ?`,
+		id, detectorbackfill.LaneName).Scan(&hit, &n); err != nil {
+		t.Fatalf("read lane attempt: %v", err)
+	}
+	if hit != 0 {
+		t.Errorf("lane attempt hit = %d; want 0. The revert un-did the instrumental verdict, so an attempt still "+
+			"reporting a hit overstates the detector's rate", hit)
+	}
+	if n != 1 {
+		t.Errorf("lane attempt rows = %d; want exactly 1 -- the revert must UPDATE the original attempt, not add one", n)
+	}
+}
+
 // TestReverse_LeavesRowThatStillPassesTheGate pins that a still-correct
 // instrumental is not disturbed.
 func TestReverse_LeavesRowThatStillPassesTheGate(t *testing.T) {

--- a/internal/instrumentalrecalib/instrumentalrecalib_test.go
+++ b/internal/instrumentalrecalib/instrumentalrecalib_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	dbpkg "github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -189,6 +190,60 @@ func TestRun_SettlesPassingVersionMatchedRow(t *testing.T) {
 		if row.ID == id {
 			t.Fatalf("expected settled row %d to no longer be a vocal-gate rejection", id)
 		}
+	}
+}
+
+// TestRun_UpdatesDetectorLaneAttemptOnFlip: a re-decision that overturns a
+// verdict must correct the recorded attempt, not leave the old one standing.
+//
+// Every row here already carries an attempt from the ORIGINAL detection pass --
+// that pass is what produced the stored telemetry this package re-decides. When
+// a loosened threshold flips a rejection to instrumental, an untouched attempt
+// keeps reporting hit=0 for a row now settled instrumental, so the per-track
+// hit-rate report (#282) describes a verdict that no longer exists. Measured on
+// a live install as a real (if small) population of such contradictory rows.
+//
+// Asserted against the REAL lane_attempts table, not a fake: the correctness of
+// this depends on the UNIQUE(queue_id, lane) upsert actually UPDATING the
+// existing row rather than inserting a second one, which only the real schema
+// can demonstrate.
+func TestRun_UpdatesDetectorLaneAttemptOnFlip(t *testing.T) {
+	ctx := context.Background()
+	q, sqlDB := openTestQueueWithDB(t)
+
+	id := seedRejection(t, q, "/music/harp.flac", queue.InstrumentalTelemetry{
+		MusicSum: 0.97, VocalPeak: 0.04, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "1.18.0",
+	})
+	// The attempt the original detection pass recorded: a miss.
+	if err := q.RecordLaneAttempts(ctx, id, []models.LaneAttempt{
+		{Lane: detectorbackfill.LaneName, Hit: false, Local: true},
+	}); err != nil {
+		t.Fatalf("seed lane attempt: %v", err)
+	}
+
+	res, err := New(q, &fakeWriter{}).Run(ctx, Options{
+		MinConfidence: 0.90, VocalMax: 0.30, SpeechMax: 0.20, CurrentVersion: "1.18.0",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Settled != 1 {
+		t.Fatalf("res = %+v; want 1 settled", res)
+	}
+
+	var hit, n int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(hit), -1), COUNT(*) FROM lane_attempts WHERE queue_id = ? AND lane = ?`,
+		id, detectorbackfill.LaneName).Scan(&hit, &n); err != nil {
+		t.Fatalf("read lane attempt: %v", err)
+	}
+	if hit != 1 {
+		t.Errorf("lane attempt hit = %d; want 1. The flip settled the row instrumental, so an attempt still "+
+			"reporting a miss contradicts the verdict the report reads", hit)
+	}
+	if n != 1 {
+		t.Errorf("lane attempt rows = %d; want exactly 1 -- the flip must UPDATE the original pass's attempt "+
+			"via UNIQUE(queue_id, lane), not add a second one that double-counts the track", n)
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -2958,10 +2958,18 @@ func requireAffected(res sql.Result, op string) error {
 // completion, so leaving the lane behind means a deferred row keeps asserting
 // that the detector completed it -- attribution for a completion that no longer
 // exists. Measured on a live install as 43 such rows before this line existed.
-// Clearing is safe precisely BECAUSE of the guard above: only a row this method
-// actually reverts is touched, so a musixmatch-completed row that is later
-// re-deferred for an --upgrade keeps its lane, which is correct history. A
-// broader "clear the lane on any non-done row" would destroy that.
+//
+// The lane predicate below is what makes that clear SAFE, and it is deliberately
+// structural rather than left to the caller. `status='done' AND
+// instrumental_result=1` does NOT establish detector ownership: a PROVIDER-
+// completed row carrying instrumental_result=1 satisfies both, and wiping its
+// lane would destroy correct history (a musixmatch-completed row later re-deferred
+// for an --upgrade must keep its attribution). Today the only caller,
+// instrumentalrecalib.Reverse, pre-filters via ListVocalGateConfirmations +
+// detectorOwnedMarker -- but that is the CALLER's invariant, and a method that
+// clears provenance should not depend on every future caller re-deriving it. The
+// lane check enforces it here: a NULL lane is accepted because a detector settle
+// predating the attribution fix legitimately has none.
 func (q *DBQueue) UnsettleInstrumental(ctx context.Context, id int64) (bool, error) {
 	res, err := q.db.ExecContext(ctx,
 		`UPDATE work_queue
@@ -2975,8 +2983,9 @@ func (q *DBQueue) UnsettleInstrumental(ctx context.Context, id int64) (bool, err
              last_error = 'instrumental verdict reversed by a tightened vocal gate'
          WHERE id = ?
            AND status = 'done'
-           AND instrumental_result = 1`,
-		PriorityScan, formatTime(q.now()), id,
+           AND instrumental_result = 1
+           AND (provider_lane IS NULL OR provider_lane = ?)`,
+		PriorityScan, formatTime(q.now()), id, detectorbackfill.LaneName,
 	)
 	if err != nil {
 		return false, fmt.Errorf("queue: unsettle instrumental: %w", err)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sydlexius/canticle/internal/backoff"
 	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/normalize"
 )
@@ -639,6 +640,18 @@ const (
 // would let the earlier stamps land on a row the worker already owns, leaving it
 // stamped instrumental while the worker goes on to complete it with real lyrics.
 //
+// provider_lane IS STAMPED HERE, in the same statement, not by a follow-up call.
+// The worker's detector path attributes its settles via SetProviderLane, but this
+// seam is the ONLY completion path the backfill callers have, and neither of them
+// stamped a lane -- so every row they settled landed with provider_lane NULL and
+// rendered as a blank lane in the reports UI while the worker's rows, identical in
+// every other respect, rendered as "Instrumental Detector". Attribution belongs in
+// the settle transaction rather than beside it: a separate advisory UPDATE could
+// fail (or be skipped by a future caller) and leave a settled row unattributed,
+// which is the exact defect this replaces. Both callers of this method are
+// detector-driven (instrumentalbackfill, instrumentalrecalib), so the lane is not
+// caller-dependent and does not need to be a parameter.
+//
 // The outcome is stateful, not a bool, because zero affected rows only proves the
 // row is no longer deferred -- it does NOT prove a worker claimed it. A PEER
 // BACKFILL may have settled it first, and the two demand opposite actions: a
@@ -663,12 +676,14 @@ func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel Instrume
              vocal_class = ?,
              detector_version = ?,
              outcome_type = 'instrumental',
+             provider_lane = ?,
              status = 'done',
              completed_at = ?,
              last_error = ''
          WHERE id = ?
            AND status = 'deferred'`,
 		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion,
+		detectorbackfill.LaneName,
 		now, id,
 	)
 	if err != nil {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -2953,11 +2953,21 @@ func requireAffected(res sql.Result, op string) error {
 // Guarded on status = 'done' AND instrumental_result = 1, so a row settled with
 // real lyrics, a row a worker has claimed, or one already reversed is left
 // alone rather than reopened. Returns whether the row was reverted.
+//
+// provider_lane IS CLEARED with the verdict. A reversal un-does the detector's
+// completion, so leaving the lane behind means a deferred row keeps asserting
+// that the detector completed it -- attribution for a completion that no longer
+// exists. Measured on a live install as 43 such rows before this line existed.
+// Clearing is safe precisely BECAUSE of the guard above: only a row this method
+// actually reverts is touched, so a musixmatch-completed row that is later
+// re-deferred for an --upgrade keeps its lane, which is correct history. A
+// broader "clear the lane on any non-done row" would destroy that.
 func (q *DBQueue) UnsettleInstrumental(ctx context.Context, id int64) (bool, error) {
 	res, err := q.db.ExecContext(ctx,
 		`UPDATE work_queue
          SET instrumental_result = 0,
              outcome_type = NULL,
+             provider_lane = NULL,
              status = 'deferred',
              completed_at = NULL,
              priority = ?,

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -626,40 +626,78 @@ const (
 	SettleRowGone
 )
 
-// SettleInstrumental records an instrumental verdict on a DEFERRED row and
-// completes it, in ONE transaction: telemetry, instrumental_result=1,
-// outcome_type='instrumental', status='done', and the scan_results writeback all
-// commit together or not at all.
+// RowOwnership says which status a settle is allowed to act on, and is the ONLY
+// thing that differs between the two callers of the settle transaction.
 //
-// It is a single guarded statement rather than the worker's
-// stamp-then-stamp-then-complete sequence because the backfill does NOT own its
-// rows. The worker holds its row in 'processing' for the whole write, so nothing
-// can race it. The backfill leaves rows 'deferred' while the (slow) detector runs,
-// and Dequeue selects status IN ('pending','failed','deferred') -- so a serve-mode
-// worker can and will claim one mid-classification. Guarding only the final step
-// would let the earlier stamps land on a row the worker already owns, leaving it
-// stamped instrumental while the worker goes on to complete it with real lyrics.
+// It is a named type rather than a raw status string so a caller cannot pass an
+// arbitrary status, and rather than a bool so neither call site reads as an
+// unexplained `true`. The zero value is deliberately OwnedByBackfill, the safer
+// of the two: it settles only a row nothing else holds, so a caller that forgets
+// to set it under-settles (a visible no-op the SettleOutcome reports) instead of
+// writing over a row a worker owns.
+type RowOwnership int
+
+const (
+	// OwnedByBackfill settles a row the caller does NOT own, guarding on
+	// 'deferred'. The backfill leaves rows deferred while the (slow) detector
+	// runs, and Dequeue selects status IN ('pending','failed','deferred') -- so a
+	// serve-mode worker can and will claim one mid-classification, and the guard
+	// is what stops this write from landing on a row that is no longer ours.
+	OwnedByBackfill RowOwnership = iota
+	// OwnedByWorker settles a row the caller already holds in 'processing'.
+	// Dequeue moved it out of the racing statuses, so nothing else can claim it;
+	// the guard proves the caller still owns it rather than protecting against a
+	// peer.
+	OwnedByWorker
+)
+
+// status returns the work_queue status this ownership is allowed to settle.
+func (o RowOwnership) status() string {
+	if o == OwnedByWorker {
+		return StatusProcessing
+	}
+	return StatusDeferred
+}
+
+// SettleInstrumental records an instrumental verdict and completes the row in ONE
+// transaction: telemetry, instrumental_result=1, outcome_type='instrumental',
+// provider_lane, status='done', and the scan_results writeback all commit
+// together or not at all.
+//
+// THIS IS THE SINGLE SETTLE PATH for both producers of a detector-sourced
+// instrumental -- the serve-mode worker and the offline backfills
+// (instrumentalbackfill, instrumentalrecalib). It previously existed twice: the
+// worker ran its own stamp-lane / stamp-result / stamp-outcome / Complete
+// sequence of four separate non-atomic writes, while the backfills used this
+// transaction. The two drifted, and the drift was the bug -- see the lane note
+// below. Collapsing them means a detector settle cannot be half-written by
+// either producer, and a change to what "settled" means has exactly one place to
+// be made.
+//
+// OWNERSHIP IS THE ONLY REAL DIFFERENCE between the callers, so it is the only
+// parameter: the worker holds its row in 'processing' for the whole write, the
+// backfill leaves it 'deferred'. Guarding on the wrong one silently matches zero
+// rows, which is why it is a typed parameter rather than a status string.
 //
 // provider_lane IS STAMPED HERE, in the same statement, not by a follow-up call.
-// The worker's detector path attributes its settles via SetProviderLane, but this
-// seam is the ONLY completion path the backfill callers have, and neither of them
-// stamped a lane -- so every row they settled landed with provider_lane NULL and
-// rendered as a blank lane in the reports UI while the worker's rows, identical in
-// every other respect, rendered as "Instrumental Detector". Attribution belongs in
-// the settle transaction rather than beside it: a separate advisory UPDATE could
-// fail (or be skipped by a future caller) and leave a settled row unattributed,
-// which is the exact defect this replaces. Both callers of this method are
-// detector-driven (instrumentalbackfill, instrumentalrecalib), so the lane is not
-// caller-dependent and does not need to be a parameter.
+// Every row the backfills settled once landed with provider_lane NULL and
+// rendered as a blank lane in the reports UI, because this transaction stamped
+// the outcome type but no lane and the backfills have no other completion path.
+// The worker did stamp a lane, but ADVISORILY -- a failed SetProviderLane logged
+// at Warn and let the row complete unattributed anyway, so it could produce the
+// same blank cell whenever that write happened to fail. Attribution belongs
+// inside the settle rather than beside it: one place, and it either commits with
+// the verdict or not at all. Both producers are detector-driven, so the lane is
+// not caller-dependent and is not a parameter.
 //
 // The outcome is stateful, not a bool, because zero affected rows only proves the
-// row is no longer deferred -- it does NOT prove a worker claimed it. A PEER
-// BACKFILL may have settled it first, and the two demand opposite actions: a
-// worker claim means this run's marker is orphaned and must be removed, while a
+// row did not match the expected status -- it does NOT prove a worker claimed it.
+// A PEER BACKFILL may have settled it first, and the two demand opposite actions:
+// a worker claim means this run's marker is orphaned and must be removed, while a
 // peer settle means the marker on disk is CORRECT and deleting it would destroy a
 // valid result. So on a no-op the row is re-read inside the same transaction and
 // classified.
-func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry) (outcome SettleOutcome, retErr error) {
+func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry, owner RowOwnership) (outcome SettleOutcome, retErr error) {
 	now := formatTime(q.now())
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -681,10 +719,10 @@ func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel Instrume
              completed_at = ?,
              last_error = ''
          WHERE id = ?
-           AND status = 'deferred'`,
+           AND status = ?`,
 		tel.MusicSum, tel.VocalPeak, tel.SpeechMean, tel.VocalClass, tel.DetectorVersion,
 		detectorbackfill.LaneName,
-		now, id,
+		now, id, owner.status(),
 	)
 	if err != nil {
 		return SettleFailed, fmt.Errorf("queue: settle instrumental: %w", err)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -697,7 +697,25 @@ func (o RowOwnership) status() string {
 // peer settle means the marker on disk is CORRECT and deleting it would destroy a
 // valid result. So on a no-op the row is re-read inside the same transaction and
 // classified.
-func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry, owner RowOwnership) (outcome SettleOutcome, retErr error) {
+// It retries on SQLITE_BUSY for the reason Complete does, and this became load-
+// bearing when the worker's completion moved into this method: a WAL write-write
+// conflict is not covered by busy_timeout, and a dropped completion has a larger
+// blast radius than a dropped poll -- the finished item stays 'processing' and is
+// re-processed. The whole transaction rolls back before commit, so a retry re-runs
+// cleanly, and a guarded no-op returns its SettleOutcome immediately rather than
+// retrying (it is not a busy error). Without this the unification would silently
+// un-do #625 for every detector settle.
+func (q *DBQueue) SettleInstrumental(ctx context.Context, id int64, tel InstrumentalTelemetry, owner RowOwnership) (SettleOutcome, error) {
+	var outcome SettleOutcome
+	err := db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
+		var err error
+		outcome, err = q.settleInstrumentalOnce(ctx, id, tel, owner)
+		return err
+	})
+	return outcome, err
+}
+
+func (q *DBQueue) settleInstrumentalOnce(ctx context.Context, id int64, tel InstrumentalTelemetry, owner RowOwnership) (outcome SettleOutcome, retErr error) {
 	now := formatTime(q.now())
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4494,6 +4494,121 @@ func TestDBQueue_UnsettleInstrumentalRevertsSettledRow(t *testing.T) {
 	}
 }
 
+// TestDBQueue_SettleInstrumentalOwnedByWorkerSettlesProcessingRow exercises the
+// OwnedByWorker half of the ownership mapping against REAL SQLite.
+//
+// Every other settle in this file passes OwnedByBackfill, so
+// `OwnedByWorker -> StatusProcessing` was only ever exercised through the worker
+// package's fake. A fake agreeing with a wrong mapping is exactly how the
+// ownership bug in this branch survived its first mutation check, so the mapping
+// is pinned here against the real `WHERE status = ?` guard: the row is left in
+// 'processing' by Dequeue (never deferred) and must settle from there.
+func TestDBQueue_SettleInstrumentalOwnedByWorkerSettlesProcessingRow(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	// Dequeue leaves the row 'processing' -- the state the worker holds it in, and
+	// deliberately NOT deferred.
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	outcome, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
+		MusicSum: 0.95, VocalPeak: 0.01, VocalClass: "Singing", DetectorVersion: "v1",
+	}, OwnedByWorker)
+	if err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+	if outcome != Settled {
+		t.Fatalf("outcome = %v; want Settled. OwnedByWorker must guard on 'processing' -- "+
+			"guarding on 'deferred' matches no row and settles nothing while still returning nil", outcome)
+	}
+
+	var status, outcomeType string
+	var result int
+	var lane *string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT status, instrumental_result, COALESCE(outcome_type,''), provider_lane FROM work_queue WHERE id = ?`,
+		item.ID).Scan(&status, &result, &outcomeType, &lane); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "done" || result != 1 || outcomeType != "instrumental" {
+		t.Errorf("row = (%q, %d, %q); want (done, 1, instrumental) -- all committed in the one transaction",
+			status, result, outcomeType)
+	}
+	if lane == nil || *lane != detectorbackfill.LaneName {
+		t.Errorf("provider_lane = %v; want %q stamped inside the same settle", lane, detectorbackfill.LaneName)
+	}
+}
+
+// TestDBQueue_UnsettleInstrumentalLeavesProviderOwnedRowsAlone pins the lane
+// guard structurally.
+//
+// `status='done' AND instrumental_result=1` does NOT establish detector
+// ownership: a PROVIDER-completed row carrying a positive instrumental verdict
+// satisfies both, and reverting it would destroy correct history AND wipe a
+// legitimate provider attribution. The only caller pre-filters for detector
+// ownership, but that is the caller's invariant -- this asserts the method
+// defends provenance on its own.
+func TestDBQueue_UnsettleInstrumentalLeavesProviderOwnedRowsAlone(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{DetectorVersion: "v1"}, OwnedByBackfill); err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+	// Re-attribute to a provider: the row now looks exactly like one a provider
+	// completed and flagged instrumental.
+	if err := q.SetProviderLane(ctx, item.ID, "musixmatch"); err != nil {
+		t.Fatalf("SetProviderLane: %v", err)
+	}
+
+	reverted, err := q.UnsettleInstrumental(ctx, item.ID)
+	if err != nil {
+		t.Fatalf("UnsettleInstrumental: %v", err)
+	}
+	if reverted {
+		t.Error("reverted a PROVIDER-attributed row; the vocal-gate reversal applies only to detector settles, " +
+			"and reverting here would both reopen a provider's completion and wipe its attribution")
+	}
+	var lane *string
+	var status string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT provider_lane, status FROM work_queue WHERE id = ?`, item.ID).Scan(&lane, &status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if lane == nil || *lane != "musixmatch" {
+		t.Errorf("provider_lane = %v; want musixmatch preserved", lane)
+	}
+	if status != "done" {
+		t.Errorf("status = %q; want done (the row must not be reopened)", status)
+	}
+}
+
 // TestDBQueue_UnsettleInstrumentalLeavesNonInstrumentalRowsAlone pins the
 // guard: only a row the DETECTOR settled instrumental is reversible. A row
 // settled with real lyrics must never be dragged back into the queue.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4023,7 +4023,7 @@ func TestDBQueue_InstrumentalWritesRefuseRowOwnedByWorker(t *testing.T) {
 		t.Fatalf("dequeue: %v", err)
 	}
 
-	outcome, err := q.SettleInstrumental(ctx, item.ID, tel)
+	outcome, err := q.SettleInstrumental(ctx, item.ID, tel, OwnedByBackfill)
 	if err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
@@ -4086,7 +4086,7 @@ func TestDBQueue_SettleInstrumentalCompletesDeferredRowAtomically(t *testing.T) 
 		t.Fatalf("defer: %v", err)
 	}
 
-	outcome, err := q.SettleInstrumental(ctx, item.ID, tel)
+	outcome, err := q.SettleInstrumental(ctx, item.ID, tel, OwnedByBackfill)
 	if err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
@@ -4144,7 +4144,7 @@ func TestDBQueue_SettleInstrumentalAttributesDetectorLane(t *testing.T) {
 
 	if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
 		MusicSum: 0.95, VocalPeak: 0.01, VocalClass: "Singing", DetectorVersion: "v1",
-	}); err != nil {
+	}, OwnedByBackfill); err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
 
@@ -4244,7 +4244,7 @@ func TestDBQueue_UnclassifiedQueriesPropagateDBFailure(t *testing.T) {
 	if _, err := q.CountUnclassified(ctx, nil, true); err == nil {
 		t.Error("CountUnclassified returned nil error on a closed database")
 	}
-	if _, err := q.SettleInstrumental(ctx, 1, InstrumentalTelemetry{}); err == nil {
+	if _, err := q.SettleInstrumental(ctx, 1, InstrumentalTelemetry{}, OwnedByBackfill); err == nil {
 		t.Error("SettleInstrumental returned nil error on a closed database")
 	}
 }
@@ -4285,11 +4285,11 @@ func TestDBQueue_SettleInstrumentalDistinguishesPeerFromWorker(t *testing.T) {
 		q := NewDBQueue(openQueueTestDB(t))
 		id := mkDeferred(t, q, "peer")
 		// The peer wins the race.
-		if out, err := q.SettleInstrumental(ctx, id, tel); err != nil || out != Settled {
+		if out, err := q.SettleInstrumental(ctx, id, tel, OwnedByBackfill); err != nil || out != Settled {
 			t.Fatalf("peer settle = (%v, %v); want (Settled, nil)", out, err)
 		}
 		// We lose it, and must be told WHY -- our marker is identical and valid.
-		out, err := q.SettleInstrumental(ctx, id, tel)
+		out, err := q.SettleInstrumental(ctx, id, tel, OwnedByBackfill)
 		if err != nil {
 			t.Fatalf("second settle: %v", err)
 		}
@@ -4304,7 +4304,7 @@ func TestDBQueue_SettleInstrumentalDistinguishesPeerFromWorker(t *testing.T) {
 		if _, err := q.Dequeue(ctx); err != nil { // a worker takes it back
 			t.Fatalf("dequeue: %v", err)
 		}
-		out, err := q.SettleInstrumental(ctx, id, tel)
+		out, err := q.SettleInstrumental(ctx, id, tel, OwnedByBackfill)
 		if err != nil {
 			t.Fatalf("settle: %v", err)
 		}
@@ -4319,7 +4319,7 @@ func TestDBQueue_SettleInstrumentalDistinguishesPeerFromWorker(t *testing.T) {
 		if _, err := q.db.ExecContext(ctx, `DELETE FROM work_queue WHERE id = ?`, id); err != nil {
 			t.Fatalf("delete: %v", err)
 		}
-		out, err := q.SettleInstrumental(ctx, id, tel)
+		out, err := q.SettleInstrumental(ctx, id, tel, OwnedByBackfill)
 		if err != nil {
 			t.Fatalf("settle: %v", err)
 		}
@@ -4451,7 +4451,7 @@ func TestDBQueue_UnsettleInstrumentalRevertsSettledRow(t *testing.T) {
 	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
 		t.Fatalf("defer: %v", err)
 	}
-	if _, err := q.SettleInstrumental(ctx, item.ID, tel); err != nil {
+	if _, err := q.SettleInstrumental(ctx, item.ID, tel, OwnedByBackfill); err != nil {
 		t.Fatalf("SettleInstrumental: %v", err)
 	}
 
@@ -4541,7 +4541,7 @@ func TestDBQueue_ListVocalGateConfirmationsReturnsSettledRowsWithTelemetry(t *te
 	}
 	if _, err := q.SettleInstrumental(ctx, settled.ID, InstrumentalTelemetry{
 		MusicSum: 0.95, VocalPeak: 0.02, VocalClass: "Singing", DetectorVersion: "v1",
-	}); err != nil {
+	}, OwnedByBackfill); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
 
@@ -4605,7 +4605,7 @@ func TestDBQueue_UnsettleInstrumentalRequeuesAtScanPriority(t *testing.T) {
 	}
 	if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
 		MusicSum: 0.95, VocalPeak: 0.02, VocalClass: "Singing", DetectorVersion: "v1",
-	}); err != nil {
+	}, OwnedByBackfill); err != nil {
 		t.Fatalf("settle: %v", err)
 	}
 	if _, err := q.UnsettleInstrumental(ctx, item.ID); err != nil {
@@ -4649,7 +4649,7 @@ func TestDBQueue_ListVocalGateConfirmationsRespectsLimit(t *testing.T) {
 		}
 		if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
 			MusicSum: 0.95, VocalPeak: 0.02, SpeechMean: 0.001, VocalClass: "Singing", DetectorVersion: "v1",
-		}); err != nil {
+		}, OwnedByBackfill); err != nil {
 			t.Fatalf("settle %d: %v", i, err)
 		}
 	}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4466,9 +4466,10 @@ func TestDBQueue_UnsettleInstrumentalRevertsSettledRow(t *testing.T) {
 	var status, outcomeType string
 	var result int
 	var vocalPeak float64
+	var lane *string
 	if err := q.db.QueryRowContext(ctx,
-		`SELECT status, instrumental_result, COALESCE(outcome_type,''), vocal_peak FROM work_queue WHERE id = ?`, item.ID,
-	).Scan(&status, &result, &outcomeType, &vocalPeak); err != nil {
+		`SELECT status, instrumental_result, COALESCE(outcome_type,''), vocal_peak, provider_lane FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&status, &result, &outcomeType, &vocalPeak, &lane); err != nil {
 		t.Fatalf("read row: %v", err)
 	}
 	if status != "deferred" {
@@ -4482,6 +4483,14 @@ func TestDBQueue_UnsettleInstrumentalRevertsSettledRow(t *testing.T) {
 	}
 	if vocalPeak != 0.02 {
 		t.Errorf("vocal_peak = %v; want 0.02 preserved as the re-decision evidence", vocalPeak)
+	}
+	// The reversal un-does the detector's COMPLETION, so the lane attributing that
+	// completion must go with it. Leaving it behind makes a deferred row assert
+	// that the detector completed it -- attribution for something that no longer
+	// happened. Measured on a live install as 43 such rows before this was fixed.
+	if lane != nil {
+		t.Errorf("provider_lane = %q; want NULL. A reverted row is no longer completed by any lane, "+
+			"so keeping the attribution asserts a completion that was just un-done", *lane)
 	}
 }
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/canticle/internal/db"
+	"github.com/sydlexius/canticle/internal/detectorbackfill"
 	"github.com/sydlexius/canticle/internal/models"
 )
 
@@ -4107,6 +4108,60 @@ func TestDBQueue_SettleInstrumentalCompletesDeferredRowAtomically(t *testing.T) 
 	}
 	if vocalClass != "Singing" {
 		t.Errorf("vocal_class = %q; want the telemetry written in the same transaction", vocalClass)
+	}
+}
+
+// TestDBQueue_SettleInstrumentalAttributesDetectorLane: a settle must stamp
+// provider_lane, not just the outcome type.
+//
+// This is the regression for the blank-lane column in the reports UI (#708). The
+// backfill callers reach completion ONLY through SettleInstrumental, so a settle
+// that stamped outcome_type without provider_lane left every backfilled row
+// unattributed, rendering as an empty lane beside worker-settled rows that showed
+// "Instrumental Detector". The assertion reads the column straight out of SQLite
+// rather than trusting the returned outcome, because the bug was precisely that a
+// fully successful settle still left the column NULL -- an assertion on the return
+// value would have passed throughout.
+func TestDBQueue_SettleInstrumentalAttributesDetectorLane(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+
+	item, err := q.Enqueue(ctx, models.Inputs{
+		Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+		Outdir:     "out",
+		Filename:   "a.lrc",
+		SourcePath: "/music/a.flac",
+	}, 1)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if _, err := q.Defer(ctx, item.ID, time.Hour, errors.New("no results found")); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+
+	if _, err := q.SettleInstrumental(ctx, item.ID, InstrumentalTelemetry{
+		MusicSum: 0.95, VocalPeak: 0.01, VocalClass: "Singing", DetectorVersion: "v1",
+	}); err != nil {
+		t.Fatalf("SettleInstrumental: %v", err)
+	}
+
+	// Scanned as a pointer so a NULL is distinguishable from the empty string:
+	// the pre-fix behavior was NULL, and scanning into a bare string would make
+	// the two indistinguishable and the failure message misleading.
+	var lane *string
+	if err := q.db.QueryRowContext(ctx,
+		`SELECT provider_lane FROM work_queue WHERE id = ?`, item.ID,
+	).Scan(&lane); err != nil {
+		t.Fatalf("read provider_lane: %v", err)
+	}
+	if lane == nil {
+		t.Fatal("provider_lane is NULL after a settle; the row renders with a blank lane in the reports UI")
+	}
+	if *lane != detectorbackfill.LaneName {
+		t.Errorf("provider_lane = %q; want %q", *lane, detectorbackfill.LaneName)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1708,14 +1708,24 @@ func (w *Worker) completeDetectorInstrumental(ctx context.Context, item queue.Wo
 	//
 	// The marker stays on disk either way: the detector's verdict was real, and a
 	// later pass rewrites it idempotently.
-	if outcome != queue.Settled {
+	switch outcome {
+	case queue.Settled:
+	case queue.SettleAlreadyInstrumental, queue.SettleRowGone:
+		// The row is NOT in 'processing' any more -- a peer settled it, or it was
+		// pruned -- so there is nothing to strand and nothing to release. Releasing
+		// anyway would be guaranteed to fail (Release is itself guarded on
+		// 'processing' and reports ErrNoRows when it matches nothing) and would emit
+		// a "may be stuck" error for a row that demonstrably is not stuck. Both are
+		// benign races, so they are recorded at Info.
+		slog.Info("worker instrumental detection: settle did not apply; the row is no longer ours",
+			"id", item.ID, "outcome", outcome)
+	default:
 		slog.Warn("worker instrumental detection: settle did not apply; releasing the row so it is not stranded in processing",
 			"id", item.ID, "outcome", outcome)
 		if relErr := w.queue.Release(ctxNoCancel, item.ID); relErr != nil {
-			// Release is itself guarded on 'processing', so a failure here means the
-			// row already moved (someone else owns it) or the DB is unhealthy. Neither
-			// is recoverable from this call site, and the settle already did not apply,
-			// so surface it rather than pretending the item completed.
+			// Here the row was expected to still be ours, so a failed release IS the
+			// stranding case: it means the row moved under us or the DB is unhealthy,
+			// and neither is recoverable from this call site.
 			slog.Error("worker instrumental detection: could not release an unsettled row; it may be stuck in processing",
 				"id", item.ID, "error", relErr)
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -56,7 +56,18 @@ type Queue interface {
 	// SetProviderLane stamps the winning provider lane name onto a work_queue row
 	// for per-track provenance. Call at completion time before Complete so the row
 	// permanently records which provider served it. An empty lane is a no-op.
+	//
+	// NOT used for a detector-sourced instrumental settle: that goes through
+	// SettleInstrumental, which stamps the lane inside the settle transaction. This
+	// remains the path for a PROVIDER hit, where the lane is one of several and the
+	// completion is the ordinary multi-step one.
 	SetProviderLane(ctx context.Context, id int64, lane string) error
+	// SettleInstrumental records a detector-sourced instrumental verdict and
+	// completes the row in ONE transaction (telemetry, instrumental_result=1,
+	// outcome_type, provider_lane, status, scan_results writeback). It is shared
+	// with the offline backfills so a detector settle has exactly one definition;
+	// OwnedByWorker guards on 'processing', the status Dequeue left the row in.
+	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error)
 	// SetCompletionProvenance stamps the identifiers and writer version the row was
 	// settled with, so an outcome that writes no tag block -- an unsynced .txt above
 	// all -- still records what produced it (#620). Call before Complete while the
@@ -745,17 +756,32 @@ func (w *Worker) SetProviderRecorder(r ProviderRecorder) {
 // stamps the lane name onto the work_queue row for per-track provenance. Both
 // operations are non-fatal: errors are logged at Warn and do not affect the
 // processing outcome.
+//
+// The detector path calls recordHitCounter instead: its lane is stamped inside
+// the settle transaction, so stamping it here too would write the same value
+// twice, once transactionally and once advisorily.
 func (w *Worker) recordHit(ctx context.Context, id int64, lane string) {
 	if lane == "" {
 		return
 	}
-	if w.providerRecorder != nil {
-		if err := w.providerRecorder.RecordProviderHit(ctx, lane); err != nil {
-			slog.Warn("worker: record provider hit failed", "lane", lane, "error", err)
-		}
-	}
+	w.recordHitCounter(ctx, lane)
 	if err := w.queue.SetProviderLane(ctx, id, lane); err != nil {
 		slog.Warn("worker: stamp provider lane failed", "id", id, "lane", lane, "error", err)
+	}
+}
+
+// recordHitCounter increments the provider-outcome hit counter WITHOUT stamping
+// the lane onto the row. It is the detector path's half of recordHit: that path
+// still owes the counter (a detector settle is a real dispatch that consulted
+// every lane, and omitting it would undercount provider_outcomes by exactly the
+// tracks the detector resolves, #282) but its per-track attribution is written
+// transactionally by SettleInstrumental.
+func (w *Worker) recordHitCounter(ctx context.Context, lane string) {
+	if lane == "" || w.providerRecorder == nil {
+		return
+	}
+	if err := w.providerRecorder.RecordProviderHit(ctx, lane); err != nil {
+		slog.Warn("worker: record provider hit failed", "lane", lane, "error", err)
 	}
 }
 
@@ -1243,9 +1269,12 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 		// would undercount provider_outcomes and leave lane_attempts with no row
 		// for this track at all - skewing both the attempt-weighted counter and
 		// the per-track hit-rate reports (#282) by exactly the tracks the
-		// detector resolves. recordHit attributes the hit to the detector lane,
-		// matching song.WinningLane.
-		w.recordHit(context.WithoutCancel(ctx), item.ID, song.WinningLane)
+		// detector resolves.
+		//
+		// recordHitCounter, not recordHit: the per-track lane attribution is
+		// stamped inside the settle transaction, so the counter is all that is
+		// owed here.
+		w.recordHitCounter(context.WithoutCancel(ctx), song.WinningLane)
 		w.recordLaneAttempts(context.WithoutCancel(ctx), item.ID, song.LaneAttempts)
 		return w.completeDetectorInstrumental(ctx, item, song)
 	}
@@ -1559,11 +1588,24 @@ func (w *Worker) stampDetectorMissTelemetry(ctxNoCancel context.Context, id int6
 	}
 }
 
-// stampDetectorInstrumental records a detector-sourced instrumental settle from
-// the orchestrator result. It replaces the old inline hand-built song path,
-// reading telemetry off the Song the detector lane produced. ctxNoCancel mirrors
-// the prior stamp code so a canceled work context cannot drop the write.
-func (w *Worker) stampDetectorInstrumental(ctxNoCancel context.Context, item queue.WorkItem, song models.Song) error {
+// settleDetectorInstrumental records a detector-sourced instrumental settle from
+// the orchestrator result and completes the row, through the SAME transaction the
+// offline backfills use. ctxNoCancel mirrors the prior stamp code so a canceled
+// work context cannot drop the write.
+//
+// This was four separate non-atomic writes (SetProviderLane via recordHit, then
+// SetInstrumentalResult, SetOutcomeType, and Complete), duplicating what
+// queue.SettleInstrumental already did in one transaction for the backfills. The
+// duplication had drifted: the lane stamp here was advisory, so a failed
+// SetProviderLane logged a warning and let the row complete unattributed, which
+// is one of the two ways a settled row ended up rendering with a blank lane in
+// the reports UI. Sharing the transaction removes both the drift and every
+// partially-written intermediate state.
+//
+// OwnedByWorker because Dequeue left this row in 'processing' and the worker
+// holds it for the whole write; the backfills pass OwnedByBackfill for a row they
+// do not own. That guard is the ONLY behavioral difference between the two.
+func (w *Worker) settleDetectorInstrumental(ctxNoCancel context.Context, item queue.WorkItem, song models.Song) (queue.SettleOutcome, error) {
 	tel := queue.InstrumentalTelemetry{
 		MusicSum:        song.DetectorMusicSum,
 		VocalPeak:       song.DetectorVocalPeak,
@@ -1571,13 +1613,11 @@ func (w *Worker) stampDetectorInstrumental(ctxNoCancel context.Context, item que
 		VocalClass:      song.DetectorVocalClass,
 		DetectorVersion: song.DetectorVersion,
 	}
-	if err := w.queue.SetInstrumentalResult(ctxNoCancel, item.ID, 1, tel); err != nil {
-		return fmt.Errorf("stamp instrumental result: %w", err)
+	outcome, err := w.queue.SettleInstrumental(ctxNoCancel, item.ID, tel, queue.OwnedByWorker)
+	if err != nil {
+		return outcome, fmt.Errorf("settle instrumental: %w", err)
 	}
-	if err := w.queue.SetOutcomeType(ctxNoCancel, item.ID, "instrumental"); err != nil {
-		return fmt.Errorf("stamp outcome_type: %w", err)
-	}
-	return nil
+	return outcome, nil
 }
 
 // completeDetectorInstrumental finalizes a fresh detector-lane instrumental
@@ -1616,30 +1656,12 @@ func (w *Worker) completeDetectorInstrumental(ctx context.Context, item queue.Wo
 	// existing rows. Re-running the detector on a later track is far cheaper
 	// than a permanently unreplayable cache row.
 	//
-	// Stamp instrumental_result=1 + telemetry + outcome type only AFTER the
-	// marker write succeeded (a failed WriteLRC above requeues and returns before
-	// here), so a transient write error never leaves a row tagged instrumental
-	// with stale telemetry. Still before Complete, so /metrics reflects it
-	// durably.
-	//
-	// The stamp is REQUIRED, not best-effort: completing the row without it
-	// would retire the work item while leaving no record that the detector was
-	// what settled it, so the verdict is neither auditable nor reproducible and
-	// no later pass would revisit it. On failure, defer and retry instead - the
-	// marker file is already written, and WriteLRC is idempotent, so the retry
-	// re-runs the write harmlessly and gets another chance to stamp.
-	if stampErr := w.stampDetectorInstrumental(ctxNoCancel, item, song); stampErr != nil {
-		slog.Warn("worker instrumental detection: stamp failed; deferring for retry", "id", item.ID, "error", stampErr)
-		if derr := w.requeueDeferred(ctx, item, stampErr); derr != nil {
-			return derr
-		}
-		w.consecutiveFailures = 0
-		return nil
-	}
-	// Provenance is advisory and stamped OUTSIDE stampDetectorInstrumental, whose
-	// stamps are deliberately required: a failed provenance write must not defer a
-	// settle whose marker is already on disk and whose verdict is already
-	// recorded.
+	// Provenance is stamped BEFORE the settle, not after. It is advisory (a failed
+	// provenance write must not defer a settle whose marker is already on disk),
+	// but the settle now COMPLETES the row in the same transaction, so anything
+	// that must land on a row still in 'processing' has to be written first. The
+	// old ordering stamped it between the required stamps and Complete; that gap
+	// no longer exists.
 	//
 	// This path records the WRITER VERSION ONLY. A detector settle resolves no
 	// identifiers (there is no provider result), and it never carries a fetch
@@ -1650,13 +1672,34 @@ func (w *Worker) completeDetectorInstrumental(ctx context.Context, item queue.Wo
 	// to tell them apart. The detector's own timing lives in completed_at and the
 	// detector telemetry, so nothing is lost by not inventing one here.
 	w.stampCompletionProvenance(ctxNoCancel, item.ID, song)
-	if completeErr := w.queue.Complete(ctxNoCancel, item.ID); completeErr != nil {
-		cause := fmt.Errorf("worker: complete instrumental item %d: %w", item.ID, completeErr)
-		w.consecutiveFailures++
-		if _, failErr := w.queue.Fail(ctxNoCancel, item.ID, cause); failErr != nil {
-			return fmt.Errorf("worker: complete instrumental item %d and mark failed: %w", item.ID, errors.Join(cause, failErr))
+	// Settle only AFTER the marker write succeeded (a failed WriteLRC above
+	// requeues and returns before here), so a transient write error never leaves a
+	// row tagged instrumental with stale telemetry.
+	//
+	// The settle is REQUIRED, not best-effort: completing the row without it would
+	// retire the work item while leaving no record that the detector was what
+	// settled it, so the verdict would be neither auditable nor reproducible and
+	// no later pass would revisit it. On failure, defer and retry -- the marker
+	// file is already written and WriteLRC is idempotent, so the retry re-runs the
+	// write harmlessly and gets another chance.
+	outcome, settleErr := w.settleDetectorInstrumental(ctxNoCancel, item, song)
+	if settleErr != nil {
+		slog.Warn("worker instrumental detection: settle failed; deferring for retry", "id", item.ID, "error", settleErr)
+		if derr := w.requeueDeferred(ctx, item, settleErr); derr != nil {
+			return derr
 		}
-		return fmt.Errorf("worker: complete instrumental item %d (marked failed): %w", item.ID, cause)
+		w.consecutiveFailures = 0
+		return nil
+	}
+	// A worker-owned settle should always match: Dequeue put this row in
+	// 'processing' and nothing else can move it while the worker holds it. Anything
+	// else means an invariant broke (a concurrent writer, or a row pruned
+	// mid-flight), so it is logged rather than silently treated as success. The
+	// marker on disk stays either way -- the detector's verdict was real, and the
+	// backfill will revisit an unsettled row later.
+	if outcome != queue.Settled {
+		slog.Warn("worker instrumental detection: settle did not apply; marker is on disk but the row was not completed",
+			"id", item.ID, "outcome", outcome)
 	}
 	w.consecutiveFailures = 0
 	return nil

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1694,12 +1694,31 @@ func (w *Worker) completeDetectorInstrumental(ctx context.Context, item queue.Wo
 	// A worker-owned settle should always match: Dequeue put this row in
 	// 'processing' and nothing else can move it while the worker holds it. Anything
 	// else means an invariant broke (a concurrent writer, or a row pruned
-	// mid-flight), so it is logged rather than silently treated as success. The
-	// marker on disk stays either way -- the detector's verdict was real, and the
-	// backfill will revisit an unsettled row later.
+	// mid-flight).
+	//
+	// RELEASING IS REQUIRED, NOT COSMETIC. Logging alone would STRAND the row: the
+	// settle folded Complete into itself, so a non-Settled outcome leaves the row
+	// in 'processing', and nothing ever reclaims that status -- Dequeue selects
+	// only ('pending','failed','deferred') and ListUnclassified requires
+	// 'deferred'. The row would be invisible to BOTH the worker and the backfill
+	// forever, with its marker on disk and no verdict recorded. The pre-unification
+	// code could not produce this: Complete errored on a non-'processing' row and
+	// the caller then failed it, which moved it somewhere re-dequeueable. Release
+	// restores prev_status so the row is retryable, keeping that property.
+	//
+	// The marker stays on disk either way: the detector's verdict was real, and a
+	// later pass rewrites it idempotently.
 	if outcome != queue.Settled {
-		slog.Warn("worker instrumental detection: settle did not apply; marker is on disk but the row was not completed",
+		slog.Warn("worker instrumental detection: settle did not apply; releasing the row so it is not stranded in processing",
 			"id", item.ID, "outcome", outcome)
+		if relErr := w.queue.Release(ctxNoCancel, item.ID); relErr != nil {
+			// Release is itself guarded on 'processing', so a failure here means the
+			// row already moved (someone else owns it) or the DB is unhealthy. Neither
+			// is recoverable from this call site, and the settle already did not apply,
+			// so surface it rather than pretending the item completed.
+			slog.Error("worker instrumental detection: could not release an unsettled row; it may be stuck in processing",
+				"id", item.ID, "error", relErr)
+		}
 	}
 	w.consecutiveFailures = 0
 	return nil

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -126,6 +126,15 @@ type fakeQueue struct {
 	// test can distinguish a transactional settle from the old stamp-then-complete
 	// sequence.
 	settledLanes []int64
+	// onSettleAttempt fires at the top of SettleInstrumental, before the ownership
+	// guard is evaluated, so a test can stage the mid-flight race the guard exists
+	// to catch (a peer moving the row out of `processing` between Dequeue and the
+	// settle). Staging it any earlier would not reproduce the real interleaving.
+	onSettleAttempt func(id int64)
+	// providerLaneStamps records ids passed to SetProviderLane, so a test can
+	// assert the detector path does NOT stamp the lane advisorily (it is written
+	// inside the settle transaction) while the provider path still does.
+	providerLaneStamps []int64
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -236,10 +245,15 @@ func (q *fakeQueue) SetTimingOutcome(_ context.Context, id int64, rec queue.Timi
 	return nil
 }
 
-func (q *fakeQueue) SetProviderLane(_ context.Context, _ int64, _ string) error {
+func (q *fakeQueue) SetProviderLane(_ context.Context, id int64, _ string) error {
 	if q.setProviderLaneErr != nil {
 		return q.setProviderLaneErr
 	}
+	// Recorded so a test can assert this was NOT called on the detector path,
+	// whose lane is stamped inside the settle transaction instead. Without this
+	// the recordHit/recordHitCounter split is unpinned in the only direction that
+	// matters -- re-introducing the double write leaves every other test green.
+	q.providerLaneStamps = append(q.providerLaneStamps, id)
 	return nil
 }
 
@@ -261,6 +275,9 @@ func (q *fakeQueue) SetProviderLane(_ context.Context, _ int64, _ string) error 
 //     records NONE of them -- a partial write is exactly what the real
 //     transaction cannot produce.
 func (q *fakeQueue) SettleInstrumental(_ context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error) {
+	if q.onSettleAttempt != nil {
+		q.onSettleAttempt(id)
+	}
 	if q.instrumentalErr != nil {
 		return queue.SettleFailed, q.instrumentalErr
 	}
@@ -2113,6 +2130,59 @@ func TestRunOnceDetectorInstrumentalSettlesAsRowOwner(t *testing.T) {
 	}
 	if got := q.outcomeTypes[260]; got != "instrumental" {
 		t.Errorf("outcome_type = %q; want %q, stamped inside the same settle", got, "instrumental")
+	}
+	// The lane is stamped INSIDE the settle, so the advisory SetProviderLane must
+	// not also fire here. That is the entire point of splitting recordHit into
+	// recordHitCounter for this path: re-introducing the double write is otherwise
+	// invisible, since both writes carry the same value.
+	if len(q.providerLaneStamps) != 0 {
+		t.Errorf("SetProviderLane called for %v; the detector path stamps its lane transactionally, "+
+			"so an advisory stamp here is a redundant second write of the same value", q.providerLaneStamps)
+	}
+}
+
+// TestRunOnceDetectorInstrumentalReleasesRowWhenSettleDoesNotApply: an unsettled
+// row must be released, never left in 'processing'.
+//
+// Folding Complete into the settle transaction created this failure mode. When
+// the settle matches no row it returns a non-Settled outcome with a NIL error, so
+// nothing looks wrong -- but the row is still 'processing', and NOTHING reclaims
+// that status: Dequeue selects only ('pending','failed','deferred') and the
+// backfill's ListUnclassified requires 'deferred'. The row would be invisible to
+// both forever, marker on disk, verdict unrecorded.
+//
+// The pre-unification code could not produce this (Complete errored on a
+// non-'processing' row, and the caller then failed it), so this is the one place
+// the refactor could regress silently, and a log line alone would not fix it.
+func TestRunOnceDetectorInstrumentalReleasesRowWhenSettleDoesNotApply(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 270,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Composer", TrackName: "Etude"},
+			Outdir:     "out",
+			Filename:   "etude.lrc",
+			SourcePath: "/music/etude.flac",
+		},
+	}}}
+	// Stage the race: the row is gone from `processing` by the time the settle
+	// runs, so the guarded UPDATE matches nothing and reports SettleClaimed with a
+	// nil error -- exactly the shape that stranded the row.
+	q.onSettleAttempt = func(id int64) { q.removeFromProcessing(id) }
+
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.EnableAudioDetector(&fakeDetector{instrumental: true, version: "9.9.9"})
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(q.settledLanes) != 0 {
+		t.Fatalf("settledLanes = %v; want none -- this test stages a settle that does NOT apply", q.settledLanes)
+	}
+	if len(q.released) != 1 || q.released[0] != 270 {
+		t.Fatalf("released = %v; want [270]. An unsettled row left in 'processing' is reclaimed by nothing -- "+
+			"Dequeue skips it and the backfill skips it -- so it is stranded with its marker on disk forever", q.released)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -122,6 +122,10 @@ type fakeQueue struct {
 	setProviderLaneErr error
 	instrumentalStamps []instrumentalStamp
 	instrumentalErr    error
+	// settledLanes records ids settled through the shared settle transaction, so a
+	// test can distinguish a transactional settle from the old stamp-then-complete
+	// sequence.
+	settledLanes []int64
 }
 
 func (q *fakeQueue) Dequeue(_ context.Context) (queue.WorkItem, error) {
@@ -237,6 +241,58 @@ func (q *fakeQueue) SetProviderLane(_ context.Context, _ int64, _ string) error 
 		return q.setProviderLaneErr
 	}
 	return nil
+}
+
+// SettleInstrumental fakes the shared settle transaction.
+//
+// It deliberately reproduces the REAL method's two defining behaviors rather than
+// just returning Settled, because a fake that always succeeds would agree with a
+// caller that passed the wrong ownership and validate nothing:
+//
+//  1. The OWNERSHIP GUARD. The real UPDATE matches only a row in the owner's
+//     expected status, so this checks the item is actually in `processing` and
+//     reports SettleClaimed when it is not. A worker that regressed to
+//     OwnedByBackfill would settle nothing in production; this makes that show up
+//     as a failing test instead of a silent no-op.
+//  2. ATOMICITY. The real transaction stamps the verdict, telemetry, outcome type
+//     and lane AND completes the row together, so on success this records all of
+//     them, writing through the same fields the pre-existing assertions read
+//     (instrumentalStamps, outcomeTypes, completed). On the guarded no-op it
+//     records NONE of them -- a partial write is exactly what the real
+//     transaction cannot produce.
+func (q *fakeQueue) SettleInstrumental(_ context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error) {
+	if q.instrumentalErr != nil {
+		return queue.SettleFailed, q.instrumentalErr
+	}
+	// Model the guard SYMMETRICALLY, the way `WHERE status = ?` behaves: a row in
+	// `processing` matches ONLY OwnedByWorker, and a row not in `processing`
+	// matches only OwnedByBackfill. An earlier version of this fake checked the
+	// OwnedByWorker case alone and let OwnedByBackfill through unconditionally,
+	// which made it agree with a worker that passed the wrong ownership -- the
+	// whole worker suite stayed green under that mutation. A fake that validates
+	// one direction of a two-directional guard validates nothing.
+	var held bool
+	for _, item := range q.processing {
+		if item.ID == id {
+			held = true
+			break
+		}
+	}
+	if held != (owner == queue.OwnedByWorker) {
+		return queue.SettleClaimed, nil
+	}
+	q.instrumentalStamps = append(q.instrumentalStamps, instrumentalStamp{ID: id, Result: 1, Tel: tel})
+	if q.outcomeTypes == nil {
+		q.outcomeTypes = make(map[int64]string)
+	}
+	q.outcomeTypes[id] = "instrumental"
+	q.settledLanes = append(q.settledLanes, id)
+	if q.onComplete != nil {
+		q.onComplete(id)
+	}
+	q.completed = append(q.completed, id)
+	q.removeFromProcessing(id)
+	return queue.Settled, nil
 }
 
 func (q *fakeQueue) removeFromProcessing(id int64) {
@@ -2009,6 +2065,57 @@ func (d *fakeDetector) Detect(_ context.Context, audioPath string) (detector.Res
 // TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes verifies that when
 // the audio detector returns instrumental=true on a benign miss, the worker
 // writes an instrumental marker, stores it in the cache, and completes the item.
+// TestRunOnceDetectorInstrumentalSettlesAsRowOwner pins the ownership argument
+// the worker passes to the shared settle transaction.
+//
+// The worker holds its row in 'processing' from Dequeue until completion, so it
+// must settle as OwnedByWorker. Passing OwnedByBackfill would guard the UPDATE on
+// status='deferred', match ZERO rows, and settle nothing -- while still returning
+// a nil error, because a guarded no-op is a legitimate outcome of that method
+// rather than a failure. The row would stay in 'processing' forever and be
+// re-dequeued, and every surface downstream (outcome type, lane, completion)
+// would silently go unwritten.
+//
+// It is asserted explicitly because nothing else catches it: verified by mutation
+// that flipping the worker to OwnedByBackfill leaves the ENTIRE rest of the worker
+// suite green.
+func TestRunOnceDetectorInstrumentalSettlesAsRowOwner(t *testing.T) {
+	q := &fakeQueue{items: []queue.WorkItem{{
+		ID: 260,
+		Inputs: models.Inputs{
+			Track:      models.Track{ArtistName: "Composer", TrackName: "Nocturne"},
+			Outdir:     "out",
+			Filename:   "nocturne.lrc",
+			SourcePath: "/music/nocturne.flac",
+		},
+	}}}
+	w := New(q, &fakeCache{}, &fakeFetcher{err: musixmatch.ErrNotFound}, &fakeWriter{})
+	w.EnableAudioDetector(&fakeDetector{instrumental: true, version: "9.9.9"})
+	w.SetInstrumentalDetectionDefault(true)
+
+	if err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// The fake enforces the guard the real UPDATE enforces: it settles only a row
+	// it is actually holding in `processing`, so a wrong ownership argument shows
+	// up here as an unsettled row rather than as a silent production no-op.
+	if len(q.settledLanes) != 1 || q.settledLanes[0] != 260 {
+		t.Fatalf("settledLanes = %v; want [260]. The worker owns its row in 'processing', "+
+			"so it must settle as OwnedByWorker; OwnedByBackfill guards on 'deferred', "+
+			"matches no row, and settles nothing while still returning nil", q.settledLanes)
+	}
+	// And the settle must be the thing that completed it: the transaction stamps
+	// the verdict, the outcome type and the completion together, so a row that
+	// settled is a row that is done.
+	if len(q.completed) != 1 || q.completed[0] != 260 {
+		t.Fatalf("completed = %v; want [260] from the settle transaction", q.completed)
+	}
+	if got := q.outcomeTypes[260]; got != "instrumental" {
+		t.Errorf("outcome_type = %q; want %q, stamped inside the same settle", got, "instrumental")
+	}
+}
+
 func TestRunOnceDetectorInstrumentalWritesMarkerAndCompletes(t *testing.T) {
 	track := models.Track{ArtistName: "Composer", TrackName: "Interlude"}
 	audioPath := "/music/interlude.flac"


### PR DESCRIPTION
## Summary

- **Detector-settled rows rendered with a blank lane column.** `queue.SettleInstrumental` stamped `outcome_type='instrumental'` but never `provider_lane`, and it is the only completion path the offline backfills have. The worker's own detector path stamped the lane *advisorily* (a failed `SetProviderLane` logged a warning and let the row complete anyway), so the same symptom had two independent causes.
- **The report's Instrumental Detector tile sat frozen** while a backfill classified thousands of tracks. `lane_attempts` was written only by the worker; the backfill paths recorded nothing at all, so both numerator and denominator stalled.
- **Root cause of both: two implementations of "settle a row as detector-instrumental" that had drifted.** The worker did four non-atomic writes; the backfills used one guarded transaction. This unifies them behind `SettleInstrumental`, with row ownership as the only parameter (`OwnedByWorker` guards on `processing`, `OwnedByBackfill` on `deferred` -- guarding on the wrong one silently matches zero rows, which is why it is a typed parameter rather than a bool).
- **Size override:** the four original commits are one defect class -- a write path that records bookkeeping its counterpart skips. Splitting was attempted and rejected: the follow-up commits do not compile on `main` (the `newFakeStore` signature change), so an independent split would duplicate the same edit across two open PRs. The two migrations are companion gap-fills for the two affected tables, and each ships with the code fix that stops its gap recurring.

Reviewers should look first at `internal/queue/queue.go` (the unified settle + the `RowOwnership` guard) and at the two migration predicates, which are where the subtle mistakes were.

## Linked issue

Part of #708, closes #282

`#708` is not closed: its originally-scoped serve-mode sweep is **not** in this PR (see Not covered).

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete; critical and important findings fixed before pushing. An adversarial review found 5 findings, all fixed in `b85d473` -- including one that would have written wrong provenance to production rows.
- [ ] Commits squashed into one clean commit. **Deliberately not squashed**: six commits, each a self-contained fix with its own rationale. Squashing would bury the review-fix and anomaly-repair reasoning.
- [x] Label set.
- [ ] UAT performed. **Not done** -- see Not covered.
- [x] Screenshot: n/a, no web-UI source change (the rendering bug is fixed in the data layer).
- [x] `make ui`: n/a, no `.templ` or CSS change.
- [x] Migration added for the one-time data corrections (039, 040).

## Test plan

- [x] `make gate` passes locally.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Every fix here was mutation-checked; the notable ones:
  - Reverting the in-settle lane stamp reddens only the lane assertion.
  - Flipping the worker to `OwnedByBackfill` reddens 10 worker tests. This one initially reddened **nothing** -- `fakeQueue` validated only one direction of a two-directional guard, so it agreed with broken production code. The fake was fixed, not the test.
  - Emptying either migration body reddens exactly its target rows, leaving the must-not-touch cases green.
  - Making `Reverse`'s attempt correction a no-op, and re-introducing the double lane write, each reddened nothing until this PR added the assertions that pin them.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Which surface this change fixes**, stated explicitly and verified per surface:
  - `work_queue.provider_lane` -> the reports **lane column** (`laneLabel` in `internal/web/`). Fixed in code + migration 039.
  - `lane_attempts` -> the dashboard's **Instrumental Detector tile** (`reports.ProviderEffectiveness`). Fixed in code + migration 040.
  - `provider_outcomes` -> `/metrics`. **Untouched and unaffected**; `recordHitCounter` preserves the counter on both paths.
- [x] Manual verification against a **copy of the production database** (`.backup` snapshot, applied, measured, then discarded):
  - [x] Migration 039 moved detector attributions 5829 -> 6530: delta exactly the 701 targeted rows.
  - [x] Migration 040 inserted exactly 2965 attempts, matching its predicted target; 0 duplicates.
  - [x] Both pre-existing anomalies (43 stale attributions, 2 contradicting attempts) go to 0.
  - [x] All 22,567 `musixmatch` attributions survive untouched -- the scoping guard holds.
  - [x] Re-applying every statement a second time changes nothing (idempotent).
- [ ] Reviewer follow-ups:
  - [ ] Migration 040's repair is **one-directional** (`hit 0 -> 1` only). The symmetric version was written first and silently reverted the recalib correction that 040's own `DO NOTHING` exists to protect -- caught by the migration test. Worth a second opinion on whether the `1 -> 0` direction should be handled at all, or correctly left to the code path that owns it.
  - [ ] `RowOwnership`'s zero value is `OwnedByBackfill` (the safer default: it under-settles visibly rather than writing over a row a worker owns). Sanity-check that reasoning.

## Not covered

- **No UAT against a running binary.** Verification was the test suite plus measurements against a production *copy*; the fixed surfaces were not observed re-rendering in a live UI.
- **The `#708` serve-mode sweep is not here.** The issue proposed building a decoupled detection pass; `internal/instrumentalbackfill` (#499) already *is* that pass, and what is missing is that nothing ever *runs* it. That sweep is still in progress and needs its throughput rationale rewritten -- measurement showed `cooldown_seconds` (3.0s) dominates the per-track cost at 91%, not `batch_size`/ffmpeg (0.10s), which the drafted code asserted.
- **Historical `lane_attempts` predating the code fix** are corrected by 040 only where a gap or an unambiguous contradiction exists. Attempts consistent with their row are left as recorded history.
- **A pre-existing detector-mutex issue is untouched:** `internal/detector/http.go` holds `d.mu` *across* the `cooldown_seconds` sleep, so any future caller sharing the worker's detector serializes against it. Relevant to the #708 sweep, not to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detector outcomes now record consistent detector lane attribution and detector lane hit/miss attempts, with ownership-aware settlement across worker and backfill.
* **Bug Fixes**
  * Database upgrades now backfill missing detector lane/attempt data and correct contradictory hit values without overwriting valid recorded attempts.
  * Reverting instrumental detector results now clears stale detector attribution and updates the recorded lane hit state.
  * Migrations include provenance repair backup to support safe restoration of overwritten values.
* **Tests**
  * Added/expanded migration and reconciliation tests covering idempotency, gap filling, and revert/flip correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->