### PR TITLE
fix(audiodur): give the duration cache a reader identity

### DIFF
--- a/internal/audiodur/audiodur.go
+++ b/internal/audiodur/audiodur.go
@@ -24,11 +24,26 @@ import (
 // safe for concurrent use because the underlying *sql.DB is.
 type Store struct {
 	db *sql.DB
+	// readerVersion identifies the parser whose output this Store may read and
+	// will stamp on what it writes. Held here rather than passed per call so the
+	// two can never disagree: a row is stamped by the same identity that will
+	// later be required to match it (#711).
+	readerVersion string
 }
 
-// New returns a Store backed by db.
-func New(db *sql.DB) *Store {
-	return &Store{db: db}
+// New returns a Store backed by db, whose cached durations were produced by --
+// and may only be read back by -- the duration parser identified by
+// readerVersion. Callers pass scanner.DurationReaderVersion; see its doc for why
+// the value is hand-set and when to bump it.
+//
+// A reader identity that does not match a row's makes the row a MISS, which is
+// the already-tested fail-open path (0, false) rather than an error, so a bump
+// re-derives the whole population lazily with no backfill and no flag day.
+// Passing the empty string is legal and simply matches only the rows stamped
+// with the empty string -- never the NULL legacy rows, since comparing NULL to
+// anything (the empty string included) yields NULL rather than true.
+func New(db *sql.DB, readerVersion string) *Store {
+	return &Store{db: db, readerVersion: readerVersion}
 }
 
 // Lookup returns the cached duration for path when the file still matches the
@@ -38,12 +53,19 @@ func New(db *sql.DB) *Store {
 //
 // mtimeNano is ModTime().UnixNano(), so a same-second rewrite to the same byte
 // size still reads as changed.
+//
+// A row whose reader_version differs from this Store's is likewise a miss: the
+// bytes are unchanged but the code that interpreted them is not the code asking
+// now, so the stored number is not a duration THIS parser would produce (#711).
+// Rows predating the column hold NULL and never match, because NULL = ? is NULL
+// rather than true -- that is what makes the legacy population invalidate itself
+// with no migration of row data.
 func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) (int, bool, error) {
 	var seconds int
 	err := s.db.QueryRowContext(ctx,
 		`SELECT duration_seconds FROM audio_durations
-		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? LIMIT 1`,
-		path, mtimeNano, size,
+		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? AND reader_version=? LIMIT 1`,
+		path, mtimeNano, size, s.readerVersion,
 	).Scan(&seconds)
 	if err == nil {
 		return seconds, true, nil
@@ -58,18 +80,24 @@ func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) 
 // replacing any previous entry for that path. Recording a non-positive duration
 // is a no-op: absence is how this table represents "unknown", so storing a 0
 // would make "never read" indistinguishable from "measured as zero-length".
+//
+// The row is stamped with this Store's reader identity, so a later parser change
+// stops it matching (#711). file_path remains the sole conflict target: one row
+// per file, re-stamped in place on a reader bump rather than accumulating one
+// row per parser version the file has ever been read by.
 func (s *Store) Record(ctx context.Context, path string, mtimeNano, size int64, seconds int) error {
 	if seconds <= 0 {
 		return nil
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO audio_durations (file_path, mtime_nsec, size_bytes, duration_seconds)
-		 VALUES (?, ?, ?, ?)
+		`INSERT INTO audio_durations (file_path, mtime_nsec, size_bytes, duration_seconds, reader_version)
+		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(file_path) DO UPDATE SET
 		     mtime_nsec       = excluded.mtime_nsec,
 		     size_bytes       = excluded.size_bytes,
-		     duration_seconds = excluded.duration_seconds`,
-		path, mtimeNano, size, seconds,
+		     duration_seconds = excluded.duration_seconds,
+		     reader_version   = excluded.reader_version`,
+		path, mtimeNano, size, seconds, s.readerVersion,
 	)
 	if err != nil {
 		return fmt.Errorf("audiodur: record %q: %w", path, err)

--- a/internal/audiodur/audiodur_test.go
+++ b/internal/audiodur/audiodur_test.go
@@ -9,14 +9,40 @@ import (
 	"github.com/sydlexius/canticle/internal/db"
 )
 
+// testReaderVersion is the parser identity every single-Store test writes and
+// reads under. Its value is irrelevant; what matters is that it is CONSTANT, so
+// these tests exercise mtime/size validation without reader identity confounding
+// the result.
+const testReaderVersion = "test-reader@v1"
+
 func openTestStore(t *testing.T) *audiodur.Store {
+	t.Helper()
+	return openTestStoreAs(t, testReaderVersion)
+}
+
+// openTestStoreAs returns a Store over a fresh database, reading and writing
+// under readerVersion.
+func openTestStoreAs(t *testing.T, readerVersion string) *audiodur.Store {
 	t.Helper()
 	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
 	t.Cleanup(func() { _ = sqlDB.Close() })
-	return audiodur.New(sqlDB)
+	return audiodur.New(sqlDB, readerVersion)
+}
+
+// openSharedDB returns two Stores over the SAME database reading under DIFFERENT
+// parser identities -- the shape a reader bump takes in production, where the
+// rows persist and the code changes underneath them.
+func openSharedDB(t *testing.T, versionA, versionB string) (a, b *audiodur.Store) {
+	t.Helper()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return audiodur.New(sqlDB, versionA), audiodur.New(sqlDB, versionB)
 }
 
 func TestLookup_UnknownPathIsAMiss(t *testing.T) {
@@ -119,6 +145,103 @@ func TestRecordUpsertsOnRepeat(t *testing.T) {
 	}
 	if !found || secs != 215 {
 		t.Fatalf("got (%d, %v), want (215, true)", secs, found)
+	}
+}
+
+// THE #711 GUARANTEE. The file is byte-identical -- same path, same mtime, same
+// size -- and the read still misses, because the PARSER changed. Without this,
+// swapping duration parsers serves numbers the running code would not produce,
+// and internal/revalidate demotes or quarantines correct sidecars on the
+// strength of them.
+func TestReaderVersionChangeIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	oldReader, newReader := openSharedDB(t, "parser@v1", "parser@v2")
+
+	if err := oldReader.Record(ctx, "/music/song.mp3", 100, 200, 210); err != nil {
+		t.Fatalf("Record under the old parser: %v", err)
+	}
+
+	// Same file, same stamp, different parser.
+	secs, found, err := newReader.Lookup(ctx, "/music/song.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("Lookup under the new parser: %v", err)
+	}
+	if found {
+		t.Fatal("a duration derived by a DIFFERENT parser must not hit; a VBR reader change moves durations by up to 10x and revalidate acts on the result")
+	}
+	if secs != 0 {
+		t.Fatalf("a miss must yield 0 seconds (the UnknownDuration fail-open path), got %d", secs)
+	}
+
+	// The old parser still hits: the row was invalidated for the NEW reader, not
+	// deleted. This is what makes the bump lazy rather than destructive.
+	if _, found, err := oldReader.Lookup(ctx, "/music/song.mp3", 100, 200); err != nil {
+		t.Fatalf("Lookup under the old parser: %v", err)
+	} else if !found {
+		t.Fatal("the recording parser must still hit its own row")
+	}
+}
+
+// A re-derivation under the new parser must RE-STAMP the existing row rather
+// than add a second one: file_path is the primary key, so a second row is not
+// merely wasteful, it is impossible -- and the upsert must therefore carry the
+// new identity or the row stays permanently unreadable and re-derives forever.
+func TestRecordRestampsRowOnReaderChange(t *testing.T) {
+	ctx := context.Background()
+	oldReader, newReader := openSharedDB(t, "parser@v1", "parser@v2")
+
+	if err := oldReader.Record(ctx, "/music/song.mp3", 100, 200, 210); err != nil {
+		t.Fatalf("Record under the old parser: %v", err)
+	}
+	// The new parser re-derives the same file and gets a different answer --
+	// the VBR case #711 exists for.
+	if err := newReader.Record(ctx, "/music/song.mp3", 100, 200, 187); err != nil {
+		t.Fatalf("Record under the new parser: %v", err)
+	}
+
+	secs, found, err := newReader.Lookup(ctx, "/music/song.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("Lookup under the new parser: %v", err)
+	}
+	if !found || secs != 187 {
+		t.Fatalf("got (%d, %v), want (187, true): the re-derived duration must be readable under the new parser", secs, found)
+	}
+
+	// And the row was re-stamped, not duplicated -- the old identity is gone.
+	if _, found, err := oldReader.Lookup(ctx, "/music/song.mp3", 100, 200); err != nil {
+		t.Fatalf("Lookup under the old parser: %v", err)
+	} else if found {
+		t.Fatal("the superseded parser must no longer hit: one row per file, re-stamped in place")
+	}
+}
+
+// Legacy rows -- written before the column existed -- hold NULL and must read as
+// a miss for EVERY reader, including one whose identity is the empty string.
+// This is the whole no-backfill argument: NULL = ? is NULL, never true, so the
+// pre-existing population invalidates itself with no row data migrated.
+func TestLegacyNullReaderVersionIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	// Write the row the way pre-#711 code did: no reader_version at all.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO audio_durations (file_path, mtime_nsec, size_bytes, duration_seconds)
+		 VALUES (?, ?, ?, ?)`,
+		"/music/legacy.mp3", 100, 200, 210,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	for _, readerVersion := range []string{"parser@v1", ""} {
+		if _, found, err := audiodur.New(sqlDB, readerVersion).Lookup(ctx, "/music/legacy.mp3", 100, 200); err != nil {
+			t.Fatalf("Lookup as %q: %v", readerVersion, err)
+		} else if found {
+			t.Fatalf("a legacy NULL-reader row must miss for reader %q; SQL NULL comparison is what invalidates the pre-existing population", readerVersion)
+		}
 	}
 }
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1085,7 +1085,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// and exposed via CacheStats.
 	cacheRepo := cache.New(sqlDB)
 	w := worker.New(workQ, cacheRepo, fetcher, writer)
-	w.SetDurationStore(audiodur.New(sqlDB))
+	w.SetDurationStore(audiodur.New(sqlDB, scanner.DurationReaderVersion))
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	w.SetCircuitBackoff(time.Duration(cfg.API.CircuitBackoffBase)*time.Second, time.Duration(cfg.API.CircuitOpenDuration)*time.Second)
 	// Dispatch strategy and the parallel-mode synced-upgrade window. Set before the
@@ -2298,7 +2298,7 @@ func scheduler(sqlDB *sql.DB, opts scanner.ScanOptions, detectOverride *bool, gl
 		// re-read (and re-warned about) on every scheduled/watched scan (#376).
 		Scanner: scanner.NewScanner(
 			scanner.WithMetadataFailureStore(scanfail.New(sqlDB)),
-			scanner.WithDurationStore(audiodur.New(sqlDB)),
+			scanner.WithDurationStore(audiodur.New(sqlDB, scanner.DurationReaderVersion)),
 		),
 		Options: opts,
 		// trigger and path disambiguate the two callers of this one callback

--- a/internal/commands/revalidate.go
+++ b/internal/commands/revalidate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sydlexius/canticle/internal/library"
 	"github.com/sydlexius/canticle/internal/realign"
 	"github.com/sydlexius/canticle/internal/revalidate"
+	"github.com/sydlexius/canticle/internal/scanner"
 	"github.com/sydlexius/canticle/internal/timing"
 )
 
@@ -95,7 +96,7 @@ func runRevalidate(ctx context.Context, out io.Writer, args RevalidateCmd) int {
 		return 2
 	}
 
-	durations := audiodur.New(sqlDB)
+	durations := audiodur.New(sqlDB, scanner.DurationReaderVersion)
 	plan, err := revalidate.New(durations.Lookup, opts).Plan(ctx)
 	if err != nil {
 		slog.Error("revalidate: scan failed", "error", err)

--- a/internal/commands/revalidate_test.go
+++ b/internal/commands/revalidate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/library"
 	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/scanner"
 )
 
 // revalidateFixture builds a config + database + library root holding one audio
@@ -65,7 +66,11 @@ func primeDuration(t *testing.T, dbPath, audio string, seconds int) {
 	if err != nil {
 		t.Fatalf("stat audio: %v", err)
 	}
-	if err := audiodur.New(sqlDB).Record(t.Context(), audio, fi.ModTime().UnixNano(), fi.Size(), seconds); err != nil {
+	// Seeded under the PRODUCTION reader identity on purpose: RevalidateCmd
+	// builds its store with scanner.DurationReaderVersion, so a seed stamped with
+	// anything else would miss and the command under test would silently take the
+	// UnknownDuration fail-open path instead of the one being asserted (#711).
+	if err := audiodur.New(sqlDB, scanner.DurationReaderVersion).Record(t.Context(), audio, fi.ModTime().UnixNano(), fi.Size(), seconds); err != nil {
 		t.Fatalf("record duration: %v", err)
 	}
 }

--- a/internal/db/migrations/041_audio_durations_reader_version.sql
+++ b/internal/db/migrations/041_audio_durations_reader_version.sql
@@ -1,0 +1,79 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Give audio_durations a READER identity (#711), so a parser change invalidates
+-- the cache the same way a file change already does.
+--
+-- THE DEFECT. Migration 035 keys this table on (file_path, mtime_nsec,
+-- size_bytes) and documents that validation makes staleness "structurally
+-- impossible". That is true for the FILE and false for the PARSER: those three
+-- columns describe the bytes on disk, and nothing in the row records which code
+-- turned those bytes into a duration. Swap the duration parser and every cached
+-- row keeps hitting while silently meaning something different -- the file did
+-- not change, the reader did.
+--
+-- WHY IT IS URGENT NOW. canticle is about to move from
+-- github.com/lizc2003/audioduration to the sydlexius fork, whose VBR handling
+-- changes the derived duration for MP3s lacking a Xing/VBRI header by up to 10x
+-- IN EITHER DIRECTION. internal/timing judges a synced lyric against this
+-- duration with a calibrated 2s tolerance, so a wrong duration is not a cosmetic
+-- staleness: internal/revalidate would demote a CORRECT .lrc to .txt, or
+-- quarantine it outright, on the strength of a cached number no longer produced
+-- by the running code. Same defect class as #702, where detector_version was
+-- keyed to the app version instead of the model.
+--
+-- NULLABLE, AND LEGACY ROWS ARE LEFT NULL ON PURPOSE. Lookup compares
+-- reader_version with =, and in SQL NULL = <anything> is NULL, never true, so
+-- every pre-existing row reads as a MISS from the first run of the new code. It
+-- is not deleted and it is not rewritten -- a rewrite would have to CLAIM a
+-- parser identity for a duration whose parser is unrecorded, which is precisely
+-- the false assertion this column exists to prevent.
+--
+-- NO BACKFILL, NO FLAG DAY, NO REMEDIATION. A miss here is already the
+-- fail-open path: audiodur.Lookup returns (0, false), callers pass that 0 to
+-- timing.Evaluate, and it returns UnknownDuration, which every consumer already
+-- handles and which never demotes or quarantines anything. So the entire stale
+-- population simply re-derives lazily, one header read per file, the next time
+-- each file is touched. A cold cache is correct, merely uninformative.
+--
+-- ADDITIVE, so SQLite rewrites no rows: ALTER TABLE ADD COLUMN on a nullable
+-- column with no default is O(1) metadata-only here. Note the deliberate absence
+-- of a CHECK constraint -- NULL is a legitimate value in this column (it is what
+-- "recorded before the reader was identified" looks like), unlike migration
+-- 035's columns where every value was known at insert.
+ALTER TABLE audio_durations ADD COLUMN reader_version TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- THE ROWS GO FIRST, AND THAT IS THE WHOLE POINT OF THIS DOWN MIGRATION.
+--
+-- An earlier draft of this file kept the durations and claimed a rollback
+-- "degrades safely to the prior reader-blind behavior". THAT WAS FALSE, and it
+-- was verified false: pre-#711 code queries WITHOUT the reader_version
+-- predicate, so it HITS a row this build stamped with a different parser and
+-- reads that parser's number with full confidence -- 187s for a fork-derived
+-- VBR row in the reproduction. It then feeds it to timing.Evaluate and
+-- internal/revalidate demotes or quarantines a CORRECT sidecar. That is exactly
+-- the silent data destruction #711 exists to prevent, merely displaced onto the
+-- rollback path.
+--
+-- So the durations cannot survive a downgrade. Once this build has run against
+-- a different parser, the table holds numbers the OLD binary must not trust,
+-- and the old binary has no way to tell which rows those are -- that
+-- discrimination is precisely the column being dropped. Deleting is safe by
+-- this migration's own argument: an empty table is a cold cache, every consumer
+-- already fails open to UnknownDuration, and each row re-derives on its next
+-- touch at one header read. A CONTAMINATED WARM CACHE HAS NO SUCH FLOOR.
+--
+-- NOTE THE LIMIT OF THIS PROTECTION, because it is not the likeliest rollback.
+-- Reverting the BINARY without running this migration hits the same hazard and
+-- nothing here can stop it: the old code simply ignores a column it does not
+-- know about. A goose-managed downgrade is protected; a bare binary revert is
+-- not. If you revert the binary after running a different duration parser,
+-- clear this table by hand:  DELETE FROM audio_durations;
+DELETE FROM audio_durations;
+
+-- SQLite has supported DROP COLUMN since 3.35 and modernc.org/sqlite is well
+-- past it (verified against 3.53.3, the version this driver currently vendors).
+ALTER TABLE audio_durations DROP COLUMN reader_version;
+-- +goose StatementEnd

--- a/internal/scanner/duration_reader_version_test.go
+++ b/internal/scanner/duration_reader_version_test.go
@@ -1,0 +1,70 @@
+package scanner_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// requireLine matches the audioduration require line in go.mod, capturing the
+// module path and its version separately. It deliberately does NOT pin the
+// owner (lizc2003 today, sydlexius after the fork swap): the point is to notice
+// the swap, not to presume which side of it we are on.
+var audiodurationRequire = regexp.MustCompile(`(?m)^\s*(\S*audioduration)\s+(v\S+)`)
+
+// THE ONE FAILURE THIS TEST EXISTS TO CAUSE. scanner.DurationReaderVersion is
+// hand-set, and internal/audiodur invalidates its duration cache by comparing
+// it. Forgetting to bump it while changing the parser is SILENT and destroys
+// user data: stale durations keep reading as cache HITS, timing.Evaluate judges
+// synced lyrics against them, and internal/revalidate demotes a correct .lrc to
+// .txt or quarantines it outright (#711).
+//
+// The imminent instance is the swap to github.com/sydlexius/audioduration
+// v0.9.0, whose VBR handling moves derived durations by up to 10x. This test
+// turns "forgot to bump the constant" from a silent data-loss bug into a red
+// build, by requiring the constant to name the module and version go.mod
+// actually declares.
+//
+// WHAT IT DOES NOT CATCH, stated plainly so nobody trusts it further than it
+// goes: a canticle-side change to audioDuration's dispatch or to
+// audioFileTypeForExt changes the derivation while go.mod sits still, and
+// nothing cheap detects that. The doc comment on the constant remains the only
+// guard there. This covers the dependency swap, which is the high-risk case,
+// not the whole class.
+func TestDurationReaderVersionMatchesGoMod(t *testing.T) {
+	goMod, err := os.ReadFile(filepath.Join("..", "..", "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+
+	m := audiodurationRequire.FindSubmatch(goMod)
+	if m == nil {
+		t.Fatal("no audioduration require line found in go.mod; if the duration parser was replaced or vendored, update this test AND scanner.DurationReaderVersion together")
+	}
+	modulePath, version := string(m[1]), string(m[2])
+
+	// The constant must name the version, or a bump was missed.
+	if !strings.Contains(scanner.DurationReaderVersion, version) {
+		t.Errorf("DurationReaderVersion = %q does not mention go.mod's audioduration version %q.\n"+
+			"If you just changed the duration parser, BUMP THE CONSTANT IN THIS SAME COMMIT: a stale value keeps "+
+			"serving cached durations the new parser would not produce, and revalidate demotes or quarantines "+
+			"correct sidecars on the strength of them (#711).",
+			scanner.DurationReaderVersion, version)
+	}
+
+	// And it must name the module, so swapping OWNER (lizc2003 -> sydlexius) at
+	// an unchanged version number cannot slip through the version check above.
+	owner := modulePath
+	if i := strings.LastIndex(strings.TrimSuffix(modulePath, "/audioduration"), "/"); i >= 0 {
+		owner = strings.TrimSuffix(modulePath, "/audioduration")[i+1:]
+	}
+	if owner != "" && !strings.Contains(scanner.DurationReaderVersion, owner) {
+		t.Errorf("DurationReaderVersion = %q does not mention the audioduration module owner %q (go.mod requires %q).\n"+
+			"A fork swap changes the PARSER even when the version string does not, so the constant must move with it (#711).",
+			scanner.DurationReaderVersion, owner, modulePath)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -28,6 +28,41 @@ import (
 // supportedFileTypes lists audio file extensions that can have metadata read.
 var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".flac", ".ogg", ".dsf"}
 
+// DurationReaderVersion identifies the code that turns a file's header into a
+// duration. internal/audiodur stamps it on every cached row and requires it to
+// match on lookup, so changing the parser invalidates the cache the same way
+// changing the file does (#711).
+//
+// BUMP THIS IN THE SAME COMMIT AS THE PARSER CHANGE, and treat that as part of
+// the change rather than follow-up work. A bump costs one header read per file,
+// lazily, on the fail-open path; forgetting one serves durations the running
+// code would not produce, and internal/revalidate acts on those -- it demotes a
+// correct .lrc to .txt or quarantines it. The failure is silent and destroys
+// user data, so err toward bumping when unsure.
+//
+// It is deliberately a HAND-SET string, not a computed one. The obvious
+// candidates are all wrong: internal/version.Version churns every release while
+// the parser sits still (exactly the #702 defect this mirrors), and a module
+// version alone misses a local change to audioDuration's own dispatch or
+// extension mapping. The value names the parser and its version because the
+// PARSE is what the row's meaning depends on -- the audioduration module today,
+// plus a suffix if canticle-side derivation changes underneath a static module
+// version.
+//
+// TestDurationReaderVersionMatchesGoMod enforces the dependency half of that:
+// the constant must name the module owner and version go.mod declares, so
+// swapping the parser without bumping this fails the build instead of silently
+// serving stale durations. A canticle-side change to audioDuration's dispatch
+// or to audioFileTypeForExt is NOT caught by anything -- there this comment is
+// the only guard.
+//
+// SCOPE LIMIT: only internal/audiodur consults this. audio_metadata
+// (migration 036) caches duration_seconds from this SAME parse and has no
+// reader identity, so it is knowingly reader-blind -- tracked as #713. It has
+// no timing/revalidate consumer today, which is the only reason that is
+// tolerable; do not add one before #713 lands.
+const DurationReaderVersion = "lizc2003/audioduration@v0.8.0"
+
 // IsAudioFile reports whether name (a file name or path) carries a supported
 // audio extension. It is the single exported accessor over supportedFileTypes so
 // consumers outside the scan loop (e.g. the realign command) classify files


### PR DESCRIPTION
## Summary

- `audio_durations` is keyed on `(file_path, mtime_nsec, size_bytes)`, which describes the BYTES ON DISK and records nothing about the code that turned them into a duration. Migration 035 claims validation makes staleness "structurally impossible" -- true for the file, false for the parser. Swap the duration parser and every cached row keeps **hitting** while silently meaning something different. Migration 041 adds a nullable `reader_version TEXT`; `Lookup` requires it to match, `Record` stamps it.
- **This is a data-safety fix, not a tidy-up.** The imminent swap to the `sydlexius/audioduration` fork moves derived durations for MP3s lacking a Xing/VBRI header by up to 10x. `internal/timing` judges synced lyrics against that duration with a calibrated 2s tolerance, so a stale-but-hitting value makes `internal/revalidate` demote a CORRECT `.lrc` to `.txt` or quarantine it. Same defect class as #702, where `detector_version` tracked the app version instead of the model.
- **Reviewers: start with the Down migration.** An earlier draft kept the rows and claimed a rollback "degrades safely". That was verified FALSE and is the most changed part of this diff. See "Behavior change" below.

## Behavior change (expected, one-time)

Every pre-existing row reads as a **miss** on first deploy -- legacy rows stay NULL, and `NULL = ?` is NULL rather than true, which is what invalidates the population with no backfill and no flag day.

A miss does not itself trigger a read: `revalidate.durationOf` fails open and never probes, and `bankDurationForSkippedFile` is `Lookup`-gated. So the cost is ~one header-only read per file, spread across the next scan cycle that was already going to spin the disks -- roughly 6,000 on the maintainer's library. **Expect one noisier scan cycle, then steady state.** No path triggers a mass synchronous re-read.

## Linked issue

Closes #711

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; 2 IMPORTANT + 1 MINOR finding all fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **not done**, see "Not covered".
- [x] Screenshot: N/A, no web-UI change.
- [x] `make ui`: N/A, no `.templ` or CSS source changed.
- [x] Migration added under `internal/db/migrations/` (041, additive + goose-managed).

## Test plan

- [x] `make gate` passes locally: race tests, coverage floors, patch coverage, codecov validation, `golangci-lint` (0 issues), actionlint, govulncheck.
- [x] New tests confirmed to **fail against unfixed code** before being trusted -- every one mutation-checked, see below.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Surface stated explicitly:** this fixes the `audio_durations` cache read by `internal/revalidate` via the `audiodur.Store` seam. It does **not** touch `audio_metadata.duration_seconds`, a second cache of the same parse -- deliberately, see "Not covered".
- [x] Manual UAT steps:
  - [x] Migration 041 applied against a populated DB: existing rows survive with `reader_version IS NULL`; fresh-DB and upgraded-DB schemas confirmed identical.
  - [x] Up -> Down -> Up round-trip verified (SQLite 3.53.3).
- [ ] Reviewer follow-ups:
  - [ ] The reader identity is a **hand-set constant**. `TestDurationReaderVersionMatchesGoMod` hard-fails a dependency swap that forgets to bump it, but nothing catches a canticle-side change to `audioDuration`'s dispatch or `audioFileTypeForExt`. If you see a cheap structural guard for that class, say so.
  - [ ] Down now `DELETE`s the durations. That is deliberate (a cold cache is correct by this migration's own argument; a contaminated warm one has no floor), but it is destructive and worth a second opinion.

### Mutation evidence

| Mutation | Result |
|---|---|
| Drop `reader_version` from `Lookup`'s `WHERE` | All 3 cache tests redden, each on its own assertion |
| Drop the re-stamp from `Record`'s upsert | Exactly 1 reddens -- the row that would otherwise go permanently unreadable and re-derive forever |
| Stale the constant against go.mod | Lockstep test reddens on both owner and version assertions |
| Pre-#711 query against a fork-stamped row | Reads 187s -- the rollback hazard, reproduced |
| Same query after the fixed Down | Misses, falls open |

## Not covered

- **`audio_metadata.duration_seconds` (migration 036) caches the same parse and remains reader-blind.** Tracked as **#713**, with a scope-limit note at the constant. It has no `timing`/`revalidate` consumer today, so the risk is latent rather than live -- but it becomes real the moment anything reads it for a timing decision, and it will silently hold a mix of pre- and post-fork durations after the swap.
- **A bare binary revert is not protected, and SQL cannot protect it.** The Down migration clears the contaminated rows, but reverting the binary *without* running the migration hits the same hazard -- old code simply ignores a column it does not know about. The migration comment names this gap and gives the manual `DELETE`.
- **No UAT against a real library.** Verification is unit + migration level; the ~6,000-file re-derive described above is reasoned from the code paths (`Lookup`-gated, fail-open, no mass-probe trigger), not measured on the array.
- **The dependency swap is NOT in this PR.** It follows separately and MUST bump `DurationReaderVersion` in the same commit -- that coupling is the entire point of this change.
