### PR TITLE
feat(scanner): swap to audioduration v0.9.1 and give audio_metadata a reader identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/creachadair/tomledit v0.0.29
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/joho/godotenv v1.5.1
-	github.com/lizc2003/audioduration v0.8.0
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/rjeczalik/notify v0.9.3
+	github.com/sydlexius/audioduration v0.9.1
 	github.com/ulikunitz/xz v0.5.16
 	github.com/valyala/fastjson v1.6.10
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/lizc2003/audioduration v0.8.0 h1:EWOR9jsSOcg1OpriKVCBAkcHce7zPX1pwTEv1Y0EgVs=
-github.com/lizc2003/audioduration v0.8.0/go.mod h1:83wTmbasMJdlL2y7YYqlpLeSoVo5CoIXdJwuqeZ3TnY=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -62,6 +60,8 @@ github.com/sethvargo/go-retry v0.4.0/go.mod h1:tvsjdKG6xfiCx4LSiUZ06kcv38xvdVQwv
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/sydlexius/audioduration v0.9.1 h1:EuOr31Hdhu7kOz9XZGaz9rs/PJcTvy90RywIuYvH+oQ=
+github.com/sydlexius/audioduration v0.9.1/go.mod h1:rEMOjfUBigfm4Esp2MgzRncdEoZmwPXUZq79Yqphvls=
 github.com/ulikunitz/xz v0.5.16 h1:ld6NyySjx5lowVKwJvMRLnW5nxKX/xnpSiFYZ/Lxur0=
 github.com/ulikunitz/xz v0.5.16/go.mod h1:H9Rt/W6/Qj27PGauhQc6nfCDy7vHpzsOThBSaYDoEhw=
 github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=

--- a/internal/audiometa/audiometa.go
+++ b/internal/audiometa/audiometa.go
@@ -29,11 +29,25 @@ import (
 // concurrent use because the underlying *sql.DB is.
 type Store struct {
 	db *sql.DB
+	// readerVersion identifies the duration parser whose output this Store may
+	// read back and will stamp on what it writes. Held here rather than passed
+	// per call so a row cannot be stamped by one identity and matched by
+	// another (#713).
+	readerVersion string
 }
 
-// New returns a Store backed by db.
-func New(db *sql.DB) *Store {
-	return &Store{db: db}
+// New returns a Store backed by db whose rows carry -- and are matched against
+// -- the duration-parser identity readerVersion. Callers pass
+// scanner.DurationReaderVersion; see its doc for why the value is hand-set and
+// when to bump it.
+//
+// A mismatch reads as a MISS, which here simply means the file's tags are
+// re-read: audio_metadata.duration_seconds comes from the same parse as
+// audio_durations (#711), so a parser change must invalidate both or this table
+// silently holds a mix of pre- and post-swap durations. A miss costs one header
+// read, never a remediation.
+func New(db *sql.DB, readerVersion string) *Store {
+	return &Store{db: db, readerVersion: readerVersion}
 }
 
 // DB returns the underlying *sql.DB for test access to query metadata directly.
@@ -48,12 +62,19 @@ func (s *Store) DB() *sql.DB {
 //
 // mtimeNano is ModTime().UnixNano(), so a same-second rewrite to the same byte
 // size still reads as changed.
+//
+// A row whose reader_version differs from this Store's is likewise stale: the
+// bytes are unchanged but the duration in that row came from a parser other
+// than the one asking, so the row is re-read rather than trusted (#713). Rows
+// predating the column hold NULL and never match, because NULL = ? is NULL
+// rather than true -- that is what invalidates the legacy population without
+// migrating any row data.
 func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) (bool, error) {
 	var one int
 	err := s.db.QueryRowContext(ctx,
 		`SELECT 1 FROM audio_metadata
-		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? LIMIT 1`,
-		path, mtimeNano, size,
+		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? AND reader_version=? LIMIT 1`,
+		path, mtimeNano, size, s.readerVersion,
 	).Scan(&one)
 	if err == nil {
 		return true, nil
@@ -76,8 +97,8 @@ func (s *Store) Record(ctx context.Context, path string, facts scanner.AudioFact
 		     file_path, mtime_nsec, size_bytes, mbid, isrc,
 		     artist, album_artist, title, album, composer, genre,
 		     year, track_no, track_total, disc_no, disc_total,
-		     format, file_type, duration_seconds
-		 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		     format, file_type, duration_seconds, reader_version
+		 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		 ON CONFLICT(file_path) DO UPDATE SET
 		     mtime_nsec       = excluded.mtime_nsec,
 		     size_bytes       = excluded.size_bytes,
@@ -97,11 +118,12 @@ func (s *Store) Record(ctx context.Context, path string, facts scanner.AudioFact
 		     format           = excluded.format,
 		     file_type        = excluded.file_type,
 		     duration_seconds = excluded.duration_seconds,
+		     reader_version   = excluded.reader_version,
 		     indexed_at       = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`,
 		path, facts.MTimeNano, facts.SizeBytes, facts.MBID, facts.ISRC,
 		facts.Artist, facts.AlbumArtist, facts.Title, facts.Album, facts.Composer, facts.Genre,
 		facts.Year, facts.TrackNo, facts.TrackTotal, facts.DiscNo, facts.DiscTotal,
-		facts.Format, facts.FileType, facts.TrackLength,
+		facts.Format, facts.FileType, facts.TrackLength, s.readerVersion,
 	)
 	if err != nil {
 		return fmt.Errorf("audiometa: record %q: %w", path, err)
@@ -123,17 +145,31 @@ func (s *Store) Record(ctx context.Context, path string, facts scanner.AudioFact
 // that '_' and '%' in a real path (e.g. "My_Album") are compared literally
 // rather than as SQL wildcards -- an escaped LIKE would work too, but a
 // non-pattern comparison sidesteps the escaping question entirely.
+//
+// COUNTS ONLY ROWS THIS READER WOULD ACTUALLY USE (#713). A row stamped by a
+// different duration parser is one Lookup treats as a miss and the next scan
+// re-reads, so counting it would report metadata the tool is about to discard.
+// Without this predicate the first run after a parser swap reports FULL
+// coverage immediately before re-reading the entire library -- exactly
+// backwards as an operator signal, and measurably so: with three stale rows,
+// Coverage said 3 while Lookup said miss on all of them. Legacy NULL-reader
+// rows are excluded for the same reason and by the same SQL mechanic (NULL = ?
+// is never true).
 func (s *Store) Coverage(ctx context.Context, pathPrefix string) (int, error) {
 	var (
 		n   int
 		err error
 	)
 	if pathPrefix == "" {
-		err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM audio_metadata`).Scan(&n)
+		err = s.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM audio_metadata WHERE reader_version=?`,
+			s.readerVersion,
+		).Scan(&n)
 	} else {
 		err = s.db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM audio_metadata WHERE substr(file_path, 1, length(?)) = ?`,
-			pathPrefix, pathPrefix,
+			`SELECT COUNT(*) FROM audio_metadata
+			 WHERE substr(file_path, 1, length(?)) = ? AND reader_version=?`,
+			pathPrefix, pathPrefix, s.readerVersion,
 		).Scan(&n)
 	}
 	if err != nil {

--- a/internal/audiometa/audiometa_test.go
+++ b/internal/audiometa/audiometa_test.go
@@ -2,6 +2,7 @@ package audiometa_test
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -10,14 +11,30 @@ import (
 	"github.com/sydlexius/canticle/internal/scanner"
 )
 
+// testReaderVersion is the duration-parser identity the single-Store tests write
+// and read under. Its value is irrelevant; what matters is that it is CONSTANT,
+// so those tests exercise mtime/size validation without reader identity
+// confounding the result.
+const testReaderVersion = "test-reader@v1"
+
 func newTestDB(t *testing.T) *audiometa.Store {
+	t.Helper()
+	sqlDB, _ := newTestDBWithHandle(t, testReaderVersion)
+	return sqlDB
+}
+
+// newTestDBWithHandle returns a Store reading under readerVersion plus the
+// underlying handle, so a test can open a SECOND Store over the SAME database
+// under a different identity -- the shape a parser swap takes in production,
+// where the rows persist and the code changes underneath them.
+func newTestDBWithHandle(t *testing.T, readerVersion string) (*audiometa.Store, *sql.DB) {
 	t.Helper()
 	sqlDB, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
 	t.Cleanup(func() { _ = sqlDB.Close() })
-	return audiometa.New(sqlDB)
+	return audiometa.New(sqlDB, readerVersion), sqlDB
 }
 
 func TestRecordThenLookupHitsWhenUnchanged(t *testing.T) {
@@ -266,5 +283,167 @@ func TestCoverageScopesByPathPrefix(t *testing.T) {
 	}
 	if n != 1 {
 		t.Errorf("Coverage(%q) = %d, want 1", rootB, n)
+	}
+}
+
+// THE #713 GUARANTEE. The file is byte-identical -- same path, same mtime, same
+// size -- and the row is still stale, because the DURATION PARSER changed.
+// audio_metadata.duration_seconds comes from the same parse as audio_durations
+// (#711), so a swap that invalidated only that table would leave this one
+// silently holding a mix of pre- and post-swap durations.
+//
+// Measured on the swap this test was written for: a VBR MP3 with no Xing header
+// read 25.05s under the old parser and 60.03s under the new one, a 2.4x error
+// in the direction that makes a correct lyric look wildly out of sync.
+func TestReaderVersionChangeIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	oldReader, sqlDB := newTestDBWithHandle(t, "parser@v1")
+	newReader := audiometa.New(sqlDB, "parser@v2")
+
+	facts := scanner.AudioFacts{
+		MTimeNano: 100, SizeBytes: 200,
+		Artist: "A", Title: "T", TrackLength: 25,
+	}
+	if err := oldReader.Record(ctx, "/music/vbr.mp3", facts); err != nil {
+		t.Fatalf("Record under the old parser: %v", err)
+	}
+
+	found, err := newReader.Lookup(ctx, "/music/vbr.mp3", 100, 200)
+	if err != nil {
+		t.Fatalf("Lookup under the new parser: %v", err)
+	}
+	if found {
+		t.Fatal("a row whose duration came from a DIFFERENT parser must read as a miss, so the file is re-read rather than trusted")
+	}
+
+	// The recording parser still hits: the row is invalidated for the NEW
+	// reader, not destroyed. That is what makes the swap lazy rather than
+	// a flag day.
+	if found, err := oldReader.Lookup(ctx, "/music/vbr.mp3", 100, 200); err != nil {
+		t.Fatalf("Lookup under the old parser: %v", err)
+	} else if !found {
+		t.Fatal("the recording parser must still hit its own row")
+	}
+}
+
+// A re-read under the new parser must RE-STAMP the row rather than leave it
+// unreadable. file_path is the conflict target, so without carrying
+// reader_version into the upsert the row would miss forever and every scan
+// would re-read the file -- a permanent I/O leak on an array kept spun down.
+func TestRecordRestampsRowOnReaderChange(t *testing.T) {
+	ctx := context.Background()
+	oldReader, sqlDB := newTestDBWithHandle(t, "parser@v1")
+	newReader := audiometa.New(sqlDB, "parser@v2")
+
+	base := scanner.AudioFacts{MTimeNano: 100, SizeBytes: 200, Artist: "A", Title: "T"}
+
+	stale := base
+	stale.TrackLength = 25 // what the old parser derived
+	if err := oldReader.Record(ctx, "/music/vbr.mp3", stale); err != nil {
+		t.Fatalf("Record under the old parser: %v", err)
+	}
+
+	fresh := base
+	fresh.TrackLength = 60 // what the new parser derives from the same bytes
+	if err := newReader.Record(ctx, "/music/vbr.mp3", fresh); err != nil {
+		t.Fatalf("Record under the new parser: %v", err)
+	}
+
+	if found, err := newReader.Lookup(ctx, "/music/vbr.mp3", 100, 200); err != nil {
+		t.Fatalf("Lookup under the new parser: %v", err)
+	} else if !found {
+		t.Fatal("the re-read row must be readable under the new parser, else it re-reads forever")
+	}
+
+	// One row per file, re-stamped in place -- the old identity is gone.
+	if found, err := oldReader.Lookup(ctx, "/music/vbr.mp3", 100, 200); err != nil {
+		t.Fatalf("Lookup under the old parser: %v", err)
+	} else if found {
+		t.Fatal("the superseded parser must no longer hit")
+	}
+
+	// And the stored duration is the NEW parser's, not the stale one.
+	var secs int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT duration_seconds FROM audio_metadata WHERE file_path=?`,
+		"/music/vbr.mp3").Scan(&secs); err != nil {
+		t.Fatalf("read back duration: %v", err)
+	}
+	if secs != 60 {
+		t.Fatalf("duration_seconds = %d, want 60: the re-read must overwrite the stale parser's value", secs)
+	}
+}
+
+// Legacy rows -- written before the column existed -- hold NULL and must read as
+// a miss for EVERY reader, the empty string included. This is the no-backfill
+// argument: NULL = ? is NULL rather than true, so the pre-existing population
+// invalidates itself with no row data migrated.
+func TestLegacyNullReaderVersionIsAMiss(t *testing.T) {
+	ctx := context.Background()
+	_, sqlDB := newTestDBWithHandle(t, "parser@v1")
+
+	// Write the row the way pre-#713 code did: no reader_version at all.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO audio_metadata (file_path, mtime_nsec, size_bytes, duration_seconds)
+		 VALUES (?, ?, ?, ?)`,
+		"/music/legacy.mp3", 100, 200, 25,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	for _, readerVersion := range []string{"parser@v1", ""} {
+		found, err := audiometa.New(sqlDB, readerVersion).Lookup(ctx, "/music/legacy.mp3", 100, 200)
+		if err != nil {
+			t.Fatalf("Lookup as %q: %v", readerVersion, err)
+		}
+		if found {
+			t.Fatalf("a legacy NULL-reader row must miss for reader %q; the SQL NULL comparison is what invalidates the pre-existing population", readerVersion)
+		}
+	}
+}
+
+// Coverage must count only rows THIS reader would use. Without the
+// reader_version predicate the first run after a parser swap reports FULL
+// coverage immediately before re-reading the entire library -- exactly backwards
+// as an operator signal, and the only signal that a swap is in flight (#713).
+//
+// This test exists because the predicate shipped UNTESTED: removing it from
+// both Coverage branches left the whole suite green.
+func TestCoverageCountsOnlyCurrentReader(t *testing.T) {
+	ctx := context.Background()
+	oldReader, sqlDB := newTestDBWithHandle(t, "parser@v1")
+	newReader := audiometa.New(sqlDB, "parser@v2")
+
+	for _, p := range []string{"/lib/a.mp3", "/lib/b.mp3", "/lib/c.mp3"} {
+		if err := oldReader.Record(ctx, p, scanner.AudioFacts{
+			MTimeNano: 100, SizeBytes: 200, Title: "T", TrackLength: 60,
+		}); err != nil {
+			t.Fatalf("Record %s: %v", p, err)
+		}
+	}
+
+	// Sanity: the recording reader sees them, so a zero below is the predicate
+	// working rather than an empty table.
+	if n, err := oldReader.Coverage(ctx, ""); err != nil {
+		t.Fatalf("Coverage under the recording reader: %v", err)
+	} else if n != 3 {
+		t.Fatalf("recording reader Coverage = %d, want 3", n)
+	}
+
+	// BOTH branches: the unprefixed count and the path-scoped one.
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{"no prefix", ""},
+		{"path prefix", "/lib/"},
+	} {
+		got, err := newReader.Coverage(ctx, tc.prefix)
+		if err != nil {
+			t.Fatalf("Coverage(%s): %v", tc.name, err)
+		}
+		if got != 0 {
+			t.Errorf("Coverage(%s) = %d under a DIFFERENT reader, want 0: rows a swap will re-read must not read as covered", tc.name, got)
+		}
 	}
 }

--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -81,7 +81,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 		return 0
 	}
 
-	store := audiometa.New(sqlDB)
+	store := audiometa.New(sqlDB, scanner.DurationReaderVersion)
 
 	// A --library run scopes the printed coverage number to that library's
 	// canonical root, per #646's AC ("how many files in library N have

--- a/internal/db/migrations/041_audio_durations_reader_version.sql
+++ b/internal/db/migrations/041_audio_durations_reader_version.sql
@@ -32,8 +32,29 @@
 -- fail-open path: audiodur.Lookup returns (0, false), callers pass that 0 to
 -- timing.Evaluate, and it returns UnknownDuration, which every consumer already
 -- handles and which never demotes or quarantines anything. So the entire stale
--- population simply re-derives lazily, one header read per file, the next time
+-- population simply re-derives lazily, one BOUNDED read per file, the next time
 -- each file is touched. A cold cache is correct, merely uninformative.
+--
+-- WHAT "BOUNDED" COSTS, measured against audioduration v0.9.1 over a SEEDED
+-- RANDOM sample of this library (1,200 of 10,894 MP3s, 300 of 57,992 FLACs):
+--   - FLAC:  exactly 42 bytes (STREAMINFO), every file, any size.
+--   - MP3 on the cheap path: 64-112 KB depending on BITRATE, flat in file size
+--     (the probe windows scale with frame length, not with length of file).
+--   - MP3 that is VBR with no Xing header: frame-counted END TO END.
+-- 89 of 1,200 MP3s (7.4%) were walked, so the pass read 8.8% of sampled MP3
+-- bytes and 4.1% of sampled bytes overall -- one noisier scan cycle, not a full
+-- re-read of the library.
+--
+-- SAMPLE RANDOMLY IF YOU RE-MEASURE. An earlier figure here (25 of 400, 5.59%)
+-- came from `find | head -400`, which is directory-traversal order, not a
+-- sample: the first 400 files of this library contain ZERO walked files while
+-- offsets 1000+ run 7-8%. Positional slices of a library ordered by
+-- artist/album correlate with encoder era, so they measure a corner and read as
+-- a population.
+--
+-- v0.9.0 instead read EVERY header-less MP3 in full, including CBR streams where
+-- size division was already exact, which is why canticle never shipped against
+-- it. Quote the parser version beside any of these figures.
 --
 -- ADDITIVE, so SQLite rewrites no rows: ALTER TABLE ADD COLUMN on a nullable
 -- column with no default is O(1) metadata-only here. Note the deliberate absence
@@ -63,7 +84,8 @@ ALTER TABLE audio_durations ADD COLUMN reader_version TEXT;
 -- discrimination is precisely the column being dropped. Deleting is safe by
 -- this migration's own argument: an empty table is a cold cache, every consumer
 -- already fails open to UnknownDuration, and each row re-derives on its next
--- touch at one header read. A CONTAMINATED WARM CACHE HAS NO SUCH FLOOR.
+-- touch at the bounded cost quantified above. A CONTAMINATED WARM CACHE HAS NO
+-- SUCH FLOOR.
 --
 -- NOTE THE LIMIT OF THIS PROTECTION, because it is not the likeliest rollback.
 -- Reverting the BINARY without running this migration hits the same hazard and

--- a/internal/db/migrations/042_audio_metadata_reader_version.sql
+++ b/internal/db/migrations/042_audio_metadata_reader_version.sql
@@ -1,0 +1,82 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Give audio_metadata a READER identity for its duration_seconds column (#713),
+-- closing the gap #711 deliberately left open next door.
+--
+-- WHY THIS WAS DEFERRED, AND WHY IT IS NOT DEFERRABLE ANY LONGER. #711 gave
+-- audio_durations a reader_version because a stale duration there flows into
+-- internal/timing and makes internal/revalidate demote or quarantine a CORRECT
+-- sidecar. audio_metadata.duration_seconds is filled from THE SAME PARSE
+-- (internal/commands/index_metadata.go -> scanner.ReadAudioFacts ->
+-- audioDuration) and was keyed on (file_path, mtime_nsec, size_bytes) with no
+-- reader identity at all. It was left alone because nothing reads that column
+-- for a timing decision, which made it LATENT rather than live.
+--
+-- The parser swap in this same change is what ends that reprieve. Measured
+-- old vs new on VBR MP3s carrying no Xing/LAME header:
+--
+--     CBR + Xing        old 60.03s   new 60.03s   ratio 1.00
+--     VBR + Xing        old 60.03s   new 60.03s   ratio 1.00
+--     VBR, no Xing      old 25.05s   new 60.03s   ratio 2.40   (true 54.49s)
+--     VBR, no Xing, V0  old 37.56s   new 60.03s   ratio 1.60   (true 56.32s)
+--
+-- The old reader assumed the first frame's bitrate held for the whole file, so
+-- such a track read at LESS THAN HALF its true length. Without this column the
+-- table would now silently hold a mix of pre- and post-swap durations, with
+-- nothing recording which is which, while presenting as the library's
+-- authoritative metadata index. The first consumer to read it for timing would
+-- inherit a data-destruction bug already baked in and invisible.
+--
+-- SAME MECHANISM AS 041, DELIBERATELY. Nullable, legacy rows left NULL, and
+-- Lookup compares with = -- in SQL NULL = <anything> is NULL, never true, so
+-- every pre-existing row reads as a MISS from the first run of the new code
+-- with no backfill and no flag day. Rows are not rewritten: doing so would have
+-- to CLAIM a parser identity for a duration whose parser is unrecorded, the
+-- exact false assertion the column exists to prevent.
+--
+-- A MISS IS CHEAP HERE. audiometa.Lookup is a PRESENCE check gating a metadata
+-- re-read, and a miss simply re-reads the file's tags -- one bounded read, the
+-- same cost the row's original write paid. It never remediates anything.
+--
+-- ADDITIVE, so SQLite rewrites no rows: ALTER TABLE ADD COLUMN on a nullable
+-- column with no default is metadata-only. No CHECK constraint, because NULL is
+-- a legitimate value here -- it is what "recorded before the reader was
+-- identified" looks like.
+ALTER TABLE audio_metadata ADD COLUMN reader_version TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- DELETE, EXACTLY AS 041 DOES. The hazard is 041's: a pre-#713 binary queries
+-- WITHOUT the reader_version predicate, so it would HIT a row this build
+-- stamped under a different parser and trust that parser's duration.
+--
+-- TWO REJECTED ALTERNATIVES, both tried, because the trap here is not obvious:
+--
+-- 1. `SET duration_seconds = 0`, on the reasoning that 0 is already this
+--    column's "unknown" sentinel. True, and IRRELEVANT: Lookup is a PRESENCE
+--    check keyed on (file_path, mtime_nsec, size_bytes), columns the zeroing
+--    never touches. The row still HITS, index_metadata takes its "current,
+--    skip" branch, the file is never re-read, and the bogus 0 becomes
+--    PERMANENT -- on 100% of rows rather than the subset a parser swap
+--    actually affected. Verified by running it: HIT=true, duration_seconds=0.
+--    STRICTLY WORSE THAN DOING NOTHING.
+--
+-- 2. `SET mtime_nsec = -1` to poison the KEY instead, so the row misses while
+--    the tag columns survive. This works mechanically (there is no CHECK on
+--    mtime_nsec, and a real file's ModTime().UnixNano() is never negative),
+--    but it buys nothing worth its cost: a magic sentinel a later reader must
+--    decode, a SECOND invalidation mechanism beside 041's, and an unstated
+--    dependency on the sign of a stat field.
+--
+-- WHAT MAKES DELETE RIGHT: audio_metadata is a CACHE, and the audio files are
+-- the source of truth. The tag columns -- artist, title, mbid, isrc -- are
+-- DERIVED, not authored here, so deleting a row destroys nothing durable; the
+-- next index-metadata run re-reads them from the files that still carry them.
+-- The earlier "deleting would discard correct data" worry treated regenerable
+-- cache data as precious. One mechanism, shared with 041, and absence cannot
+-- satisfy a presence check.
+DELETE FROM audio_metadata;
+
+ALTER TABLE audio_metadata DROP COLUMN reader_version;
+-- +goose StatementEnd

--- a/internal/scanner/duration_reader_version_test.go
+++ b/internal/scanner/duration_reader_version_test.go
@@ -16,6 +16,10 @@ import (
 // the swap, not to presume which side of it we are on.
 var audiodurationRequire = regexp.MustCompile(`(?m)^\s*(\S*audioduration)\s+(v\S+)`)
 
+// replaceLine matches a `replace` directive whose TARGET is an audioduration
+// module, in either the single-line or the block form.
+var replaceLine = regexp.MustCompile(`(?m)^\s*(replace\s+)?\S*audioduration\S*\s+(\S+\s+)?=>`)
+
 // THE ONE FAILURE THIS TEST EXISTS TO CAUSE. scanner.DurationReaderVersion is
 // hand-set, and internal/audiodur invalidates its duration cache by comparing
 // it. Forgetting to bump it while changing the parser is SILENT and destroys
@@ -39,6 +43,20 @@ func TestDurationReaderVersionMatchesGoMod(t *testing.T) {
 	goMod, err := os.ReadFile(filepath.Join("..", "..", "go.mod"))
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
+	}
+
+	// A `replace` directive silently redirects the module the require line names,
+	// so checking only `require` leaves a hole: `go mod edit -replace` can point
+	// audioduration at a DIFFERENT parser (an older version, or back to the
+	// upstream fork) while this test stays green and the cache keeps serving
+	// durations that parser never produced. That is exactly the silent
+	// data-destruction path #711 exists to close, so any replace targeting this
+	// module fails here rather than being reasoned about.
+	if replaceLine.Match(goMod) {
+		t.Fatalf("go.mod contains a `replace` directive for audioduration.\n" +
+			"A replace redirects the parser without changing the require line this test reads, " +
+			"so the reader identity can no longer be trusted to describe the code that actually runs (#711). " +
+			"Remove the replace, or extend this test to resolve it and bump DurationReaderVersion to match.")
 	}
 
 	m := audiodurationRequire.FindSubmatch(goMod)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/dhowden/tag"
 	"github.com/dhowden/tag/mbz"
-	"github.com/lizc2003/audioduration"
+	"github.com/sydlexius/audioduration"
 	"github.com/sydlexius/canticle/internal/lyrics"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/pathutil"
@@ -34,8 +34,9 @@ var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".fla
 // changing the file does (#711).
 //
 // BUMP THIS IN THE SAME COMMIT AS THE PARSER CHANGE, and treat that as part of
-// the change rather than follow-up work. A bump costs one header read per file,
-// lazily, on the fail-open path; forgetting one serves durations the running
+// the change rather than follow-up work. A bump costs one bounded read per file
+// (see bankDurationForSkippedFile for what that means per format), lazily, on
+// the fail-open path; forgetting one serves durations the running
 // code would not produce, and internal/revalidate acts on those -- it demotes a
 // correct .lrc to .txt or quarantines it. The failure is silent and destroys
 // user data, so err toward bumping when unsure.
@@ -56,12 +57,14 @@ var supportedFileTypes = []string{".mp3", ".m4a", ".m4b", ".m4p", ".alac", ".fla
 // or to audioFileTypeForExt is NOT caught by anything -- there this comment is
 // the only guard.
 //
-// SCOPE LIMIT: only internal/audiodur consults this. audio_metadata
-// (migration 036) caches duration_seconds from this SAME parse and has no
-// reader identity, so it is knowingly reader-blind -- tracked as #713. It has
-// no timing/revalidate consumer today, which is the only reason that is
-// tolerable; do not add one before #713 lands.
-const DurationReaderVersion = "lizc2003/audioduration@v0.8.0"
+// TWO CONSUMERS, and every cache of this parse must be one of them. Both
+// internal/audiodur (audio_durations, migration 041) and internal/audiometa
+// (audio_metadata.duration_seconds, migration 042) stamp and match on this
+// value. They are separate tables filled from the SAME parse, so a cache that
+// did NOT consult this would silently hold a mix of pre- and post-swap
+// durations with nothing recording which -- the #713 defect. If a third cache
+// of a derived duration ever appears, it consults this too.
+const DurationReaderVersion = "sydlexius/audioduration@v0.9.1"
 
 // IsAudioFile reports whether name (a file name or path) carries a supported
 // audio extension. It is the single exported accessor over supportedFileTypes so
@@ -538,7 +541,33 @@ func (sc *Scanner) recordDuration(ctx context.Context, path string, f *os.File, 
 // unconditionally would re-read a header for tens of thousands of files per
 // pass and keep the array awake forever -- trading a starved cache for the
 // exact symptom #684 is filed to eliminate. With the gate, a given file version
-// costs one header read ONCE, ever.
+// is read ONCE, ever.
+//
+// WHAT THAT ONE READ COSTS, measured against audioduration v0.9.1 over a SEEDED
+// RANDOM sample of this library (1,200 of 10,894 MP3s, 300 of 57,992 FLACs). It
+// is NOT uniformly a header read, and an earlier version of this comment said so:
+//   - FLAC: exactly 42 bytes (STREAMINFO), every file, any size.
+//   - MP3 on the cheap path: 64-112 KB depending on BITRATE. Flat in FILE SIZE
+//     -- the probe windows scale with frame length -- so a 20 MB file costs the
+//     same as a 1 MB one at equal bitrate.
+//   - MP3 that is VBR with NO Xing header: frame-counted END TO END, because
+//     nothing else yields a correct duration for it. Such a file reads slightly
+//     MORE than its own size, since the trailer peel re-reads the tail first.
+//
+// 89 of 1,200 sampled MP3s (7.4%) were walked: 8.8% of sampled MP3 bytes, 4.1%
+// of sampled bytes overall. The tail case is bounded by the FILE, not by a
+// header, which is precisely why the Lookup gate above must stay: paying it once
+// per file version is fine, once per scan is not.
+//
+// RE-MEASURE ON ANY PARSER BUMP, AND SAMPLE RANDOMLY. An earlier figure here
+// (25 of 400, 5.59%) came from `find | head -400` -- directory-traversal order,
+// not a sample. The first 400 files of this library contain ZERO walked files
+// while offsets 1000+ run 7-8%, because a library ordered by artist/album
+// correlates with encoder era. That flawed measurement also invented a phantom
+// "the parser grew stricter between its branch and its tag" explanation for what
+// was pure sampling artifact: those two trees are byte-identical.
+// v0.9.0 was genuinely worse -- it walked EVERY header-less MP3 in full,
+// including CBR streams where size division was already exact.
 //
 // Every failure degrades to "no row", never to a wrong row and never to a
 // failed scan: this is bookkeeping for a file the scan has already decided to
@@ -826,7 +855,7 @@ func (sc *Scanner) scanDir(ctx context.Context, dir, absRoot, canonRoot string, 
 			// Bank the duration BEFORE skipping (#684). This file has a .lrc,
 			// which is exactly what makes revalidate care about it later, and
 			// exactly what stops it ever reaching the enrichment probe below.
-			// Cached-gated, so it costs one header read per file version, not
+			// Cache-gated, so it costs one bounded read per file VERSION, not
 			// one per scan.
 			if opts.EnrichRecording {
 				sc.bankDurationForSkippedFile(ctx, pathutil.RebaseUnderCanonicalRoot(absRoot, canonRoot, filepath.Join(dir, file.Name())), ext)


### PR DESCRIPTION
## Summary

- **Swaps the duration parser** from `lizc2003/audioduration v0.8.0` to `sydlexius/audioduration v0.9.1`, bumping `scanner.DurationReaderVersion` in the same commit -- the coupling #711 built and `TestDurationReaderVersionMatchesGoMod` enforces. This repairs an **existing** defect: on a sampled comparison of real library MP3s, v0.8.0 was off by **up to 157 seconds** (a 78-second track read as 236 seconds), and the new parser wins every disagreement within 0.026-0.078s against decoded PCM.
- **Adds migration 042**, giving `audio_metadata.duration_seconds` a reader identity. It is filled from the SAME parse as `audio_durations` and had none, so the swap would otherwise leave it silently holding a mix of pre- and post-swap durations while presenting as the library's authoritative metadata index. Closes the gap #711 knowingly deferred.
- **Reviewers: the evidence layer is where this PR has been wrong twice.** An adversarial pass found three false claims in the previous revision's own commit message -- corrected here, with the corrections documented in-place rather than quietly dropped. See "What review caught" below.

## Behavior change (expected, one-time)

Every pre-existing row in both `audio_durations` and `audio_metadata` reads as a **miss** on first deploy -- legacy rows are NULL, and `NULL = ?` is NULL rather than true, which is what invalidates the population with no backfill.

Measured over a **seeded random sample** (1,200 of 10,894 MP3s, 300 of 57,992 FLACs):

| | Cost |
|---|---|
| FLAC | exactly 42 bytes per file, any size |
| MP3, cheap path | 64-112 KB depending on **bitrate**, flat in file size |
| MP3, VBR with no Xing header | frame-counted end to end (89 of 1,200 files, 7.4%) |
| **Total** | **8.8% of sampled MP3 bytes, 4.1% of sampled bytes overall** |

Expect one noisier scan cycle, then steady state. Nothing triggers a synchronous mass re-read: `scan index-metadata` is operator-invoked, and the serve scheduler banks durations through the `Lookup`-gated path.

## Linked issue

Closes #713

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; all four findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **not done**, see "Not covered".
- [x] Screenshot: N/A, no web-UI change.
- [x] `make ui`: N/A, no `.templ` or CSS source changed.
- [x] Migration added under `internal/db/migrations/` (042, additive + goose-managed).

## Test plan

- [x] `make gate` passes: race tests, coverage floors, patch coverage, codecov validation, `golangci-lint` (0 issues), actionlint, govulncheck.
- [x] New tests confirmed to **fail against unfixed code** -- every one mutation-checked, see the table below.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Surface stated explicitly:** this changes durations read by `internal/timing` via both `audiodur` (migration 041, merged) and `audiometa` (migration 042, this PR). `index_metadata.go` remains the only production reader/writer of `audio_metadata`.
- [x] Manual UAT steps:
  - [x] Migration 042 verified nullable, and Up -> Down -> Up round-trips.
  - [x] After Down, a pre-#713 query (no `reader_version` predicate) MISSES, forcing a re-read rather than trusting a foreign parser's number.
  - [x] Accuracy adjudicated against decoded PCM on real library files, MP3 and FLAC.
- [ ] Reviewer follow-ups:
  - [ ] The reader identity is a **hand-set constant**. The lockstep test now covers a dependency bump *and* a `replace` directive, but a canticle-side change to `audioDuration`'s dispatch or `audioFileTypeForExt` is still caught by nothing but the doc comment.
  - [ ] Migration 042's Down **deletes rows**. Deliberate -- every column is derived from the file and regenerates -- but destructive, and worth a second opinion.

### Mutation evidence

| Mutation | Result |
|---|---|
| Drop `reader_version` from `Lookup`'s `WHERE` | All 3 cache tests redden |
| Drop the re-stamp from `Record`'s upsert | Exactly 1 reddens -- the row that would otherwise miss forever |
| Truncate the identity in `New()` | 2 redden (see the test-identity note below) |
| Remove the `Coverage` predicate from **both** branches | New Coverage test reddens, one message per branch |
| Revert `DurationReaderVersion` with the new dep in place | Lockstep test fires both assertions by name |
| `go mod edit -replace` pointing audioduration elsewhere | Lockstep test now fails (previously a silent bypass) |

## What review caught

Recorded because the corrections are load-bearing, not because the process is interesting:

1. **A test-strength claim that was exactly backwards.** The previous revision used the real module strings as test identities and claimed that made them stronger. Verified by running: a truncating mutation *survives* real strings (`@v0.8.0` -> `@v0.8.` stays distinct) and is *caught* by synthetic `parser@v1`/`parser@v2` (both collapse to `parser@v`). Reverted to the synthetic pair, which `internal/audiodur` already used for this reason.
2. **A phantom causal explanation.** The previous revision explained a walked-file count moving 9 -> 25 as the parser "growing stricter between its release branch and its tag". Those two trees are **byte-identical** -- there was no code difference to explain anything.
3. **The real cause, and wrong figures.** The measurement used `find | head -400` -- directory-traversal order, not a sample. The first 400 files of this library contain **zero** walked files while offsets 1000+ run 7-8%, because a library ordered by artist/album correlates with encoder era. Re-measured with a seeded random sample; all figures in the code comments now carry the sample size and the denominator.
4. **`Coverage()`'s new predicate was untested** -- removing it from both branches left the whole suite green. Now has a mutation-verified regression test.

## Not covered

- **No UAT against the live library.** Verification is unit, migration, and measurement level. The re-derive cost is measured, not observed in a production scan.
- **A canticle-side parse change still bumps nothing automatically.** The lockstep test guards the dependency, not `audioDuration`'s own dispatch or extension mapping.
- **`gridSlackBytes` in the upstream fork** bounds the largest anomaly that can hide undetected at a few tens of milliseconds -- orders of magnitude inside `timing`'s 2s tolerance, so it cannot flip a verdict, but it is an upstream tuning decision this PR inherits.
- **Figures are parser-version-specific.** They moved once already for measurement reasons; the comments say to re-measure on any bump and to sample randomly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated audio duration parsing to use the newer parser implementation.
  * Prevented stale cached metadata and durations from being reused after parser changes.
  * Ensured cache coverage reflects only data compatible with the active parser version.
* **Database**
  * Added reader-version tracking for audio metadata and duration cache records.
  * Existing metadata is safely invalidated when upgrading parser versions.
* **Tests**
  * Added coverage for parser changes, legacy cache entries, record restamping, and version-specific cache counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->