### PR TITLE
perf(worker): serve fetch-time metadata from audio_metadata instead of re-reading every file

### DIFF
--- a/internal/audiometa/audiometa.go
+++ b/internal/audiometa/audiometa.go
@@ -85,6 +85,61 @@ func (s *Store) Lookup(ctx context.Context, path string, mtimeNano, size int64) 
 	return false, fmt.Errorf("audiometa: lookup %q: %w", path, err)
 }
 
+// Facts returns the cached recording disambiguators for path when the row is
+// current -- same mtime, same size, same reader identity as Lookup requires.
+// found is false for an absent row, a stale one, or one written by a different
+// duration parser, exactly as in Lookup: to a caller they are the same fact,
+// this file needs reading.
+//
+// WHY THIS EXISTS ALONGSIDE Lookup RATHER THAN REPLACING IT (#712). Lookup is a
+// PRESENCE check and that is the right contract for the scanner, which only
+// decides whether to read a file. The worker needs the VALUES: it re-opens every
+// queued item's audio file at fetch time purely to recover duration, ISRC and
+// album, and on the reference library 96.8% of deferred rows already have those
+// values sitting in this table. Widening Lookup's signature would push a
+// values-shaped contract onto the scanner, which does not want it; a second
+// method leaves both callers with exactly the read they need.
+//
+// THE IDENTITY GUARANTEE IS PRESERVED, and that is the load-bearing property.
+// The worker's fetch-time read exists to avoid pasting lyrics onto the wrong
+// track, so serving it from cache is only safe while the cached row provably
+// describes the file on disk NOW. The (mtime_nsec, size_bytes) key is what
+// provides that: a re-encoded, retagged, or replaced file stops matching and the
+// caller falls back to reading the file. This method therefore requires the
+// caller to pass the CURRENT stat values -- it never stats the path itself,
+// because a stat here would describe whatever the path resolves to at this
+// instant rather than the file the caller is actually working on.
+//
+// The returned AudioFacts carries only the fields this table stores; a caller
+// wanting the full tag set still reads the file.
+func (s *Store) Facts(ctx context.Context, path string, mtimeNano, size int64) (scanner.AudioFacts, bool, error) {
+	var f scanner.AudioFacts
+	err := s.db.QueryRowContext(ctx,
+		`SELECT mbid, isrc, artist, album_artist, title, album, composer, genre,
+		        year, track_no, track_total, disc_no, disc_total,
+		        format, file_type, duration_seconds
+		 FROM audio_metadata
+		 WHERE file_path=? AND mtime_nsec=? AND size_bytes=? AND reader_version=? LIMIT 1`,
+		path, mtimeNano, size, s.readerVersion,
+	).Scan(
+		&f.MBID, &f.ISRC, &f.Artist, &f.AlbumArtist, &f.Title, &f.Album,
+		&f.Composer, &f.Genre, &f.Year, &f.TrackNo, &f.TrackTotal,
+		&f.DiscNo, &f.DiscTotal, &f.Format, &f.FileType, &f.TrackLength,
+	)
+	if err == nil {
+		// Echo back the identity the row was matched on rather than re-deriving
+		// it: these are the caller's own stat values, so a consumer that banks
+		// them downstream (the worker's duration cache write) stamps the same
+		// file version this row was validated against.
+		f.MTimeNano, f.SizeBytes = mtimeNano, size
+		return f, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return scanner.AudioFacts{}, false, nil
+	}
+	return scanner.AudioFacts{}, false, fmt.Errorf("audiometa: facts %q: %w", path, err)
+}
+
 // Record stores facts as the metadata for path, replacing any previous row.
 //
 // path MUST be the canonical form (#643): use

--- a/internal/audiometa/audiometa_test.go
+++ b/internal/audiometa/audiometa_test.go
@@ -447,3 +447,154 @@ func TestCoverageCountsOnlyCurrentReader(t *testing.T) {
 		}
 	}
 }
+
+// --- Facts: the value-returning read (#712) -----------------------------
+//
+// These mirror the Lookup/Record tests deliberately. Facts is a SECOND query
+// with its own WHERE clause and its own column list, so it inherits none of
+// Lookup's coverage -- and review proved that: stripping mtime_nsec, size_bytes
+// AND reader_version from Facts' predicate left every package green. That
+// mutation is the wrong-track-attribution bug this cache exists to avoid, since a
+// retagged or replaced file would serve its pre-change ISRC and duration and the
+// worker would fetch lyrics for the wrong recording.
+
+// Every column round-trips into the right field. Values are DISTINCT per field
+// on purpose: two fields sharing a value would make a Scan-order swap (say
+// Album into Artist) undetectable, and Facts' Scan list is long enough that a
+// transposition is a live risk.
+func TestFactsRoundTripsEveryFieldDistinctly(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+
+	want := scanner.AudioFacts{
+		MTimeNano: 111111, SizeBytes: 222222,
+		MBID: "mbid-value", ISRC: "isrc-value",
+		Artist: "artist-value", AlbumArtist: "album-artist-value",
+		Title: "title-value", Album: "album-value",
+		Composer: "composer-value", Genre: "genre-value",
+		Year: 1991, TrackNo: 3, TrackTotal: 12, DiscNo: 2, DiscTotal: 4,
+		Format: "format-value", FileType: "filetype-value", TrackLength: 333,
+	}
+	if err := s.Record(ctx, "/lib/full.mp3", want); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	got, found, err := s.Facts(ctx, "/lib/full.mp3", 111111, 222222)
+	if err != nil {
+		t.Fatalf("Facts: %v", err)
+	}
+	if !found {
+		t.Fatal("a current row must be found")
+	}
+	if got != want {
+		t.Errorf("Facts round-trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// A CHANGED FILE MUST MISS. This is the identity guarantee the whole cache
+// rests on: the fetch-time read exists to stop lyrics being pasted onto the
+// wrong track, so a row may serve it only while it still describes the file on
+// disk. Nanosecond mtime precision is load-bearing -- a same-second rewrite to
+// the same byte size must still read as changed.
+func TestFactsMissesWhenFileChanged(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+	if err := s.Record(ctx, "/lib/a.mp3", scanner.AudioFacts{
+		MTimeNano: 1000, SizeBytes: 4096, ISRC: "ORIGINAL", TrackLength: 210,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		mtime int64
+		size  int64
+	}{
+		{"one-nanosecond mtime change", 1001, 4096},
+		{"size change", 1000, 4097},
+		{"both changed", 2000, 8192},
+	} {
+		got, found, err := s.Facts(ctx, "/lib/a.mp3", tc.mtime, tc.size)
+		if err != nil {
+			t.Fatalf("Facts(%s): %v", tc.name, err)
+		}
+		if found {
+			t.Errorf("%s: a changed file must MISS, else the worker fetches lyrics using a replaced file's identity (got ISRC %q)", tc.name, got.ISRC)
+		}
+		if got != (scanner.AudioFacts{}) {
+			t.Errorf("%s: a miss must yield the zero value, got %+v", tc.name, got)
+		}
+	}
+}
+
+// An absent row is a miss, not an error: to a caller "no row" and "stale row"
+// are the same fact, and the worker falls back to reading the file for both.
+func TestFactsMissesWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestDB(t)
+
+	got, found, err := s.Facts(ctx, "/lib/never-indexed.mp3", 1, 1)
+	if err != nil {
+		t.Fatalf("an absent row must not be an error: %v", err)
+	}
+	if found {
+		t.Error("an unrecorded file must miss")
+	}
+	if got != (scanner.AudioFacts{}) {
+		t.Errorf("a miss must yield the zero value, got %+v", got)
+	}
+}
+
+// A row written by a DIFFERENT duration parser must miss (#713). The bytes are
+// unchanged but TrackLength came from code that is not the code asking, and the
+// worker feeds that duration to the provider query.
+func TestFactsMissesOnReaderVersionChange(t *testing.T) {
+	ctx := context.Background()
+	oldReader, sqlDB := newTestDBWithHandle(t, "parser@v1")
+	newReader := audiometa.New(sqlDB, "parser@v2")
+
+	if err := oldReader.Record(ctx, "/lib/vbr.mp3", scanner.AudioFacts{
+		MTimeNano: 100, SizeBytes: 200, TrackLength: 25, ISRC: "OLD-PARSER",
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if _, found, err := newReader.Facts(ctx, "/lib/vbr.mp3", 100, 200); err != nil {
+		t.Fatalf("Facts under the new parser: %v", err)
+	} else if found {
+		t.Error("a row derived by a DIFFERENT parser must miss; a VBR reader change moves durations severalfold")
+	}
+
+	// The recording parser still hits: invalidated for the new reader, not
+	// destroyed.
+	if _, found, err := oldReader.Facts(ctx, "/lib/vbr.mp3", 100, 200); err != nil {
+		t.Fatalf("Facts under the recording parser: %v", err)
+	} else if !found {
+		t.Error("the recording parser must still hit its own row")
+	}
+}
+
+// Legacy rows predating the reader_version column hold NULL and must miss for
+// EVERY reader, the empty string included. After migration 042 that is the whole
+// pre-existing population until it is re-indexed, so this is the post-deploy
+// path rather than an edge case.
+func TestFactsMissesOnLegacyNullReaderVersion(t *testing.T) {
+	ctx := context.Background()
+	_, sqlDB := newTestDBWithHandle(t, "parser@v1")
+
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO audio_metadata (file_path, mtime_nsec, size_bytes, duration_seconds, isrc)
+		 VALUES (?, ?, ?, ?, ?)`,
+		"/lib/legacy.mp3", 100, 200, 210, "LEGACY",
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	for _, readerVersion := range []string{"parser@v1", ""} {
+		if _, found, err := audiometa.New(sqlDB, readerVersion).Facts(ctx, "/lib/legacy.mp3", 100, 200); err != nil {
+			t.Fatalf("Facts as %q: %v", readerVersion, err)
+		} else if found {
+			t.Errorf("a legacy NULL-reader row must miss for reader %q", readerVersion)
+		}
+	}
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -24,6 +24,7 @@ import (
 	arg "github.com/alexflint/go-arg"
 	"github.com/sydlexius/canticle/internal/app"
 	"github.com/sydlexius/canticle/internal/audiodur"
+	"github.com/sydlexius/canticle/internal/audiometa"
 	"github.com/sydlexius/canticle/internal/auth"
 	"github.com/sydlexius/canticle/internal/cache"
 	"github.com/sydlexius/canticle/internal/config"
@@ -1086,6 +1087,11 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	cacheRepo := cache.New(sqlDB)
 	w := worker.New(workQ, cacheRepo, fetcher, writer)
 	w.SetDurationStore(audiodur.New(sqlDB, scanner.DurationReaderVersion))
+	// Answer the fetch-time metadata read from audio_metadata rather than by
+	// opening each item's audio file (#712). Same reader identity as the duration
+	// store: both tables cache output of the same parse, so both must invalidate
+	// together when it changes (#713).
+	w.SetMetadataCache(audiometa.New(sqlDB, scanner.DurationReaderVersion))
 	w.SetCircuitOpenDuration(time.Duration(cfg.API.CircuitOpenDuration) * time.Second)
 	w.SetCircuitBackoff(time.Duration(cfg.API.CircuitBackoffBase)*time.Second, time.Duration(cfg.API.CircuitOpenDuration)*time.Second)
 	// Dispatch strategy and the parallel-mode synced-upgrade window. Set before the

--- a/internal/worker/metadata_cache_test.go
+++ b/internal/worker/metadata_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/scanner"
@@ -237,5 +238,27 @@ func TestSetMetadataCacheTakesEffect(t *testing.T) {
 	w.SetMetadataCache(cache)
 	if w.metaCache == nil {
 		t.Fatal("SetMetadataCache did not take effect")
+	}
+}
+
+// The stat error must carry context. resolveMetadata logs it at Debug on the
+// cache path, and a bare os.Stat error ("stat /path: no such file") is
+// indistinguishable in a log from every other file error in the process -- so a
+// cache-path stat failure could not be attributed to the cache path at all.
+// Also the repo convention: wrap errors with fmt.Errorf("context: %w", err).
+func TestStatFileIdentityWrapsItsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.mp3")
+
+	_, _, err := statFileIdentity(missing)
+	if err == nil {
+		t.Fatal("statting a missing file must return an error")
+	}
+	if !strings.Contains(err.Error(), "worker: stat") {
+		t.Errorf("error %q lacks the wrapping context; a bare os.Stat error is unattributable in a log", err)
+	}
+	// The wrap must PRESERVE the cause, not replace it: callers and errors.Is
+	// need the underlying os.ErrNotExist.
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("wrapping dropped the cause; errors.Is(err, os.ErrNotExist) must still hold, got %q", err)
 	}
 }

--- a/internal/worker/metadata_cache_test.go
+++ b/internal/worker/metadata_cache_test.go
@@ -1,0 +1,241 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/scanner"
+)
+
+// fakeMetaCache records what it was asked for and returns a canned answer.
+type fakeMetaCache struct {
+	facts scanner.AudioFacts
+	found bool
+	err   error
+
+	gotPath  string
+	gotMtime int64
+	gotSize  int64
+	calls    int
+}
+
+func (f *fakeMetaCache) Facts(_ context.Context, path string, mtimeNano, size int64) (scanner.AudioFacts, bool, error) {
+	f.calls++
+	f.gotPath, f.gotMtime, f.gotSize = path, mtimeNano, size
+	return f.facts, f.found, f.err
+}
+
+// newCacheTestWorker builds a Worker wired for the metadata-cache path with a
+// file reader that FAILS THE TEST if it is ever called. That is the whole point
+// of #712: a cache hit must not open the audio file, and the only way to prove
+// it is to make the open observable rather than to reason about it.
+func newCacheTestWorker(t *testing.T, cache MetadataCache, mtimeNano, size int64) (*Worker, *int) {
+	t.Helper()
+	fileReads := 0
+	w := &Worker{
+		enrichRecordingDefault: true,
+		metaCache:              cache,
+		statFile: func(string) (int64, int64, error) {
+			return mtimeNano, size, nil
+		},
+		readMetadata: func(string) (scanner.AudioMetadata, error) {
+			fileReads++
+			return scanner.AudioMetadata{TrackLength: 999, ISRC: "FROM-FILE", AlbumName: "FromFile"}, nil
+		},
+	}
+	return w, &fileReads
+}
+
+// THE #712 ACCEPTANCE CRITERION. A current cached row must serve the fetch-time
+// read WITHOUT the audio file being opened. On the reference library 96.8% of
+// deferred rows have such a row, so this is the path nearly every queued item
+// takes; if it silently fell through to the reader the change would be a no-op
+// that still looked correct.
+func TestResolveMetadataCacheHitDoesNotReadFile(t *testing.T) {
+	cache := &fakeMetaCache{
+		found: true,
+		facts: scanner.AudioFacts{TrackLength: 210, ISRC: "USRC17607839", Album: "Cached Album"},
+	}
+	w, fileReads := newCacheTestWorker(t, cache, 100, 200)
+
+	meta, err := w.resolveMetadata(context.Background(), "/music/song.mp3")
+	if err != nil {
+		t.Fatalf("resolveMetadata: %v", err)
+	}
+
+	if *fileReads != 0 {
+		t.Errorf("audio file was opened %d time(s) on a cache HIT; #712 exists to prevent exactly this", *fileReads)
+	}
+	if meta.TrackLength != 210 || meta.ISRC != "USRC17607839" || meta.AlbumName != "Cached Album" {
+		t.Errorf("got %+v, want the CACHED values", meta)
+	}
+	// The identity must be echoed back: recordDuration banks against it, so a
+	// zero stamp would silently disable the duration cache write on every hit.
+	if meta.MTimeNano != 100 || meta.SizeBytes != 200 {
+		t.Errorf("identity = (%d, %d), want (100, 200): recordDuration banks against this stamp",
+			meta.MTimeNano, meta.SizeBytes)
+	}
+	// And the cache must be asked about the file as it is NOW, not some other key.
+	if cache.gotPath != "/music/song.mp3" || cache.gotMtime != 100 || cache.gotSize != 200 {
+		t.Errorf("cache queried with (%q, %d, %d), want the current stat identity",
+			cache.gotPath, cache.gotMtime, cache.gotSize)
+	}
+}
+
+// A miss must fall back to the file reader and return ITS values. This is the
+// coverage-gap path: rows enqueued before the index existed, files the scanner
+// skipped, and -- after a reader-identity bump (#713) -- the entire legacy
+// population until it is re-indexed.
+func TestResolveMetadataCacheMissReadsFile(t *testing.T) {
+	w, fileReads := newCacheTestWorker(t, &fakeMetaCache{found: false}, 100, 200)
+
+	meta, err := w.resolveMetadata(context.Background(), "/music/song.mp3")
+	if err != nil {
+		t.Fatalf("resolveMetadata: %v", err)
+	}
+	if *fileReads != 1 {
+		t.Errorf("file read %d times on a cache MISS, want exactly 1", *fileReads)
+	}
+	if meta.ISRC != "FROM-FILE" {
+		t.Errorf("got ISRC %q, want the FILE's value on a miss", meta.ISRC)
+	}
+}
+
+// A cache ERROR must degrade to the file reader, never fail the item. The cache
+// is an optimization over a read that must still happen correctly.
+func TestResolveMetadataCacheErrorReadsFile(t *testing.T) {
+	w, fileReads := newCacheTestWorker(t, &fakeMetaCache{err: errors.New("database is locked")}, 100, 200)
+
+	meta, err := w.resolveMetadata(context.Background(), "/music/song.mp3")
+	if err != nil {
+		t.Fatalf("a cache error must not surface as an error: %v", err)
+	}
+	if *fileReads != 1 {
+		t.Errorf("file read %d times after a cache error, want exactly 1", *fileReads)
+	}
+	if meta.ISRC != "FROM-FILE" {
+		t.Errorf("got ISRC %q, want the FILE's value after a cache error", meta.ISRC)
+	}
+}
+
+// A STAT failure must also degrade to the file reader. A stat can fail where an
+// open succeeds, and if the open genuinely fails too, readMetadata reports the
+// real error -- this is not the place to decide the item's fate.
+func TestResolveMetadataStatFailureReadsFile(t *testing.T) {
+	cache := &fakeMetaCache{found: true, facts: scanner.AudioFacts{TrackLength: 210, ISRC: "CACHED"}}
+	w, fileReads := newCacheTestWorker(t, cache, 0, 0)
+	w.statFile = func(string) (int64, int64, error) { return 0, 0, errors.New("no such file") }
+
+	meta, err := w.resolveMetadata(context.Background(), "/music/song.mp3")
+	if err != nil {
+		t.Fatalf("resolveMetadata: %v", err)
+	}
+	if *fileReads != 1 {
+		t.Errorf("file read %d times after a stat failure, want exactly 1", *fileReads)
+	}
+	if cache.calls != 0 {
+		t.Error("the cache must not be consulted when the identity to validate against is unknown")
+	}
+	if meta.ISRC != "FROM-FILE" {
+		t.Errorf("got ISRC %q, want the FILE's value", meta.ISRC)
+	}
+}
+
+// With no cache wired, behavior is exactly pre-#712: every item reads the file.
+// Nil must disable the feature rather than panic or silently skip the refresh.
+func TestResolveMetadataNilCacheReadsFile(t *testing.T) {
+	w, fileReads := newCacheTestWorker(t, nil, 100, 200)
+	w.metaCache = nil
+
+	if _, err := w.resolveMetadata(context.Background(), "/music/song.mp3"); err != nil {
+		t.Fatalf("resolveMetadata: %v", err)
+	}
+	if *fileReads != 1 {
+		t.Errorf("file read %d times with no cache wired, want exactly 1", *fileReads)
+	}
+}
+
+// THE CACHE KEY MUST BE CANONICAL (#643, #712). audio_metadata rows are written
+// under an absolute, symlink-resolved key, while a scan-enqueued item's
+// SourcePath carries the CONFIGURED root's spelling. Querying the raw path
+// misses every row on a symlinked library root -- the deployment shape #643 was
+// filed against -- turning this cache into a silent no-op that still costs a
+// stat and a query per item. Review caught this: recordDuration, twenty lines
+// below, re-derives its key for exactly this reason and resolveMetadata did not.
+func TestResolveMetadataCanonicalizesTheCacheKey(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "array", "music")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	link := filepath.Join(base, "music")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	song := filepath.Join(real, "song.mp3")
+	if err := os.WriteFile(song, []byte("audio"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// The row is written under the RESOLVED path, as index_metadata.go does.
+	wantKey, err := filepath.EvalSymlinks(song)
+	if err != nil {
+		t.Fatalf("evalsymlinks: %v", err)
+	}
+
+	cache := &fakeMetaCache{found: true, facts: scanner.AudioFacts{TrackLength: 210, ISRC: "CACHED"}}
+	w, fileReads := newCacheTestWorker(t, cache, 100, 200)
+
+	// The worker is handed the SYMLINKED spelling, as a scan-enqueued item is.
+	viaLink := filepath.Join(link, "song.mp3")
+	if _, err := w.resolveMetadata(context.Background(), viaLink); err != nil {
+		t.Fatalf("resolveMetadata: %v", err)
+	}
+
+	if cache.gotPath != wantKey {
+		t.Errorf("cache queried with %q, want the canonical %q; a raw key misses every row on a symlinked root",
+			cache.gotPath, wantKey)
+	}
+	if *fileReads != 0 {
+		t.Errorf("file opened %d time(s) on a hit", *fileReads)
+	}
+}
+
+// New() must wire statFile, or resolveMetadata's nil guard silently disables the
+// cache for every production worker. Review deleted that one line and the whole
+// suite stayed green.
+func TestNewWiresStatFile(t *testing.T) {
+	w := New(nil, nil, nil, nil)
+	if w.statFile == nil {
+		t.Fatal("New must wire statFile; without it resolveMetadata's guard disables the cache for every production worker (#712)")
+	}
+	// And it must report a real file's identity, not a zero stamp.
+	f := filepath.Join(t.TempDir(), "x.mp3")
+	if err := os.WriteFile(f, []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mtime, size, err := w.statFile(f)
+	if err != nil {
+		t.Fatalf("statFile: %v", err)
+	}
+	if mtime == 0 || size != 3 {
+		t.Errorf("statFile = (%d, %d), want a real mtime and size 3", mtime, size)
+	}
+}
+
+// SetMetadataCache must actually take effect, so a wiring regression in runServe
+// cannot pass as a no-op.
+func TestSetMetadataCacheTakesEffect(t *testing.T) {
+	w := New(nil, nil, nil, nil)
+	if w.metaCache != nil {
+		t.Fatal("a fresh Worker must have no cache until one is wired")
+	}
+	cache := &fakeMetaCache{}
+	w.SetMetadataCache(cache)
+	if w.metaCache == nil {
+		t.Fatal("SetMetadataCache did not take effect")
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -133,6 +134,25 @@ const escalationThreshold = 5
 // identityrepair's IdentityReader.
 type MetadataReader func(path string) (scanner.AudioMetadata, error)
 
+// MetadataCache serves the fetch-time recording disambiguators from
+// audio_metadata instead of re-opening the audio file (#712). A nil cache
+// disables the feature and every item reads from disk, the pre-#712 behavior.
+//
+// WHY THIS IS WORTH A SEAM. The fetch-time read exists to avoid pasting lyrics
+// onto the wrong track, so it cannot simply be removed -- but it re-derives tags
+// the metadata index already holds. Measured on the reference library, 20,303 of
+// 20,964 deferred queue rows (96.8%) already have a current row here, so nearly
+// every item in a queue drain was opening a file to learn what SQLite could have
+// answered. That is one array read per queued row, indefinitely, on disks the
+// rest of the system works to keep spun down.
+//
+// Facts takes the CURRENT (mtimeNano, size) and returns found=false unless the
+// row still matches them, which is what preserves the identity guarantee: a
+// re-encoded or retagged file misses and the caller reads from disk.
+type MetadataCache interface {
+	Facts(ctx context.Context, path string, mtimeNano, size int64) (scanner.AudioFacts, bool, error)
+}
+
 // DurationStore banks the exact audio duration the fetch path already re-read
 // from disk, so the revalidation path (#441) does not have to open the file
 // again. A nil store disables the feature.
@@ -165,6 +185,14 @@ type Worker struct {
 	// answers with its default recording, which writes a live or remastered cut's
 	// lyrics onto a studio track. Defaults to scanner.ReadAudioMetadata.
 	readMetadata MetadataReader
+	// metaCache, when set, answers the fetch-time metadata read from
+	// audio_metadata so the item's audio file is never opened (#712). A miss or
+	// any error falls through to readMetadata. Nil disables it.
+	metaCache MetadataCache
+	// statFile resolves a path's current (mtimeNano, size) so a cached row can be
+	// validated against the file on disk. Injectable purely so tests can drive the
+	// cache path without real files; production uses os.Stat.
+	statFile func(path string) (mtimeNano, size int64, err error)
 	// durations, when set, banks the duration refreshRecordingIdentity re-read
 	// from disk, so the revalidation path (#441) does not re-open the file. Nil
 	// disables it.
@@ -357,6 +385,7 @@ func New(q Queue, c Cache, fetcher musixmatch.Fetcher, writer lyrics.Writer) *Wo
 		// config.Enrichment.Enabled's own default, so a caller that never calls the
 		// setters still gets fetch-mode parity rather than a silently disabled fix.
 		readMetadata:           scanner.ReadAudioMetadata,
+		statFile:               statFileIdentity,
 		enrichRecordingDefault: true,
 		baseBackoff:            backoff.DefaultBase,
 		maxBackoff:             backoff.DefaultMax,
@@ -710,6 +739,27 @@ func (w *Worker) SetMetadataReader(r MetadataReader) {
 		return
 	}
 	w.readMetadata = r
+}
+
+// SetMetadataCache wires the metadata index so the fetch-time read is answered
+// from SQLite rather than by opening the item's audio file (#712). Nil disables
+// it, restoring the read-every-file behavior.
+func (w *Worker) SetMetadataCache(c MetadataCache) {
+	w.metaCache = c
+}
+
+// statFileIdentity returns the file's (ModTime().UnixNano(), Size()) -- the
+// identity audio_metadata rows are keyed on.
+//
+// Nanosecond precision matters for the same reason it does in the table itself:
+// a same-second rewrite to the same byte size must still read as changed, or a
+// retagged file serves its pre-retag identity.
+func statFileIdentity(path string) (mtimeNano, size int64, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	return info.ModTime().UnixNano(), info.Size(), nil
 }
 
 // SetDurationStore wires a store so the duration re-read at fetch time is banked
@@ -1466,7 +1516,7 @@ func (w *Worker) refreshRecordingIdentity(ctx context.Context, item queue.WorkIt
 	if strings.TrimSpace(item.Inputs.SourcePath) == "" {
 		return track
 	}
-	meta, err := w.readMetadata(item.Inputs.SourcePath)
+	meta, err := w.resolveMetadata(ctx, item.Inputs.SourcePath)
 	if err != nil {
 		slog.Warn("fetch-time metadata refresh failed; querying with enqueue-time identity",
 			"id", item.ID, "artist", track.ArtistName, "track", track.TrackName, "error", err)
@@ -1485,6 +1535,72 @@ func (w *Worker) refreshRecordingIdentity(ctx context.Context, item queue.WorkIt
 		track.AlbumName = meta.AlbumName
 	}
 	return track
+}
+
+// resolveMetadata returns the fetch-time recording disambiguators for path,
+// preferring the metadata index over opening the audio file (#712).
+//
+// EVERY FAILURE FALLS THROUGH TO THE FILE READER, never to an error and never to
+// empty facts. The cache is an optimization over a read that must still happen
+// correctly: a miss, a stat failure, a stale row, or a database error all mean
+// the same thing here -- this file needs reading -- so the only outcome that
+// skips the open is a row that provably describes the file on disk now.
+//
+// THE STAT IS THE PRICE OF THE GUARANTEE. Validating a cached row requires the
+// file's current (mtime, size), and work_queue stores neither, so a cache hit
+// costs one os.Stat. That is deliberate rather than incidental: the fetch-time
+// read exists to stop lyrics being pasted onto the wrong track, and serving it
+// from a row that might describe a since-replaced file would trade the bug this
+// path prevents for the I/O it costs. A stat is one syscall against an open plus
+// a tag parse -- and, for a VBR file with no Xing header, a full-file read -- so
+// the trade is heavily favorable while keeping the identity check exact.
+func (w *Worker) resolveMetadata(ctx context.Context, path string) (scanner.AudioMetadata, error) {
+	if w.metaCache == nil || w.statFile == nil {
+		return w.readMetadata(path)
+	}
+
+	mtimeNano, size, serr := w.statFile(path)
+	if serr != nil {
+		// The file may still be readable through the normal path (a stat can fail
+		// for reasons an open does not), and if it is not, readMetadata reports the
+		// real error. Either way this is not the place to decide the item's fate.
+		slog.Debug("metadata cache: stat failed, reading the file", "path", path, "error", serr)
+		return w.readMetadata(path)
+	}
+
+	// THE CACHE KEY MUST BE CANONICAL, exactly as recordDuration's must (#643).
+	// audio_metadata rows are written under
+	// pathutil.RebaseUnderCanonicalRoot (index_metadata.go), i.e. absolute and
+	// symlink-resolved, while item.Inputs.SourcePath arrives in two spellings: a
+	// scan-enqueued item carries the CONFIGURED root's spelling, unresolved, and a
+	// webhook item carries an already-resolved one. Querying the raw path
+	// therefore MISSES EVERY ROW on a symlinked library root -- the shape #643 was
+	// filed against (/music -> /mnt/array/music) -- which would make this cache a
+	// silent no-op that still costs a stat and a query per item. It is a miss and
+	// never a wrong hit (divergent keys cannot collide), so this is a performance
+	// defect rather than a correctness one, but it would have removed the entire
+	// benefit on the deployment that motivated the work.
+	key := pathutil.CanonicalPath(path)
+
+	facts, found, cerr := w.metaCache.Facts(ctx, key, mtimeNano, size)
+	if cerr != nil {
+		slog.Warn("metadata cache lookup failed; reading the file", "path", path, "error", cerr)
+		return w.readMetadata(path)
+	}
+	if !found {
+		return w.readMetadata(path)
+	}
+
+	// A hit still yields the identity stamp, because recordDuration banks the
+	// duration against it. Those are the stat values the row was matched on, so
+	// the banked row describes the same file version the cache validated.
+	return scanner.AudioMetadata{
+		TrackLength: facts.TrackLength,
+		ISRC:        facts.ISRC,
+		AlbumName:   facts.Album,
+		MTimeNano:   mtimeNano,
+		SizeBytes:   size,
+	}, nil
 }
 
 // recordDuration banks a fetch-time duration for the revalidation path (#441).

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -757,7 +757,7 @@ func (w *Worker) SetMetadataCache(c MetadataCache) {
 func statFileIdentity(path string) (mtimeNano, size int64, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("worker: stat %q: %w", path, err)
 	}
 	return info.ModTime().UnixNano(), info.Size(), nil
 }


### PR DESCRIPTION
## Summary

- The worker re-opened **every** queued item's audio file at fetch time to recover duration, ISRC and album -- values `audio_metadata` already holds. That is one array read per queued row, indefinitely, on disks the rest of the system works to keep spun down. This serves them from SQLite instead, falling back to the file reader on any miss.
- **Measured before building**, because the issue flagged the decisive unknown. Live database, read-only, aggregate counts only: **20,303 of 20,964 deferred rows (96.8%)** already have a current metadata row. The index is not sparse, so no backfill is needed and the avoidable-read count is 20,303, not the ~6,000 the issue estimated.
- **Reviewers: start with `audiometa.Facts`' WHERE clause and the tests around it.** The first draft of this PR had zero coverage there, and stripping the entire staleness predicate left all three packages green. See "What review caught".

## The safety property this change must not break

The fetch-time read exists to stop lyrics being pasted onto the **wrong track**: `work_queue` persists neither duration nor ISRC, so without the refresh a provider query degrades to artist+title and answers with a default recording -- writing a live or remastered cut's lyrics onto a studio track.

A cached row may therefore serve that read only while it provably describes the file on disk **now**. `Facts` takes the current `(mtime, size)` and returns `found=false` unless the row still matches, so a re-encoded, retagged or replaced file misses and the caller reads from disk.

**The stat is the price of that guarantee**, stated plainly rather than elided: `work_queue` stores no file identity, so a cache hit costs one `os.Stat`. That is one syscall against an open plus a tag parse -- and, for a VBR file with no Xing header, a full-file read.

## Linked issue

Closes #712

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; 1 CRITICAL + 2 IMPORTANT findings all fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **not done**, see "Not covered".
- [x] Screenshot: N/A, no web-UI change.
- [x] `make ui`: N/A, no `.templ` or CSS source changed.
- [x] Migration: N/A, no schema change (uses the columns migration 036 already defines).

## Test plan

- [x] `make gate` passes: race tests, coverage floors, patch coverage, codecov validation, `golangci-lint` (0 issues), actionlint, govulncheck.
- [x] New tests confirmed to **fail against unfixed code** -- every one mutation-checked, table below.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Surface stated explicitly:** this changes the worker's fetch-time metadata resolution only. `runServe` is the sole `worker.New` call site; fetch-mode CLI uses `internal/app` and is untouched.
- [x] Manual UAT steps:
  - [x] Coverage measured against the live database (read-only): 96.8%.
  - [x] Symlinked-root canonicalization verified against a real symlink and temp file.
- [ ] Reviewer follow-ups:
  - [ ] The `w.statFile == nil` guard silently disables the cache. Unreachable today since `New` always wires it, and now covered by a test -- but it is a capability check whose failure branch is quiet, which the repo's own no-silent-failure rule warns about.
  - [ ] `recordDuration`'s doc comment says its stamp is "stat'd from the still-open handle". On a **cache hit** it now comes from `statFileIdentity`'s path-based stat. Self-consistent (the duration is validated against that same stat) but the comment is no longer precise.

### Mutation evidence

| Mutation | Result |
|---|---|
| Strip `mtime_nsec` + `size_bytes` + `reader_version` from `Facts` | 5 tests redden (**passed everything before this PR's fixes**) |
| Swap two columns in `Facts`' `Scan` (`Album` ↔ `Artist`) | Round-trip test reddens |
| Force a cache-hit fall-through | `audio file was opened 1 time(s) on a cache HIT` |
| Drop the identity echo on a hit | `identity = (0, 0), want (100, 200)` |
| Query the raw path instead of the canonical key | Reports the symlinked spelling against the canonical one |
| Delete `statFile` wiring from `New` | New-wiring test reddens (**was green before**) |
| Delete `SetMetadataCache` from `runServe` | Build fails on the orphaned import |

## What review caught

Recorded because the corrections are load-bearing:

1. **`Facts` had zero test coverage (CRITICAL).** Stripping its entire staleness predicate -- mtime, size, and reader identity -- left `audiometa`, `worker` and `commands` all green. That mutation *is* the wrong-track bug this change promises to avoid. The five worker tests mocked `MetadataCache` entirely, so they verified the plumbing and never the predicate underneath it. **A mock verifies the caller's logic and can never verify the contract it replaces.** `Facts` now has the same coverage `Lookup` and `Record` already had.
2. **The cache key was not canonicalized (IMPORTANT).** Rows are written under `RebaseUnderCanonicalRoot`; the lookup used the raw `SourcePath`. On a symlinked library root -- the shape #643 was filed against -- it would have missed every row: a silent no-op still costing a stat and a query per item, on exactly the deployment that motivated the work. A miss, never a wrong hit, so a performance defect rather than a correctness one. `recordDuration` twenty lines below already solved this and documented why.
3. **The production wiring was untested (IMPORTANT).** Two separate one-line deletions each turned the feature into a complete no-op with the suite green.

## Not covered

- **No UAT against a live queue drain.** Verification is unit-level plus a read-only coverage measurement; the I/O reduction is reasoned from the code path, not observed in a running scan.
- **Deploy ordering, not a blocker.** Coverage is 96.8% today, but migration 042 (#713, same release) adds `reader_version` and all 83,862 legacy rows hold NULL -- a miss by design. Coverage drops to 0% at deploy and returns after `scan index-metadata` re-runs. The fallback makes that safe; it means the win arrives after a re-index, which should be scheduled with the release rather than discovered later.
- **Does not address `audio_metadata`'s own reader-identity staleness** beyond what #713 added, and does not change what the fetch-time read is *for*.
- **#684's idle window is not re-measured here.** That was the motivating goal and it needs a fresh measurement with a non-empty queue after this deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio metadata caching to speed up recording metadata processing.
  * Cached metadata is reused when files are unchanged and automatically refreshed when files change.
  * Metadata lookup safely falls back to reading the audio file if the cache is unavailable, stale, or encounters an error.
  * Canonical file paths are supported for reliable cache matching.

* **Tests**
  * Added coverage for cache hits, misses, invalidation, fallbacks, and legacy metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->