### PR TITLE
feat(scanner): surface duration parse failures instead of silently recording 0

### DIFF
--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -99,7 +99,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 	// (finding: --limit is per-root, not per-run). Threading it as a *int
 	// alongside the other counters makes the budget carry over correctly from
 	// one root to the next, exactly like walked/indexed/skipped/unreadable.
-	var walked, indexed, skipped, unreadable, walkErrors, workDone int
+	var walked, indexed, skipped, unreadable, walkErrors, workDone, durationFailures int
 	limitReached := false
 	interrupted := false
 	for _, root := range roots {
@@ -119,7 +119,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 			walkErrors++
 			continue
 		}
-		if err := walkIndexMetadata(ctx, store, root, args, &walked, &indexed, &skipped, &unreadable, &walkErrors, &workDone, &limitReached); err != nil {
+		if err := walkIndexMetadata(ctx, store, root, args, &walked, &indexed, &skipped, &unreadable, &walkErrors, &workDone, &durationFailures, &limitReached); err != nil {
 			if errors.Is(err, context.Canceled) {
 				slog.Info("index-metadata: interrupted", "walked", walked, "indexed", indexed)
 				interrupted = true
@@ -149,8 +149,15 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 	if args.Yes {
 		verb = "indexed"
 	}
-	_, _ = fmt.Fprintf(out, "index-metadata: walked %d file(s); %s %d (%d skipped unchanged, %d unreadable, %d walk error(s)); coverage now %d row(s)%s\n",
-		walked, verb, indexed, skipped, unreadable, walkErrors, coverage, suffixDryRun(args.Yes))
+	// Duration-parse failures are appended only when non-zero, so the healthy
+	// case reads exactly as before and a non-zero count is conspicuous rather
+	// than a column of noise an operator learns to skip (#651).
+	durationNote := ""
+	if durationFailures > 0 {
+		durationNote = fmt.Sprintf("; %d duration parse failure(s)", durationFailures)
+	}
+	_, _ = fmt.Fprintf(out, "index-metadata: walked %d file(s); %s %d (%d skipped unchanged, %d unreadable, %d walk error(s))%s; coverage now %d row(s)%s\n",
+		walked, verb, indexed, skipped, unreadable, walkErrors, durationNote, coverage, suffixDryRun(args.Yes))
 	// An operator-initiated Ctrl-C after partial, already-committed work is
 	// not a failure: the work done so far is real and the summary above
 	// reports it accurately, so exit 0 rather than 1. A genuine error path
@@ -195,7 +202,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 // reset to zero at the start of every root, letting a run over N roots read
 // up to Limit*N files (finding: --limit is per-root, not per-run).
 func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string, args ScanIndexMetadataCmd,
-	walked, indexed, skipped, unreadable, walkErrors, workDone *int, limitReached *bool,
+	walked, indexed, skipped, unreadable, walkErrors, workDone, durationFailures *int, limitReached *bool,
 ) error {
 	absRoot, canonRoot := pathutil.CanonicalRoot(root)
 	return filepath.WalkDir(absRoot, func(p string, d os.DirEntry, walkErr error) error {
@@ -288,6 +295,17 @@ func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string,
 			*unreadable++
 			*workDone++
 			return nil
+		}
+
+		// A file whose TAGS read fine but whose DURATION could not be parsed is
+		// neither unreadable nor a walk error -- the row is written, only the
+		// duration is missing (#651). Counted separately so it cannot hide in
+		// either bucket: this is the exact class of failure that let a
+		// third-party parser defect sit unnoticed until someone inspected an
+		// index run by hand. The row is still recorded; the count only makes the
+		// gap visible.
+		if facts.DurationErr != nil {
+			*durationFailures++
 		}
 
 		if args.Yes {

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -590,7 +590,12 @@ func TestRunScanCmd_DispatchesIndexMetadata(t *testing.T) {
 // the tag block is valid and only the audio frames are unparsable, which is
 // the case that used to be invisible.
 func TestIndexMetadataDurationParseFailureIsCounted(t *testing.T) {
-	cfgPath, _, root := setupIndexMetadata(t, "good.mp3")
+	// NO extra .mp3 fixture: testutil.WriteAudioFile writes a frameless ID3
+	// block, so a second .mp3 would be a SECOND duration failure and the exact
+	// counts below could not be asserted. That is not hypothetical -- the first
+	// draft of this test used "good.mp3" and reported 2 failures while claiming
+	// to test 1.
+	cfgPath, _, root := setupIndexMetadata(t)
 
 	// A valid ID3 tag block followed by bytes that are not decodable frames:
 	// tag.ReadFrom succeeds, the duration parser runs and fails.
@@ -619,13 +624,15 @@ func TestIndexMetadataDurationParseFailureIsCounted(t *testing.T) {
 		t.Fatalf("a duration parse failure must not fail the run; exit = %d: %s", code, got)
 	}
 	// The whole point: it must be COUNTED, and countable separately.
-	if !strings.Contains(got, "duration parse failure") {
-		t.Errorf("summary must report duration parse failures; got: %s", got)
+	if !strings.Contains(got, "1 duration parse failure(s)") {
+		t.Errorf("summary must report EXACTLY 1 duration parse failure; got: %s", got)
 	}
 	// And it must NOT be conflated with the unreadable bucket -- the file's
 	// tags read fine, so counting it there would hide it among genuinely
 	// unopenable files.
-	if strings.Contains(got, "1 unreadable") {
+	// Positive assertion, not a negative one: `!Contains("1 unreadable")` would
+	// also pass on "2 unreadable", so it accepted wrong answers.
+	if !strings.Contains(got, "0 unreadable") {
 		t.Errorf("a duration failure must not be counted as unreadable; got: %s", got)
 	}
 }

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -576,3 +576,84 @@ func TestRunScanCmd_DispatchesIndexMetadata(t *testing.T) {
 		t.Errorf("dispatched run indexed %d rows, want 1", n)
 	}
 }
+
+// A file whose TAGS read fine but whose DURATION cannot be parsed is neither
+// unreadable nor a walk error: the row is written, only the duration is
+// missing. Before #651 that left no trace anywhere -- the failure was logged at
+// Debug (off in production) and discarded -- which is how a third-party parser
+// defect sat unnoticed on two library files until someone inspected an index
+// run by hand.
+//
+// This is deliberately NOT the garbage-content case that
+// TestIndexMetadataUnreadableFileIsCountedNotFatal covers: garbage fails the
+// TAG read and is counted unreadable, never reaching the duration parser. Here
+// the tag block is valid and only the audio frames are unparsable, which is
+// the case that used to be invisible.
+func TestIndexMetadataDurationParseFailureIsCounted(t *testing.T) {
+	cfgPath, _, root := setupIndexMetadata(t, "good.mp3")
+
+	// A valid ID3 tag block followed by bytes that are not decodable frames:
+	// tag.ReadFrom succeeds, the duration parser runs and fails.
+	if err := testutil.WriteAudioFile(root, "noduration.mp3", "Artist", "Title", "Album", ""); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	p := filepath.Join(root, "noduration.mp3")
+	raw, err := os.ReadFile(p) //nolint:gosec // test fixture path
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	// Keep the ID3 header, corrupt everything after it.
+	if len(raw) > 128 {
+		copy(raw[128:], bytes.Repeat([]byte{0x00}, len(raw)-128))
+	}
+	if err := os.WriteFile(p, raw, 0o644); err != nil { //nolint:gosec // test fixture file
+		t.Fatalf("rewrite fixture: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+	got := out.String()
+
+	// Fail-safe is preserved: a parse failure must never abort or fail the run.
+	if code != 0 {
+		t.Fatalf("a duration parse failure must not fail the run; exit = %d: %s", code, got)
+	}
+	// The whole point: it must be COUNTED, and countable separately.
+	if !strings.Contains(got, "duration parse failure") {
+		t.Errorf("summary must report duration parse failures; got: %s", got)
+	}
+	// And it must NOT be conflated with the unreadable bucket -- the file's
+	// tags read fine, so counting it there would hide it among genuinely
+	// unopenable files.
+	if strings.Contains(got, "1 unreadable") {
+		t.Errorf("a duration failure must not be counted as unreadable; got: %s", got)
+	}
+}
+
+// The healthy case must read exactly as before: no duration-failure text at
+// all, so a non-zero count stays conspicuous instead of becoming a column
+// operators learn to skip.
+//
+// FIXTURES MUST BE .flac HERE, and that is itself a finding worth recording.
+// testutil.WriteAudioFile writes an ID3v2 tag block with NO MPEG AUDIO FRAMES,
+// so every .mp3 fixture in this suite has a genuinely unparsable duration --
+// the first draft of this test used .mp3 and correctly reported "2 duration
+// parse failure(s)" on files it called clean. testutil.GenerateFLAC emits a
+// real STREAMINFO block carrying sample rate and total samples, so a .flac
+// fixture has a parseable duration and exercises the actually-clean path.
+func TestIndexMetadataNoDurationNoteWhenClean(t *testing.T) {
+	cfgPath, _, root := setupIndexMetadata(t)
+	for _, name := range []string{"a.flac", "b.flac"} {
+		if err := os.WriteFile(filepath.Join(root, name), testutil.GenerateFLAC(44100, 44100*30), 0o644); err != nil { //nolint:gosec // test fixture file
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	var out bytes.Buffer
+	if code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("clean run failed: %d: %s", code, out.String())
+	}
+	if strings.Contains(out.String(), "duration parse failure") {
+		t.Errorf("a clean run must not mention duration failures; got: %s", out.String())
+	}
+}

--- a/internal/scanner/duration_failure_test.go
+++ b/internal/scanner/duration_failure_test.go
@@ -1,0 +1,47 @@
+package scanner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A duration parse failure previously left NO TRACE: it was logged at Debug --
+// off in production -- and discarded, so a caller could not distinguish an
+// unparsable file from one that legitimately has no duration. Two library
+// files recorded duration 0 for months on a third-party parser defect and
+// surfaced only when someone inspected an index run by hand (#651).
+//
+// These tests pin the distinction the fix rests on: a parser that RAN AND
+// FAILED is reported upward, while an extension with NO PARSER is not.
+
+// audioDuration must tag the no-parser case with a sentinel, so callers can
+// tell "this scanner never times .wma" from "this .mp3 is broken". Without the
+// sentinel the two collapse into one string-matched error and the real signal
+// is buried in the expected one.
+func TestAudioDurationSentinelsUnsupportedExtension(t *testing.T) {
+	_, err := audioDuration(strings.NewReader(""), ".wma")
+	if err == nil {
+		t.Fatal("an unsupported extension must return an error")
+	}
+	if !errors.Is(err, ErrNoDurationParser) {
+		t.Errorf("error %q is not ErrNoDurationParser; callers cannot distinguish it from a real parse failure", err)
+	}
+	if !strings.Contains(err.Error(), ".wma") {
+		t.Errorf("error %q should name the extension", err)
+	}
+}
+
+// A SUPPORTED extension whose parse fails must NOT carry the sentinel: it is a
+// genuine defect, and conflating it with "no parser" is exactly how the
+// original bug stayed invisible.
+func TestAudioDurationRealFailureIsNotSentinelled(t *testing.T) {
+	// Valid extension, garbage content: the parser runs and fails.
+	_, err := audioDuration(strings.NewReader("not an mp3 at all"), ".mp3")
+	if err == nil {
+		t.Fatal("garbage content on a supported extension must return an error")
+	}
+	if errors.Is(err, ErrNoDurationParser) {
+		t.Error("a real parse failure must NOT be tagged ErrNoDurationParser; that would hide it among expected cases")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -231,6 +231,22 @@ type AudioFacts struct {
 	Format      string
 	FileType    string
 	TrackLength int
+
+	// DurationErr is non-nil when the duration parser RAN AND FAILED on a
+	// supported extension, leaving TrackLength at the 0 sentinel (#651).
+	//
+	// It exists because that failure previously had nowhere to go: it was logged
+	// at Debug and discarded, so a caller could not tell an unparsable file from
+	// one that legitimately has no duration. Two library files recorded duration
+	// 0 for months on a third-party parser defect and surfaced only when someone
+	// inspected an index run by hand -- there was no mechanism that would ever
+	// have raised it.
+	//
+	// NOT SET for an extension with no parser at all (ErrNoDurationParser): that
+	// is expected and uninteresting, and counting it here would bury the real
+	// signal. Reading this is optional -- TrackLength is still 0 either way, so a
+	// caller that ignores it behaves exactly as before.
+	DurationErr error
 }
 
 // ReadAudioFacts opens the audio file at path and returns every fact the tag
@@ -250,9 +266,20 @@ func ReadAudioFacts(path string) (AudioFacts, error) {
 	// tag.ReadFrom; no rewind is needed. A parse failure degrades to the
 	// unknown-duration sentinel exactly as scanDir does.
 	dur, derr := audioDuration(f, strings.ToLower(filepath.Ext(path)))
+	var durationErr error
 	if derr != nil {
-		slog.Debug("duration parse failed; using 0", "file", path, "error", derr)
 		dur = 0
+		if errors.Is(derr, ErrNoDurationParser) {
+			// Expected: this scanner has no parser for the extension. Not a
+			// defect, so it stays at Debug and is not reported upward.
+			slog.Debug("no duration parser for extension; using 0", "file", path, "error", derr)
+		} else {
+			// The parser RAN and FAILED on a file it should handle. Warn rather
+			// than Debug: this is the class of failure that hid a third-party
+			// parser defect for months (#651), and Debug is off in production.
+			slog.Warn("duration parse failed; recording unknown duration", "file", path, "error", derr)
+			durationErr = derr
+		}
 	}
 
 	var mtimeNano, sizeBytes int64
@@ -284,6 +311,7 @@ func ReadAudioFacts(path string) (AudioFacts, error) {
 		Format:      string(m.Format()),
 		FileType:    string(m.FileType()),
 		TrackLength: dur,
+		DurationErr: durationErr,
 	}, nil
 }
 
@@ -465,13 +493,25 @@ func NewScanner(opts ...Option) *Scanner {
 	return sc
 }
 
+// ErrNoDurationParser reports that an extension has no duration parser at all,
+// as distinct from a parser that ran and FAILED.
+//
+// The two are different facts and #651 turns on the difference: a file this
+// scanner was never able to time is expected and uninteresting, while a
+// supported file whose parse failed is a defect -- in the parser, or in the
+// file -- that previously left no trace anywhere. Counting them together would
+// bury the second in the first.
+var ErrNoDurationParser = errors.New("no duration parser for extension")
+
 // audioDuration reads the header of r to determine duration in seconds.
 // Returns 0 and a wrapped error for unknown extension or parse failure;
 // callers treat 0 as the "unknown duration" sentinel (duration_bucket=0).
+// An unknown extension is wrapped with ErrNoDurationParser so callers can tell
+// it apart from a parser that ran and failed (#651).
 func audioDuration(r io.ReadSeeker, ext string) (int, error) {
 	ft, ok := audioFileTypeForExt(ext)
 	if !ok {
-		return 0, fmt.Errorf("no duration parser for %s", ext)
+		return 0, fmt.Errorf("%w: %s", ErrNoDurationParser, ext)
 	}
 	secs, err := audioduration.Duration(r, ft)
 	if err != nil {
@@ -1053,8 +1093,14 @@ func (sc *Scanner) scanDir(ctx context.Context, dir, absRoot, canonRoot string, 
 			var durErr error
 			dur, durErr = sc.probeDuration(f, ext)
 			if durErr != nil {
-				slog.Debug("duration parse failed; using 0", "file", file.Name(), "error", durErr)
 				dur = 0
+				if errors.Is(durErr, ErrNoDurationParser) {
+					slog.Debug("no duration parser for extension; using 0", "file", file.Name(), "error", durErr)
+				} else {
+					// See ReadAudioFacts: a parser that RAN and FAILED is a defect
+					// worth surfacing, and Debug is off in production (#651).
+					slog.Warn("duration parse failed; using unknown duration", "file", file.Name(), "error", durErr)
+				}
 			}
 			// Bank the duration we just paid a header read for (#441). The stamp
 			// comes from the open handle f, not a path re-stat, so no path is


### PR DESCRIPTION
## Summary

- A duration parse failure was logged at **Debug** -- off in production -- and then discarded. `scanner.AudioFacts` had no field to carry it, so a caller could not distinguish an unparsable file from one that legitimately has no duration. That is how a third-party parser defect sat on two library files until someone inspected an index run by hand.
- Fixing the parser (#650, now closed) did **not** fix this. The next unparsable file would have been just as invisible. This makes the failure countable, logged, and reportable.
- **Reviewers: the interesting part is the sentinel distinction.** "No parser for this extension" and "the parser ran and failed" are different facts, and counting them together would bury the second in the first.

## What changed

**`ErrNoDurationParser` sentinel.** An unsupported extension is expected and uninteresting; a supported file whose parse failed is a defect. Callers can now tell them apart via `errors.Is`.

**`AudioFacts.DurationErr`.** The field the failure travels on, set only for real failures. Reading it is optional -- `TrackLength` is still 0 either way, so a caller that ignores it behaves exactly as before.

**Debug → Warn** at both drop sites, for genuine failures only.

**A separate counter** in the `index-metadata` summary, appended only when non-zero so the healthy case reads exactly as before and a non-zero count stays conspicuous rather than becoming a column operators learn to skip.

## The test found a real blind spot on first contact

The "clean run" test initially reported **2 duration parse failures on files it called healthy**. The counter was right and my premise was wrong: `testutil.WriteAudioFile` writes an ID3v2 tag block with **no MPEG audio frames**, so every `.mp3` fixture in this suite has a genuinely unparsable duration.

The clean case now uses `.flac` via `testutil.GenerateFLAC` (a real STREAMINFO block), and the test records why so the next reader does not rediscover it.

That is the feature working before it even merged.

## Linked issue

Closes #651

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **not done**, see "Not covered".
- [x] Screenshot: N/A, no web-UI change.
- [x] `make ui`: N/A, no `.templ` or CSS source changed.
- [x] Migration: N/A, no schema change.

## Test plan

- [x] `make gate` passes: race tests, coverage floors, patch coverage, `golangci-lint` (0 issues), actionlint, govulncheck.
- [x] New tests confirmed to **fail against unfixed code** -- mutation table below.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Surface stated explicitly:** this changes what `scan index-metadata` reports and what `scanner.ReadAudioFacts` returns. It does not change which files are indexed, or any duration value.
- [x] Manual UAT steps:
  - [x] Verified the healthy-run summary is byte-identical to before (no duration text when the count is zero).
- [ ] Reviewer follow-ups:
  - [ ] Only `index-metadata` counts these today. A library `scan` logs at Warn but has no equivalent counter -- deliberate (its summary is a different shape), but worth a second opinion.
  - [ ] `testutil.WriteAudioFile` producing frameless MP3s affects other tests that may silently assume a parsable duration. Not in scope here; flagged because this PR is what surfaced it.

### Mutation evidence

| Mutation | Result |
|---|---|
| Never increment the counter | `summary must report duration parse failures` |
| Collapse the sentinel distinction (treat every failure as no-parser) | Same test reddens |
| Fail-safe behavior | Pinned by its own assertion: a parse failure must not abort the walk or fail the run |

## Acceptance criteria (from #651)

- [x] A file whose duration cannot be parsed is **counted** in the `index-metadata` summary
- [x] The count is distinguishable from `unreadable` and from `walk error(s)` -- the test asserts it is *not* counted as unreadable
- [x] The underlying parse error is logged rather than discarded
- [x] Fail-safe preserved: a parse failure still does not abort the walk or fail the run

## Not covered

- **No UAT against the live library.** Verification is unit-level. The production re-index run earlier today reported 1 unreadable file across 84,431 walked, which is the closest real-world signal but predates this change.
- **Does not invalidate rows already written with `duration_seconds = 0`.** The `(path, mtime, size)` staleness check skips unchanged files, so pre-existing zero-duration rows are not re-read by this change. #651 noted that gap; making them countable is the prerequisite for targeting them, not the fix itself.
- **Only `index-metadata` reports a count.** The scan path logs at Warn but does not aggregate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio metadata indexing to distinguish unsupported formats from genuine duration parsing failures.
  * Indexing now completes successfully when duration parsing fails, while clearly reporting the affected files.
  * Prevented duration parsing failures from being incorrectly counted as unreadable audio.
  * Clean indexing summaries no longer display unnecessary duration-failure notices.

* **Tests**
  * Added coverage for unsupported formats, invalid audio data, and successful duration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->