### PR TITLE
feat(index-metadata): bank durations from the read the sweep already performs

### DIFF
--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sydlexius/canticle/internal/audiodur"
 	"github.com/sydlexius/canticle/internal/audiometa"
 	"github.com/sydlexius/canticle/internal/config"
 	"github.com/sydlexius/canticle/internal/db"
@@ -83,6 +84,25 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 
 	store := audiometa.New(sqlDB, scanner.DurationReaderVersion)
 
+	// Bank the duration from the SAME read that fills audio_metadata (#717).
+	//
+	// This walk already opens every file and already holds facts.TrackLength
+	// alongside the (mtime, size) audiodur keys on -- it simply threw the
+	// duration away, so audio_durations stayed sparse while audio_metadata went
+	// complete. Measured on the reference library: 0 scan_results rows missing a
+	// metadata row, but 12,990 missing a duration row. Every one of those is a
+	// file this sweep had open, read, and could have settled.
+	//
+	// The consequence is a repeat OPEN, which is what makes it worth fixing:
+	// a spin-up event costs the same whether it reads one byte or a gigabyte, so
+	// the count of touches is the metric, not their size. A duration miss sends
+	// a later caller back to the disk for a file this command already read.
+	//
+	// Both stores share scanner.DurationReaderVersion, so a parser change
+	// invalidates the two together and they can never disagree about which
+	// reader produced them.
+	durations := audiodur.New(sqlDB, scanner.DurationReaderVersion)
+
 	// A --library run scopes the printed coverage number to that library's
 	// canonical root, per #646's AC ("how many files in library N have
 	// complete metadata"); a whole-library-set run keeps the global total.
@@ -119,7 +139,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 			walkErrors++
 			continue
 		}
-		if err := walkIndexMetadata(ctx, store, root, args, &walked, &indexed, &skipped, &unreadable, &walkErrors, &workDone, &durationFailures, &limitReached); err != nil {
+		if err := walkIndexMetadata(ctx, store, durations, root, args, &walked, &indexed, &skipped, &unreadable, &walkErrors, &workDone, &durationFailures, &limitReached); err != nil {
 			if errors.Is(err, context.Canceled) {
 				slog.Info("index-metadata: interrupted", "walked", walked, "indexed", indexed)
 				interrupted = true
@@ -201,7 +221,7 @@ func runIndexMetadata(ctx context.Context, out io.Writer, args ScanIndexMetadata
 // configured roots, not a per-root allowance: a local counter here would
 // reset to zero at the start of every root, letting a run over N roots read
 // up to Limit*N files (finding: --limit is per-root, not per-run).
-func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string, args ScanIndexMetadataCmd,
+func walkIndexMetadata(ctx context.Context, store *audiometa.Store, durations *audiodur.Store, root string, args ScanIndexMetadataCmd,
 	walked, indexed, skipped, unreadable, walkErrors, workDone, durationFailures *int, limitReached *bool,
 ) error {
 	absRoot, canonRoot := pathutil.CanonicalRoot(root)
@@ -311,6 +331,21 @@ func walkIndexMetadata(ctx context.Context, store *audiometa.Store, root string,
 		if args.Yes {
 			if rerr := store.Record(ctx, canonPath, facts); rerr != nil {
 				return fmt.Errorf("index-metadata: record %q: %w", canonPath, rerr)
+			}
+			// Bank the duration from the read just performed (#717). Keyed on the
+			// identity the OPEN HANDLE reported (facts.MTimeNano/SizeBytes), not a
+			// fresh os.Stat: re-statting would both cost another syscall and open a
+			// TOCTOU window where a file rewritten mid-walk gets its new stat
+			// stamped onto the old read's duration.
+			//
+			// NON-FATAL, unlike the metadata Record above. audio_metadata is this
+			// command's product and a failure there means the run did not do its
+			// job; audio_durations is an opportunistic byproduct, so failing the
+			// whole sweep over it would trade a complete index for a partial one.
+			// Record itself no-ops on a non-positive duration, so a file with an
+			// unparsable duration (counted above) simply banks nothing.
+			if derr := durations.Record(ctx, canonPath, facts.MTimeNano, facts.SizeBytes, facts.TrackLength); derr != nil {
+				slog.Warn("index-metadata: could not bank duration; metadata row still recorded", "file", canonPath, "error", derr)
 			}
 			if indexMetadataRowCommitted != nil {
 				indexMetadataRowCommitted()

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -779,3 +779,57 @@ func TestIndexMetadataUnparsableDurationBanksNoRow(t *testing.T) {
 		t.Errorf("audio_durations rows = %d, want 0: an unparsable duration must bank nothing, not a 0", n)
 	}
 }
+
+// TestIndexMetadataDurationBankFailureIsNonFatal pins the asymmetry between the
+// two writes this command performs. audio_metadata is its PRODUCT: a failure
+// there means the run did not do its job, so it aborts. audio_durations is an
+// opportunistic byproduct banked from the same read, so a failure there must be
+// logged and stepped over -- failing the whole sweep would trade a complete
+// index for a partial one, which is the opposite of what #717 is for.
+//
+// Without this test the degraded path is unexecuted: every other test in this
+// file exercises the branch where Record succeeds, so nothing proves the run
+// survives a duration-store failure OR that the metadata row still lands when
+// it does.
+func TestIndexMetadataDurationBankFailureIsNonFatal(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t)
+
+	// A file with a REAL duration, so the code reaches durations.Record rather
+	// than short-circuiting on the non-positive no-op path.
+	const sampleRate, totalSamples = 44100, 44100
+	if err := os.WriteFile(filepath.Join(root, "known.flac"),
+		testutil.GenerateFLAC(sampleRate, totalSamples), 0o600); err != nil {
+		t.Fatalf("write flac fixture: %v", err)
+	}
+
+	// Break ONLY the duration store, by dropping the table the migrations just
+	// created. This is the narrowest available fault injection: audiodur.Record
+	// fails on a missing relation while every other store keeps working, so the
+	// test isolates the branch under examination instead of breaking the DB
+	// wholesale and asserting on a failure that could have come from anywhere.
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, "DROP TABLE audio_durations"); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("drop audio_durations: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close after drop: %v", err)
+	}
+
+	var out bytes.Buffer
+	code := runIndexMetadata(ctx, &out, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true})
+
+	// The contract, both halves:
+	//   1. the run still succeeds -- a byproduct failure is not the run's failure
+	if code != 0 {
+		t.Fatalf("a duration-bank failure must not fail the run; exit = %d: %s", code, out.String())
+	}
+	//   2. the metadata row -- the thing this command exists to write -- is still there
+	if n := countAudioMetadataRows(t, dbPath); n != 1 {
+		t.Errorf("audio_metadata rows = %d, want 1: a duration-bank failure must not cost the file its index entry", n)
+	}
+}

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/library"
 	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/pathutil"
 	"github.com/sydlexius/canticle/internal/testutil"
 )
 
@@ -662,5 +665,117 @@ func TestIndexMetadataNoDurationNoteWhenClean(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "duration parse failure") {
 		t.Errorf("a clean run must not mention duration failures; got: %s", out.String())
+	}
+}
+
+// countAudioDurationRows counts audio_durations rows, the table index-metadata
+// began banking into in #717.
+func countAudioDurationRows(t *testing.T, dbPath string) int {
+	t.Helper()
+	return countRows(t, context.Background(), dbPath, "audio_durations")
+}
+
+// bankedDuration returns the duration_seconds stored for path, and whether a row
+// exists at all. Absence and a stored value are different facts here: audiodur
+// represents "unknown" by having no row, so a test asserting the no-op path must
+// be able to tell "no row" from "a row saying 0".
+func bankedDuration(t *testing.T, dbPath, filePath string) (seconds int, found bool) {
+	t.Helper()
+	ctx := context.Background()
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer sqlDB.Close() //nolint:errcheck // test cleanup
+	err = sqlDB.QueryRowContext(ctx,
+		"SELECT duration_seconds FROM audio_durations WHERE file_path = ?", filePath).Scan(&seconds)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false
+	}
+	if err != nil {
+		t.Fatalf("query audio_durations: %v", err)
+	}
+	return seconds, true
+}
+
+// TestIndexMetadataBanksDurationFromTheSameRead is the #717 regression: the walk
+// already opens every file and already holds facts.TrackLength, so a run must
+// leave audio_durations populated too. Before the fix audio_metadata went
+// complete while audio_durations stayed sparse (measured: 12,990 scan_results
+// rows with a metadata row but no duration row), and every one of those sent a
+// later caller back to the disk for a file this command had already read.
+func TestIndexMetadataBanksDurationFromTheSameRead(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t)
+
+	// A header-only FLAC with an exact, known duration: 44100 samples at 44100 Hz
+	// is 1 second. WriteAudioFile's frameless ID3 cannot be used here -- it has NO
+	// parsable duration, which is the negative case asserted separately below.
+	const sampleRate, totalSamples = 44100, 44100
+	flacPath := filepath.Join(root, "known.flac")
+	if err := os.WriteFile(flacPath, testutil.GenerateFLAC(sampleRate, totalSamples), 0o600); err != nil {
+		t.Fatalf("write flac fixture: %v", err)
+	}
+
+	var out bytes.Buffer
+	if code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{
+		ConfigPath: cfgPath,
+		Yes:        true,
+	}); code != 0 {
+		t.Fatalf("exit code = %d, want 0; output: %s", code, out.String())
+	}
+
+	// The metadata row is the command's existing product; the duration row is the
+	// behavior #717 added. Assert both, so a regression that quietly stops banking
+	// durations cannot pass by leaving the metadata index intact.
+	if n := countAudioMetadataRows(t, dbPath); n != 1 {
+		t.Errorf("audio_metadata rows = %d, want 1", n)
+	}
+	if n := countAudioDurationRows(t, dbPath); n != 1 {
+		t.Fatalf("audio_durations rows = %d, want 1: the duration must be banked from the read the walk already performed", n)
+	}
+
+	// The banked value must be the real duration, not merely a row: a cache that
+	// stores the wrong number is worse than one that stores nothing, because a
+	// later caller trusts it instead of reading the file.
+	// Query under the SAME canonical spelling walkIndexMetadata records with, not
+	// the raw temp path: on macOS /var is a symlink to /private/var, so a raw-path
+	// lookup misses every row and the assertion would pass or fail on which
+	// directory the OS handed the test.
+	absRoot, canonRoot := pathutil.CanonicalRoot(root)
+	got, found := bankedDuration(t, dbPath, pathutil.RebaseUnderCanonicalRoot(absRoot, canonRoot, flacPath))
+	if !found {
+		t.Fatalf("no audio_durations row for %s", flacPath)
+	}
+	if want := totalSamples / sampleRate; got != want {
+		t.Errorf("banked duration = %ds, want %ds", got, want)
+	}
+}
+
+// TestIndexMetadataUnparsableDurationBanksNoRow pins the no-op half of the
+// contract. audiodur.Record ignores a non-positive duration because absence is
+// how the table spells "unknown" -- storing a 0 would make "never read" and
+// "measured as zero-length" indistinguishable, and a later caller would treat
+// the 0 as settled rather than reading the file.
+func TestIndexMetadataUnparsableDurationBanksNoRow(t *testing.T) {
+	// The frameless ID3 file WriteAudioFile produces: tags read fine, duration
+	// does not parse. Exactly the shape TestIndexMetadataDurationParseFailureIsCounted
+	// relies on.
+	cfgPath, dbPath, _ := setupIndexMetadata(t, "noduration.mp3")
+
+	var out bytes.Buffer
+	if code := runIndexMetadata(context.Background(), &out, ScanIndexMetadataCmd{
+		ConfigPath: cfgPath,
+		Yes:        true,
+	}); code != 0 {
+		t.Fatalf("exit code = %d, want 0; output: %s", code, out.String())
+	}
+
+	// The metadata row is still written -- an unparsable duration must not cost
+	// the file its index entry.
+	if n := countAudioMetadataRows(t, dbPath); n != 1 {
+		t.Errorf("audio_metadata rows = %d, want 1: an unparsable duration must not skip the metadata row", n)
+	}
+	if n := countAudioDurationRows(t, dbPath); n != 0 {
+		t.Errorf("audio_durations rows = %d, want 0: an unparsable duration must bank nothing, not a 0", n)
 	}
 }


### PR DESCRIPTION
## Summary

- `scan index-metadata` already opened every audio file and already held `facts.TrackLength` alongside the `(mtime, size)` that `audiodur` keys on -- it wrote `audio_metadata` and discarded the duration. Measured on the reference library: **0** `scan_results` rows missing a metadata row, **12,990** missing a duration row. Every one of those is a file this command had open, read, and could have settled, and every one sends a later caller back to the disk.
- Reuses the existing command and the existing read: no new subcommand, no new `os.Open`, no second `os.Stat`. The library lives on spun-down array disks, where the metric is the **number of touch events**, not bytes -- a repeat open costs a spin-up whether it reads one byte or a gigabyte.
- Reviewers look first at the identity source: the duration is keyed on what the **open handle** reported (`facts.MTimeNano`/`SizeBytes`, set from `f.Stat()` in `scanner.ReadAudioFacts`), not a fresh `os.Stat`. That avoids a syscall and closes a TOCTOU window where a file rewritten mid-walk would get its new stat stamped onto the old read's duration.

No user-visible interface change: no flag added, no subcommand added, output text unchanged. Shell completion is unaffected (`index-metadata` was already in `completionCandidates` with an unchanged flag set).

## Linked issue

Closes #717

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; no critical or important findings.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
- [x] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A, none changed.
- [x] Migration added under `internal/db/migrations/` if this is a one-time data correction -- N/A. `audio_durations` and its `reader_version` already exist (#441, #711); this fills rows through the normal `audiodur.Store.Record` upsert, so there is no schema change and nothing to migrate.

## Test plan

- [x] `make gate` passes locally. Verified from the run log rather than the exit code: `OK: all pre-push checks passed`, golangci-lint 0 issues, govulncheck 0 vulnerabilities, every package at or above its coverage floor, zero FAIL lines.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Mutation: deleting the `durations.Record` call makes `TestIndexMetadataBanksDurationFromTheSameRead` fail at its assertion -- `audio_durations rows = 0, want 1` -- not at a build or setup error. Restored and re-verified green.
- [x] Patch coverage meets the Codecov threshold: **86.96%** (20/23 executable lines) against the 70% target.
- [x] Which **surface** this change fixes is stated explicitly and was verified on it: the `audio_durations` table. Confirmed by asserting the stored `duration_seconds` value, not merely row presence -- a cache holding the wrong number is worse than an empty one, because a later caller trusts it instead of reading the file. The fixture is a header-only FLAC of exactly 44,100 samples at 44,100 Hz, so the expected value is 1 second by construction.
- [x] The write key was checked against the **readers'** key, not assumed. `walkIndexMetadata` records under `pathutil.RebaseUnderCanonicalRoot`, the same canonical spelling `worker.recordDuration` uses via `pathutil.CanonicalPath` (the `worker.go` comment names `index_metadata.go` as the reference). A divergent key here would have been a silent no-op that still cost a stat and a query per file.
- [x] Both stores share `scanner.DurationReaderVersion`, so a parser change invalidates `audio_metadata` and `audio_durations` together and they cannot disagree about which reader produced them.
- [ ] Manual UAT steps (list the specific flows exercised):
  - [ ] Run `scan index-metadata --yes` against the production library and confirm the 12,990-row `audio_durations` gap closes in one pass, with already-banked files skipped without being opened.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] The duration write is deliberately **non-fatal** while the metadata write is fatal. Rationale: `audio_metadata` is this command's product, so a failure there means the run did not do its job; `audio_durations` is an opportunistic byproduct, and failing the whole sweep over it would trade a complete index for a partial one. Worth confirming that asymmetry reads correctly.

## Not covered

- **Gap 1 of #717 is untouched.** `identityrepair` still re-reads tags with no cache gate (`scanner.ReadArtistIdentity` per row). Real, but operator-invoked rather than hot-path, so it accounts for far fewer touch events than the duration hole this PR closes.
- **Gap 2 (verification sample caching) is untouched** and remains a deliberate open decision, per the issue's own framing that declining is a legitimate outcome.
- **Gap 3 (the enumeration test) is not implemented.** Nothing yet enforces the one-read-per-song invariant mechanically, so the next unguarded read will still be found by hand.
- **`revalidate.durationOf` looks up the raw companion path** rather than a canonicalized one, so on a symlinked library root it can miss rows this command banks. Pre-existing and not touched here; it fails open to unknown-duration and can never produce a wrong hit, since divergent keys cannot collide. Worth its own issue rather than widening this diff.
- No production run has been performed yet -- the 12,990-row figure is a measurement of the current gap, not a verified post-fix result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata indexing now records audio durations alongside file metadata.
  * Duration information is reused from the same file scan, improving indexing efficiency.

* **Bug Fixes**
  * Files with unreadable or unknown durations are still indexed successfully.
  * Unknown durations remain unrecorded rather than being incorrectly stored as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->