### PR TITLE
docs(detector): correct the inference-cost claim and document the taming knobs

### DIFF
--- a/deploy/yamnet-detector/README.md
+++ b/deploy/yamnet-detector/README.md
@@ -105,11 +105,51 @@ everything else running on it. `docker-compose.example.yml` therefore ships a
 (the SavedModel plus the TF runtime sit around 1.5GB resident).
 
 Treat 4 as a floor for good-neighbor behavior, not a performance target.
-Inference is the dominant cost in the detector path, so this limit trades
-detector throughput for isolation: raise it on a host with cores to spare, lower
-it on a busy one. Nothing breaks either way -- a slower sidecar just means a
-longer per-track detection, and Canticle's own detector cooldown and circuit
-breaker already bound how hard it is driven.
+
+**THIS IS AN ISOLATION KNOB, NOT A THROUGHPUT KNOB.** An earlier version of this
+section said inference was "the dominant cost in the detector path" and told you
+to size this against it. That is wrong, and a companion claim of ~40-67s per
+track is off by roughly 300x -- it almost certainly timed the whole detector path
+(ffmpeg reading audio off the array, plus a cold model load) rather than the
+classify call. Measured against a running sidecar, canticle 1.30.1:
+
+| operation | cost |
+|---|---|
+| `/classify`, 30s sample (typical) | 0.07-0.11s |
+| `/classify`, 60s sample (the longest sent) | 0.13-0.24s |
+| ffmpeg spread-sample extraction | ~0.10s |
+
+Inference is a fifth of a second, so raising this limit buys almost no
+throughput. What it buys is a bound on how much of the host TensorFlow may seize
+while it runs. Raise it on a host with cores to spare, lower it on a busy one;
+nothing breaks either way.
+
+The real per-track cost is **reading audio off the array**, which is what the
+throughput and wattage knobs below actually govern.
+
+### Taming detection (low-wattage recipe)
+
+Detection is deliberately bursty: work that once dripped across days at the
+provider's pace now runs in bounded cycles, because a contiguous burst is what
+lets the library disks idle afterward. That is better for spindown and strictly
+worse for peak draw while a cycle runs, so the bound is worth setting
+deliberately. Size against disk reads, not inference.
+
+| knob | where | what it governs |
+|---|---|---|
+| `instrumental_detector.backfill.batch_size` | canticle config | rows per sweep cycle -- the main wattage/throughput lever (default 100) |
+| `instrumental_detector.backfill.interval_minutes` | canticle config | spacing between cycles; longer gaps mean longer contiguous idle windows (default 60) |
+| `instrumental_detector.backfill.enabled` | canticle config | turns the automatic sweep off entirely (default true) |
+| `instrumental_detector.spread_samples` | canticle config | windows sampled per track; multiplies the ffmpeg work, so it multiplies disk reads |
+| `--limit` | `scan reconcile-instrumental` | drains a backlog in bounded manual chunks instead of one sustained run |
+| `cpus:` | yamnet compose service | isolation only -- caps TF's forward pass, not throughput |
+
+The defaults (100 rows every 60 minutes) drain roughly 2,400 rows/day without a
+sustained burst, so an untended install converges on its own. For a quieter host,
+lower `batch_size` or lengthen `interval_minutes` before touching `cpus:` --
+those two govern disk reads, which is the cost that matters. Disabling the sweep
+leaves the CLI path fully functional, so an operator can still drain a backlog on
+their own schedule with `scan reconcile-instrumental --limit N`.
 
 The deployed copy lives on the Unraid host at
 `/mnt/vms/dockerappdata/yamnet-detector/`; Canticle reaches it at


### PR DESCRIPTION
## Summary

- `deploy/yamnet-detector/README.md` still told operators that inference is the dominant cost in the detector path and to size the yamnet `cpus:` limit against it. Measured against a running sidecar (canticle 1.30.1): `/classify` is **0.07-0.24s** and ffmpeg spread-sample extraction is **~0.10s**, so the companion "~40-67s per track" figure is off by roughly **300x** -- it almost certainly timed the whole detector path, including reading audio off the array, rather than the classify call. `docker-compose.example.yml` was corrected in #710; this brings the README into line with it.
- Sizing against the wrong constraint has a real cost now that #710 made the backfill sweep automatic and default-on. The knobs that govern **disk reads** (`batch_size`, `interval_minutes`, `spread_samples`, `--limit`) are the throughput and wattage levers; `cpus:` only bounds how much of the host TensorFlow may seize while it runs. An operator tuning for low wattage would otherwise reach for the knob governing a fifth of a second and leave the ones governing spin-ups untouched.
- Adds a low-wattage recipe table naming each knob, where it lives, and what it governs. Reviewers: the table is the part worth checking.

Documentation only. No Go files, no behavior change.

## Linked issue

Part of #708

(Deliberately `Part of`, not `Closes`. #708's remaining acceptance criterion is a measurement -- re-check #684's contiguous idle window once the sweep drains the backlog -- not a code change.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; no critical or important findings.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes -- N/A, documentation only.
- [x] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A, none changed.
- [x] Migration added under `internal/db/migrations/` -- N/A, no data change.

## Test plan

- [x] `make gate` passes locally. Verified from the run log rather than the exit code: `OK: all pre-push checks passed`, zero FAIL lines, 0 vulnerabilities.
- [x] New tests confirmed to fail against unfixed code -- N/A. This is a documentation correction with no code path to test; there is nothing a test could assert that reading the file does not.
- [x] Patch coverage -- N/A, no Go source changed.
- [x] **Every knob named in the new table was verified to exist before being documented**, since a docs page naming a nonexistent flag is worse than no page. `instrumental_detector.backfill.enabled`, `.batch_size`, `.interval_minutes`, and `instrumental_detector.spread_samples` each confirmed present in `internal/config/registry.go`; `--limit` confirmed on the `ScanReconcileInstrumentalCmd` struct (`internal/commands/commands.go:266`).
- [x] The documented defaults were read from `internal/config/config.go` (`detectorBackfillBatchSizeDefault = 100`, `detectorBackfillIntervalMinutesDefault = 60`) rather than copied from the issue thread.
- [ ] Reviewer follow-ups:
  - [ ] The "~2,400 rows/day" figure is arithmetic from the shipped defaults (100 rows x 24 cycles), not an observed drain rate. Worth confirming against the real sweep once the backlog moves.

## Not covered

- **The measured timings are re-used from #708's investigation, not re-measured for this PR.** They were taken against the running sidecar at canticle 1.30.1 and are the basis for the correction; a reviewer wanting independent confirmation would need to re-run `curl` against the sidecar.
- **#708 is not closed by this.** Its remaining criterion is to re-measure #684's contiguous idle window after the backlog drains, which is an observation on prod rather than a change to the repo.
- No verification that the low-wattage recipe actually lowers draw on a specific host -- the knobs are documented against what they control, not against a wattage measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated YAMNet detector tuning guidance with more accurate, measurement-backed performance information.
  * Clarified the impact of resource limits and audio-reading costs during detection.
  * Added practical recommendations and a configuration table for batching, scan intervals, sampling, chunking, and CPU isolation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->