### PR TITLE
fix(index-metadata): bank durations for already-indexed files

### DIFF
--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -299,6 +299,36 @@ func walkIndexMetadata(ctx context.Context, store *audiometa.Store, durations *a
 		}
 		if hit {
 			*skipped++
+			// Bank the duration from the METADATA ROW, not from a re-read (#724).
+			//
+			// #720 attached the duration write to the read path below, but this
+			// skip returns first, so a file already in audio_metadata could never
+			// gain a duration row: measured on prod, 12,990 rows had a current
+			// metadata row and no duration row, and the sweep banked exactly zero
+			// of them however many times it ran. The skip is correct and
+			// load-bearing -- it is what makes a re-run over an unchanged library
+			// nearly free on spun-down disks -- so the fix belongs HERE, not in
+			// weakening it.
+			//
+			// NO FILE IS OPENED. Facts re-queries the row the Lookup above just
+			// validated against this same (mtime, size), so the duration is
+			// already stored and costs one indexed SELECT rather than a spin-up.
+			// That makes this strictly cheaper than the read path it complements.
+			//
+			// Non-fatal for the same reason as the read path: audio_metadata is
+			// this command's product, audio_durations an opportunistic byproduct.
+			// Record itself no-ops on a non-positive duration, so a row whose
+			// duration never parsed banks nothing rather than a misleading 0 --
+			// absence is how that table spells "unknown".
+			facts, ok, ferr := store.Facts(ctx, canonPath, mtimeNano, size)
+			switch {
+			case ferr != nil:
+				slog.Warn("index-metadata: could not read cached facts to bank duration", "file", canonPath, "error", ferr)
+			case ok:
+				if derr := durations.Record(ctx, canonPath, mtimeNano, size, facts.TrackLength); derr != nil {
+					slog.Warn("index-metadata: could not bank duration from the metadata row", "file", canonPath, "error", derr)
+				}
+			}
 			return nil
 		}
 

--- a/internal/commands/index_metadata.go
+++ b/internal/commands/index_metadata.go
@@ -324,7 +324,13 @@ func walkIndexMetadata(ctx context.Context, store *audiometa.Store, durations *a
 			switch {
 			case ferr != nil:
 				slog.Warn("index-metadata: could not read cached facts to bank duration", "file", canonPath, "error", ferr)
-			case ok:
+			// GATED ON args.Yes, like every other write in this command. Without
+			// it a DRY RUN mutated audio_durations on any already-indexed
+			// library: the skip path returns before the args.Yes check that
+			// guards the read-path write, so "preview" silently wrote rows. A
+			// preview that mutates is worse than no preview, because the operator
+			// has been told it is safe.
+			case ok && args.Yes:
 				if derr := durations.Record(ctx, canonPath, mtimeNano, size, facts.TrackLength); derr != nil {
 					slog.Warn("index-metadata: could not bank duration from the metadata row", "file", canonPath, "error", derr)
 				}

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -833,3 +833,85 @@ func TestIndexMetadataDurationBankFailureIsNonFatal(t *testing.T) {
 		t.Errorf("audio_metadata rows = %d, want 1: a duration-bank failure must not cost the file its index entry", n)
 	}
 }
+
+// TestIndexMetadataBanksDurationOnCacheHitWithoutReading is the #724 regression.
+//
+// #720 attached the duration bank to the READ path, but walkIndexMetadata
+// consults audio_metadata and returns early on a hit BEFORE ReadAudioFacts is
+// called -- so a file already indexed by an older build could never gain a
+// duration row. Measured on prod: 12,990 rows had a metadata row and no
+// duration row, and the sweep banked exactly zero of them, twice.
+//
+// The state under test is the one that exists in production and that no other
+// test in this file constructs: audio_metadata CURRENT, audio_durations ABSENT.
+// Every other test starts from an empty DB, so the walk always reaches the read
+// and this path is never entered.
+//
+// It must also bank WITHOUT opening the audio file, which is the whole point --
+// the duration is already in the metadata row. The audio file is deleted after
+// indexing, so any attempt to read it would fail loudly rather than silently
+// passing for the wrong reason.
+func TestIndexMetadataBanksDurationOnCacheHitWithoutReading(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t)
+	ctx := context.Background()
+
+	const sampleRate, totalSamples = 44100, 44100 // exactly 1 second
+	flacPath := filepath.Join(root, "known.flac")
+	if err := os.WriteFile(flacPath, testutil.GenerateFLAC(sampleRate, totalSamples), 0o600); err != nil {
+		t.Fatalf("write flac fixture: %v", err)
+	}
+
+	// Pass 1: populate audio_metadata normally.
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first pass exit = %d: %s", code, first.String())
+	}
+	if n := countAudioMetadataRows(t, dbPath); n != 1 {
+		t.Fatalf("setup: audio_metadata rows = %d, want 1", n)
+	}
+
+	// Now forge the production state: delete the duration row that pass 1 wrote,
+	// leaving the metadata row current. This is what an upgrade from a build that
+	// indexed metadata but never banked durations looks like on disk.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, "DELETE FROM audio_durations"); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("clear audio_durations: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close after clear: %v", err)
+	}
+	if n := countAudioDurationRows(t, dbPath); n != 0 {
+		t.Fatalf("setup: audio_durations rows = %d, want 0", n)
+	}
+
+	// Pass 2 must bank the duration from the metadata row WITHOUT reading the
+	// file. Make the audio UNREADABLE rather than deleting it: the walk must
+	// still find and stat it (a deleted file is never visited at all, so the
+	// skip path under test would not be reached and the test would pass or fail
+	// for the wrong reason), but any attempt to OPEN it fails loudly.
+	if err := os.Chmod(flacPath, 0o000); err != nil {
+		t.Fatalf("chmod audio fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(flacPath, 0o600) }) // so t.TempDir cleanup can remove it
+
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("second pass exit = %d: %s", code, second.String())
+	}
+
+	if n := countAudioDurationRows(t, dbPath); n != 1 {
+		t.Fatalf("audio_durations rows = %d, want 1: a file already in audio_metadata must still gain its duration row, sourced from that row rather than from a re-read", n)
+	}
+	absRoot, canonRoot := pathutil.CanonicalRoot(root)
+	got, found := bankedDuration(t, dbPath, pathutil.RebaseUnderCanonicalRoot(absRoot, canonRoot, flacPath))
+	if !found {
+		t.Fatalf("no audio_durations row for the indexed file")
+	}
+	if want := totalSamples / sampleRate; got != want {
+		t.Errorf("banked duration = %ds, want %ds: the value must come from the metadata row, not a guess", got, want)
+	}
+}

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -915,3 +915,50 @@ func TestIndexMetadataBanksDurationOnCacheHitWithoutReading(t *testing.T) {
 		t.Errorf("banked duration = %ds, want %ds: the value must come from the metadata row, not a guess", got, want)
 	}
 }
+
+// TestIndexMetadataCacheHitDurationBankFailureIsNonFatal covers the degraded
+// branch of the #724 skip-path bank: the metadata row is current (so the walk
+// takes the cache-hit path) but banking the duration fails. That must warn and
+// continue, exactly as the read path does -- audio_metadata is this command's
+// product, audio_durations an opportunistic byproduct, so a byproduct failure
+// must never fail a run whose real work already succeeded.
+func TestIndexMetadataCacheHitDurationBankFailureIsNonFatal(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t)
+	ctx := context.Background()
+
+	if err := os.WriteFile(filepath.Join(root, "known.flac"),
+		testutil.GenerateFLAC(44100, 44100), 0o600); err != nil {
+		t.Fatalf("write flac fixture: %v", err)
+	}
+
+	// Pass 1 populates audio_metadata, so pass 2 takes the cache-hit path.
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first pass exit = %d: %s", code, first.String())
+	}
+
+	// Break ONLY the duration store, leaving audio_metadata intact: the Lookup
+	// still hits, the walk still takes the skip path, and Record then fails on a
+	// missing relation.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, "DROP TABLE audio_durations"); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("drop audio_durations: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close after drop: %v", err)
+	}
+
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("a cache-hit duration-bank failure must not fail the run; exit = %d: %s", code, second.String())
+	}
+	// The file must still be reported as skipped -- the failed bank must not
+	// change how the walk classifies it.
+	if !strings.Contains(second.String(), "1 skipped") {
+		t.Errorf("the unchanged file must still count as skipped; got: %s", second.String())
+	}
+}

--- a/internal/commands/index_metadata_test.go
+++ b/internal/commands/index_metadata_test.go
@@ -889,14 +889,37 @@ func TestIndexMetadataBanksDurationOnCacheHitWithoutReading(t *testing.T) {
 	}
 
 	// Pass 2 must bank the duration from the metadata row WITHOUT reading the
-	// file. Make the audio UNREADABLE rather than deleting it: the walk must
-	// still find and stat it (a deleted file is never visited at all, so the
-	// skip path under test would not be reached and the test would pass or fail
-	// for the wrong reason), but any attempt to OPEN it fails loudly.
-	if err := os.Chmod(flacPath, 0o000); err != nil {
-		t.Fatalf("chmod audio fixture: %v", err)
+	// file. Corrupt the CONTENTS rather than the permissions: a 0o000 fixture is
+	// still readable by a root test process (CI images often run as root), so a
+	// permissions-based guard would let a re-read regression pass silently.
+	// Same-size garbage keeps the (mtime, size) identity the cache hit is keyed
+	// on -- restored below -- while making any parse deterministically fail.
+	//
+	// The file must still EXIST: deleting it means WalkDir never visits it, so
+	// the skip path under test is never reached and the test would pass for the
+	// wrong reason. That is not hypothetical; it was the first version of this
+	// test.
+	origInfo, err := os.Stat(flacPath)
+	if err != nil {
+		t.Fatalf("stat fixture before corrupting: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(flacPath, 0o600) }) // so t.TempDir cleanup can remove it
+	if err := os.WriteFile(flacPath, bytes.Repeat([]byte{0x00}, int(origInfo.Size())), 0o600); err != nil {
+		t.Fatalf("corrupt audio fixture: %v", err)
+	}
+	if err := os.Chtimes(flacPath, origInfo.ModTime(), origInfo.ModTime()); err != nil {
+		t.Fatalf("restore fixture mtime: %v", err)
+	}
+	// Verify the identity the cache hit depends on actually survived, so a
+	// failure below means "the duration was not banked" rather than "the fixture
+	// drifted and the lookup missed".
+	newInfo, err := os.Stat(flacPath)
+	if err != nil {
+		t.Fatalf("stat fixture after corrupting: %v", err)
+	}
+	if newInfo.Size() != origInfo.Size() || !newInfo.ModTime().Equal(origInfo.ModTime()) {
+		t.Fatalf("fixture identity drifted: size %d->%d, mtime %v->%v",
+			origInfo.Size(), newInfo.Size(), origInfo.ModTime(), newInfo.ModTime())
+	}
 
 	var second bytes.Buffer
 	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
@@ -960,5 +983,54 @@ func TestIndexMetadataCacheHitDurationBankFailureIsNonFatal(t *testing.T) {
 	// change how the walk classifies it.
 	if !strings.Contains(second.String(), "1 skipped") {
 		t.Errorf("the unchanged file must still count as skipped; got: %s", second.String())
+	}
+}
+
+// TestIndexMetadataDryRunWritesNoDurationOnCacheHit pins the dry-run contract on
+// the #724 skip path. TestIndexMetadataDryRunWritesNothing asserts only that
+// audio_metadata stays empty, so it could never have caught a write to the OTHER
+// table -- which is exactly the gap the cache-hit bank opened: the skip path ran
+// before any args.Yes check, so a dry run over an already-indexed library
+// mutated audio_durations.
+//
+// Dry-run must write NOTHING. A command whose preview mutates the database is
+// worse than one with no preview at all, because the operator has been told it
+// is safe.
+func TestIndexMetadataDryRunWritesNoDurationOnCacheHit(t *testing.T) {
+	cfgPath, dbPath, root := setupIndexMetadata(t)
+	ctx := context.Background()
+
+	if err := os.WriteFile(filepath.Join(root, "known.flac"),
+		testutil.GenerateFLAC(44100, 44100), 0o600); err != nil {
+		t.Fatalf("write flac fixture: %v", err)
+	}
+
+	// Pass 1 (--yes) populates audio_metadata so pass 2 takes the cache-hit path.
+	var first bytes.Buffer
+	if code := runIndexMetadata(ctx, &first, ScanIndexMetadataCmd{ConfigPath: cfgPath, Yes: true}); code != 0 {
+		t.Fatalf("first pass exit = %d: %s", code, first.String())
+	}
+
+	// Clear the duration rows pass 1 wrote, leaving the metadata rows current.
+	sqlDB, err := db.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, "DELETE FROM audio_durations"); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("clear audio_durations: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close after clear: %v", err)
+	}
+
+	// Pass 2 WITHOUT --yes: the walk takes the skip path and must write nothing.
+	var second bytes.Buffer
+	if code := runIndexMetadata(ctx, &second, ScanIndexMetadataCmd{ConfigPath: cfgPath}); code != 0 {
+		t.Fatalf("dry run exit = %d: %s", code, second.String())
+	}
+
+	if n := countAudioDurationRows(t, dbPath); n != 0 {
+		t.Errorf("dry run wrote %d audio_durations row(s), want 0: a preview must never mutate the database", n)
 	}
 }


### PR DESCRIPTION
## Summary

- **This fixes a regression I shipped in #720.** That change attached the duration write to the read path, but `walkIndexMetadata` consults `audio_metadata` and returns early on a cache hit **before** `ReadAudioFacts` runs. Every file already indexed by an older build therefore hit the cache, skipped the open, and could never gain a duration row. Measured on prod at v1.32.1: 12,990 rows had a current metadata row and no duration row, and the sweep banked **exactly zero** of them across two runs.
- The skip is correct and load-bearing -- it is what makes a re-run over an unchanged library nearly free on spun-down disks -- so the bank belongs **on the skip path**, not in weakening the skip.
- **The gap closes DB-to-DB with no file opens.** Measured against prod, all 12,990 of those rows already carry `duration_seconds > 0` in `audio_metadata`. `Facts` re-queries the row the `Lookup` just validated against the same `(mtime, size)`, so this costs one indexed SELECT rather than a spin-up per file -- strictly cheaper than the read path it complements, which matters on an array this project works to keep asleep.

## Linked issue

Closes #724

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; no critical or important findings.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite). **Deliberately unchecked -- see Not covered.**
- [x] Screenshot attached for any web-UI change -- N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A.
- [x] Migration added under `internal/db/migrations/` -- N/A. No schema change; this fills existing rows through the normal `audiodur.Store.Record` upsert.

## Test plan

- [x] `make gate` passes locally. Verified from the run log rather than the exit code: `OK: all pre-push checks passed`, zero FAIL lines, 0 vulnerabilities.
- [x] **The new test was confirmed red against unfixed code, twice**: once before the fix was written, and again by mutation after (removing the cache-hit bank makes it fail at its assertion, `audio_durations rows = 0, want 1` -- not at a build or setup error).
- [x] **The test constructs the production state that no other test in the file does**: `audio_metadata` current, `audio_durations` absent. Every existing test starts from an empty DB, so the walk always reaches the read and the skip path is never entered -- which is precisely why #720's defect shipped with a green suite.
- [x] **The "no file is opened" claim is tested, not asserted.** The fixture chmods the audio to `0000` after indexing, so the walk still visits and stats it while any open fails loudly. A first attempt *deleted* the file instead; that made the test pass for the wrong reason, because `WalkDir` never visits a deleted file and the skip path was never reached at all. Worth stating because it is the same class of mistake as the bug itself.
- [x] A metadata row with a non-positive duration banks nothing: `audiodur.Record` no-ops, preserving "absence means unknown" rather than storing a misleading 0.
- [ ] Reviewer follow-ups:
  - [ ] The duration write is non-fatal on **both** paths now. Worth confirming that asymmetry still reads correctly with two call sites rather than one.

## Not covered

**The claim that matters most in this PR is unverified.** A green suite is exactly what #720 had, and it banked zero rows on real data. So, stated plainly:

- **No production run has happened.** The 12,990 -> ~0 measurement requires this to be released and `scan index-metadata --yes` run against the live library. Until that number exists, "the gap closes" is a claim, not a result. #724's acceptance criteria require that measurement rather than a passing test.
- **v1.32.1's release notes are wrong and need correcting.** They instruct an operator to run `scan index-metadata --yes` to close the gap in one pass, which is precisely what does not work. That correction is not in this PR.
- **This does not address why this keeps recurring.** Ten issues now target this one gap (#441, #641, #643, #650, #651, #711, #713, #717, #720, #724), six closed in the last five days, and every one was found by a human noticing a symptom on prod -- none by a test. #717's Gap 3 (an enumeration test asserting every audio-read site is cache-gated or explicitly allowlisted) is the item that would have made this defect unshippable rather than merely findable afterward. I closed #717 having done the cheap half and scoped that out; it should be tracked and built.
- The `scan_results` (64,394) vs `audio_metadata` (84,430) count difference is a separate question, untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duration information not being recorded when existing audio metadata is reused.
  * Duration data can now be restored from cached metadata without reopening or rereading the audio file.
  * Improved resilience by treating failures during this recovery as non-blocking warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->