### PR TITLE
fix(detector,verification,db): bound captured subprocess output in last_error

### DIFF
--- a/internal/db/migration_043_test.go
+++ b/internal/db/migration_043_test.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/ffmpeg"
+)
+
+// Migration 043 bounds oversized work_queue.last_error values already stored
+// (#731). Asserted against the REAL migration via openAtVersion -- see the
+// comment on that helper in migration_038_test.go for why a hand-executed copy
+// of the UPDATE proves nothing.
+//
+// The behaviors that matter are the ones a careless bound gets wrong: an
+// oversized value must lose its middle while keeping BOTH ends (a head-only
+// truncation discards the terminating line that carries the actual cause), and
+// an ordinary value must come through byte-identical rather than being reformatted
+// by a statement that matched more rows than it should.
+func TestMigration043BoundsOnlyOversizedLastErrors(t *testing.T) {
+	ctx := context.Background()
+	dbh, provider := openAtVersion(t, 42) // the state a real deployment upgrades FROM
+
+	const (
+		firstLine = "FIRSTLINE decoder opened"
+		lastLine  = "LASTLINE decode error rate exceeds maximum"
+	)
+	oversized := firstLine + "\n" + strings.Repeat("Header missing\n", 20000) + lastLine
+	ordinary := "musixmatch: no results found"
+	// Exactly at the threshold: the WHERE clause is strictly greater-than, so this
+	// must NOT be touched. An off-by-one that used >= would reformat it.
+	atCap := strings.Repeat("z", 4096)
+
+	insert := `INSERT INTO work_queue (id, artist_key, title_key, artist, title, source_path, status, last_error, updated_at)
+	           VALUES (?, ?, ?, 'a', 't', '/x.mp3', 'deferred', ?, '2026-08-04T00:00:00Z')`
+	for _, r := range []struct {
+		id  int64
+		key string
+		val any
+	}{
+		{801, "k1", oversized},
+		{802, "k2", ordinary},
+		{803, "k3", atCap},
+		// No NULL case: work_queue.last_error is NOT NULL, so the schema already
+		// rules it out and an inserted NULL fails the constraint rather than
+		// reaching the migration.
+	} {
+		if _, err := dbh.ExecContext(ctx, insert, r.id, r.key, r.key, r.val); err != nil {
+			t.Fatalf("insert %d: %v", r.id, err)
+		}
+	}
+
+	if _, err := provider.UpTo(ctx, 43); err != nil {
+		t.Fatalf("migrate to 43: %v", err)
+	}
+
+	get := func(id int64) string {
+		var s string
+		if err := dbh.QueryRowContext(ctx, `SELECT last_error FROM work_queue WHERE id = ?`, id).Scan(&s); err != nil {
+			t.Fatalf("select %d: %v", id, err)
+		}
+		return s
+	}
+
+	got := get(801)
+	if len(got) > 4096 {
+		t.Errorf("oversized value still exceeds the cap: %d bytes", len(got))
+	}
+	if !strings.Contains(got, firstLine) {
+		t.Error("bound dropped the head, which names the failing decoder")
+	}
+	if !strings.Contains(got, lastLine) {
+		t.Error("bound dropped the tail, which carries the terminating cause")
+	}
+	if !strings.Contains(got, "omitted") {
+		t.Error("bounded value does not announce its elision, so it reads as complete")
+	}
+
+	if got := get(802); got != ordinary {
+		t.Errorf("ordinary value was altered:\n got %q\nwant %q", got, ordinary)
+	}
+	if got := get(803); got != atCap {
+		t.Errorf("value exactly at the cap was altered (off-by-one in the WHERE clause): got %d chars", len(got))
+	}
+}
+
+// The migration reimplements ffmpeg.BoundOutput's policy in SQL because SQLite
+// cannot call into Go. That makes the two independently editable and therefore
+// able to drift: raising the Go cap while leaving the migration at 4096 would
+// leave the database enforcing a stricter rule than the code, silently.
+//
+// This pins them together. It asserts the CEILING rather than exact equality --
+// the SQL marker's length varies slightly with the magnitude of the omitted
+// count, and SQLite counts characters where Go counts bytes, so the SQL result
+// can land marginally under. Under is the safe direction for a size bound; over
+// is the regression worth failing on.
+func TestMigration043BoundMatchesBoundOutput(t *testing.T) {
+	ctx := context.Background()
+	dbh, provider := openAtVersion(t, 42)
+
+	oversized := "HEAD marker\n" + strings.Repeat("noise\n", 50000) + "TAIL marker"
+
+	if _, err := dbh.ExecContext(ctx,
+		`INSERT INTO work_queue (id, artist_key, title_key, artist, title, source_path, status, last_error, updated_at)
+		 VALUES (811, 'p1', 'p1', 'a', 't', '/x.mp3', 'deferred', ?, '2026-08-04T00:00:00Z')`,
+		oversized); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 43); err != nil {
+		t.Fatalf("migrate to 43: %v", err)
+	}
+
+	var sqlBounded string
+	if err := dbh.QueryRowContext(ctx, `SELECT last_error FROM work_queue WHERE id = 811`).Scan(&sqlBounded); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	goBounded := ffmpeg.BoundOutput(oversized)
+
+	if len(sqlBounded) > len(goBounded) {
+		t.Errorf("the migration's bound is LOOSER than ffmpeg.BoundOutput -- the two have drifted:\n"+
+			"  SQL kept %d bytes, Go kept %d bytes", len(sqlBounded), len(goBounded))
+	}
+	// Both must preserve the same ends, or they disagree about WHICH bytes matter
+	// rather than merely how many.
+	for _, want := range []string{"HEAD marker", "TAIL marker"} {
+		if !strings.Contains(sqlBounded, want) {
+			t.Errorf("SQL bound dropped %q, which ffmpeg.BoundOutput retains", want)
+		}
+		if !strings.Contains(goBounded, want) {
+			t.Errorf("ffmpeg.BoundOutput dropped %q, which the SQL bound retains", want)
+		}
+	}
+}

--- a/internal/db/migration_043_test.go
+++ b/internal/db/migration_043_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/sydlexius/canticle/internal/ffmpeg"
 )
@@ -85,50 +86,81 @@ func TestMigration043BoundsOnlyOversizedLastErrors(t *testing.T) {
 	}
 }
 
-// The migration reimplements ffmpeg.BoundOutput's policy in SQL because SQLite
-// cannot call into Go. That makes the two independently editable and therefore
-// able to drift: raising the Go cap while leaving the migration at 4096 would
-// leave the database enforcing a stricter rule than the code, silently.
+// The migration reimplements BoundOutput's policy in SQL because SQLite cannot
+// call into Go, so the two are independently editable and can drift.
 //
-// This pins them together. It asserts the CEILING rather than exact equality --
-// the SQL marker's length varies slightly with the magnitude of the omitted
-// count, and SQLite counts characters where Go counts bytes, so the SQL result
-// can land marginally under. Under is the safe direction for a size bound; over
-// is the regression worth failing on.
+// BOTH SIDES ARE PINNED TO A HARD LITERAL, not to each other. An earlier version
+// of this test asserted only `len(sql) > len(go)`, which is one-sided and
+// therefore vacuous in the direction that actually happens: raising
+// maxCapturedOutput makes the Go result BIGGER, so the comparison is satisfied
+// MORE easily and the test passes under the exact drift its comment claimed to
+// catch (verified -- setting the constant to 1048576 left this green). A test
+// that passes under the drift it names is worse than none: it is a false
+// assurance a future editor will trust.
+//
+// The literal 4096 is the contract both implementations must satisfy. The two
+// are NOT required to produce identical output -- the SQL cut is deliberately
+// more conservative, since it must assume worst-case 4-byte runes to stay
+// byte-bounded without splitting one. What must hold for both is: at or under
+// the byte cap, and both diagnostic ends retained.
 func TestMigration043BoundMatchesBoundOutput(t *testing.T) {
 	ctx := context.Background()
 	dbh, provider := openAtVersion(t, 42)
 
-	oversized := "HEAD marker\n" + strings.Repeat("noise\n", 50000) + "TAIL marker"
-
-	if _, err := dbh.ExecContext(ctx,
-		`INSERT INTO work_queue (id, artist_key, title_key, artist, title, source_path, status, last_error, updated_at)
-		 VALUES (811, 'p1', 'p1', 'a', 't', '/x.mp3', 'deferred', ?, '2026-08-04T00:00:00Z')`,
-		oversized); err != nil {
-		t.Fatalf("insert: %v", err)
+	// ASCII and multi-byte. The multi-byte case is the one that caught the real
+	// defect: a character-counting migration bounded 12,000 bytes to "4,096"
+	// characters that were 8,162 bytes, and let a 3,000-character/12,000-byte
+	// value through untouched because length() never saw it as oversized.
+	cases := []struct {
+		id        int64
+		key       string
+		oversized string
+	}{
+		{811, "p1", "HEAD marker\n" + strings.Repeat("noise\n", 50000) + "TAIL marker"},
+		{812, "p2", "HEAD marker\n" + strings.Repeat("é", 200000) + "\nTAIL marker"},
+		{813, "p3", "HEAD marker\n" + strings.Repeat("😀", 100000) + "\nTAIL marker"},
+		// Under the character threshold but far OVER the byte threshold: the exact
+		// shape that evaded the first draft's WHERE clause entirely.
+		{814, "p4", "HEAD marker\n" + strings.Repeat("😀", 3000) + "\nTAIL marker"},
+	}
+	for _, c := range cases {
+		if _, err := dbh.ExecContext(ctx,
+			`INSERT INTO work_queue (id, artist_key, title_key, artist, title, source_path, status, last_error, updated_at)
+			 VALUES (?, ?, ?, 'a', 't', '/x.mp3', 'deferred', ?, '2026-08-04T00:00:00Z')`,
+			c.id, c.key, c.key, c.oversized); err != nil {
+			t.Fatalf("insert %d: %v", c.id, err)
+		}
 	}
 	if _, err := provider.UpTo(ctx, 43); err != nil {
 		t.Fatalf("migrate to 43: %v", err)
 	}
 
-	var sqlBounded string
-	if err := dbh.QueryRowContext(ctx, `SELECT last_error FROM work_queue WHERE id = 811`).Scan(&sqlBounded); err != nil {
-		t.Fatalf("select: %v", err)
-	}
-	goBounded := ffmpeg.BoundOutput(oversized)
-
-	if len(sqlBounded) > len(goBounded) {
-		t.Errorf("the migration's bound is LOOSER than ffmpeg.BoundOutput -- the two have drifted:\n"+
-			"  SQL kept %d bytes, Go kept %d bytes", len(sqlBounded), len(goBounded))
-	}
-	// Both must preserve the same ends, or they disagree about WHICH bytes matter
-	// rather than merely how many.
-	for _, want := range []string{"HEAD marker", "TAIL marker"} {
-		if !strings.Contains(sqlBounded, want) {
-			t.Errorf("SQL bound dropped %q, which ffmpeg.BoundOutput retains", want)
+	for _, c := range cases {
+		var sqlBounded string
+		if err := dbh.QueryRowContext(ctx,
+			`SELECT last_error FROM work_queue WHERE id = ?`, c.id).Scan(&sqlBounded); err != nil {
+			t.Fatalf("select %d: %v", c.id, err)
 		}
-		if !strings.Contains(goBounded, want) {
-			t.Errorf("ffmpeg.BoundOutput dropped %q, which the SQL bound retains", want)
+		goBounded := ffmpeg.BoundOutput(c.oversized)
+
+		if len(sqlBounded) > 4096 {
+			t.Errorf("id %d: the migration left %d BYTES, over the 4096 cap", c.id, len(sqlBounded))
+		}
+		if len(goBounded) > 4096 {
+			t.Errorf("id %d: ffmpeg.BoundOutput left %d BYTES, over the 4096 cap", c.id, len(goBounded))
+		}
+		if !utf8.ValidString(sqlBounded) {
+			t.Errorf("id %d: the migration produced invalid UTF-8", c.id)
+		}
+		// Both must preserve the same ends, or they disagree about WHICH bytes
+		// matter rather than merely how many.
+		for _, want := range []string{"HEAD marker", "TAIL marker"} {
+			if !strings.Contains(sqlBounded, want) {
+				t.Errorf("id %d: SQL bound dropped %q", c.id, want)
+			}
+			if !strings.Contains(goBounded, want) {
+				t.Errorf("id %d: ffmpeg.BoundOutput dropped %q", c.id, want)
+			}
 		}
 	}
 }

--- a/internal/db/migrations/043_work_queue_last_error_bound.sql
+++ b/internal/db/migrations/043_work_queue_last_error_bound.sql
@@ -62,9 +62,22 @@
 -- is a no-op independently of goose. An ordinary last_error is left
 -- byte-identical.
 --
--- LOSSY BY DESIGN, AND THAT IS THE POINT. The omitted BYTE count is written into
--- the marker so the elision is self-describing and a reader can never mistake a
--- bounded value for a complete one.
+-- LOSSY BY DESIGN, AND THAT IS THE POINT. A marker is written into the middle so
+-- the elision is self-describing and a reader can never mistake a bounded value
+-- for a complete one.
+--
+-- THE NUMBER IN THAT MARKER IS "BYTES OVER THE CAP", NOT BYTES DROPPED, and it
+-- is deliberately the weaker of the two claims. The count actually omitted is
+-- larger: the marker and its two newlines occupy part of the budget, and the
+-- worst-case-rune character budget above retains less than the byte cap would
+-- allow -- on ASCII, roughly 3,000 bytes less. Computing the exact figure in SQL
+-- would mean measuring the retained head and tail after the fact, which the
+-- single-statement form cannot do without a second pass.
+--
+-- The Go helper DOES restate its count exactly (ffmpeg.BoundOutput), so the two
+-- differ here on purpose. A reader who needs an exact number should not infer one
+-- from this marker: it is a lower bound on what was removed, and is written as a
+-- floor rather than a measurement.
 --
 -- THIS IS NOT REDACTION. It bounds SIZE only. Secrets are kept out of these
 -- strings at their construction sites (#431); a size cap is as likely to

--- a/internal/db/migrations/043_work_queue_last_error_bound.sql
+++ b/internal/db/migrations/043_work_queue_last_error_bound.sql
@@ -1,0 +1,94 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Bound oversized work_queue.last_error values already stored (#731).
+--
+-- WHY A MIGRATION AND NOT ONLY THE CODE FIX. The accompanying change caps
+-- captured subprocess output at its three capture sites, so no NEW oversized
+-- value can be written. It does nothing for values already in the database, and
+-- those persist indefinitely: a 'deferred' row keeps its last_error until it
+-- eventually succeeds, and a row whose source file is corrupt never will. Every
+-- install that has ever fed a corrupt audio file to the detector is carrying
+-- these rows right now, so shipping the code fix alone would leave the actual
+-- symptom -- a report screen rendering hundreds of kilobytes -- in place on
+-- exactly the deployments that hit the bug.
+--
+-- On the deployment this was diagnosed against, ONE row held 531,138 bytes of
+-- raw ffmpeg stderr: 34% of every last_error byte in the database (1,549,278
+-- total across all rows). The content is ffmpeg's per-frame decode diagnostics
+-- on a corrupt MP3 -- one 'Header missing' line per bad frame until the
+-- decode-error-rate ceiling aborts the run.
+--
+-- THE POLICY MIRRORS ffmpeg.BoundOutput DELIBERATELY. Head and tail are kept
+-- and the middle is elided, because the two ends carry different information:
+-- the opening lines name the stream and decoder that failed, and the closing
+-- lines carry the cause that actually terminated the run. A plain head
+-- truncation would keep the symptom and discard the diagnosis. The retained
+-- sizes and the marker text are kept in step with internal/ffmpeg/capture.go;
+-- TestMigrationBoundMatchesBoundOutput pins the two together so a change to the
+-- Go cap that forgets this file fails the build rather than drifting silently.
+--
+-- CHARACTERS VS BYTES. SQLite's length() and substr() count CHARACTERS, while
+-- the Go cap counts BYTES. Two consequences, both benign. First, substr can
+-- never split a multi-byte rune, so the UTF-8 hazard handled explicitly in Go is
+-- structurally absent here. Second, for non-ASCII text this cap is CONSERVATIVE
+-- (a 4096-character result is at most 4096 bytes only when every character is
+-- ASCII), so a row bounded here is always at or under the Go byte cap, never
+-- over. Erring small is the safe direction for a value whose whole problem was
+-- being too large.
+--
+-- ONLY OVERSIZED ROWS ARE TOUCHED. The WHERE clause means an ordinary
+-- last_error -- the overwhelming majority, all well under the cap -- is left
+-- byte-identical. The statement is re-runnable: a row already bounded is shorter
+-- than the threshold and no longer matches, so re-applying this is a no-op
+-- independently of goose.
+--
+-- LOSSY BY DESIGN, AND THAT IS THE POINT. The elided middle is the same line
+-- repeated thousands of times; it carries no information the head and tail do
+-- not already give. The omitted-byte count is written into the marker so the
+-- elision is self-describing and a reader can never mistake a bounded value for
+-- a complete one.
+--
+-- THIS IS NOT REDACTION. It bounds SIZE only. Secrets are kept out of these
+-- strings at their construction sites (#431); a size cap is as likely to
+-- preserve a secret as to cut one, and must never be relied on as a control.
+--
+-- Side effect: the update_work_queue_updated_at trigger (migration 012) fires on
+-- each touched row, so updated_at is rewritten to the deploy timestamp for the
+-- rows corrected here. Cosmetic, and the blast radius is tiny (single-digit rows
+-- on the reference database, versus ~48k for migration 032, which documented the
+-- same effect). Noted so the bump is not mistaken for real churn.
+-- THE RETAINED SIZES ARE DERIVED, NOT HARDCODED. The marker embeds the omitted
+-- count, so its length varies with that number's magnitude -- a fixed head/tail
+-- split is therefore off by a character or two depending on the input, and a
+-- first draft of this statement overshot the cap by exactly one byte because of
+-- it. Computing the head from the marker's ACTUAL rendered length keeps the
+-- result at or under the cap for every input instead of for the one that was
+-- tested. TestMigration043BoundMatchesBoundOutput pins this against
+-- ffmpeg.BoundOutput so the two cannot drift apart silently.
+--
+-- The tail is fixed at 2033 and the head absorbs the variation, because the tail
+-- carries the terminating cause -- the most valuable line in the stream -- and
+-- should not shrink to pay for a longer count.
+UPDATE work_queue
+SET last_error =
+    substr(
+        last_error,
+        1,
+        4096 - 2033 - 2 - length('... [' || (length(last_error) - 4096) || ' bytes omitted] ...')
+    )
+    || char(10)
+    || '... [' || (length(last_error) - 4096) || ' bytes omitted] ...'
+    || char(10)
+    || substr(last_error, -2033)
+WHERE length(last_error) > 4096;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Irreversible by design: the elided text is discarded, not stashed, so there is
+-- nothing to restore it from. That is deliberate -- retaining a copy would keep
+-- the bytes this migration exists to remove. Deliberate no-op; restore from
+-- backup if a full stderr stream must be recovered. (Matches migrations 028 and
+-- 032.)
+SELECT 1;
+-- +goose StatementEnd

--- a/internal/db/migrations/043_work_queue_last_error_bound.sql
+++ b/internal/db/migrations/043_work_queue_last_error_bound.sql
@@ -9,8 +9,8 @@
 -- eventually succeeds, and a row whose source file is corrupt never will. Every
 -- install that has ever fed a corrupt audio file to the detector is carrying
 -- these rows right now, so shipping the code fix alone would leave the actual
--- symptom -- a report screen rendering hundreds of kilobytes -- in place on
--- exactly the deployments that hit the bug.
+-- symptom -- a report screen and a /metrics label rendering hundreds of
+-- kilobytes -- in place on exactly the deployments that hit the bug.
 --
 -- On the deployment this was diagnosed against, ONE row held 531,138 bytes of
 -- raw ffmpeg stderr: 34% of every last_error byte in the database (1,549,278
@@ -18,35 +18,53 @@
 -- on a corrupt MP3 -- one 'Header missing' line per bad frame until the
 -- decode-error-rate ceiling aborts the run.
 --
--- THE POLICY MIRRORS ffmpeg.BoundOutput DELIBERATELY. Head and tail are kept
--- and the middle is elided, because the two ends carry different information:
--- the opening lines name the stream and decoder that failed, and the closing
--- lines carry the cause that actually terminated the run. A plain head
--- truncation would keep the symptom and discard the diagnosis. The retained
--- sizes and the marker text are kept in step with internal/ffmpeg/capture.go;
--- TestMigrationBoundMatchesBoundOutput pins the two together so a change to the
--- Go cap that forgets this file fails the build rather than drifting silently.
+-- BYTES, NOT CHARACTERS -- AND THIS IS THE SUBTLE PART. SQLite's length() and
+-- substr() count CHARACTERS; Go's cap counts BYTES. A first draft of this
+-- migration used length()/substr() throughout and was WRONG IN BOTH DIRECTIONS
+-- on non-ASCII input:
 --
--- CHARACTERS VS BYTES. SQLite's length() and substr() count CHARACTERS, while
--- the Go cap counts BYTES. Two consequences, both benign. First, substr can
--- never split a multi-byte rune, so the UTF-8 hazard handled explicitly in Go is
--- structurally absent here. Second, for non-ASCII text this cap is CONSERVATIVE
--- (a 4096-character result is at most 4096 bytes only when every character is
--- ASCII), so a row bounded here is always at or under the Go byte cap, never
--- over. Erring small is the safe direction for a value whose whole problem was
--- being too large.
+--   * A 12,000-character value of 2-byte runes bounded to 4,096 CHARACTERS --
+--     8,162 BYTES, double the cap it was supposed to enforce.
+--   * A 3,000-character value of 4-byte runes is 12,000 bytes, but length()
+--     reports 3,000, so `WHERE length(...) > 4096` never matched and the row
+--     escaped bounding ENTIRELY.
 --
--- ONLY OVERSIZED ROWS ARE TOUCHED. The WHERE clause means an ordinary
--- last_error -- the overwhelming majority, all well under the cap -- is left
--- byte-identical. The statement is re-runnable: a row already bounded is shorter
--- than the threshold and no longer matches, so re-applying this is a no-op
--- independently of goose.
+-- The predicate below therefore measures length(CAST(... AS BLOB)), the true
+-- byte length, so an oversized-in-bytes row can never evade it.
 --
--- LOSSY BY DESIGN, AND THAT IS THE POINT. The elided middle is the same line
--- repeated thousands of times; it carries no information the head and tail do
--- not already give. The omitted-byte count is written into the marker so the
--- elision is self-describing and a reader can never mistake a bounded value for
--- a complete one.
+-- THE CUT IS DELIBERATELY MORE CONSERVATIVE THAN ffmpeg.BoundOutput. The Go
+-- helper cuts at a byte offset and walks back to a rune boundary. SQL has no
+-- cheap equivalent: a byte-wise substr over a BLOB would split a rune and put
+-- invalid UTF-8 into a TEXT column (and from there into the HTML report), while
+-- a character-wise substr cannot predict its own byte length. So the character
+-- budget here is derived from the byte budget assuming the WORST CASE of 4
+-- bytes per character. That is exact for the pathological population (ffmpeg
+-- stderr is ASCII) in the sense that it never exceeds the cap, and for ASCII it
+-- retains ~1,046 characters rather than the ~4,065 the Go helper would keep.
+--
+-- Retaining less is the correct direction to err for a value whose entire defect
+-- was being too large, and it costs nothing real: on the row that motivated this,
+-- the whole diagnostic payload -- the line naming the failing decoder and the
+-- 'Decode error rate exceeds maximum' line that terminated the run -- is roughly
+-- 450 characters. The middle that is dropped is one line repeated thousands of
+-- times.
+--
+-- Because the cut is character-wise it can never split a rune, so the output is
+-- always valid UTF-8 without any boundary repair.
+--
+-- HEAD AND TAIL, NOT A PREFIX. Both ends are kept because they carry different
+-- information: the opening lines name the stream and decoder that failed, and
+-- the closing lines carry the cause that actually terminated the run. A plain
+-- head truncation would keep the symptom and discard the diagnosis.
+--
+-- ONLY OVERSIZED ROWS ARE TOUCHED, and the statement is re-runnable: a bounded
+-- row is far under the byte threshold and no longer matches, so re-applying this
+-- is a no-op independently of goose. An ordinary last_error is left
+-- byte-identical.
+--
+-- LOSSY BY DESIGN, AND THAT IS THE POINT. The omitted BYTE count is written into
+-- the marker so the elision is self-describing and a reader can never mistake a
+-- bounded value for a complete one.
 --
 -- THIS IS NOT REDACTION. It bounds SIZE only. Secrets are kept out of these
 -- strings at their construction sites (#431); a size cap is as likely to
@@ -57,30 +75,28 @@
 -- rows corrected here. Cosmetic, and the blast radius is tiny (single-digit rows
 -- on the reference database, versus ~48k for migration 032, which documented the
 -- same effect). Noted so the bump is not mistaken for real churn.
--- THE RETAINED SIZES ARE DERIVED, NOT HARDCODED. The marker embeds the omitted
--- count, so its length varies with that number's magnitude -- a fixed head/tail
--- split is therefore off by a character or two depending on the input, and a
--- first draft of this statement overshot the cap by exactly one byte because of
--- it. Computing the head from the marker's ACTUAL rendered length keeps the
--- result at or under the cap for every input instead of for the one that was
--- tested. TestMigration043BoundMatchesBoundOutput pins this against
--- ffmpeg.BoundOutput so the two cannot drift apart silently.
 --
--- The tail is fixed at 2033 and the head absorbs the variation, because the tail
--- carries the terminating cause -- the most valuable line in the stream -- and
--- should not shrink to pay for a longer count.
+-- The repeated marker subexpression is spelled out rather than factored into a
+-- CTE so the statement stays a single self-contained UPDATE; SQLite evaluates it
+-- per row either way.
 UPDATE work_queue
 SET last_error =
     substr(
         last_error,
         1,
-        4096 - 2033 - 2 - length('... [' || (length(last_error) - 4096) || ' bytes omitted] ...')
+        ((4096 - length('... [' || (length(CAST(last_error AS BLOB)) - 4096) || ' bytes omitted] ...') - 2) / 4) / 2
     )
     || char(10)
-    || '... [' || (length(last_error) - 4096) || ' bytes omitted] ...'
+    || '... [' || (length(CAST(last_error AS BLOB)) - 4096) || ' bytes omitted] ...'
     || char(10)
-    || substr(last_error, -2033)
-WHERE length(last_error) > 4096;
+    || substr(
+        last_error,
+        -(
+            ((4096 - length('... [' || (length(CAST(last_error AS BLOB)) - 4096) || ' bytes omitted] ...') - 2) / 4)
+            - ((4096 - length('... [' || (length(CAST(last_error AS BLOB)) - 4096) || ' bytes omitted] ...') - 2) / 4) / 2
+        )
+    )
+WHERE length(CAST(last_error AS BLOB)) > 4096;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/canticle/internal/config"
+	"github.com/sydlexius/canticle/internal/ffmpeg"
 )
 
 // HTTPDetector calls an external AudioSet classifier over HTTP. It serializes
@@ -637,7 +638,12 @@ func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("detector: sample audio: %w", ctxErr)
 		}
-		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
+		// BoundOutput, not TrimSpace alone: a corrupt file makes ffmpeg emit one
+		// error-level line per bad frame until its decode-error-rate ceiling aborts
+		// the run, and this error string is persisted to work_queue.last_error and
+		// then rendered into the Failure Analysis report. Unbounded, that reached
+		// 519 KB in one row on a live install (#731).
+		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }
@@ -828,7 +834,11 @@ func (d *HTTPDetector) probeDurationSeconds(ctx context.Context, audioPath strin
 	}
 	dur, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
 	if err != nil {
-		return 0, fmt.Errorf("detector: parse ffprobe duration %q: %w", strings.TrimSpace(string(out)), err)
+		// A well-behaved ffprobe prints one short number here, so this bound is a
+		// backstop rather than a fix for an observed case: nothing in the contract
+		// guarantees the output is small, and this string reaches last_error by the
+		// same route as the sampler's (#731).
+		return 0, fmt.Errorf("detector: parse ffprobe duration %q: %w", ffmpeg.BoundOutput(string(out)), err)
 	}
 	return dur, nil
 }

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -638,12 +638,20 @@ func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("detector: sample audio: %w", ctxErr)
 		}
+		// NAME THE FILE. Without the path this reports that something is corrupt
+		// without saying what, leaving an operator to find it by hand across a
+		// library of tens of thousands. ffmpeg's own stderr sometimes carries the
+		// path, but that is exactly the text the bound elides, so the path must
+		// live in the WRAPPING CONTEXT where it is never truncated away.
+		//
 		// BoundOutput, not TrimSpace alone: a corrupt file makes ffmpeg emit one
 		// error-level line per bad frame until its decode-error-rate ceiling aborts
 		// the run, and this error string is persisted to work_queue.last_error and
 		// then rendered into the Failure Analysis report. Unbounded, that reached
 		// 519 KB in one row on a live install (#731).
-		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
+		slog.Warn("detector: ffmpeg could not sample this audio file; it may be corrupt",
+			"path", audioPath, "error", err)
+		return "", fmt.Errorf("detector: sample audio with ffmpeg %q: %w: %s", audioPath, err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }

--- a/internal/detector/http.go
+++ b/internal/detector/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -638,20 +639,25 @@ func (d *HTTPDetector) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("detector: sample audio: %w", ctxErr)
 		}
-		// NAME THE FILE. Without the path this reports that something is corrupt
-		// without saying what, leaving an operator to find it by hand across a
-		// library of tens of thousands. ffmpeg's own stderr sometimes carries the
-		// path, but that is exactly the text the bound elides, so the path must
-		// live in the WRAPPING CONTEXT where it is never truncated away.
+		// NAME THE FILE -- IN THE LOG, DELIBERATELY NOT IN THE ERROR. Without the
+		// path an operator is told something is corrupt but not what, and must
+		// find it by hand across a library of tens of thousands. The log is the
+		// right home for it and the error is NOT: this error becomes
+		// work_queue.last_error, which CountFailuresByReason groups verbatim into
+		// the mxlrcgo_queue_failures{reason=...} Prometheus label
+		// (internal/server/metrics.go). A library path is private metadata, and
+		// /metrics is scraped by an external Prometheus that retains label values
+		// outside this host -- a wider surface than the local DB and self-hosted
+		// UI. last_error has leaked to a report surface before (#431).
 		//
 		// BoundOutput, not TrimSpace alone: a corrupt file makes ffmpeg emit one
 		// error-level line per bad frame until its decode-error-rate ceiling aborts
 		// the run, and this error string is persisted to work_queue.last_error and
 		// then rendered into the Failure Analysis report. Unbounded, that reached
-		// 519 KB in one row on a live install (#731).
+		// 531,138 bytes in one row on a live install (#731).
 		slog.Warn("detector: ffmpeg could not sample this audio file; it may be corrupt",
 			"path", audioPath, "error", err)
-		return "", fmt.Errorf("detector: sample audio with ffmpeg %q: %w: %s", audioPath, err, ffmpeg.BoundOutput(string(output)))
+		return "", fmt.Errorf("detector: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }
@@ -840,13 +846,26 @@ func (d *HTTPDetector) probeDurationSeconds(ctx context.Context, audioPath strin
 	if err != nil {
 		return 0, fmt.Errorf("detector: ffprobe duration: %w", err)
 	}
-	dur, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+	trimmed := strings.TrimSpace(string(out))
+	dur, err := strconv.ParseFloat(trimmed, 64)
 	if err != nil {
-		// A well-behaved ffprobe prints one short number here, so this bound is a
-		// backstop rather than a fix for an observed case: nothing in the contract
-		// guarantees the output is small, and this string reaches last_error by the
-		// same route as the sampler's (#731).
-		return 0, fmt.Errorf("detector: parse ffprobe duration %q: %w", ffmpeg.BoundOutput(string(out)), err)
+		// BOUND THE OPERAND AND DROP THE WRAPPED ERROR. strconv.ParseFloat returns
+		// a *strconv.NumError that carries its OWN copy of the full input string,
+		// so a `%w` here re-embeds the very bytes the bound just removed --
+		// measured at 264,180 bytes escaping through the wrap while the operand
+		// beside it was correctly capped. Reporting err.(*NumError).Err (the bare
+		// cause, e.g. ErrSyntax) keeps the diagnosis without the payload.
+		//
+		// A well-behaved ffprobe prints one short number, so this is a backstop
+		// rather than a fix for an observed case -- but nothing in the contract
+		// guarantees the output is small, and it reaches last_error by the same
+		// route as the sampler's (#731).
+		cause := err
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			cause = numErr.Err
+		}
+		return 0, fmt.Errorf("detector: parse ffprobe duration %q: %w", ffmpeg.BoundOutput(trimmed), cause)
 	}
 	return dur, nil
 }

--- a/internal/detector/sample_bound_test.go
+++ b/internal/detector/sample_bound_test.go
@@ -1,8 +1,10 @@
 package detector
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,8 +71,9 @@ func TestDetectorSampleErrorIsBounded(t *testing.T) {
 	}
 
 	msg := err.Error()
-	// The raw stream is ~300 KB. Allow generous headroom for the wrapping context
-	// so this asserts "bounded", not an exact size the implementation may retune.
+	// A HARD LITERAL, not maxCapturedOutput. Asserting against the constant makes
+	// the test a tautology: raising the cap would raise the assertion with it and
+	// the suite would stay green while the defect returned.
 	if len(msg) > 8192 {
 		t.Errorf("error carries unbounded ffmpeg output: %d bytes", len(msg))
 	}
@@ -80,10 +83,80 @@ func TestDetectorSampleErrorIsBounded(t *testing.T) {
 	if !strings.Contains(msg, "LASTLINE") {
 		t.Error("bounded error dropped the terminating line, which carries the actual cause")
 	}
-	// The path is the only thing that tells an operator WHICH file to go fix, and
-	// it must survive in the wrapping context rather than inside the bounded
-	// output, where the elision could remove it.
-	if !strings.Contains(msg, audioPath) {
-		t.Errorf("error does not name the offending file; want %q in:\n%s", audioPath, msg)
+	// The path must NOT be in the error. last_error is grouped verbatim into the
+	// mxlrcgo_queue_failures{reason=...} Prometheus label, which an external
+	// scraper retains off-host, and a library path is private metadata (#431 is
+	// the precedent for last_error reaching a report surface). The operator gets
+	// the path from the slog.Warn instead -- see TestDetectorSampleLogsThePath.
+	if strings.Contains(msg, audioPath) {
+		t.Errorf("error leaks the library path into last_error (and thence a Prometheus label):\n%s", msg)
+	}
+}
+
+// The path has to reach the operator SOMEWHERE, or "which file is corrupt?" is
+// unanswerable. It goes to the log rather than the error; this pins that, so
+// removing the slog.Warn cannot silently strip the only signal that names the
+// file.
+func TestDetectorSampleLogsThePath(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "corrupt.mp3")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			return
+		}
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(Config{
+		ClassifierURL:         srv.URL,
+		SampleDurationSeconds: 30,
+		MinConfidence:         0.90,
+		InstrumentalClasses:   []string{"Music"},
+		VocalClasses:          []string{"Singing"},
+		VocalMaxConfidence:    0.05,
+		FFmpegPath:            floodingFFmpeg(t),
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+	if _, err := d.Detect(context.Background(), audioPath); err == nil {
+		t.Fatal("Detect succeeded; want a sampling failure")
+	}
+
+	if !strings.Contains(buf.String(), audioPath) {
+		t.Errorf("the log does not name the offending file; want %q in:\n%s", audioPath, buf.String())
+	}
+}
+
+// The ffprobe parse-failure branch interpolates captured output too, so it
+// carries the same unbounded-capture risk as the sampler. A well-behaved ffprobe
+// prints one short number, so this is a backstop rather than a fix for an
+// observed case -- but nothing in the contract guarantees the output is small,
+// and it reaches last_error by the same route.
+func TestProbeDurationBoundsUnparsableOutput(t *testing.T) {
+	probe := filepath.Join(t.TempDir(), "ffprobe")
+	// Emits a large unparsable blob, so ParseFloat fails and the error carries
+	// the captured text.
+	script := "#!/bin/sh\ni=0\nwhile [ $i -lt 20000 ]; do printf 'not-a-number '; i=$((i+1)); done\n"
+	if err := os.WriteFile(probe, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	d := &HTTPDetector{ffprobePath: probe}
+	_, err := d.probeDurationSeconds(context.Background(), "/some/audio.mp3")
+	if err == nil {
+		t.Fatal("probeDurationSeconds succeeded; want a parse failure")
+	}
+	if len(err.Error()) > 8192 {
+		t.Errorf("ffprobe parse error carries unbounded output: %d bytes", len(err.Error()))
 	}
 }

--- a/internal/detector/sample_bound_test.go
+++ b/internal/detector/sample_bound_test.go
@@ -1,0 +1,83 @@
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// floodingFFmpeg writes a large volume of stderr and exits nonzero, reproducing
+// the production failure shape: a corrupt input makes ffmpeg emit one
+// error-level line per bad frame until its decode-error-rate ceiling aborts the
+// run. The head and tail lines are distinctive so the test can assert which
+// parts of the stream survived bounding.
+func floodingFFmpeg(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\n" +
+		"echo 'FIRSTLINE decoder opened' >&2\n" +
+		"i=0\n" +
+		"while [ $i -lt 20000 ]; do echo 'Header missing' >&2; i=$((i+1)); done\n" +
+		"echo 'LASTLINE decode error rate exceeds maximum' >&2\n" +
+		"exit 69\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatalf("write flooding ffmpeg: %v", err)
+	}
+	return path
+}
+
+// The unit tests cover BoundOutput in isolation; this one proves the bound is
+// actually WIRED -- that the error a caller receives, and therefore the string
+// persisted to work_queue.last_error, is bounded. Without this, moving the
+// helper call or dropping it would leave every ffmpeg test green (#731).
+func TestDetectorSampleErrorIsBounded(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "corrupt.mp3")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0600); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			return
+		}
+		t.Errorf("classifier was called at %q; sampling should have failed first", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	d, err := NewHTTPDetector(Config{
+		ClassifierURL:         srv.URL,
+		SampleDurationSeconds: 30,
+		MinConfidence:         0.90,
+		InstrumentalClasses:   []string{"Music"},
+		VocalClasses:          []string{"Singing"},
+		VocalMaxConfidence:    0.05,
+		FFmpegPath:            floodingFFmpeg(t),
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPDetector: %v", err)
+	}
+
+	_, err = d.Detect(context.Background(), audioPath)
+	if err == nil {
+		t.Fatal("Detect succeeded; want a sampling failure")
+	}
+
+	msg := err.Error()
+	// The raw stream is ~300 KB. Allow generous headroom for the wrapping context
+	// so this asserts "bounded", not an exact size the implementation may retune.
+	if len(msg) > 8192 {
+		t.Errorf("error carries unbounded ffmpeg output: %d bytes", len(msg))
+	}
+	if !strings.Contains(msg, "FIRSTLINE") {
+		t.Error("bounded error dropped the opening line, which names the failing decoder")
+	}
+	if !strings.Contains(msg, "LASTLINE") {
+		t.Error("bounded error dropped the terminating line, which carries the actual cause")
+	}
+}

--- a/internal/detector/sample_bound_test.go
+++ b/internal/detector/sample_bound_test.go
@@ -80,4 +80,10 @@ func TestDetectorSampleErrorIsBounded(t *testing.T) {
 	if !strings.Contains(msg, "LASTLINE") {
 		t.Error("bounded error dropped the terminating line, which carries the actual cause")
 	}
+	// The path is the only thing that tells an operator WHICH file to go fix, and
+	// it must survive in the wrapping context rather than inside the bounded
+	// output, where the elision could remove it.
+	if !strings.Contains(msg, audioPath) {
+		t.Errorf("error does not name the offending file; want %q in:\n%s", audioPath, msg)
+	}
 }

--- a/internal/ffmpeg/capture.go
+++ b/internal/ffmpeg/capture.go
@@ -44,20 +44,33 @@ const elisionMarker = "... [%d bytes omitted] ..."
 // sites (#431), and a cap would in any case be as likely to preserve a secret
 // as to cut it.
 func BoundOutput(out string) string {
+	return boundTo(out, maxCapturedOutput)
+}
+
+// boundTo is BoundOutput with the cap injected. The cap is a parameter purely so
+// the small-cap guard below is REACHABLE from a test: with the constant inlined,
+// that branch was dead code carrying the elision-marker invariant with no way to
+// exercise it, and dead code that asserts an invariant is exactly the code that
+// rots. Callers outside this file use BoundOutput; the policy lives here.
+func boundTo(out string, limit int) string {
 	s := strings.TrimSpace(out)
-	if len(s) <= maxCapturedOutput {
+	if len(s) <= limit {
 		return s
 	}
 
 	// Reserve room for the marker so the result honors the cap including it.
-	marker := fmt.Sprintf(elisionMarker, len(s)-maxCapturedOutput)
-	budget := maxCapturedOutput - len(marker) - 2 // two newlines around the marker
+	marker := fmt.Sprintf(elisionMarker, len(s)-limit)
+	budget := limit - len(marker) - 2 // two newlines around the marker
 	if budget < 2 {
-		// A cap this small cannot carry the marker plus meaningful text. Degrade to
-		// a plain head so the function stays total rather than returning nonsense;
-		// unreachable at the current constant, and guarded so a future edit that
-		// lowers it fails safe instead of slicing out of range.
-		return truncateRunes(s, maxCapturedOutput)
+		// Unreachable at the current constant: the marker is 24 characters plus the
+		// omitted-count digits, so the budget stays far above 2 for any input that
+		// reaches here. Kept as a total-function guard against a future edit that
+		// lowers maxCapturedOutput, and it deliberately still emits the marker --
+		// dropping it would make a truncated value read as a complete one, which is
+		// the single property every caller relies on. Panicking or returning the
+		// input unbounded would both be worse: this is a diagnostic path, and the
+		// cap exists precisely because the caller cannot be trusted to be small.
+		return marker
 	}
 
 	headBudget := budget / 2

--- a/internal/ffmpeg/capture.go
+++ b/internal/ffmpeg/capture.go
@@ -1,0 +1,96 @@
+package ffmpeg
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// maxCapturedOutput bounds how much subprocess output may be carried in an
+// error string. The captured text ends up in work_queue.last_error and is then
+// rendered into the Failure Analysis report, so the ceiling is set by what an
+// operator can read on a screen, not by what a decoder can print.
+//
+// Sized for the real failure mode: a corrupt MP3 makes ffmpeg emit one
+// error-level line per bad frame until its decode-error-rate ceiling aborts the
+// run. On a live install that produced a 531,138-byte last_error in a single
+// row -- 34% of every last_error byte in the database (#731). 4 KiB comfortably
+// holds an ordinary multi-line ffmpeg failure whole, so the bound only engages
+// on the pathological case it exists for.
+const maxCapturedOutput = 4096
+
+// elisionMarker separates the retained head from the retained tail. It is
+// deliberately conspicuous: without it, a truncated capture reads as a complete
+// one, and a reader would draw conclusions from text that is missing its middle.
+const elisionMarker = "... [%d bytes omitted] ..."
+
+// BoundOutput trims and size-bounds captured subprocess output so it is safe to
+// interpolate into an error.
+//
+// It keeps the HEAD AND THE TAIL rather than a plain prefix, because for a
+// failing ffmpeg run the two ends carry different and equally necessary
+// information: the opening lines name the stream and decoder that failed, while
+// the closing lines carry the cause that actually terminated the run (the
+// "Decode error rate ... exceeds maximum" line, in the case that motivated
+// this). A head-only truncation keeps the symptom and discards the diagnosis.
+// The repeated middle is what the operator does not need -- it is the same line
+// thousands of times over.
+//
+// Input at or under the cap is returned trimmed and otherwise untouched, so the
+// ordinary failure path is unaffected.
+//
+// This bounds SIZE ONLY. It is not redaction and must not be relied on as any
+// part of one: secrets are kept out of these strings at their construction
+// sites (#431), and a cap would in any case be as likely to preserve a secret
+// as to cut it.
+func BoundOutput(out string) string {
+	s := strings.TrimSpace(out)
+	if len(s) <= maxCapturedOutput {
+		return s
+	}
+
+	// Reserve room for the marker so the result honors the cap including it.
+	marker := fmt.Sprintf(elisionMarker, len(s)-maxCapturedOutput)
+	budget := maxCapturedOutput - len(marker) - 2 // two newlines around the marker
+	if budget < 2 {
+		// A cap this small cannot carry the marker plus meaningful text. Degrade to
+		// a plain head so the function stays total rather than returning nonsense;
+		// unreachable at the current constant, and guarded so a future edit that
+		// lowers it fails safe instead of slicing out of range.
+		return truncateRunes(s, maxCapturedOutput)
+	}
+
+	headBudget := budget / 2
+	tailBudget := budget - headBudget
+
+	head := truncateRunes(s, headBudget)
+	tail := truncateRunesFromEnd(s, tailBudget)
+
+	return head + "\n" + marker + "\n" + tail
+}
+
+// truncateRunes returns at most n bytes from the start of s, cutting on a rune
+// boundary. A byte-wise cut through a multi-byte character would put invalid
+// UTF-8 into the database and then into the HTML report.
+func truncateRunes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+// truncateRunesFromEnd returns at most n bytes from the end of s, cutting on a
+// rune boundary.
+func truncateRunesFromEnd(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	start := len(s) - n
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return s[start:]
+}

--- a/internal/ffmpeg/capture.go
+++ b/internal/ffmpeg/capture.go
@@ -58,19 +58,30 @@ func boundTo(out string, limit int) string {
 		return s
 	}
 
-	// Reserve room for the marker so the result honors the cap including it.
-	marker := fmt.Sprintf(elisionMarker, len(s)-limit)
-	budget := limit - len(marker) - 2 // two newlines around the marker
+	// Size the marker from a PROVISIONAL count, then restate it from what was
+	// really dropped. The two differ by the marker-plus-newline overhead (31 bytes
+	// on a 100 KB input: claimed 95,904 vs 95,935 actually omitted). The number is
+	// stated to the byte, so it should be true to the byte -- a figure that is
+	// merely close invites a reader to trust the next one that is not.
+	//
+	// The provisional marker is only a LENGTH ESTIMATE for the budget. Its own
+	// length can shift when the final count has more digits, which would eat into
+	// the retained text; padding to the width of the largest possible count keeps
+	// the budget an upper bound, so the final marker never exceeds the space
+	// reserved for it.
+	provisional := fmt.Sprintf(elisionMarker, len(s))
+	budget := limit - len(provisional) - 2 // two newlines around the marker
 	if budget < 2 {
-		// Unreachable at the current constant: the marker is 24 characters plus the
-		// omitted-count digits, so the budget stays far above 2 for any input that
-		// reaches here. Kept as a total-function guard against a future edit that
-		// lowers maxCapturedOutput, and it deliberately still emits the marker --
-		// dropping it would make a truncated value read as a complete one, which is
-		// the single property every caller relies on. Panicking or returning the
-		// input unbounded would both be worse: this is a diagnostic path, and the
-		// cap exists precisely because the caller cannot be trusted to be small.
-		return marker
+		// Unreachable at the current constant: the marker is 24 bytes plus the
+		// count's digits, so the budget stays far above 2 for any input reaching
+		// here. Kept as a total-function guard against a future edit that lowers
+		// maxCapturedOutput, and it deliberately still emits a marker -- dropping it
+		// would make a truncated value read as a complete one, which is the single
+		// property every caller relies on.
+		//
+		// The marker is itself bounded: with a very small limit it can exceed the
+		// cap, and a guard that violates the cap it exists to enforce is no guard.
+		return truncateRunes(fmt.Sprintf(elisionMarker, len(s)), limit)
 	}
 
 	headBudget := budget / 2
@@ -78,6 +89,15 @@ func boundTo(out string, limit int) string {
 
 	head := truncateRunes(s, headBudget)
 	tail := truncateRunesFromEnd(s, tailBudget)
+
+	// Restate the count from what was actually dropped, now that the retained
+	// lengths are known. Padded to the provisional marker's width so a
+	// shorter-rendering count cannot shrink the marker below the reserved budget
+	// and let the total drift over the cap.
+	marker := fmt.Sprintf(elisionMarker, len(s)-len(head)-len(tail))
+	for len(marker) < len(provisional) {
+		marker += " "
+	}
 
 	return head + "\n" + marker + "\n" + tail
 }

--- a/internal/ffmpeg/capture_test.go
+++ b/internal/ffmpeg/capture_test.go
@@ -1,6 +1,7 @@
 package ffmpeg
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -106,6 +107,43 @@ func TestBoundOutputDoesNotSplitARune(t *testing.T) {
 	got := BoundOutput(strings.Repeat("é", maxCapturedOutput))
 	if strings.ContainsRune(got, '�') {
 		t.Fatal("bounding split a multi-byte rune, producing U+FFFD")
+	}
+}
+
+// The marker states a byte count to the byte, so it has to be true to the byte.
+// An earlier version reported "bytes over the cap" rather than bytes actually
+// dropped, overstating retention by the marker-plus-newline overhead (claimed
+// 95,904 against 95,935 really omitted on a 100 KB input). Small, but a figure
+// that is merely close invites a reader to trust the next one that is not.
+func TestBoundOutputOmittedCountIsExact(t *testing.T) {
+	for _, size := range []int{5000, 100000, 600000} {
+		s := strings.Repeat("x", size)
+		got := BoundOutput(s)
+
+		open := strings.Index(got, "... [")
+		markerTail := strings.Index(got, " bytes omitted] ...")
+		if open < 0 || markerTail < 0 {
+			t.Fatalf("size %d: no elision marker in output", size)
+		}
+		var claimed int
+		if _, err := fmt.Sscanf(got[open:], "... [%d bytes omitted]", &claimed); err != nil {
+			t.Fatalf("size %d: could not parse the claimed count: %v", size, err)
+		}
+
+		// Retained text is everything outside the marker line.
+		headLen := open - 1 // less the newline before the marker
+		markerEnd := markerTail + len(" bytes omitted] ...")
+		tailLen := len(got) - markerEnd - 1 // less the newline after it
+		// Trailing pad keeps the marker at the reserved width; it is not retained text.
+		tailLen -= strings.Count(got[markerEnd:], " ")
+
+		if actual := size - headLen - tailLen; claimed != actual {
+			t.Errorf("size %d: marker claims %d bytes omitted, but %d were dropped (off by %d)",
+				size, claimed, actual, actual-claimed)
+		}
+		if len(got) > 4096 {
+			t.Errorf("size %d: restating the count pushed the result over the cap: %d bytes", size, len(got))
+		}
 	}
 }
 

--- a/internal/ffmpeg/capture_test.go
+++ b/internal/ffmpeg/capture_test.go
@@ -42,8 +42,13 @@ func TestBoundOutputKeepsHeadAndTail(t *testing.T) {
 
 	got := BoundOutput(b.String())
 
-	if len(got) > maxCapturedOutput {
-		t.Fatalf("bounded output exceeds the cap: got %d bytes, cap %d", len(got), maxCapturedOutput)
+	// A HARD LITERAL, deliberately not maxCapturedOutput. Asserting against the
+	// constant makes every size check a tautology -- raising the cap raises the
+	// assertion with it, and the suite stays green while the defect this exists to
+	// prevent comes back. The literal is the contract; the constant is an
+	// implementation detail that must satisfy it.
+	if len(got) > 4096 {
+		t.Fatalf("bounded output exceeds the cap: got %d bytes, want <= 4096", len(got))
 	}
 	if !strings.Contains(got, first) {
 		t.Errorf("head was dropped; want the opening line %q retained", first)
@@ -62,17 +67,36 @@ func TestBoundOutputAnnouncesTheElision(t *testing.T) {
 	if !strings.Contains(got, "omitted") {
 		t.Fatalf("truncated output does not announce the elision: %q", head(got))
 	}
-	if strings.Contains(got, "\nx\n") {
-		t.Log("marker is present on its own line, as intended")
-	}
 }
 
 // A cap that only holds for multi-line input would miss exactly the case that
 // motivated it if a subprocess ever emits one enormous line.
 func TestBoundOutputCapsSingleEnormousLine(t *testing.T) {
 	got := BoundOutput(strings.Repeat("y", 600_000))
-	if len(got) > maxCapturedOutput {
-		t.Fatalf("single-line input evaded the cap: got %d bytes, cap %d", len(got), maxCapturedOutput)
+	if len(got) > 4096 {
+		t.Fatalf("single-line input evaded the cap: got %d bytes, want <= 4096", len(got))
+	}
+}
+
+// The cap is a BYTE cap, and multi-byte input is where a length-vs-bytes mix-up
+// hides: the migration's first draft measured characters and let a 12,000-byte
+// value through as "4,096". Pin the byte ceiling across encodings so the Go side
+// can never acquire the same defect.
+func TestBoundOutputCapsBytesNotCharacters(t *testing.T) {
+	for _, tc := range []struct{ name, r string }{
+		{"two-byte runes", "é"},
+		{"three-byte runes", "€"},
+		{"four-byte runes", "😀"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BoundOutput(strings.Repeat(tc.r, 20000))
+			if len(got) > 4096 {
+				t.Errorf("multi-byte input exceeded the BYTE cap: got %d bytes, want <= 4096", len(got))
+			}
+			if strings.ContainsRune(got, '�') {
+				t.Error("bounding produced U+FFFD, so it cut through a rune")
+			}
+		})
 	}
 }
 
@@ -82,6 +106,40 @@ func TestBoundOutputDoesNotSplitARune(t *testing.T) {
 	got := BoundOutput(strings.Repeat("é", maxCapturedOutput))
 	if strings.ContainsRune(got, '�') {
 		t.Fatal("bounding split a multi-byte rune, producing U+FFFD")
+	}
+}
+
+// The small-cap guard exists to keep boundTo total if maxCapturedOutput is ever
+// lowered. It is unreachable through BoundOutput at the current constant, which
+// is exactly why boundTo takes the limit as a parameter -- an invariant asserted
+// only by unreachable code is an invariant nothing protects.
+//
+// What must hold: the result still honors the limit it was given, and it still
+// ANNOUNCES the elision. Silently returning a bare prefix here would make a
+// truncated value read as a complete one, which is the property every caller
+// depends on.
+func TestBoundToSmallCapStillAnnouncesTheElision(t *testing.T) {
+	got := boundTo(strings.Repeat("x", 1000), 30)
+
+	if !strings.Contains(got, "omitted") {
+		t.Errorf("small-cap path dropped the elision marker, so the result reads as complete: %q", got)
+	}
+	if strings.Contains(got, "xxxxxxxxxx") {
+		t.Errorf("small-cap path leaked a run of payload it had no budget for: %q", got)
+	}
+}
+
+// Both rune-walking helpers short-circuit when the string already fits. That
+// branch is what keeps an ordinary, in-budget capture from being copied through
+// a needless boundary walk, so it is worth pinning directly rather than only
+// through BoundOutput.
+func TestTruncateHelpersReturnShortInputUnchanged(t *testing.T) {
+	const s = "short"
+	if got := truncateRunes(s, 100); got != s {
+		t.Errorf("truncateRunes altered an in-budget string: got %q, want %q", got, s)
+	}
+	if got := truncateRunesFromEnd(s, 100); got != s {
+		t.Errorf("truncateRunesFromEnd altered an in-budget string: got %q, want %q", got, s)
 	}
 }
 

--- a/internal/ffmpeg/capture_test.go
+++ b/internal/ffmpeg/capture_test.go
@@ -1,0 +1,93 @@
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBoundOutputShortInputIsUnchanged(t *testing.T) {
+	in := "exit status 1: no such file"
+	if got := BoundOutput(in); got != in {
+		t.Fatalf("short input was altered:\n got %q\nwant %q", got, in)
+	}
+}
+
+func TestBoundOutputTrimsSurroundingSpace(t *testing.T) {
+	if got := BoundOutput("  \n padded \n\n"); got != "padded" {
+		t.Fatalf("surrounding space not trimmed: got %q", got)
+	}
+}
+
+func TestBoundOutputEmptyStaysEmpty(t *testing.T) {
+	if got := BoundOutput("   \n\t "); got != "" {
+		t.Fatalf("whitespace-only input should reduce to empty, got %q", got)
+	}
+}
+
+// The head and the tail are the two ends that carry diagnostic value: the first
+// lines name the failing decoder, the last lines carry the cause that actually
+// terminated the run. A plain head truncation would keep the former and discard
+// the latter, which is the wrong half to lose -- so assert BOTH survive.
+func TestBoundOutputKeepsHeadAndTail(t *testing.T) {
+	const (
+		first = "FIRST-LINE-MARKER decoder opened"
+		last  = "LAST-LINE-MARKER decode error rate exceeds maximum"
+	)
+	var b strings.Builder
+	b.WriteString(first + "\n")
+	for range 20000 {
+		b.WriteString("Header missing\n")
+	}
+	b.WriteString(last)
+
+	got := BoundOutput(b.String())
+
+	if len(got) > maxCapturedOutput {
+		t.Fatalf("bounded output exceeds the cap: got %d bytes, cap %d", len(got), maxCapturedOutput)
+	}
+	if !strings.Contains(got, first) {
+		t.Errorf("head was dropped; want the opening line %q retained", first)
+	}
+	if !strings.Contains(got, last) {
+		t.Errorf("tail was dropped; want the terminating line %q retained", last)
+	}
+}
+
+// The elision marker is what tells a reader the text is partial. Without it a
+// truncated capture reads as a complete one, and the omitted-byte count is the
+// signal that the run was pathological rather than merely noisy.
+func TestBoundOutputAnnouncesTheElision(t *testing.T) {
+	got := BoundOutput(strings.Repeat("x", maxCapturedOutput*3))
+
+	if !strings.Contains(got, "omitted") {
+		t.Fatalf("truncated output does not announce the elision: %q", head(got))
+	}
+	if strings.Contains(got, "\nx\n") {
+		t.Log("marker is present on its own line, as intended")
+	}
+}
+
+// A cap that only holds for multi-line input would miss exactly the case that
+// motivated it if a subprocess ever emits one enormous line.
+func TestBoundOutputCapsSingleEnormousLine(t *testing.T) {
+	got := BoundOutput(strings.Repeat("y", 600_000))
+	if len(got) > maxCapturedOutput {
+		t.Fatalf("single-line input evaded the cap: got %d bytes, cap %d", len(got), maxCapturedOutput)
+	}
+}
+
+// Bounding must not corrupt multi-byte characters: a byte-wise cut through a
+// rune would put invalid UTF-8 into last_error and then into the HTML report.
+func TestBoundOutputDoesNotSplitARune(t *testing.T) {
+	got := BoundOutput(strings.Repeat("é", maxCapturedOutput))
+	if strings.ContainsRune(got, '�') {
+		t.Fatal("bounding split a multi-byte rune, producing U+FFFD")
+	}
+}
+
+func head(s string) string {
+	if len(s) <= 200 {
+		return s
+	}
+	return s[:200] + "..."
+}

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -17,6 +17,7 @@ import (
 	"unicode"
 
 	"github.com/sydlexius/canticle/internal/config"
+	"github.com/sydlexius/canticle/internal/ffmpeg"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/normalize"
 )
@@ -127,7 +128,10 @@ func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("verification: sample audio: %w", ctxErr)
 		}
-		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, strings.TrimSpace(string(output)))
+		// Bounded for the same reason as the detector's sampler: this string is
+		// persisted to work_queue.last_error and rendered into a report, and a
+		// corrupt input makes ffmpeg's stderr grow without limit (#731).
+		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -129,14 +129,15 @@ func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("verification: sample audio: %w", ctxErr)
 		}
-		// Named and bounded for the same reasons as the detector's sampler: the
-		// path identifies the offending file (and must sit in the wrapping context,
-		// since the bound may elide it from ffmpeg's own output), while the bound
-		// keeps a corrupt input's unbounded stderr out of work_queue.last_error and
-		// the Failure Analysis report (#731).
+		// Logged and bounded for the same reasons as the detector's sampler: the
+		// path names the offending file for an operator but stays OUT of the
+		// error, which becomes work_queue.last_error and from there a verbatim
+		// Prometheus label on an externally-scraped surface; the bound keeps a
+		// corrupt input's unbounded stderr out of that column and the Failure
+		// Analysis report (#731).
 		slog.Warn("verification: ffmpeg could not sample this audio file; it may be corrupt",
 			"path", audioPath, "error", err)
-		return "", fmt.Errorf("verification: sample audio with ffmpeg %q: %w: %s", audioPath, err, ffmpeg.BoundOutput(string(output)))
+		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }

--- a/internal/verification/verification.go
+++ b/internal/verification/verification.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -128,10 +129,14 @@ func (v *HTTPVerifier) sample(ctx context.Context, audioPath string) (_ string, 
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", fmt.Errorf("verification: sample audio: %w", ctxErr)
 		}
-		// Bounded for the same reason as the detector's sampler: this string is
-		// persisted to work_queue.last_error and rendered into a report, and a
-		// corrupt input makes ffmpeg's stderr grow without limit (#731).
-		return "", fmt.Errorf("verification: sample audio with ffmpeg: %w: %s", err, ffmpeg.BoundOutput(string(output)))
+		// Named and bounded for the same reasons as the detector's sampler: the
+		// path identifies the offending file (and must sit in the wrapping context,
+		// since the bound may elide it from ffmpeg's own output), while the bound
+		// keeps a corrupt input's unbounded stderr out of work_queue.last_error and
+		// the Failure Analysis report (#731).
+		slog.Warn("verification: ffmpeg could not sample this audio file; it may be corrupt",
+			"path", audioPath, "error", err)
+		return "", fmt.Errorf("verification: sample audio with ffmpeg %q: %w: %s", audioPath, err, ffmpeg.BoundOutput(string(output)))
 	}
 	return samplePath, nil
 }


### PR DESCRIPTION
## Summary

- Captured subprocess output was interpolated into an error string with no size bound. That string is persisted to `work_queue.last_error`, rendered into the Failure Analysis report, and grouped verbatim into a Prometheus label. On a live install one row held **531,138 bytes** of raw ffmpeg stderr -- 34% of every `last_error` byte in the database.
- Adds `ffmpeg.BoundOutput` (head+tail retention, elision announced, rune-safe) and wires it at all three capture sites, **plus a goose migration** that bounds values already stored. The code fix alone would have left the symptom in place on exactly the installs that hit the bug: a `deferred` row keeps its `last_error` until it succeeds, and a row whose source file is corrupt never will.
- Also names the corrupt file in the **log** (`slog.Warn`) at both samplers. Previously an operator was told something was corrupt but not what, across a library of tens of thousands.
- Reviewers should look first at `internal/db/migrations/043_*.sql` (the bytes-vs-characters reasoning) and at `TestMigration043BoundMatchesBoundOutput` (a one-sided assertion made an earlier version of that test vacuous).

## Linked issue

Closes #731

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [ ] Commits squashed into one clean commit before the first push (reviewers read the diff at PR open).
      **Deliberately three commits.** The third is the adversarial-review fix round and documents what
      the first two got wrong; squashing would destroy exactly the reasoning a reviewer most needs.
      Happy to squash on request -- `/merge-pr` squashes at merge regardless.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
      **Partial.** The migration was applied to a COPY of a production database (see Test plan);
      the binary itself was not run against a live library.
- [x] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A, no templ/CSS change.
- [x] Migration added under `internal/db/migrations/` if this is a one-time data correction.

## Test plan

- [x] `make gate` passes locally (verified from the log, not the exit code -- a piped `tail` masked
      two genuine failures earlier in this work).
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written.
      Mutation results, each failing at an assertion rather than a build error:
  - Unwiring `BoundOutput` at the sampler: `error carries unbounded ffmpeg output: 300119 bytes`.
  - Head-only retention (Go and SQL): both drop the terminating `Decode error rate` line.
  - Reverting the migration to character-counting: `id 814: the migration left 12024 BYTES, over the 4096 cap`.
  - Raising `maxCapturedOutput` to 1 MB: fails **six** tests. It previously passed all of them.
  - Removing the `slog.Warn`: `the log does not name the offending file`.
- [x] Patch coverage meets the Codecov threshold: **93.02%** (`capture.go` at 100%).
- [x] Which **surface** this change fixes is stated explicitly and was verified by looking at it.
      Three surfaces share `last_error`: the DB column, the Failure Analysis report, and the
      `mxlrcgo_queue_failures{reason=...}` Prometheus label. The migration fixes stored rows; the
      capture-site bound fixes new ones. That third surface is why the file path is deliberately
      **not** in the returned error -- see "Not covered".
- [x] Manual UAT steps:
  - [x] Migration applied to a copy of a production database. The 531,138-byte row became 4,096
        bytes while retaining both the line naming the failing decoder and the line carrying the
        terminating cause; total `last_error` bytes fell 1,548,821 -> 1,021,779 (34%). The copy was
        deleted afterward; production was read-only throughout.
- [ ] Reviewer follow-ups:
  - [ ] The migration's character budget assumes worst-case 4-byte runes, so on ASCII it retains
        ~1,046 characters where `BoundOutput` keeps ~4,065. Deliberate (erring small is the safe
        direction for an oversize defect), but a second opinion on that tradeoff is welcome.
  - [ ] `boundTo` takes the limit as a parameter solely to make the small-cap guard reachable from
        a test. If that reads as test-driven API surface rather than a genuine seam, say so.

## Not covered

- **The `slog.Warn` is unbounded in time.** A permanently-corrupt file re-defers on geometric
  backoff forever, so it logs roughly 24 lines/day indefinitely; 100 corrupt files is ~2,400
  lines/day. Bounded and not a flood, and each line is the only operator-visible signal naming the
  file -- but a once-per-path-per-process suppression would be cheap. Not done here.
- **Prometheus label cardinality is unchanged.** `reason` was already high-cardinality (raw stderr
  differs per file). Bounding caps each label at 4 KiB but does not reduce the number of distinct
  series. A normalized reason column, distinct from the operator-facing detail, is the real fix and
  is out of scope. This is also why the file path stays out of the returned error: `/metrics` is
  scraped by an external Prometheus that retains label values off-host, and a library path is
  private metadata (#431 is the precedent for `last_error` reaching a report surface).
- **The elision marker is forgeable.** Captured output can contain a literal `... [N bytes
  omitted] ...`. Already true of the unbounded string, and the marker is not load-bearing for any
  control decision -- it can mislead a human reader, nothing more.
- **Related failures found in the same census, filed not fixed:** #732 (a renamed directory below a
  library root strands its rows -- 5 rows fetch successfully then fail at write, forever, spending a
  provider request each time) and #733 (a shutdown cancellation is recorded as a hard failure).
