### PR TITLE
fix(prune): retire a gone row that can never be relinked, instead of retaining it forever

### DIFF
--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -137,11 +137,20 @@ type RetainedRow struct {
 	Reason     string
 	MBID       string
 	ISRC       string
-	// Retired reports that this row was taken out of the dequeue-eligible set as
-	// well as retained. It is still a RetainedRow -- nothing was deleted and the
-	// operator-facing accounting is unchanged -- but the worker will no longer
-	// attempt it. See retireUnresolvable for when this is set.
+	// Retired reports that this row was ACTUALLY taken out of the dequeue-eligible
+	// set: the UPDATE ran and affected a row. It is still a RetainedRow -- nothing
+	// was deleted and the operator-facing accounting is unchanged -- but the worker
+	// will no longer attempt it.
+	//
+	// COMMITTED STATE, NEVER INTENT. False in a dry run (which mutates nothing) and
+	// false when the UPDATE's status guard declined the row, so a report can never
+	// describe a change the database did not make. Use WouldRetire to preview.
 	Retired bool
+	// WouldRetire reports that this row QUALIFIED for retirement: gone, carrying no
+	// identity, still holding dequeue-eligible work. It is the plan, so it is set
+	// identically whether or not the sweep is a dry run -- which is what makes a
+	// dry run's report a truthful preview of a real one.
+	WouldRetire bool
 }
 
 // unresolvableGoneError is the last_error value written when a row is retired as
@@ -286,11 +295,18 @@ type candidate struct {
 	// processing is true when any linked work_queue row is still 'processing',
 	// so the whole source is deferred (the worker owns it) to avoid a half-prune.
 	processing bool
-	// settled is true when every linked work_queue row has reached 'done' -- it is
-	// no longer work, so there is nothing to retire. Distinct from processing: a
-	// settled row is still a valid relink and prune target, it just must not be
-	// re-retired and re-reported on every sweep.
+	// settled is true when EVERY linked work_queue row has reached 'done' -- the
+	// source is no longer work, so there is nothing to retire. Distinct from
+	// processing: a settled source is still a valid relink and prune target, it
+	// just must not be re-retired and re-reported on every sweep.
+	//
+	// Derived by markSettled after the gather, never latched during it: a source
+	// may carry several work_queue rows, and "at least one is done" is a strictly
+	// weaker claim that would drop a candidate still holding eligible work.
 	settled bool
+	// doneWorkItems counts linked work_queue rows already in 'done'. Compared
+	// against len(workItems) to derive settled.
+	doneWorkItems int
 	// libraryID scopes the present-file candidate pool this row's identity is
 	// matched against. Known whenever a scan_results row backs this source;
 	// nil for a link-less work_queue-only candidate (no scan_results row at
@@ -368,7 +384,14 @@ func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Gr
 			// did not commit -- the same backup-first discipline deletePruned follows.
 			// A dry run retires nothing: the CLI's dry-run default is load-bearing, and
 			// a preview that mutates is worse than no preview.
-			if cg.retained.Retired && !dryRun {
+			// Retired reports COMMITTED state, never intent -- so it starts false and
+			// is set only by an UPDATE that actually affected a row. A dry run
+			// therefore reports Retired=false throughout: it changes nothing, and a
+			// preview that claims a queue row moved is exactly the defect #725 shipped
+			// (a dry run whose report described writes it never made). WouldRetire
+			// carries the plan for anyone previewing.
+			cg.retained.WouldRetire = cg.shouldRetire
+			if cg.shouldRetire && !dryRun {
 				retired, err := p.retireUnresolvable(ctx, cg.c)
 				if err != nil {
 					return Result{}, fmt.Errorf("prune: retire %q: %w", src, err)
@@ -476,6 +499,11 @@ type classifiedRelink struct {
 type classified struct {
 	outcome  outcome
 	retained RetainedRow
+	// shouldRetire is the PLAN: this candidate qualifies for retirement. Kept
+	// internal and separate from RetainedRow.Retired, which reports what actually
+	// committed -- collapsing the two is how a dry run ends up claiming a write it
+	// never made.
+	shouldRetire bool
 	classifiedRelink
 }
 
@@ -508,11 +536,12 @@ func (p *Pruner) classify(ctx context.Context, idx *presentIndex, policy Policy,
 			retained: RetainedRow{
 				SourcePath: src,
 				Reason:     "identity absent; never deleted on a guess",
-				// Only a row that is still WORK can be retired. A settled row either was
-				// never queued or has already been retired by a previous sweep; either
-				// way there is nothing to take out of the dequeue-eligible set.
-				Retired: policy == PolicyFull && !c.settled && len(c.workItems) > 0,
 			},
+			// Only a row that is still WORK can be retired. A settled candidate has
+			// every linked item in 'done' already -- either never queued, or retired by
+			// an earlier sweep -- so there is nothing to take out of the eligible set.
+			// This is the PLAN; RetainedRow.Retired records what actually committed.
+			shouldRetire: policy == PolicyFull && !c.settled && len(c.workItems) > 0,
 			// Carry the candidate so the retire step can reach its work_queue rows.
 			// The embedded classifiedRelink is otherwise only populated on the relink
 			// path, and a nil c here made retireUnresolvable a silent no-op.
@@ -977,15 +1006,17 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 			c.processing = true
 			return nil
 		}
+		// Count settled vs total linked work items rather than latching a flag. A
+		// source is not constrained to one work_queue row (there is no UNIQUE on
+		// source_path), so a mix of {done, failed} is representable -- and a latched
+		// "any row is done" would classify the whole candidate as settled, dropping
+		// it from the sweep while its still-eligible sibling kept being worked,
+		// unretired AND unreported. Invisible is worse than permanent.
+		//
+		// Settledness is derived once, after the gather completes, from these two
+		// counts; see markSettled.
 		if status == "done" {
-			// A settled row is not work, so it is not a retirement candidate. Tracking
-			// this is what makes retirement CONVERGE: without it, a row retired to
-			// 'done' is still gathered from scan_results on the next sweep, re-reported
-			// as retained, and re-retired -- relocating the non-converging fixed point
-			// (#732) instead of removing it. Recorded rather than returned early,
-			// because a 'done' row still belongs to the candidate for the relink and
-			// prune paths, which act on settled rows too.
-			c.settled = true
+			c.doneWorkItems++
 		}
 		var paths []models.OutputPath
 		if outputPaths != "" {
@@ -1016,7 +1047,26 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 	}); err != nil {
 		return nil, fmt.Errorf("prune: gather work_queue: %w", err)
 	}
+	markSettled(bySource)
 	return bySource, nil
+}
+
+// markSettled derives candidate.settled once the whole gather is complete.
+//
+// It cannot be latched during the gather: rows arrive one at a time, so the
+// moment a 'done' row is seen there is no way to know whether a later row for
+// the same source will be dequeue-eligible. Deriving it here, from the finished
+// counts, is what makes "settled" mean EVERY linked work item is done rather
+// than "at least one is" -- the weaker reading would drop a candidate that still
+// holds eligible work, leaving that row unretired and unreported.
+//
+// A candidate with no work items at all is NOT settled: there is nothing to
+// retire, but nothing has been settled either, and the relink and prune paths
+// still need to see it.
+func markSettled(bySource map[string]*candidate) {
+	for _, c := range bySource {
+		c.settled = len(c.workItems) > 0 && c.doneWorkItems == len(c.workItems)
+	}
 }
 
 // deletePruned deletes the pruned rows in a single transaction, invoking report

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -25,6 +25,17 @@
 // delete, and the reactive PrunePath path never performs one at all (relink or
 // retain only), leaving genuine deletion to the periodic sweep and the CLI, by
 // which time a rescan has had time to settle.
+//
+// A retained row is additionally RETIRED when it is provably unactionable --
+// gone AND carrying no identity, so no future sweep could ever relink it (#732).
+// Retiring deletes nothing and preserves every telemetry column; it only settles
+// the work_queue row so the worker stops re-fetching lyrics it can never write.
+// Before this, such a row stayed dequeue-eligible forever and each sweep
+// re-classified it identically, a fixed point that never converged. Retirement
+// is a mutation, so it obeys the same discipline as a genuine delete: never in a
+// dry run, never on an in-flight row, and only under PolicyFull -- the reactive
+// pass defers it to the periodic sweep, by which time a rescan of a moved file's
+// new location has had time to re-create the row with identity.
 package prune
 
 import (
@@ -37,11 +48,17 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/identity"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/pathutil"
 )
+
+// timeFormat is the timestamp layout every stored column uses. Declared locally
+// rather than shared, matching internal/queue and internal/reports, which each
+// carry their own copy of the same constant.
+const timeFormat = time.RFC3339
 
 // Granularity selects how a candidate source path is tested for existence.
 type Granularity int
@@ -120,7 +137,22 @@ type RetainedRow struct {
 	Reason     string
 	MBID       string
 	ISRC       string
+	// Retired reports that this row was taken out of the dequeue-eligible set as
+	// well as retained. It is still a RetainedRow -- nothing was deleted and the
+	// operator-facing accounting is unchanged -- but the worker will no longer
+	// attempt it. See retireUnresolvable for when this is set.
+	Retired bool
 }
+
+// unresolvableGoneError is the last_error value written when a row is retired as
+// permanently unactionable: its source file is gone AND it carries no identity,
+// so no relink can ever resolve it. Defined once so the SQL bind, the tests, and
+// any log or inspection of the sentinel cannot drift -- the same discipline as
+// queue.missLimitReachedError, whose retire-to-'done' pattern this mirrors.
+//
+// The text is written for someone reading it six months from now with no context:
+// it states the mechanism, not a verdict.
+const unresolvableGoneError = "source file is gone and the row carries no ISRC or MBID, so it can never be relinked; retired as unactionable"
 
 // Result reports the totals and per-row detail of a prune (or, in dry-run, what
 // would happen).
@@ -254,6 +286,11 @@ type candidate struct {
 	// processing is true when any linked work_queue row is still 'processing',
 	// so the whole source is deferred (the worker owns it) to avoid a half-prune.
 	processing bool
+	// settled is true when every linked work_queue row has reached 'done' -- it is
+	// no longer work, so there is nothing to retire. Distinct from processing: a
+	// settled row is still a valid relink and prune target, it just must not be
+	// re-retired and re-reported on every sweep.
+	settled bool
 	// libraryID scopes the present-file candidate pool this row's identity is
 	// matched against. Known whenever a scan_results row backs this source;
 	// nil for a link-less work_queue-only candidate (no scan_results row at
@@ -320,7 +357,27 @@ func (p *Pruner) reconcile(ctx context.Context, sc scope, libraryID *int64, g Gr
 			return Result{}, err
 		}
 		switch cg.outcome {
+		case outcomeSettled:
+			// Nothing to do and nothing to say: this candidate is already in its
+			// terminal state. Deliberately absent from every Result slice, so a
+			// repeat sweep over a settled library reports an empty result rather
+			// than re-listing rows no action will ever touch again.
+			continue
 		case outcomeRetain:
+			// Retire before reporting, so a report never describes a retirement that
+			// did not commit -- the same backup-first discipline deletePruned follows.
+			// A dry run retires nothing: the CLI's dry-run default is load-bearing, and
+			// a preview that mutates is worse than no preview.
+			if cg.retained.Retired && !dryRun {
+				retired, err := p.retireUnresolvable(ctx, cg.c)
+				if err != nil {
+					return Result{}, fmt.Errorf("prune: retire %q: %w", src, err)
+				}
+				// An in-flight row is skipped by the UPDATE's status guard. Report it as
+				// the plain retain it actually was, rather than claiming a retirement the
+				// database declined to make.
+				cg.retained.Retired = retired
+			}
 			res.Retained = append(res.Retained, cg.retained)
 			if hooks.Retained != nil {
 				if err := hooks.Retained(cg.retained); err != nil {
@@ -400,6 +457,11 @@ const (
 	outcomePrune outcome = iota
 	outcomeRelink
 	outcomeRetain
+	// outcomeSettled is a candidate there is nothing left to do about: gone,
+	// unresolvable, and already out of the dequeue-eligible set. It is reported
+	// nowhere and mutates nothing, which is what lets a sweep CONVERGE -- see the
+	// settled field on candidate.
+	outcomeSettled
 )
 
 // classifiedRelink carries both the reporting-facing RelinkedRow and the
@@ -424,7 +486,38 @@ type classified struct {
 // delete).
 func (p *Pruner) classify(ctx context.Context, idx *presentIndex, policy Policy, src string, c *candidate) (classified, error) {
 	if c.mbid == "" && c.isrc == "" {
-		return classified{outcome: outcomeRetain, retained: RetainedRow{SourcePath: src, Reason: "identity absent; never deleted on a guess"}}, nil
+		// Already retired by an earlier sweep (or never queued at all): gone,
+		// unresolvable, and no longer work. Re-reporting it every sweep is exactly
+		// the churn #732 exists to stop, so it drops out of the candidate set here.
+		if c.settled && len(c.workItems) > 0 {
+			return classified{outcome: outcomeSettled}, nil
+		}
+		// Gone, and carrying no identity: no relink can ever resolve this row, at any
+		// future sweep, because there is nothing to resolve it BY. Keeping it is still
+		// right -- deleting on a guess is what #640 exists to prevent -- but leaving it
+		// dequeue-eligible made the worker re-fetch lyrics it could never write, every
+		// backoff period, forever (#732).
+		//
+		// So: retain AND retire. Nothing is deleted, every telemetry column survives,
+		// and the row simply stops being work. Retirement is a mutation, so it follows
+		// the same policy discipline as a genuine delete -- the reactive pass defers it
+		// to the periodic sweep, by which time a rescan of a moved file's new location
+		// has had time to settle and re-create the row with identity.
+		return classified{
+			outcome: outcomeRetain,
+			retained: RetainedRow{
+				SourcePath: src,
+				Reason:     "identity absent; never deleted on a guess",
+				// Only a row that is still WORK can be retired. A settled row either was
+				// never queued or has already been retired by a previous sweep; either
+				// way there is nothing to take out of the dequeue-eligible set.
+				Retired: policy == PolicyFull && !c.settled && len(c.workItems) > 0,
+			},
+			// Carry the candidate so the retire step can reach its work_queue rows.
+			// The embedded classifiedRelink is otherwise only populated on the relink
+			// path, and a nil c here made retireUnresolvable a silent no-op.
+			classifiedRelink: classifiedRelink{src: src, c: c},
+		}, nil
 	}
 	pool, err := idx.pool(ctx, c.libraryID)
 	if err != nil {
@@ -884,6 +977,16 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 			c.processing = true
 			return nil
 		}
+		if status == "done" {
+			// A settled row is not work, so it is not a retirement candidate. Tracking
+			// this is what makes retirement CONVERGE: without it, a row retired to
+			// 'done' is still gathered from scan_results on the next sweep, re-reported
+			// as retained, and re-retired -- relocating the non-converging fixed point
+			// (#732) instead of removing it. Recorded rather than returned early,
+			// because a 'done' row still belongs to the candidate for the relink and
+			// prune paths, which act on settled rows too.
+			c.settled = true
+		}
 		var paths []models.OutputPath
 		if outputPaths != "" {
 			if err := json.Unmarshal([]byte(outputPaths), &paths); err != nil {
@@ -930,6 +1033,51 @@ func (p *Pruner) gatherCandidates(ctx context.Context, sc scope, libraryID *int6
 // forever while still deleting its scan_results row. It returns the actual rows
 // deleted (via RowsAffected) so the caller's totals reflect what happened, not
 // just what was intended.
+// retireUnresolvable takes a permanently-unactionable row out of the
+// dequeue-eligible set without deleting anything (#732). It reports whether any
+// row was actually retired.
+//
+// WHY 'done' AND NOT A NEW STATUS. work_queue.status carries a CHECK constraint,
+// so a genuinely new value means recreating the table -- a migration far out of
+// proportion to the fix. queue.RetireMiss already established the cheaper
+// pattern for exactly this shape: settle to 'done' and record WHY in last_error.
+// A distinct terminal state is the subject of #477, which will want to convert
+// both this and RetireMiss together rather than have one of them arrive early
+// and differently.
+//
+// THE STATUS GUARD IS THE IN-FLIGHT GUARD. `status NOT IN ('processing','done')`
+// does two jobs: it never retires a row the worker currently owns, and it makes
+// the whole operation idempotent, since an already-retired row is 'done' and no
+// longer matches. That idempotence is the point of the fix -- without it this
+// would relocate the non-converging fixed point rather than remove it.
+//
+// completed_at is stamped because the row IS settled; leaving it null would make
+// a retired row look perpetually in-flight to every report that reads it.
+func (p *Pruner) retireUnresolvable(ctx context.Context, c *candidate) (bool, error) {
+	if c == nil || len(c.workItems) == 0 {
+		return false, nil
+	}
+	now := time.Now().UTC().Format(timeFormat)
+	retired := false
+	for _, w := range c.workItems {
+		res, err := p.db.ExecContext(ctx,
+			`UPDATE work_queue
+             SET status = 'done',
+                 completed_at = ?,
+                 last_error = ?
+             WHERE id = ?
+               AND status NOT IN ('processing', 'done')`,
+			now, unresolvableGoneError, w.id)
+		if err != nil {
+			return false, fmt.Errorf("retire work item %d: %w", w.id, err)
+		}
+		if rowsAffected(res) > 0 {
+			retired = true
+		}
+	}
+	return retired, nil
+}
+
 func (p *Pruner) deletePruned(ctx context.Context, pruned []PrunedRow, report func(PrunedRow) error) (scanDeleted, workDeleted int, retErr error) {
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/prune/prune_retire_test.go
+++ b/internal/prune/prune_retire_test.go
@@ -13,12 +13,23 @@ import (
 // the dequeue-eligible set.
 func statusOf(t *testing.T, ctx context.Context, sqlDB *sql.DB, sourcePath string) (status, lastError string) {
 	t.Helper()
+	status, lastError, _ = rowStateOf(t, ctx, sqlDB, sourcePath)
+	return status, lastError
+}
+
+// rowStateOf also returns completed_at, so a test can assert the row was settled
+// rather than merely re-statused -- and so a dry-run test can catch a write that
+// touches ONLY the timestamp. Read as NullString because an unsettled row has
+// none.
+func rowStateOf(t *testing.T, ctx context.Context, sqlDB *sql.DB, sourcePath string) (status, lastError string, completedAt sql.NullString) {
+	t.Helper()
 	err := sqlDB.QueryRowContext(ctx,
-		`SELECT status, last_error FROM work_queue WHERE source_path = ?`, sourcePath).Scan(&status, &lastError)
+		`SELECT status, last_error, completed_at FROM work_queue WHERE source_path = ?`,
+		sourcePath).Scan(&status, &lastError, &completedAt)
 	if err != nil {
 		t.Fatalf("read work_queue row for %q: %v", sourcePath, err)
 	}
-	return status, lastError
+	return status, lastError, completedAt
 }
 
 // A row whose file is gone and whose identity is absent is RETAINED by design
@@ -52,13 +63,23 @@ func TestSweep_RetiresUnresolvableGoneRow(t *testing.T) {
 	if len(res.Retained) != 1 {
 		t.Fatalf("Retained = %d, want 1 (a retired row is still a retained row)", len(res.Retained))
 	}
-	// ...but it is no longer dequeue-eligible.
-	status, lastErr := statusOf(t, ctx, sqlDB, gone)
-	if status == "failed" || status == "pending" || status == "deferred" {
-		t.Errorf("row is still dequeue-eligible (status=%q); the worker will keep attempting a file that does not exist", status)
+	if !res.Retained[0].Retired {
+		t.Error("Retained[0].Retired = false; a committed retirement must be reported as one")
+	}
+
+	// Assert the EXACT terminal state, not merely "not one of the eligible three".
+	// A negative assertion would pass for any typo'd or unintended status value.
+	status, lastErr, completedAt := rowStateOf(t, ctx, sqlDB, gone)
+	if status != "done" {
+		t.Errorf("status = %q, want done (the retirement terminal state)", status)
 	}
 	if lastErr != unresolvableGoneError {
 		t.Errorf("last_error = %q, want %q so the reason is legible six months from now", lastErr, unresolvableGoneError)
+	}
+	// completed_at must be stamped: the row IS settled, and leaving it null makes a
+	// retired row read as perpetually in-flight to every report that joins on it.
+	if !completedAt.Valid || completedAt.String == "" {
+		t.Errorf("completed_at = %v, want a populated timestamp on a settled row", completedAt)
 	}
 }
 
@@ -132,17 +153,40 @@ func TestSweep_DryRunDoesNotRetire(t *testing.T) {
 		t.Fatalf("remove source: %v", err)
 	}
 
+	// Capture the full pre-sweep state, so a write that touches ONLY completed_at
+	// is still caught. Asserting status alone let exactly that class of bug ship
+	// once before (#725: a dry run that mutated a column no test was reading).
+	beforeStatus, beforeErr, beforeCompleted := rowStateOf(t, ctx, sqlDB, gone)
+
 	p := New(sqlDB)
-	if _, err := p.Sweep(ctx, SweepOptions{Granularity: Exact, DryRun: true}); err != nil {
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact, DryRun: true})
+	if err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
 
-	status, lastErr := statusOf(t, ctx, sqlDB, gone)
-	if status != "failed" {
-		t.Errorf("dry run mutated status to %q; it must write nothing", status)
+	afterStatus, afterErr, afterCompleted := rowStateOf(t, ctx, sqlDB, gone)
+	if afterStatus != beforeStatus {
+		t.Errorf("dry run mutated status: %q -> %q; it must write nothing", beforeStatus, afterStatus)
 	}
-	if lastErr == unresolvableGoneError {
-		t.Error("dry run wrote the retirement marker; it must write nothing")
+	if afterErr != beforeErr {
+		t.Errorf("dry run mutated last_error: %q -> %q; it must write nothing", beforeErr, afterErr)
+	}
+	if afterCompleted != beforeCompleted {
+		t.Errorf("dry run mutated completed_at: %v -> %v; it must write nothing", beforeCompleted, afterCompleted)
+	}
+
+	// The REPORT must be honest too, not just the database. Retired means
+	// committed, so it stays false here; WouldRetire carries the plan, which is
+	// what makes a dry run a truthful preview rather than a claim about writes
+	// that never happened.
+	if len(res.Retained) != 1 {
+		t.Fatalf("Retained = %d, want 1 (a dry run still reports what it would do)", len(res.Retained))
+	}
+	if res.Retained[0].Retired {
+		t.Error("dry run reported Retired=true; that field means COMMITTED, and nothing was committed")
+	}
+	if !res.Retained[0].WouldRetire {
+		t.Error("dry run reported WouldRetire=false; the preview must still name the intended action")
 	}
 }
 
@@ -211,6 +255,55 @@ func TestRetireUnresolvable_SkipsRowThatRacedIntoProcessing(t *testing.T) {
 	}
 	if lastErr == unresolvableGoneError {
 		t.Error("wrote the retirement marker onto an in-flight row")
+	}
+}
+
+// settled must mean EVERY linked work item is done, not "at least one is".
+// Nothing constrains source_path to a single work_queue row, so a source can
+// carry a mix -- and deriving settled from any one 'done' row silently drops the
+// whole candidate, leaving its still-eligible sibling unretired AND unreported.
+// The row would go on being fetched forever with nothing in the sweep output
+// naming it, which is worse than the bug this PR fixes: invisible rather than
+// merely permanent.
+//
+// Latent rather than live (zero such rows on the reference install today), but
+// nothing prevents the state and the doc comment already claimed the stronger
+// property. Found by CodeRabbit on #735.
+func TestSweep_MixedWorkItemsAreNotTreatedAsSettled(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistMixed", "01. mixed.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "done", "", "")
+
+	// A second work_queue row on the SAME source, still dequeue-eligible.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO work_queue (artist_key, title_key, artist, title, source_path, outdir, filename, status)
+		 VALUES ('mixed', 'mixed', 'Artist', 'Title', ?, ?, ?, 'failed')`,
+		gone, filepath.Dir(gone), filepath.Base(gone)); err != nil {
+		t.Fatalf("insert second work_queue row: %v", err)
+	}
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if len(res.Retained) == 0 {
+		t.Fatal("the candidate was dropped as settled while a dequeue-eligible row remained; " +
+			"it is now invisible to the sweep AND still being worked")
+	}
+
+	var eligible int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT count(*) FROM work_queue WHERE source_path = ? AND status IN ('pending','failed','deferred')`,
+		gone).Scan(&eligible); err != nil {
+		t.Fatalf("count eligible: %v", err)
+	}
+	if eligible != 0 {
+		t.Errorf("%d work_queue row(s) for a vanished source are still dequeue-eligible after the sweep", eligible)
 	}
 }
 

--- a/internal/prune/prune_retire_test.go
+++ b/internal/prune/prune_retire_test.go
@@ -1,0 +1,231 @@
+package prune
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// statusOf reads one work_queue row's status and last_error, which is how a
+// retirement is observed: the row survives with all its telemetry, but leaves
+// the dequeue-eligible set.
+func statusOf(t *testing.T, ctx context.Context, sqlDB *sql.DB, sourcePath string) (status, lastError string) {
+	t.Helper()
+	err := sqlDB.QueryRowContext(ctx,
+		`SELECT status, last_error FROM work_queue WHERE source_path = ?`, sourcePath).Scan(&status, &lastError)
+	if err != nil {
+		t.Fatalf("read work_queue row for %q: %v", sourcePath, err)
+	}
+	return status, lastError
+}
+
+// A row whose file is gone and whose identity is absent is RETAINED by design
+// (#640: never delete on a guess). But retention left it in 'failed', which
+// Dequeue still selects, so the worker re-fetched lyrics it could never write --
+// forever, because nothing in the retain path mutates the row (#732).
+//
+// Retiring it keeps every telemetry column and deletes nothing; it only takes
+// the row out of the dequeue-eligible set. That is the whole fix: the retain
+// decision was correct, its permanence was not.
+func TestSweep_RetiresUnresolvableGoneRow(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistGone", "01. gone.flac")
+	// No MBID, no ISRC -- the 77.6%-of-library case that can never relink.
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "failed", "", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// Nothing is deleted: the row and its telemetry survive.
+	if sr, wq, _ := rowCounts(t, ctx, sqlDB); sr != 1 || wq != 1 {
+		t.Fatalf("rows were deleted: scan=%d wq=%d, want 1/1 (retire must never delete)", sr, wq)
+	}
+	// It is still reported as retained, so the operator-facing accounting is unchanged.
+	if len(res.Retained) != 1 {
+		t.Fatalf("Retained = %d, want 1 (a retired row is still a retained row)", len(res.Retained))
+	}
+	// ...but it is no longer dequeue-eligible.
+	status, lastErr := statusOf(t, ctx, sqlDB, gone)
+	if status == "failed" || status == "pending" || status == "deferred" {
+		t.Errorf("row is still dequeue-eligible (status=%q); the worker will keep attempting a file that does not exist", status)
+	}
+	if lastErr != unresolvableGoneError {
+		t.Errorf("last_error = %q, want %q so the reason is legible six months from now", lastErr, unresolvableGoneError)
+	}
+}
+
+// Idempotence is the property that distinguishes this from the retain it
+// replaces: a second sweep must find nothing left to do. Without it the fix
+// would merely move the non-converging fixed point rather than remove it.
+func TestSweep_RetireIsIdempotent(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistGone", "01. gone.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "failed", "", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	p := New(sqlDB)
+	if _, err := p.Sweep(ctx, SweepOptions{Granularity: Exact}); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	statusAfterFirst, _ := statusOf(t, ctx, sqlDB, gone)
+
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("second Sweep: %v", err)
+	}
+	if len(res.Retained) != 0 {
+		t.Errorf("second sweep re-reported %d retained row(s); a retired row must leave the candidate set, "+
+			"or this reproduces the non-converging fixed point it exists to remove", len(res.Retained))
+	}
+	statusAfterSecond, _ := statusOf(t, ctx, sqlDB, gone)
+	if statusAfterFirst != statusAfterSecond {
+		t.Errorf("status churned between sweeps: %q then %q", statusAfterFirst, statusAfterSecond)
+	}
+}
+
+// A row that CAN still relink must not be retired out from under the relink
+// tier. Identity present and matching a live file is the case #640 built, and
+// retirement must not pre-empt it.
+func TestSweep_DoesNotRetireARowWithUsableIdentity(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistA", "01. old.flac")
+	moved := filepath.Join(root, "ArtistA", "01. new.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "failed", "mbid-shared", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+	// seedPresentScanResult, not seedRowWithIdentity: the relink target must be a
+	// scan_results row with no work_queue row of its own. Giving it one makes the
+	// target already junction-linked to a DIFFERENT work item, which relinkOne
+	// correctly declines and reports as retained -- a real behavior, but not the
+	// one under test here.
+	seedPresentScanResult(t, ctx, sqlDB, libID, moved, "mbid-shared", "")
+
+	p := New(sqlDB)
+	res, err := p.Sweep(ctx, SweepOptions{Granularity: Exact})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Relinked) != 1 {
+		t.Fatalf("Relinked = %d, want 1 (identity resolves uniquely; retirement must not pre-empt the relink tier)", len(res.Relinked))
+	}
+}
+
+// Dry run must not retire. The CLI's dry-run default is load-bearing here: a
+// preview that mutates is worse than no preview, because the operator has been
+// told it is safe.
+func TestSweep_DryRunDoesNotRetire(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistGone", "01. gone.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "failed", "", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	p := New(sqlDB)
+	if _, err := p.Sweep(ctx, SweepOptions{Granularity: Exact, DryRun: true}); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	status, lastErr := statusOf(t, ctx, sqlDB, gone)
+	if status != "failed" {
+		t.Errorf("dry run mutated status to %q; it must write nothing", status)
+	}
+	if lastErr == unresolvableGoneError {
+		t.Error("dry run wrote the retirement marker; it must write nothing")
+	}
+}
+
+// A row still being worked must never be retired mid-flight.
+//
+// This asserts the OUTER defense: reconcile short-circuits on c.processing
+// before classify runs, so an in-flight row never reaches the retire path at
+// all. It deliberately does NOT prove the UPDATE's own status guard -- see
+// TestRetireUnresolvable_SkipsRowThatRacedIntoProcessing for that, which calls
+// retireUnresolvable directly because no Sweep-level fixture can reach it.
+func TestSweep_DoesNotRetireProcessingRow(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	gone := filepath.Join(root, "ArtistGone", "01. gone.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, gone, "done", "processing", "", "")
+	if err := os.Remove(gone); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	p := New(sqlDB)
+	if _, err := p.Sweep(ctx, SweepOptions{Granularity: Exact}); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	status, _ := statusOf(t, ctx, sqlDB, gone)
+	if status != "processing" {
+		t.Errorf("status = %q, want processing (an in-flight row must not be retired under the worker)", status)
+	}
+}
+
+// The UPDATE's own `status NOT IN ('processing','done')` guard closes a TOCTOU
+// window: gather reads the row as retirable, the worker claims it, and only then
+// does the retire fire. Sweep cannot produce that interleaving from a fixture --
+// the c.processing short-circuit gets there first -- so the guard is exercised
+// directly. Without this, removing 'processing' from the SQL guard leaves the
+// whole suite green (verified: it did).
+//
+// (TOCTOU -- time-of-check to time-of-use: state changes between the moment you
+// check it and the moment you act on it, so the check no longer describes
+// reality.)
+func TestRetireUnresolvable_SkipsRowThatRacedIntoProcessing(t *testing.T) {
+	ctx, sqlDB, libID, root := openSeeded(t)
+	racing := filepath.Join(root, "ArtistRace", "01. racing.flac")
+	seedRowWithIdentity(t, ctx, sqlDB, libID, racing, "done", "processing", "", "")
+
+	var wqID int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT id FROM work_queue WHERE source_path = ?`, racing).Scan(&wqID); err != nil {
+		t.Fatalf("read work_queue id: %v", err)
+	}
+
+	// The candidate as gather would have built it BEFORE the worker claimed the
+	// row: the work item is present and looks retirable. Only the UPDATE's guard
+	// stands between this and a row retired out from under the worker.
+	p := New(sqlDB)
+	retired, err := p.retireUnresolvable(ctx, &candidate{workItems: []workRow{{id: wqID}}})
+	if err != nil {
+		t.Fatalf("retireUnresolvable: %v", err)
+	}
+	if retired {
+		t.Error("reported a retirement for a row that raced into 'processing'; the caller would log a mutation that never happened")
+	}
+
+	status, lastErr := statusOf(t, ctx, sqlDB, racing)
+	if status != "processing" {
+		t.Errorf("status = %q, want processing (the worker still owns this row)", status)
+	}
+	if lastErr == unresolvableGoneError {
+		t.Error("wrote the retirement marker onto an in-flight row")
+	}
+}
+
+// A candidate with no work_queue rows at all (a scan_results row that was never
+// enqueued) must report no retirement rather than a phantom one, or the caller
+// records a mutation that did not happen.
+func TestRetireUnresolvable_NoWorkItemsReportsNothing(t *testing.T) {
+	ctx, sqlDB, _, _ := openSeeded(t)
+	p := New(sqlDB)
+
+	retired, err := p.retireUnresolvable(ctx, &candidate{})
+	if err != nil {
+		t.Fatalf("retireUnresolvable: %v", err)
+	}
+	if retired {
+		t.Error("reported a retirement with no work items to retire")
+	}
+}


### PR DESCRIPTION
## Summary

- A row whose source file is gone and which carries no ISRC or MBID is **retained** by design (#640: never delete on a guess). But retention left it in `failed`, which `Dequeue` still selects, so the worker kept fetching lyrics it could never write -- forever, because nothing in the retain path mutates the row. **The retain decision was correct; its permanence was not.**
- Such a row is now also **retired**: settled to `done` with a `last_error` naming the mechanism. Nothing is deleted, every telemetry column survives, and the row simply stops being work.
- **The diagnosis in the issue body was wrong and is corrected on the issue.** I filed it against `Directory` granularity's parent-only stat. `gone()` actually stats `filepath.Dir(src)` -- the ALBUM directory -- which is genuinely absent, so the sweep *did* reach these rows every cycle. Switching to `Exact` would have fixed nothing while statting every file in the library, which is exactly the disk I/O the idle-disk work has been removing.
- Reviewers should look first at the `settled` marker (convergence turns on it) and at `TestRetireUnresolvable_SkipsRowThatRacedIntoProcessing`, which exists because an earlier test of the same guard was vacuous.

## Linked issue

Closes #732

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), verified from the log rather than an exit code.
- [x] Code review pass complete; findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
      **Not done.** This changes serve-mode sweep behavior against a live queue; validating it properly means a dry run against a copy of a real database, which is a reviewer/maintainer call rather than something to assert from a test suite. See "Not covered".
- [x] Screenshot attached for any web-UI change -- N/A, no web-UI change.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A.
- [x] Migration added if this is a one-time data correction -- **N/A by design.** Existing stuck rows are retired by the next sweep through the normal code path; no migration is needed and none is added.

## Test plan

- [x] `make gate` passes locally (conflict markers, gofmt, `make ui`, build, race tests + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, govulncheck).
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. Every mutation fails at an assertion, not a build error:
  - Never retire (`Retired: false`): `TestSweep_RetiresUnresolvableGoneRow` and `TestSweep_RetireIsIdempotent` both fail.
  - Drop the `settled` convergence check: idempotence fails -- the second sweep re-reports the row.
  - Drop `'processing'` from the SQL guard: 3 assertions fail. **This mutation was GREEN before the direct-call test was added** -- see below.
- [x] Patch coverage meets the threshold.
- [x] Which **surface** this change fixes is stated explicitly and verified: `work_queue.status`, which is what `Dequeue` selects on. The row remains in `scan_results` and remains reported as retained, so the operator-facing accounting is unchanged.
- [ ] Manual UAT steps -- none run; see the checklist note above.
- [ ] Reviewer follow-ups:
  - [ ] Retiring to `done` reuses `RetireMiss`'s pattern rather than adding a status value, because `work_queue.status` has a `CHECK` constraint and a new value means recreating the table. #477 should convert both call sites together. If you would rather block this on #477 instead, say so -- the retire is easy to re-point at a real terminal state later.
  - [ ] `outcomeSettled` makes a settled candidate absent from every `Result` slice. That is deliberate (it is what lets a repeat sweep report an empty result), but it does mean a retired row stops appearing in sweep output entirely. If you want it visible-but-inert instead, that is a one-line change.

## One test was vacuous, and mutation testing caught it

Worth calling out rather than burying. `TestSweep_DoesNotRetireProcessingRow` **passed with the SQL guard deleted**: `reconcile` short-circuits on `c.processing` before `classify` runs, so an in-flight row never reaches the retire path and the `UPDATE`'s own guard was never exercised. The test proved the outer short-circuit works -- real, but not what its name claimed.

`TestRetireUnresolvable_SkipsRowThatRacedIntoProcessing` calls `retireUnresolvable` directly to reach the TOCTOU window no `Sweep`-level fixture can produce (gather reads the row as retirable, the worker claims it, then the retire fires). The same mutation now fails at three assertions.

## Not covered

- **No UAT against a live queue.** The tests cover the decision logic; they do not prove behavior against a real database with real row shapes. A dry run against a copy of a production database is the honest next check, and it is deliberately left to the maintainer.
- **This does not give identity to rows that lack it.** On the reference install **51,285 of 66,096 `scan_results` rows (77.6%) carry no ISRC or MBID**, so any of them that moves lands in this same unresolvable state. This change stops those rows accumulating as permanent queue work; it does nothing about the underlying identity gap. Whether that gap is a tagging reality or an ingestion bug is unanswered and worth its own issue.
- **A path-similarity relink tier for identity-less rows is not attempted.** `internal/realign` already has `heuristic-nm` with a margin rule (#672) built for re-attaching a sidecar with no provenance; the pruner has no equivalent tier. That would address the 77.6% structurally rather than retiring it, and carries every risk a name heuristic carries.
- **Cost correction:** the issue body implied a tight retry loop. Measured on the affected install, all five rows show `attempts=1` over ~12 days -- geometric backoff has them at roughly hourly. Real waste, but bounded. This is a correctness and hygiene fix, not a resource fire, and it should be prioritized as such.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unresolvable, missing work items are now retired instead of deleted.
  * Retired items retain their history, completion timestamp, and error details.
  * Retirement is reported once and safely skipped on subsequent sweeps.

* **Bug Fixes**
  * Prevented retirement during dry runs or while items are actively processing.
  * Preserved relinking for items that still have usable identity information.
  * Added safeguards against race conditions during retirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->