### PR TITLE
fix(worker): release the in-flight item on shutdown instead of failing it

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1939,7 +1939,14 @@ func (w *Worker) releaseAfterThrottle(ctx context.Context, item queue.WorkItem) 
 //     as one. Keying on the error alone would swallow every provider timeout --
 //     a far worse bug than the cosmetic one this fixes.
 func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) error {
-	if ctx.Err() != nil && errors.Is(cause, context.Canceled) {
+	// errors.Is(ctx.Err(), context.Canceled), NOT ctx.Err() != nil. The looser
+	// form admits a parent that expired by DEADLINE, which is a timeout rather
+	// than a shutdown: a caller that ever wraps the worker context in a
+	// WithTimeout would see its timed-out items released instead of failed, and
+	// the timeout would go unrecorded. Verified against a real expired
+	// WithTimeout parent -- the loose form takes this branch, the strict one does
+	// not.
+	if errors.Is(ctx.Err(), context.Canceled) && errors.Is(cause, context.Canceled) {
 		// Not a failure: do not touch consecutiveFailures or the last-failure fields,
 		// or a few restarts would put the next run into a backoff it never earned.
 		// WithoutCancel because the release must land despite the canceled parent --

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1916,7 +1916,40 @@ func (w *Worker) releaseAfterThrottle(ctx context.Context, item queue.WorkItem) 
 	return nil
 }
 
+// fail records a work item's hard failure -- EXCEPT when the "failure" is this
+// process shutting down, in which case the item is released back to the queue
+// instead (#733).
+//
+// A shutdown cancellation is not the item's verdict. Worker.run already treats
+// it correctly at the loop level, but the item in flight when the signal arrived
+// was still driven through this path, stamping 'context canceled' onto the row
+// and parking it in the failed bucket -- indistinguishable on the Failure
+// Analysis report from a genuine hard error, and accruing one such row per
+// unlucky restart. Releasing restores the row's prior status and clears the
+// error, so the next run picks it up with no residue and no attempt consumed.
+//
+// THE DISCRIMINATOR IS BOTH HALVES, AND THAT IS THE WHOLE CARE HERE. The parent
+// context must be canceled AND the cause must be that cancellation:
+//
+//   - ctx.Err() alone is not enough: an item that genuinely failed microseconds
+//     before the signal arrived would have its real error discarded and be
+//     silently released, losing a defect the operator needed to see.
+//   - The error value alone is not enough either: a per-request
+//     context.DeadlineExceeded is a REAL provider failure and must keep counting
+//     as one. Keying on the error alone would swallow every provider timeout --
+//     a far worse bug than the cosmetic one this fixes.
 func (w *Worker) fail(ctx context.Context, item queue.WorkItem, cause error) error {
+	if ctx.Err() != nil && errors.Is(cause, context.Canceled) {
+		// Not a failure: do not touch consecutiveFailures or the last-failure fields,
+		// or a few restarts would put the next run into a backoff it never earned.
+		// WithoutCancel because the release must land despite the canceled parent --
+		// the same reason every other queue effect on this path uses it.
+		if err := w.queue.Release(context.WithoutCancel(ctx), item.ID); err != nil {
+			return fmt.Errorf("worker: release item %d after shutdown: %w", item.ID, err)
+		}
+		slog.Info("worker: released in-flight item on shutdown", "id", item.ID)
+		return nil
+	}
 	w.consecutiveFailures++
 	w.lastFailID = item.ID
 	w.lastFailArtist = item.Inputs.Track.ArtistName

--- a/internal/worker/worker_cancel_test.go
+++ b/internal/worker/worker_cancel_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/queue"
 )
@@ -144,6 +145,44 @@ func TestFailSurfacesABookkeepingFailure(t *testing.T) {
 	// The counter still moved: the item DID fail, even though recording it did not.
 	if w.consecutiveFailures != 1 {
 		t.Errorf("consecutiveFailures = %d, want 1", w.consecutiveFailures)
+	}
+}
+
+// An EXPIRED-BY-DEADLINE parent is a timeout, not a shutdown, even when the
+// cause happens to wrap context.Canceled -- a lane can surface a canceled inner
+// request while the worker's own context died of a deadline.
+//
+// The original guard used `ctx.Err() != nil`, which admits DeadlineExceeded and
+// so released the item and skipped failure accounting entirely. Verified against
+// a real expired WithTimeout parent before fixing: the loose form takes the
+// release branch, the strict `errors.Is(ctx.Err(), context.Canceled)` does not.
+//
+// No caller wraps the worker context in a WithTimeout today, so this is latent
+// -- but it is one line to be exactly right, and a silently-swallowed timeout is
+// the kind of bug nobody reports. Found by CodeRabbit on #736.
+func TestFailStillFailsWhenParentExpiredByDeadline(t *testing.T) {
+	q := &fakeQueue{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 13}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // let the deadline actually pass
+
+	// The cause wraps Canceled (an inner request was canceled) while the parent
+	// died of a DEADLINE. That combination is what separates the two guards.
+	if err := w.fail(ctx, item, fmt.Errorf("lane musixmatch: %w", context.Canceled)); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	if len(q.failed) != 1 || q.failed[0] != item.ID {
+		t.Errorf("failed = %v, want [%d]: a deadline is a timeout, not a shutdown", q.failed, item.ID)
+	}
+	if len(q.released) != 0 {
+		t.Errorf("released = %v, want empty: releasing here would swallow the timeout unrecorded", q.released)
+	}
+	if w.consecutiveFailures != 1 {
+		t.Errorf("consecutiveFailures = %d, want 1 (a timeout still counts against the pipeline)", w.consecutiveFailures)
 	}
 }
 

--- a/internal/worker/worker_cancel_test.go
+++ b/internal/worker/worker_cancel_test.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/queue"
+)
+
+// A shutdown cancellation is not the item's verdict. Worker.run already handles
+// cancellation correctly at the LOOP level, but the item in flight when the
+// signal arrives was still completed through the ordinary failure path -- so a
+// routine restart stamped 'context canceled' onto a work_queue row and left it
+// in the failed bucket, indistinguishable on the Failure Analysis report from a
+// genuine hard error (#733).
+//
+// Releasing restores the row's prior status and clears the error, so the item is
+// picked up again next run with no residue and no attempt consumed.
+func TestFailReleasesOnShutdownCancellation(t *testing.T) {
+	q := &fakeQueue{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 7}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the shutdown signal has already arrived
+
+	if err := w.fail(ctx, item, fmt.Errorf("worker: find lyrics: %w", context.Canceled)); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	if len(q.failed) != 0 {
+		t.Errorf("item was marked failed on a shutdown cancellation; a restart must leave no residue on the failures view")
+	}
+	if len(q.released) != 1 || q.released[0] != item.ID {
+		t.Errorf("released = %v, want [%d]: the item must return to the queue for the next run", q.released, item.ID)
+	}
+	// The consecutive-failure counter drives the worker's backoff. A shutdown is
+	// not evidence the pipeline is unhealthy, so it must not count toward it --
+	// otherwise a few restarts make the next run start in a backoff it did not earn.
+	if w.consecutiveFailures != 0 {
+		t.Errorf("consecutiveFailures = %d, want 0 (a shutdown is not a pipeline failure)", w.consecutiveFailures)
+	}
+}
+
+// A DeadlineExceeded from a per-request timeout is a REAL failure and must keep
+// being recorded as one. The discriminator is whether the parent context was
+// canceled, not the error value alone -- without that, this fix would silently
+// swallow every provider timeout, which is a far worse bug than the cosmetic one
+// it set out to fix.
+func TestFailStillFailsOnRequestTimeout(t *testing.T) {
+	q := &fakeQueue{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 8}
+
+	// Live parent context: the deadline belonged to one request, not to shutdown.
+	cause := fmt.Errorf("musixmatch: fetch: %w", context.DeadlineExceeded)
+	if err := w.fail(context.Background(), item, cause); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	if len(q.failed) != 1 || q.failed[0] != item.ID {
+		t.Errorf("failed = %v, want [%d]: a request timeout is a genuine failure", q.failed, item.ID)
+	}
+	if len(q.released) != 0 {
+		t.Errorf("released = %v, want empty: a request timeout must not be released as if it were a shutdown", q.released)
+	}
+	if w.consecutiveFailures != 1 {
+		t.Errorf("consecutiveFailures = %d, want 1 (a real failure still counts)", w.consecutiveFailures)
+	}
+}
+
+// An ordinary provider error under a live context is untouched by this change.
+// The regression that matters most is the one where every failure starts being
+// released, silently emptying the failed bucket.
+func TestFailStillFailsOnOrdinaryError(t *testing.T) {
+	q := &fakeQueue{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 9}
+
+	if err := w.fail(context.Background(), item, errors.New("musixmatch: unexpected matcher status_code 500")); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	if len(q.failed) != 1 {
+		t.Errorf("failed = %v, want one entry: an ordinary provider error is still a failure", q.failed)
+	}
+	if len(q.released) != 0 {
+		t.Errorf("released = %v, want empty", q.released)
+	}
+}
+
+// A canceled context with a NON-cancellation cause is still a real failure.
+// Guards against keying the decision on ctx.Err() alone: an item that genuinely
+// failed just before the shutdown signal arrived would otherwise have its real
+// error discarded and be silently released.
+func TestFailRecordsARealErrorThatRacedWithShutdown(t *testing.T) {
+	q := &fakeQueue{}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 10}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := w.fail(ctx, item, errors.New("worker: write item 10: refusing to write: output dir does not exist")); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	if len(q.failed) != 1 {
+		t.Errorf("failed = %v, want one entry: the cause is a real error, not the cancellation", q.failed)
+	}
+	if len(q.released) != 0 {
+		t.Errorf("released = %v, want empty: a genuine failure racing a shutdown must still be recorded", q.released)
+	}
+}

--- a/internal/worker/worker_cancel_test.go
+++ b/internal/worker/worker_cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/queue"
@@ -71,6 +72,32 @@ func TestFailStillFailsOnRequestTimeout(t *testing.T) {
 	}
 }
 
+// A failed Release must surface, not be swallowed. If the release errors the
+// item is still 'processing' in the database, so silently returning nil would
+// leave it wedged there with nothing reporting why -- the worker that owns it is
+// shutting down and will not come back to it.
+func TestFailSurfacesAReleaseFailureOnShutdown(t *testing.T) {
+	q := &fakeQueue{releaseErr: errors.New("database is locked")}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 11}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := w.fail(ctx, item, fmt.Errorf("worker: find lyrics: %w", context.Canceled))
+	if err == nil {
+		t.Fatal("a failed release returned nil; the item is left 'processing' with nothing reporting it")
+	}
+	if !strings.Contains(err.Error(), "release item 11") {
+		t.Errorf("error does not identify the item or the operation: %v", err)
+	}
+	// It must not silently fall through to the failure path either -- that would
+	// record a hard failure for what was only a shutdown.
+	if len(q.failed) != 0 {
+		t.Errorf("failed = %v, want empty: a release error must not become a recorded failure", q.failed)
+	}
+}
+
 // An ordinary provider error under a live context is untouched by this change.
 // The regression that matters most is the one where every failure starts being
 // released, silently emptying the failed bucket.
@@ -88,6 +115,35 @@ func TestFailStillFailsOnOrdinaryError(t *testing.T) {
 	}
 	if len(q.released) != 0 {
 		t.Errorf("released = %v, want empty", q.released)
+	}
+}
+
+// A failed Fail must surface too, carrying BOTH the original cause and the
+// bookkeeping error. Losing the original would leave an operator with "the
+// database was busy" and no trace of what the item actually did wrong.
+//
+// This branch predates the shutdown-release change, but it sits in the same
+// function and was never exercised; covering it here is cheaper than arguing it
+// out of scope.
+func TestFailSurfacesABookkeepingFailure(t *testing.T) {
+	q := &fakeQueue{failErr: errors.New("database is locked")}
+	w := New(q, &fakeCache{}, &fakeFetcher{}, &fakeWriter{})
+	item := queue.WorkItem{ID: 12}
+
+	cause := errors.New("musixmatch: unexpected matcher status_code 500")
+	err := w.fail(context.Background(), item, cause)
+	if err == nil {
+		t.Fatal("a failed Fail returned nil; the item is left 'processing' with nothing reporting it")
+	}
+	if !strings.Contains(err.Error(), "status_code 500") {
+		t.Errorf("the original cause was lost, leaving only the bookkeeping error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "database is locked") {
+		t.Errorf("the bookkeeping error was lost: %v", err)
+	}
+	// The counter still moved: the item DID fail, even though recording it did not.
+	if w.consecutiveFailures != 1 {
+		t.Errorf("consecutiveFailures = %d, want 1", w.consecutiveFailures)
 	}
 }
 


### PR DESCRIPTION
## Summary

- An item being processed when serve shuts down was driven through the ordinary failure path, stamping `context canceled` onto its `work_queue` row and parking it in the failed bucket -- indistinguishable on the Failure Analysis report from a genuine hard error. The container restarts nightly for an appdata backup, so these accumulate one per unlucky restart.
- `Worker.run` already handled cancellation correctly at the **loop** level. The gap was per-**item**: the one in flight when the signal arrived still had the cancellation recorded as its verdict. It is now **released** instead -- restoring the row's prior status and clearing `last_error`, the same escape hatch the throttle path already uses. No residue, no attempt consumed.
- Reviewers should look first at the **discriminator**, which deliberately requires both halves. Either one alone is a worse bug than the one being fixed; see below.

## Linked issue

Closes #733

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), verified from the log rather than an exit code.
- [x] Code review pass complete; findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes.
      **Not done.** Exercising this means restarting serve mid-item against a live queue. The tests drive `fail` directly with a canceled context, which covers the decision but not the real shutdown sequence. See "Not covered".
- [x] Screenshot attached for any web-UI change -- N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed -- N/A.
- [x] Migration added if this is a one-time data correction -- **N/A by design.** Existing `context canceled` rows are already retryable and clear themselves on the next successful attempt; no backfill is warranted for a cosmetic residue.

## Test plan

- [x] `make gate` passes locally.
- [x] New tests were confirmed to **fail against unfixed code** -- but only ONE of the four does, and that is the point. The other three guard against over-reach and passed *before* the change: a per-request timeout, an ordinary provider error, and a real error racing the shutdown must all still fail as they always did.
- [x] Both wrong discriminators were written as mutations, and each fails at the assertion aimed at it:
  - Key on `ctx.Err()` alone → `TestFailRecordsARealErrorThatRacedWithShutdown` fails: "the cause is a real error, not the cancellation".
  - Key on the error value alone → `TestFailStillFailsOnRequestTimeout` fails: "a request timeout is a genuine failure".
- [x] Patch coverage: **100% (10/10)**.

  **Correction.** This line previously claimed the patch gate self-skipped because `internal/worker/worker.go` was on the codecov `ignore` list. That was wrong -- it is not on that list, and I stated a false reason here. The local gate printed "no Go source changes in scope"; Codecov disagreed and `codecov/patch` FAILED. Codecov was right, and the merge oracle blocked on it.

  Two error branches were uncovered and are now tested: the `Release` failure on the new shutdown path, and the pre-existing `Fail` failure in the same function (never previously exercised). I accepted a skip as a pass, which is exactly what this checklist item warns against.
- [x] Which **surface** this change fixes is stated explicitly: `work_queue.status` and `last_error`, which feed both the Failure Analysis report and the `mxlrcgo_queue_failures{reason=...}` metric. A released row appears in neither.
- [ ] Manual UAT steps -- none run; see above.
- [ ] Reviewer follow-ups:
  - [ ] The shutdown path deliberately leaves `consecutiveFailures` and the last-failure fields untouched, so a restart cannot start the next run in a backoff it never earned. Worth a second opinion on whether any caller depends on those being set for *every* `fail` invocation -- I read the call sites and found none.

## The discriminator needs both halves

```go
if ctx.Err() != nil && errors.Is(cause, context.Canceled)
```

Each half alone fails in a way that is worse than the cosmetic bug this fixes:

- **`ctx.Err()` alone** -- an item that genuinely failed microseconds before the signal arrived would have its real error discarded and be silently released. The operator loses a defect they needed to see.
- **The error value alone** -- a per-request `context.DeadlineExceeded` is a real provider failure. Keying on the error would swallow every provider timeout, silently emptying the failed bucket.

The three over-reach guards exist specifically because this fix's failure mode is making failures *disappear*, which is exactly the class of bug nobody notices.

## Not covered

- **No UAT against a live queue.** The tests call `fail` directly with a canceled context. That covers the decision, not the surrounding shutdown sequence -- signal handling, in-flight goroutine teardown, and the release landing before the process exits. The release uses `context.WithoutCancel` for that reason, but it is reasoned rather than observed.
- **Only the `w.fail` path is changed.** The `Complete`-failure site (`worker.go:1420`) calls `w.queue.Fail` directly and is untouched. A cancellation cannot plausibly surface there -- it fires only when `Complete` itself errors, after the output is already on disk -- but I did not restructure that path, so it is not covered by this change.
- **Existing `context canceled` rows are not cleaned up.** They are retryable and clear themselves on the next successful attempt. A migration would be disproportionate for cosmetic residue, and unlike #731's oversized values these rows are not permanent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling to safely release in-flight work without incorrectly recording failures or increasing backoff.
  * Preserved normal failure handling for request timeouts, ordinary errors, and genuine errors occurring during shutdown.
  * Improved error reporting when releasing work or updating failure records encounters an error.

* **Tests**
  * Added coverage for shutdown cancellation, timeouts, ordinary failures, bookkeeping errors, and shutdown race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->