### PR TITLE
fix(failsig): normalize the failure signature so one root cause is one group

### DIFF
--- a/internal/failsig/failsig.go
+++ b/internal/failsig/failsig.go
@@ -1,0 +1,98 @@
+// Package failsig normalizes a work_queue.last_error string into a stable
+// grouping key: one root cause yields one signature, regardless of which item,
+// file, or ephemeral port happened to produce it.
+//
+// It exists for two reasons that turn out to be the same fix (#478).
+//
+// GROUPING. The Failure Analysis report and the /metrics failure counter both
+// GROUP BY the raw last_error. That already works well for benign misses, whose
+// text is fixed -- 20,124 deferred rows collapse to 13 groups on the reference
+// install. It barely works for hard failures, whose text embeds per-item
+// variable data: 14 failed rows produced 10 "categories", so five write failures
+// with a single root cause read as five separate problems.
+//
+// PRIVACY. The same variable text is private metadata. work_queue.last_error is
+// grouped by queue.CountFailuresByReason and emitted VERBATIM as the
+// mxlrcgo_queue_failures{reason="..."} Prometheus label
+// (internal/server/metrics.go), which an external scraper stores and retains
+// off-host. Five of the 14 failed signatures carried absolute library paths onto
+// that surface. That is the same exposure removed from the detector's error in
+// #731 and from a report in #431, reached by a third route.
+//
+// Normalizing the key fixes both at once, and drops label cardinality as a side
+// effect -- the label previously earned a distinct time series per failing file.
+//
+// WHAT IT DOES NOT DO. This is not redaction and must not be relied on as any
+// part of one: secrets are kept out of these strings at their construction
+// sites. It removes text that is VARIABLE, which is a different property from
+// text that is SECRET, and a value that is neither stays untouched.
+package failsig
+
+import (
+	"regexp"
+	"strings"
+)
+
+// The order of these patterns matters where they can overlap; each is applied in
+// sequence by Normalize.
+//
+// Every placeholder is a fixed token, never a hash or an index, so the result is
+// deterministic and idempotent: normalizing a normalized string is a no-op
+// because the placeholders themselves match nothing here.
+var replacements = []struct {
+	re   *regexp.Regexp
+	with string
+}{
+	// A quoted absolute path, e.g. output dir "/Share/Music/...". Handled before
+	// the bare-path rule so the quotes are consumed with it rather than left as
+	// an empty pair.
+	{regexp.MustCompile(`"(?:/[^"\n]*)"`), `"<path>"`},
+	// An ephemeral host:port inside a dial/read address, e.g. 127.0.0.1:56723.
+	// Before the bare-IP rule, which would otherwise leave the port stranded.
+	{regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}:\d+`), `<addr>`},
+	// A bare IPv4 address, e.g. a container IP that changes on every restart.
+	{regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`), `<ip>`},
+	// A hex memory address, e.g. ffmpeg's "[mp3float @ 0x14e1cf868a80]". The
+	// allocator hands out a different address every run, so two occurrences of
+	// ONE ffmpeg failure never grouped together -- verified against the real
+	// signature before adding this. Same class as the ports and IPs above:
+	// variable per run, carrying no diagnostic value.
+	{regexp.MustCompile(`\b0x[0-9a-fA-F]+\b`), `<addr>`},
+	// A work_queue row id, e.g. "write item 77508 output". Anchored to the word
+	// "item" so an ordinary number elsewhere in a message is not eaten -- notably
+	// NOT a status code, which is the actionable signal and must survive.
+	{regexp.MustCompile(`\bitem \d+\b`), `item <id>`},
+	// A bare absolute path. Last, so the quoted and address forms above have
+	// already claimed their text.
+	//
+	// IT MUST NOT STOP AT WHITESPACE. Library paths routinely contain spaces
+	// ("/Share/Music/Some Artist/Album One/07. Track.lrc"), and a \S-based rule
+	// shreds one path into fragments -- leaving "(27)" and "Album" and the
+	// filename behind as residue that still varies per row, so the grouping does
+	// not collapse AND the leaked text is only partly removed. Measured on the
+	// real signatures: three write failures still produced three groups.
+	//
+	// These messages delimit a path with ": " (colon-SPACE) or end-of-line, so
+	// that is the terminator. RE2 has no lookahead, so the delimiter is captured
+	// and restored rather than peeked at.
+	{regexp.MustCompile(`/[^"\n]*?(: |\n|$)`), `<path>${1}`},
+}
+
+// Normalize returns a stable grouping key for one last_error value.
+//
+// An empty or whitespace-only input returns empty: the SQL layer already maps
+// that to "unknown", and minting a second empty bucket here would split one
+// group in two.
+//
+// A signature carrying no variable text is returned unchanged, so the
+// already-well-grouped benign-miss population is untouched.
+func Normalize(s string) string {
+	out := strings.TrimSpace(s)
+	if out == "" {
+		return ""
+	}
+	for _, r := range replacements {
+		out = r.re.ReplaceAllString(out, r.with)
+	}
+	return out
+}

--- a/internal/failsig/failsig.go
+++ b/internal/failsig/failsig.go
@@ -47,17 +47,35 @@ var replacements = []struct {
 	// the bare-path rule so the quotes are consumed with it rather than left as
 	// an empty pair.
 	{regexp.MustCompile(`"(?:/[^"\n]*)"`), `"<path>"`},
-	// An ephemeral host:port inside a dial/read address, e.g. 127.0.0.1:56723.
+	// A bracketed IPv6 endpoint, e.g. [2001:db8::1]:8080. First, because the
+	// brackets must be consumed with the address rather than left stranded.
+	{regexp.MustCompile(`\[[0-9a-fA-F:]+\]:\d+`), `<addr>`},
+	// A bare IPv6 address, in two alternatives -- the "::"-compressed form first
+	// so it wins on a compressed address, then the full uncompressed 8-group form.
+	//
+	// DELIBERATELY NARROW, because a loose colon-group pattern eats CLOCK TIMES:
+	// "12:30:45" and "1:02:03" are hex-group-shaped, and collapsing them to <ip>
+	// would merge distinct timings. Requiring either a literal "::" or all eight
+	// groups excludes a 3-field time by construction. A first draft that merely
+	// required 2+ groups both ate clock times AND stranded a digit
+	// ("2001:db8::1" -> "<ip>1"), which is why this is probed rather than assumed.
+	{regexp.MustCompile(`\b(?:[0-9a-fA-F]{1,4}:){1,7}:(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4})*)?|\b[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){7}\b`), `<ip>`},
+	// An ephemeral IPv4 host:port inside a dial/read address, e.g. 127.0.0.1:56723.
 	// Before the bare-IP rule, which would otherwise leave the port stranded.
 	{regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}:\d+`), `<addr>`},
 	// A bare IPv4 address, e.g. a container IP that changes on every restart.
 	{regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`), `<ip>`},
-	// A hex memory address, e.g. ffmpeg's "[mp3float @ 0x14e1cf868a80]". The
-	// allocator hands out a different address every run, so two occurrences of
-	// ONE ffmpeg failure never grouped together -- verified against the real
-	// signature before adding this. Same class as the ports and IPs above:
-	// variable per run, carrying no diagnostic value.
-	{regexp.MustCompile(`\b0x[0-9a-fA-F]+\b`), `<addr>`},
+	// A hex memory address in ALLOCATOR SYNTAX ONLY, e.g. ffmpeg's
+	// "[mp3float @ 0x14e1cf868a80]". The allocator hands out a different address
+	// every run, so two occurrences of ONE ffmpeg failure never grouped together.
+	//
+	// ANCHORED TO "@ ", DELIBERATELY. A bare \b0x[0-9a-fA-F]+\b also matches a hex
+	// STATUS code -- "exit status 0xC0000005" (access violation) and
+	// "exit status 0xC0000409" (stack buffer overrun) are different failures that
+	// collapsed into one group. That is the over-normalization this package is
+	// supposed to prevent, so the rule is narrowed to the one syntax where a hex
+	// token is provably an address rather than a code.
+	{regexp.MustCompile(`@ 0x[0-9a-fA-F]+`), `@ <addr>`},
 	// A work_queue row id, e.g. "write item 77508 output". Anchored to the word
 	// "item" so an ordinary number elsewhere in a message is not eaten -- notably
 	// NOT a status code, which is the actionable signal and must survive.
@@ -72,10 +90,24 @@ var replacements = []struct {
 	// not collapse AND the leaked text is only partly removed. Measured on the
 	// real signatures: three write failures still produced three groups.
 	//
-	// These messages delimit a path with ": " (colon-SPACE) or end-of-line, so
-	// that is the terminator. RE2 has no lookahead, so the delimiter is captured
-	// and restored rather than peeked at.
-	{regexp.MustCompile(`/[^"\n]*?(: |\n|$)`), `<path>${1}`},
+	// IT MUST ALSO NOT RUN TO END-OF-LINE. An earlier version terminated on
+	// ": " OR end-of-line, and the end-of-line branch swallowed the diagnostic
+	// suffix: "read /mnt/a permission denied" and "read /mnt/a checksum mismatch"
+	// both became "read <path>", merging two distinct root causes. Erasing the
+	// cause is strictly worse than leaking the path, because the report then
+	// shows one group that means nothing.
+	//
+	// So the ONLY terminator is ": " (colon-SPACE), the delimiter these messages
+	// actually use, plus a newline. A path that ends a line without a delimiter is
+	// left alone rather than guessed at -- see pathToEOL below, which handles the
+	// one shape where end-of-line is provably safe. RE2 has no lookahead, so the
+	// delimiter is captured and restored rather than peeked at.
+	{regexp.MustCompile(`/[^"\n]*?(: |\n)`), `<path>${1}`},
+	// A path that ends the line, but ONLY when the line has no further text after
+	// it -- i.e. the path IS the tail. Anchored to a quote or a known
+	// path-introducing token so an unquoted path followed by prose (the case
+	// above) is never consumed.
+	{regexp.MustCompile(`(output |file |path )/[^"\n]*$`), `${1}<path>`},
 }
 
 // Normalize returns a stable grouping key for one last_error value.

--- a/internal/failsig/failsig_test.go
+++ b/internal/failsig/failsig_test.go
@@ -145,3 +145,70 @@ func TestNormalizeHandlesMultiLine(t *testing.T) {
 		t.Errorf("normalized signature retains a container IP:\n%s", got)
 	}
 }
+
+// An IPv6 endpoint is private endpoint metadata exactly as an IPv4 one is, and
+// the first draft handled only IPv4 -- so a v6 address reached the Prometheus
+// label untouched. Found by CodeRabbit on #737.
+func TestNormalizeCollapsesIPv6(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"bracketed with port", `dial tcp [2001:db8::1]:8080: connect: refused`},
+		{"bare compressed", `lookup host on 2001:db8::1: timeout`},
+		{"short compressed", `dial fe80::1 refused`},
+		{"full uncompressed", `dial 2001:0db8:85a3:0000:0000:8a2e:0370:7334 refused`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Normalize(tc.in)
+			for _, leak := range []string{"2001", "db8", "fe80", "8a2e"} {
+				if strings.Contains(got, leak) {
+					t.Errorf("IPv6 fragment %q survived normalization: %s", leak, got)
+				}
+			}
+		})
+	}
+}
+
+// A CLOCK TIME is hex-group-shaped, so a loose IPv6 rule eats it -- and
+// collapsing "12:30:45" to <ip> would merge distinct timings into one group.
+// This is the false positive that a first-draft IPv6 pattern actually produced,
+// which is why the shipped rule requires either a literal "::" or all eight
+// groups.
+func TestNormalizeDoesNotEatClockTimes(t *testing.T) {
+	for _, in := range []string{
+		"ffmpeg: duration 12:30:45 exceeded",
+		"stalled after 1:02:03 total",
+	} {
+		if got := Normalize(in); got != in {
+			t.Errorf("a clock time was normalized as an address:\n got %q\nwant %q", got, in)
+		}
+	}
+}
+
+// A HEX STATUS CODE is not an allocator address. 0xC0000005 (access violation)
+// and 0xC0000409 (stack buffer overrun) are different failures; collapsing them
+// is the over-normalization this package exists to avoid. The shipped rule is
+// anchored to "@ " -- the one syntax where a hex token is provably an address.
+func TestNormalizeKeepsDistinctHexStatusCodes(t *testing.T) {
+	a := Normalize("worker: ffmpeg: exit status 0xC0000005")
+	b := Normalize("worker: ffmpeg: exit status 0xC0000409")
+	if a == b {
+		t.Errorf("two distinct hex status codes collapsed into one group: %s", a)
+	}
+	if !strings.Contains(a, "0xC0000005") {
+		t.Errorf("the status code was normalized away; it is the actionable signal: %s", a)
+	}
+}
+
+// THE ROOT CAUSE MUST SURVIVE AN UNQUOTED PATH. An earlier path rule terminated
+// on end-of-line, so it swallowed everything after the path: two different
+// failures on the same file became one meaningless group. Erasing the cause is
+// strictly worse than leaking the path.
+func TestNormalizeKeepsTheCauseAfterAnUnquotedPath(t *testing.T) {
+	a := Normalize("read /mnt/a permission denied")
+	b := Normalize("read /mnt/a checksum mismatch")
+	if a == b {
+		t.Errorf("two distinct root causes collapsed: %s", a)
+	}
+	if !strings.Contains(a, "permission denied") {
+		t.Errorf("the diagnostic suffix was erased: %s", a)
+	}
+}

--- a/internal/failsig/failsig_test.go
+++ b/internal/failsig/failsig_test.go
@@ -1,0 +1,147 @@
+package failsig
+
+import (
+	"strings"
+	"testing"
+)
+
+// The five write failures on the reference install differ ONLY by item id and
+// path, so the report showed five "categories" for one root cause -- and each
+// carried an absolute library path onto a Prometheus label an external scraper
+// retains off-host (#478).
+//
+// Both properties are asserted together because they are the same fix: the
+// variable text that defeats grouping IS the private metadata that must not
+// leak.
+func TestNormalizeCollapsesWriteFailures(t *testing.T) {
+	in := []string{
+		`worker: write item 77508 output /Share/Music/Artist (27)/Album One/07. Track.lrc: refusing to write: output dir "/Share/Music/Artist (27)/Album One" does not exist`,
+		`worker: write item 77485 output /Share/Music/Artist (27)/Other/05. Different.lrc: refusing to write: output dir "/Share/Music/Artist (27)/Other" does not exist`,
+		`worker: write item 77542 output /Share/Music/Other Artist/The 6th/06. Song.lrc: refusing to write: output dir "/Share/Music/Other Artist/The 6th" does not exist`,
+	}
+
+	got := make(map[string]bool)
+	for _, s := range in {
+		n := Normalize(s)
+		got[n] = true
+		if strings.Contains(n, "/Share/") {
+			t.Errorf("normalized signature still carries a library path:\n%s", n)
+		}
+		if strings.Contains(n, "77508") || strings.Contains(n, "77485") || strings.Contains(n, "77542") {
+			t.Errorf("normalized signature still carries an item id:\n%s", n)
+		}
+	}
+	if len(got) != 1 {
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		t.Errorf("one root cause produced %d groups, want 1:\n%s", len(got), strings.Join(keys, "\n"))
+	}
+}
+
+// Transport failures embed an ephemeral source port and a container IP, so two
+// instances of one outage never collapse.
+func TestNormalizeCollapsesTransportFailures(t *testing.T) {
+	a := Normalize(`lane musixmatch: find lyrics: musixmatch: transport error: proxyconnect tcp: dial tcp: lookup proxy-host on 127.0.0.11:53: read udp 127.0.0.1:56723->127.0.0.11:53: i/o timeout`)
+	b := Normalize(`lane musixmatch: find lyrics: musixmatch: transport error: proxyconnect tcp: dial tcp: lookup proxy-host on 127.0.0.11:53: read udp 127.0.0.1:47269->127.0.0.11:53: i/o timeout`)
+	if a != b {
+		t.Errorf("two instances of one transport outage did not collapse:\n%s\n%s", a, b)
+	}
+	if strings.Contains(a, "56723") {
+		t.Errorf("normalized signature retains an ephemeral port:\n%s", a)
+	}
+}
+
+// ffmpeg stamps an allocator address into its decoder diagnostics, and that
+// address differs on every run -- so two occurrences of ONE corrupt-file failure
+// landed in two groups. Found by running the normalizer over the real production
+// signatures rather than over fixtures, which is the only reason it surfaced.
+func TestNormalizeCollapsesHexAddresses(t *testing.T) {
+	a := Normalize("detector: sample audio with ffmpeg: exit status 69: [mp3float @ 0x14e1cf868a80] Header missing")
+	b := Normalize("detector: sample audio with ffmpeg: exit status 69: [mp3float @ 0x7f2a11b04220] Header missing")
+	if a != b {
+		t.Errorf("one ffmpeg failure produced two groups; the allocator address varies per run:\n%s\n%s", a, b)
+	}
+	if strings.Contains(a, "0x14e1") {
+		t.Errorf("normalized signature retains a memory address:\n%s", a)
+	}
+	// The exit status is the actionable part and must survive.
+	if !strings.Contains(a, "exit status 69") {
+		t.Errorf("the exit status was normalized away; it is the signal:\n%s", a)
+	}
+}
+
+// A DISTINCTION THAT MUST SURVIVE. Over-normalizing is the failure mode that
+// would make this change harmful rather than merely useless: collapsing a 500
+// into a 400 hides a permanent misconfiguration inside a transient-outage group.
+// The status code is the signal, not noise.
+func TestNormalizeKeepsDistinctStatusCodes(t *testing.T) {
+	a := Normalize("lane musixmatch: find lyrics: musixmatch: unexpected matcher status_code 500")
+	b := Normalize("lane musixmatch: find lyrics: musixmatch: unexpected matcher status_code 400")
+	if a == b {
+		t.Errorf("a 500 and a 400 collapsed into one group; the status code is the actionable signal:\n%s", a)
+	}
+}
+
+// Two genuinely different root causes must stay apart even though both are
+// "musixmatch failed".
+func TestNormalizeKeepsDistinctRootCauses(t *testing.T) {
+	a := Normalize("lane musixmatch: find lyrics: musixmatch: unexpected matcher status_code 500")
+	b := Normalize("lane musixmatch: find lyrics: musixmatch: transport error: proxyconnect tcp: connection refused")
+	if a == b {
+		t.Errorf("a provider 5xx and a transport failure collapsed:\n%s", a)
+	}
+}
+
+// The benign-miss signatures already group perfectly (13 groups over 20,124 rows
+// on the reference install). Normalization must not disturb them -- a change
+// that "improves" the working case is a regression in disguise.
+func TestNormalizeLeavesCleanSignaturesAlone(t *testing.T) {
+	for _, s := range []string{
+		"orchestrator: lane benign miss (no result)",
+		"musixmatch: no lyrics available: no synced or unsynced lyrics",
+		"musixmatch: no results found",
+		"musixmatch: truncated or empty response body: subtitle_body empty despite HasSubtitles=1",
+		"unknown",
+	} {
+		if got := Normalize(s); got != s {
+			t.Errorf("a clean signature was altered:\n got %q\nwant %q", got, s)
+		}
+	}
+}
+
+// A normalized signature is a GROUPING KEY, so it must be stable: the same input
+// always yields the same output, and normalizing twice changes nothing. Without
+// idempotence a re-normalized value could drift into its own group.
+func TestNormalizeIsIdempotent(t *testing.T) {
+	in := `worker: write item 42 output /Share/Music/A/B/c.lrc: refusing to write: output dir "/Share/Music/A/B" does not exist`
+	once := Normalize(in)
+	if twice := Normalize(once); twice != once {
+		t.Errorf("not idempotent:\n once %q\ntwice %q", once, twice)
+	}
+}
+
+// Empty and whitespace-only input must not become a distinct group -- the SQL
+// already maps an empty last_error to "unknown", and normalization must not
+// reintroduce a second empty bucket alongside it.
+func TestNormalizeEmptyIsStable(t *testing.T) {
+	for _, s := range []string{"", "   ", "\n\t "} {
+		if got := Normalize(s); got != "" {
+			t.Errorf("Normalize(%q) = %q, want empty", s, got)
+		}
+	}
+}
+
+// A multi-line error (the detector lane wraps its cause on a second line) keeps
+// its shape: the first line is the category, and later lines are where the
+// variable text lives.
+func TestNormalizeHandlesMultiLine(t *testing.T) {
+	got := Normalize("detector request failed: orchestrator: lane outage\ndetector: classifier unavailable: Post \"http://yamnet:8080/classify\": dial tcp 172.22.0.2:8080: connect: connection refused")
+	if !strings.Contains(got, "detector request failed") {
+		t.Errorf("the leading category was lost:\n%s", got)
+	}
+	if strings.Contains(got, "172.22.0.2") {
+		t.Errorf("normalized signature retains a container IP:\n%s", got)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sydlexius/canticle/internal/backoff"
 	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/detectorbackfill"
+	"github.com/sydlexius/canticle/internal/failsig"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/normalize"
 )
@@ -1524,6 +1525,10 @@ func (q *DBQueue) CountDone(ctx context.Context) (int64, error) {
 // not errors. Used by the GET /metrics endpoint.
 func (q *DBQueue) CountFailuresByReason(ctx context.Context) (map[string]int64, error) {
 	rows, err := q.db.QueryContext(ctx,
+		// Grouped raw in SQL, then re-merged on the NORMALIZED key below. The
+		// database collapses the row count to a couple of dozen groups first, so
+		// this never pulls every failed row across just to normalize it; SQLite has
+		// no regex, so the normalization cannot live in the query (#478).
 		`SELECT COALESCE(NULLIF(last_error, ''), 'unknown') AS reason, COUNT(*)
          FROM work_queue
          WHERE status = 'failed'
@@ -1540,12 +1545,37 @@ func (q *DBQueue) CountFailuresByReason(ctx context.Context) (map[string]int64, 
 		if err := rows.Scan(&reason, &n); err != nil {
 			return nil, fmt.Errorf("queue: scan failure reason count: %w", err)
 		}
-		counts[reason] = n
+		// += so several raw reasons that normalize to one key accumulate rather
+		// than overwrite. That is the whole point: five write failures differing
+		// only by item id and path are ONE failure category, and their counts must
+		// add up.
+		counts[normalizedReason(reason)] += n
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("queue: count failures by reason rows: %w", err)
 	}
 	return counts, nil
+}
+
+// normalizedReason collapses a raw last_error into a stable failure signature
+// for the metrics label, preserving the 'unknown' sentinel the SQL COALESCE
+// produces for an empty error.
+//
+// This label is the reason the normalization is not merely cosmetic:
+// internal/server/metrics.go emits it VERBATIM as
+// mxlrcgo_queue_failures{reason="..."}, which an external Prometheus scrapes and
+// retains off-host. A raw signature carries absolute library paths onto that
+// surface -- private metadata, and the same exposure class as #431 and #731 by a
+// third route. It also earned a distinct time series per failing file, so
+// normalizing drops cardinality as well.
+func normalizedReason(reason string) string {
+	if reason == "unknown" {
+		return reason
+	}
+	if n := failsig.Normalize(reason); n != "" {
+		return n
+	}
+	return reason
 }
 
 // CountByStatus returns the number of work_queue rows grouped by status.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1575,7 +1575,11 @@ func normalizedReason(reason string) string {
 	if n := failsig.Normalize(reason); n != "" {
 		return n
 	}
-	return reason
+	// Normalization reduced the value to nothing, which means the raw text was
+	// whitespace-only. NULLIF(last_error, '') does not catch that -- it only maps
+	// the EMPTY string -- so returning `reason` here would mint a blank group
+	// alongside 'unknown' instead of joining it. Both mean "no cause recorded".
+	return "unknown"
 }
 
 // CountByStatus returns the number of work_queue rows grouped by status.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -4897,5 +4898,59 @@ func TestDBQueue_SetTimingOutcome(t *testing.T) {
 	// A missing id is a benign no-op (no error), matching the sibling stamps.
 	if err := q.SetTimingOutcome(ctx, 999999, TimingRecord{Outcome: "ok", Measured: true, EvaluatedAt: when}); err != nil {
 		t.Errorf("SetTimingOutcome on missing id: want nil error, got %v", err)
+	}
+}
+
+// The /metrics failure label is the reason this normalization is not cosmetic:
+// internal/server/metrics.go emits the reason VERBATIM as
+// mxlrcgo_queue_failures{reason="..."}, which an external Prometheus scrapes and
+// retains off-host. A raw signature puts absolute library paths on that surface
+// (#478), the same exposure class as #431 and #731 reached by a third route.
+//
+// This proves the normalization is WIRED here, not merely available: without it
+// the failsig unit tests stay green while the label keeps leaking.
+func TestDBQueue_CountFailuresByReasonNormalizesSignatures(t *testing.T) {
+	ctx := context.Background()
+	q := NewDBQueue(openQueueTestDB(t))
+	q.SetRandomized(false)
+	now := time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+	q.now = func() time.Time { return now }
+
+	enqAndFail := func(title, reason string) {
+		t.Helper()
+		if _, err := q.Enqueue(ctx, models.Inputs{Track: models.Track{ArtistName: "A", TrackName: title}}, PriorityScan); err != nil {
+			t.Fatalf("Enqueue %s: %v", title, err)
+		}
+		item, err := q.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("Dequeue %s: %v", title, err)
+		}
+		if _, err := q.Fail(ctx, item.ID, errors.New(reason)); err != nil {
+			t.Fatalf("Fail %s: %v", title, err)
+		}
+	}
+
+	// Three write failures, one root cause, differing only by item id and path.
+	enqAndFail("one", `worker: write item 101 output /lib/Artist A/Album/01. One.lrc: refusing to write: output dir "/lib/Artist A/Album" does not exist`)
+	enqAndFail("two", `worker: write item 202 output /lib/Artist B/Other/05. Two.lrc: refusing to write: output dir "/lib/Artist B/Other" does not exist`)
+	enqAndFail("three", `worker: write item 303 output /lib/Artist C/Third/09. Three.lrc: refusing to write: output dir "/lib/Artist C/Third" does not exist`)
+
+	counts, err := q.CountFailuresByReason(ctx)
+	if err != nil {
+		t.Fatalf("CountFailuresByReason: %v", err)
+	}
+	if len(counts) != 1 {
+		t.Fatalf("got %d label series, want 1 (one root cause): %v", len(counts), counts)
+	}
+	for reason, n := range counts {
+		if n != 3 {
+			t.Errorf("count = %d, want 3: merged series must SUM, not overwrite", n)
+		}
+		if strings.Contains(reason, "/lib/") {
+			t.Errorf("the metrics label still carries a library path: %q", reason)
+		}
+		if strings.Contains(reason, "101") || strings.Contains(reason, "202") {
+			t.Errorf("the metrics label still carries an item id: %q", reason)
+		}
 	}
 }

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -10,7 +10,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"time"
+
+	"github.com/sydlexius/canticle/internal/failsig"
 )
 
 // timeFormat matches the layout work_queue.completed_at is stored in
@@ -341,18 +344,62 @@ func (r *Repo) FailureAnalysis(ctx context.Context) ([]FailureGroup, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []FailureGroup
+	// Merge in Go on the NORMALIZED key, keeping the SQL GROUP BY on the raw one.
+	//
+	// The database has already collapsed tens of thousands of rows into a couple
+	// of dozen raw groups, so this loop re-merges those few rather than pulling
+	// every failed row across the wire to normalize it here (#478). SQLite has no
+	// regex, so the normalization itself cannot move into the query.
+	merged := map[FailureGroup]int64{}
+	var order []FailureGroup
 	for rows.Next() {
 		var g FailureGroup
 		if err := rows.Scan(&g.Status, &g.Reason, &g.Count); err != nil {
 			return nil, fmt.Errorf("reports: scan failure group: %w", err)
 		}
-		out = append(out, g)
+		count := g.Count
+		g.Count = 0 // the key is (status, normalized reason); the count is the value
+		g.Reason = normalizedReason(g.Reason)
+		if _, seen := merged[g]; !seen {
+			order = append(order, g)
+		}
+		merged[g] += count
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("reports: failure analysis rows: %w", err)
 	}
+
+	out := make([]FailureGroup, 0, len(order))
+	for _, k := range order {
+		k.Count = merged[k]
+		out = append(out, k)
+	}
+	// Re-sort: merging changes the counts the SQL ordered by, so a group that
+	// absorbed several others can outrank one the database listed above it.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if out[i].Status != out[j].Status {
+			return out[i].Status < out[j].Status
+		}
+		return out[i].Reason < out[j].Reason
+	})
 	return out, nil
+}
+
+// normalizedReason applies the shared signature normalization while preserving
+// the 'unknown' sentinel the SQL COALESCE produces for an empty last_error.
+// Normalize maps empty to empty, so routing the sentinel through it unchanged
+// keeps one bucket rather than splitting into 'unknown' and ”.
+func normalizedReason(reason string) string {
+	if reason == "unknown" {
+		return reason
+	}
+	if n := failsig.Normalize(reason); n != "" {
+		return n
+	}
+	return reason
 }
 
 // UpNextItem is one buffered work_queue row the worker will claim next, in the

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -391,7 +391,7 @@ func (r *Repo) FailureAnalysis(ctx context.Context) ([]FailureGroup, error) {
 // normalizedReason applies the shared signature normalization while preserving
 // the 'unknown' sentinel the SQL COALESCE produces for an empty last_error.
 // Normalize maps empty to empty, so routing the sentinel through it unchanged
-// keeps one bucket rather than splitting into 'unknown' and ”.
+// keeps one bucket rather than splitting into 'unknown' and an empty string.
 func normalizedReason(reason string) string {
 	if reason == "unknown" {
 		return reason
@@ -399,7 +399,11 @@ func normalizedReason(reason string) string {
 	if n := failsig.Normalize(reason); n != "" {
 		return n
 	}
-	return reason
+	// Normalization reduced the value to nothing, which means the raw text was
+	// whitespace-only. NULLIF(last_error, '') does not catch that -- it only maps
+	// the EMPTY string -- so returning `reason` here would mint a blank group
+	// alongside 'unknown' instead of joining it. Both mean "no cause recorded".
+	return "unknown"
 }
 
 // UpNextItem is one buffered work_queue row the worker will claim next, in the

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -709,5 +710,78 @@ func TestQueueEligibilityEmpty(t *testing.T) {
 	}
 	if got.Eligible != 0 || got.Cooldown != 0 {
 		t.Errorf("empty queue = %+v, want {0 0}", got)
+	}
+}
+
+// The unit tests cover failsig.Normalize in isolation; this proves it is WIRED
+// into the report. Without it, moving or dropping the call would leave every
+// failsig test green while the report went back to showing one "category" per
+// failing file (#478).
+func TestFailureAnalysisNormalizesVariableSignatures(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// Three write failures with ONE root cause, differing only by item id and
+	// path -- the exact shape measured on a production install.
+	for i, e := range []string{
+		`worker: write item 101 output /lib/Artist A/Album/01. One.lrc: refusing to write: output dir "/lib/Artist A/Album" does not exist`,
+		`worker: write item 202 output /lib/Artist B/Other/05. Two.lrc: refusing to write: output dir "/lib/Artist B/Other" does not exist`,
+		`worker: write item 303 output /lib/Artist C/Third/09. Three.lrc: refusing to write: output dir "/lib/Artist C/Third" does not exist`,
+	} {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "w" + string(rune('a'+i)), status: "failed", lastError: e})
+	}
+
+	got, err := repo.FailureAnalysis(ctx)
+	if err != nil {
+		t.Fatalf("FailureAnalysis: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d groups, want 1 (one root cause): %+v", len(got), got)
+	}
+	if got[0].Count != 3 {
+		t.Errorf("Count = %d, want 3: the merged group must SUM its members, not overwrite them", got[0].Count)
+	}
+	// The library path is private metadata and must not survive into the report.
+	if strings.Contains(got[0].Reason, "/lib/") {
+		t.Errorf("the reported signature still carries a library path: %q", got[0].Reason)
+	}
+	if strings.Contains(got[0].Reason, "101") {
+		t.Errorf("the reported signature still carries an item id: %q", got[0].Reason)
+	}
+}
+
+// Merging changes the counts the SQL ordered by, so the result must be re-sorted:
+// a group that absorbed several others can outrank one the database listed above
+// it. Without the re-sort the most significant failure category can appear below
+// a rarer one.
+func TestFailureAnalysisOrdersByMergedCount(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// Two rows sharing one raw signature: the DB returns this as a single group
+	// of 2, which outranks each individual write failure before merging.
+	for i := 0; i < 2; i++ {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "t" + string(rune('a'+i)), status: "failed", lastError: "musixmatch: unexpected matcher status_code 500"})
+	}
+	// Three rows that only become one group of 3 AFTER normalization.
+	for i, e := range []string{
+		`worker: write item 11 output /lib/A/x/1.lrc: refusing to write: output dir "/lib/A/x" does not exist`,
+		`worker: write item 22 output /lib/B/y/2.lrc: refusing to write: output dir "/lib/B/y" does not exist`,
+		`worker: write item 33 output /lib/C/z/3.lrc: refusing to write: output dir "/lib/C/z" does not exist`,
+	} {
+		insertWorkItem(t, sqlDB, workItem{artist: "A", title: "w" + string(rune('a'+i)), status: "failed", lastError: e})
+	}
+
+	got, err := repo.FailureAnalysis(ctx)
+	if err != nil {
+		t.Fatalf("FailureAnalysis: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d groups, want 2: %+v", len(got), got)
+	}
+	if got[0].Count != 3 {
+		t.Errorf("first group Count = %d, want 3: the merged group must sort above the smaller one", got[0].Count)
 	}
 }

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -785,3 +785,30 @@ func TestFailureAnalysisOrdersByMergedCount(t *testing.T) {
 		t.Errorf("first group Count = %d, want 3: the merged group must sort above the smaller one", got[0].Count)
 	}
 }
+
+// A whitespace-only last_error must join the 'unknown' group, not mint a blank
+// one beside it. NULLIF(last_error, ”) only maps the EMPTY string, so " \t"
+// survives the SQL and reached the report as its own group. Found by CodeRabbit
+// on #737.
+func TestFailureAnalysisWhitespaceOnlyJoinsUnknown(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "empty", status: "failed", lastError: ""})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "ws", status: "failed", lastError: " \t"})
+
+	got, err := repo.FailureAnalysis(ctx)
+	if err != nil {
+		t.Fatalf("FailureAnalysis: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d groups, want 1 (both mean 'no cause recorded'): %+v", len(got), got)
+	}
+	if got[0].Reason != "unknown" {
+		t.Errorf("Reason = %q, want unknown", got[0].Reason)
+	}
+	if got[0].Count != 2 {
+		t.Errorf("Count = %d, want 2", got[0].Count)
+	}
+}


### PR DESCRIPTION
## Summary

- The Failure Analysis report and the `/metrics` failure counter both `GROUP BY` the **raw** `last_error`. That works for benign misses (20,124 deferred rows → 13 groups) but barely works for hard failures, whose text embeds per-item variable data: 14 failed rows produced 10 "categories", because five write failures with one root cause differ only by item id and file path.
- **The stronger reason is not readability.** `queue.CountFailuresByReason` feeds `internal/server/metrics.go`, which emits the reason verbatim as `mxlrcgo_queue_failures{reason="..."}` — scraped by an external Prometheus that retains it off-host. **5 of the 14 failed signatures carried absolute library paths onto that surface.** Same exposure class as #431 and #731, reached by a third route.
- Adds `internal/failsig` (a leaf package, no internal imports) and wires it into both consumers. Reviewers should look first at what the normalizer deliberately **keeps** — see "What must survive" below.

## Linked issue

Part of #478

Scoped deliberately to the signature-normalization half. The expand-group and transient-vs-persistent UI work from that issue is independent, larger, and does not need to block a live metadata-exposure fix. #478 stays open for it.

## Correction to the issue body

#478 says the view "lists failures row-by-row." **It has grouped since it was written** (`internal/reports/reports.go`). The defect is not missing grouping — it is the key that grouping uses. Correction posted to the issue before this was built.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), verified from the log rather than an exit code.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes.
      **Partial, and stronger than a UAT in one respect:** the normalizer was run against **all 23 real signatures** exported from a production database (23 → 18 groups, 0 path leaks, write failures 5 → 1). The serve-mode report and `/metrics` surfaces were not exercised end-to-end. See "Not covered".
- [x] Screenshot attached for any web-UI change — N/A, no template change.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added if this is a one-time data correction — **N/A by design.** This changes how `last_error` is *read*, never what is stored. Existing rows are unmodified and their labels normalize on the next scrape.

## Test plan

- [x] `make gate` passes locally.
- [x] Patch coverage **94.23%** (49/52); `internal/failsig` at 100%.
- [x] New tests confirmed to **fail against unfixed code**. Each mutation fails at an assertion, not a build error:
  - Unwire the metrics normalization → 3 label series instead of 1, with the raw paths visible in the failure output.
  - Overwrite instead of `+=` on merge → `count = 1, want 3`.
  - Drop the report's re-sort → the smaller group sorts first (`first group Count = 2, want 3`).
  - Revert the hex-address rule → one ffmpeg failure produces two groups.
- [x] Which **surface** this fixes is stated explicitly and verified on both: the report (`FailureAnalysis`) and the metrics label (`CountFailuresByReason`). Each has its own wiring test, because a shared helper that is only wired at one call site is the obvious failure mode here.
- [ ] Manual UAT steps — none run against a live serve instance; see "Not covered".
- [ ] Reviewer follow-ups:
  - [ ] The path rule terminates on `": "` or end-of-line rather than whitespace, because library paths contain spaces. A `\S`-based rule shredded one path into fragments and left per-row residue — the grouping did not collapse *and* the leak was only partly removed. If a message ever delimits a path differently, this rule needs revisiting.
  - [ ] `normalizedReason` is duplicated in `reports` and `queue` (four lines each) rather than exported from `failsig`, because the `'unknown'` sentinel is a property of each caller's SQL, not of normalization. Say the word if you would rather it were shared.

## What must survive (the over-normalization risk)

Collapsing too much is the failure mode that would make this harmful rather than merely useless, so it is tested explicitly:

- **Distinct status codes stay distinct.** A 500 collapsing into a 400 would hide a permanent misconfiguration inside a transient-outage group.
- **Distinct root causes stay apart** — a provider 5xx and a transport failure do not merge.
- **The already-well-grouped benign-miss signatures are byte-identical.** A change that "improves" the working case is a regression in disguise.

The 18 surviving production groups were inspected individually: six genuinely distinct detector causes, distinct status codes, distinct ffmpeg exit codes. Collapsing further would remove signal an operator needs.

## Running it against production data found a bug the fixtures missed

ffmpeg stamps an allocator address into its decoder output (`[mp3float @ 0x…]`), and that address differs on every run — so two occurrences of **one** corrupt-file failure never grouped. Same class as the ports and IPs already handled. It surfaced only because the normalizer was run over the real signatures rather than over test data, and is now pinned by `TestNormalizeCollapsesHexAddresses`.

## Not covered

- **No end-to-end UAT against a live serve instance.** The normalization is verified at both call sites and against real signature text, but the rendered report page and a live `/metrics` scrape were not observed. That is the honest next check.
- **This is not redaction, and must not be relied on as any part of one.** It removes text that is *variable*, which is a different property from text that is *secret*. Secrets are kept out of these strings at their construction sites; a value that is neither variable nor secret is returned untouched.
- **Existing stored `last_error` values are unchanged.** Only the read path normalizes. A row's raw text still contains its path — this stops that text reaching the report and the metrics label, not the database.
- **Label cardinality is reduced but not bounded.** A previously-unseen error shape still mints a new series. A bounded reason vocabulary is a larger design question and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure metrics now group equivalent errors consistently, even when paths, IP addresses, ports, memory addresses, or item IDs differ.
  * Failure analysis combines matching error categories and recalculates totals accurately.
  * Actionable status codes and distinct root causes remain distinguishable.
* **Tests**
  * Added coverage for normalization, aggregation, sorting, multiline errors, empty values, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->