### PR TITLE
chore(gate): clean the shared lint cache when a worktree disappears

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -177,11 +177,20 @@ echo "==> golangci-lint"
 # -- the lint step is one of the slowest in the gate, so that trade matters.
 if command -v golangci-lint >/dev/null 2>&1; then
   WT_ROSTER="$(git rev-parse --git-common-dir)/golangci-worktree-roster"
-  WT_NOW="$(git worktree list --porcelain | awk '/^worktree /{print $2}' | sort)"
+  # STRIP THE PREFIX, do not field-split. `awk '{print $2}'` truncates a path at
+  # the first space, and a worktree under a directory with a space in its name is
+  # entirely ordinary. A truncated path never matches the live list, so it reads
+  # as "removed" on EVERY run and would clean the cache every time -- silently
+  # discarding the warm-cache trade this whole block exists to preserve.
+  #
+  # LC_ALL=C throughout: comm requires both inputs in the SAME collation, and the
+  # roster outlives the run that wrote it. A locale change between runs would
+  # otherwise make comm reject a roster it had itself produced.
+  WT_NOW="$(git worktree list --porcelain | sed -n 's/^worktree //p' | LC_ALL=C sort)"
   if [ -f "$WT_ROSTER" ]; then
     # A path in the recorded roster that is absent from the live list was removed.
     # comm -23 prints lines unique to the first (recorded) side.
-    if WT_GONE="$(comm -23 "$WT_ROSTER" <(printf '%s\n' "$WT_NOW"))" && [ -n "$WT_GONE" ]; then
+    if WT_GONE="$(LC_ALL=C comm -23 "$WT_ROSTER" <(printf '%s\n' "$WT_NOW"))" && [ -n "$WT_GONE" ]; then
       echo "    worktree removed since the last gate run; cleaning the shared lint cache:"
       printf '%s\n' "$WT_GONE" | sed 's/^/      - /'
       golangci-lint cache clean || echo "    WARNING: cache clean failed; phantom findings may follow" >&2

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -155,6 +155,40 @@ else
 fi
 
 echo "==> golangci-lint"
+# A REMOVED WORKTREE POISONS THE SHARED LINT CACHE (#669). golangci-lint's cache
+# is USER-GLOBAL (~/Library/Caches/golangci-lint on macOS), not per-worktree, so
+# deleting one worktree leaves entries keyed to paths that no longer exist. The
+# next gate in a SIBLING worktree then reports dozens of findings against files
+# it cannot even open -- 107 on one occurrence measured 2026-08-05, every one
+# naming a path inside the removed directory and none in the working tree.
+#
+# The cost is entirely in wasted time and misdirection: the findings are not
+# real, but they fail the gate, and the natural response is to go looking for a
+# bug in code that is fine. This blocked three gate runs in a single session --
+# including a release tag push -- and none of them had changed a line of Go.
+#
+# So the gate detects the condition itself rather than relying on whoever removed
+# the worktree to remember. The roster lives under the COMMON git dir, which every
+# worktree of this clone shares, so a removal recorded by one gate run is visible
+# to the next run in any sibling.
+#
+# It cleans only on a DISAPPEARANCE. Adding a worktree is harmless (nothing is
+# stale), and cleaning unconditionally would throw away a warm cache on every run
+# -- the lint step is one of the slowest in the gate, so that trade matters.
+if command -v golangci-lint >/dev/null 2>&1; then
+  WT_ROSTER="$(git rev-parse --git-common-dir)/golangci-worktree-roster"
+  WT_NOW="$(git worktree list --porcelain | awk '/^worktree /{print $2}' | sort)"
+  if [ -f "$WT_ROSTER" ]; then
+    # A path in the recorded roster that is absent from the live list was removed.
+    # comm -23 prints lines unique to the first (recorded) side.
+    if WT_GONE="$(comm -23 "$WT_ROSTER" <(printf '%s\n' "$WT_NOW"))" && [ -n "$WT_GONE" ]; then
+      echo "    worktree removed since the last gate run; cleaning the shared lint cache:"
+      printf '%s\n' "$WT_GONE" | sed 's/^/      - /'
+      golangci-lint cache clean || echo "    WARNING: cache clean failed; phantom findings may follow" >&2
+    fi
+  fi
+  printf '%s\n' "$WT_NOW" > "$WT_ROSTER"
+fi
 golangci-lint run ./... || fail "lint"
 
 echo "==> actionlint (workflow lint)"


### PR DESCRIPTION
## Summary

- golangci-lint's cache is **user-global** (`~/Library/Caches/golangci-lint`), not per-worktree. Removing one worktree leaves entries keyed to paths that no longer exist, so the next gate in a **sibling** worktree reports findings against files it cannot open.
- The gate now keeps a worktree roster under the **common** git dir and cleans the cache when a recorded path has **disappeared** — detecting the condition where it bites rather than where it originates.
- Reviewers should look first at **why this is not the fix the issue proposed** — that reasoning is the substance of the change, not the eight lines of shell.

## Linked issue

Closes #669

## Correction to the issue's recommended fix

#669 recommends Option 1: clean after `git worktree remove`, via a make target or documented wrapper.

**That would have caught none of the three occurrences on 2026-08-05.** Every removal came from `cleanup-worktree.sh` in the orchestrate plugin — maintained outside this repo, so no local target can hook it. Any fix keyed to the removal *site* inherits that gap: it works only if whoever removes the worktree happens to use the wrapper.

Detecting it in the gate is independent of how the removal happened.

## Measurements from today (posted to the issue)

| Occurrence | Findings | Cost |
|---|---|---|
| v1.32.3 tag push | 3 (real + phantom mixed) | tag push **failed**, retried after a manual clean |
| #733 gate | 3 real + phantoms | one wasted gate run |
| #478 gate | **107**, all in a removed worktree | one wasted gate run |

The issue recorded 81 and 40; 107 today, so the magnitude is not settling.

**The detail worth keeping:** in the 107 case, all 107 findings pointed at `../canticle-733` and **zero** at the working tree. But on the tag push, **3 findings survived the clean and were genuinely mine** (British spellings the linter rejects). Writing a whole batch off as phantom would have pushed a real lint failure to CI — which is why the fix cleans the cache rather than suppressing or ignoring findings.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), verified from the log rather than an exit code.
- [x] Code review pass complete.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed — this change *is* gate tooling, and it was exercised by a real gate run; see Test plan.
- [x] Screenshot attached for any web-UI change — N/A.
- [x] `make ui` re-run if any `.templ` or CSS source changed — N/A.
- [x] Migration added if this is a one-time data correction — N/A; no schema or data change.

## Test plan

- [x] `make gate` passes locally (`GATE_EXIT=0`, zero FAILs, lint `0 issues`).
- [x] The roster written by that run matches `git worktree list` exactly — the first-run path (no roster yet → write, do not clean) works.
- [x] The comparison was probed across all five state transitions:
  - unchanged → no clean
  - removed → **clean**
  - **added → no clean** (the trade being protected: a warm cache survives the common case)
  - swapped → clean
  - all-removed → clean
- [x] The real detection block was run against a **seeded roster naming a nonexistent worktree** and correctly identified it. That is the failure this exists to catch, reproduced deliberately rather than waited for.
- [x] `bash -n` clean; the roster path resolves to the shared `.git` dir, so a removal seen by one worktree is visible to every sibling.
- [ ] Reviewer follow-ups:
  - [ ] The roster is `.git/golangci-worktree-roster` — inside the git dir, so it needs no `.gitignore` entry and is never committed. Flagging in case a different location is preferred.
  - [ ] A failed `cache clean` **warns** rather than failing the gate. A stale cache produces noise; refusing to lint at all would be worse. Say the word if you would rather it were fatal.

## Not covered

- **The cache is global to the machine, not to this repo.** A worktree removed in a *different* repository can still poison this one, and this gate cannot see that. It fixes the case that actually recurred here — sibling worktrees of this clone — and does not attempt the general problem.
- **Option 2 from the issue is untouched** (skipping lint/tests for a push containing no source changes). The tag-push occurrence is exactly what it would address, and it would also cut the wall-clock cost of a full gate to move a tag. It is a larger change, needs care so the gate cannot skip itself for the wrong reason, and overlaps #662 — so it is deliberately left out rather than bundled here.
- **No automated regression test.** There is no shell-test harness in this repo, so the five transitions and the seeded-roster case were verified by hand rather than pinned. A future `scripts/*_test.sh` convention would be the place for them.
