### PR TITLE
fix(petitlyrics): give the lane an error policy and surface a revoked application id

### DIFF
--- a/internal/orchestrator/errors.go
+++ b/internal/orchestrator/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/sydlexius/canticle/internal/musixmatch"
+	"github.com/sydlexius/canticle/internal/petitlyrics"
 )
 
 // ErrLaneUnavailable is the sentinel a lane returns when its breaker is open and
@@ -99,10 +100,29 @@ func ClassifyOutcome(err error) OutcomeClass {
 		return OutcomeUnavailable
 	case errors.Is(err, musixmatch.ErrTokenRenewalRequired),
 		errors.Is(err, musixmatch.ErrUnauthorized),
-		errors.Is(err, musixmatch.ErrRateLimited):
+		errors.Is(err, musixmatch.ErrRateLimited),
+		// petitlyrics equivalents (#607). ErrProviderUnavailable is listed here
+		// and must stay AHEAD of the benign-miss case below, because it wraps
+		// ErrNotFound: tested after it, a credential outage would classify as an
+		// ordinary miss and the worker would record a stable miss against every
+		// track it touched during the outage.
+		//
+		// ErrForbidden is deliberately ABSENT. A 403 is a refused request SHAPE,
+		// not a credential or throttle condition, and no amount of waiting or
+		// rotation fixes it; bucketing it here would repeat the #495
+		// misdiagnosis. It falls to OutcomeTransport, which is correct.
+		errors.Is(err, petitlyrics.ErrProviderUnavailable),
+		errors.Is(err, petitlyrics.ErrUnauthorized),
+		errors.Is(err, petitlyrics.ErrRateLimited):
 		return OutcomeAuthRateLimit
 	case musixmatch.IsBenignMiss(err), errors.Is(err, musixmatch.ErrTruncatedResponse),
-		errors.Is(err, ErrLaneBenignMiss):
+		errors.Is(err, ErrLaneBenignMiss),
+		// A petitlyrics miss is the same OUTCOME as a musixmatch miss. Without
+		// these the two provider lanes disagreed about what a miss is, and the
+		// worker (worker.go:1187) released the item on a different path depending
+		// on which lane produced it.
+		errors.Is(err, petitlyrics.ErrNotFound),
+		errors.Is(err, petitlyrics.ErrUnsupportedTier):
 		return OutcomeBenignMiss
 	case errors.Is(err, ErrLaneNotReady):
 		return OutcomeLaneNotReady

--- a/internal/orchestrator/errors.go
+++ b/internal/orchestrator/errors.go
@@ -85,9 +85,19 @@ const (
 
 // ClassifyOutcome maps a lane error to its OutcomeClass. A nil error is a
 // success. The auth/rate-limit check folds in the Musixmatch throttle sentinels
-// the worker historically tripped the circuit on; classification is per-provider
-// today (only Musixmatch lanes exist) and lives here so the breaker stays
-// provider-agnostic. ErrTruncatedResponse is deliberately NOT in the
+// the worker historically tripped the circuit on, plus the petitlyrics
+// equivalents (#607). Classification is per-provider and lives here so the
+// breaker stays provider-agnostic.
+//
+// Both providers' sentinels must be enumerated. Before #607 only Musixmatch was,
+// so a routine petitlyrics miss fell to the default OutcomeTransport, which
+// OUTRANKS a benign miss in precedence -- meaning an ordinary double-miss (both
+// lanes found nothing, the common case for a saturated queue) surfaced as the
+// petitlyrics transport error and the worker recorded a queue FAILURE against
+// the row, consuming an attempt and ramping its backoff toward retirement. A
+// provider added here without its sentinels does the same thing again.
+//
+// ErrTruncatedResponse is deliberately NOT in the
 // auth/rate-limit bucket: it is a deterministic per-request condition (an
 // empty body), not a transient throttle, so it must classify as a benign miss
 // and take the bounded-retry path rather than the no-cost throttle release

--- a/internal/orchestrator/petitlyrics_lane_test.go
+++ b/internal/orchestrator/petitlyrics_lane_test.go
@@ -124,3 +124,133 @@ func TestPetitLyricsUnsupportedTierIsBenignMiss(t *testing.T) {
 		t.Error("an undecodable tier must NOT set EverSucceeded: no lyric was written")
 	}
 }
+
+func TestPetitLyricsProviderUnavailableTripsBreaker(t *testing.T) {
+	// Sustained zero-results almost certainly means a dead application id, so the
+	// lane opens rather than continuing to spend requests on a provider that
+	// answers nothing. The breaker's backoff re-probes periodically, so a
+	// transient cause still recovers without operator action.
+	//
+	// This ordering is load-bearing: ErrProviderUnavailable WRAPS ErrNotFound, so
+	// it must be tested BEFORE the benign-miss branch. Reversed, the wrapper would
+	// match the miss case first and the outage would reset the ramp instead of
+	// tripping the lane, which is the exact silent-degradation #607 exists to end.
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrProviderUnavailable}
+	l, cb := newTestLane(p)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrProviderUnavailable) {
+		t.Fatalf("err = %v; want ErrProviderUnavailable preserved for ranking", err)
+	}
+	if cb.Allow() != circuit.StateOpen {
+		t.Error("a sustained zero-result outage left the breaker CLOSED. The lane " +
+			"would keep firing paced requests at a provider returning nothing, " +
+			"indefinitely, while appearing to serve honest misses.")
+	}
+}
+
+// pacingStub is a stubProvider that also satisfies providers.AdaptivePacer, so a
+// test can observe whether the lane ratcheted the pacer. stubProvider itself does
+// not implement the optional interface, and NewProviderLane type-asserts for it,
+// so a plain stub silently receives no notifications.
+type pacingStub struct {
+	stubProvider
+	throttles int
+	successes int
+}
+
+func (p *pacingStub) OnThrottle() { p.throttles++ }
+func (p *pacingStub) OnSuccess()  { p.successes++ }
+
+func TestPetitLyricsProviderUnavailableDoesNotRatchetPacer(t *testing.T) {
+	// A dead credential is not a throttle. Ratcheting the adaptive pacer here
+	// would slow a lane that is not being rate limited, and would keep it slow
+	// after the credential is restored.
+	p := &pacingStub{stubProvider: stubProvider{name: "petitlyrics", err: petitlyrics.ErrProviderUnavailable}}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewProviderLane(p, cb)
+
+	_, _ = l.FindLyrics(context.Background(), models.Track{}, "")
+
+	if cb.Allow() != circuit.StateOpen {
+		t.Fatal("precondition: the sentinel should have opened the breaker")
+	}
+	if p.throttles != 0 {
+		t.Errorf("pacer ratcheted %d time(s) on a credential outage; only an "+
+			"explicit 429 is a throttle signal, and slowing a lane that is not "+
+			"rate limited would persist after the credential is restored", p.throttles)
+	}
+}
+
+func TestPetitLyricsRateLimitedDoesRatchetPacer(t *testing.T) {
+	// The control for the test above: an explicit 429 SHOULD ratchet. Without
+	// this, "throttles == 0" above would also pass if the pacer were never wired
+	// up at all, which would make it a tautology.
+	p := &pacingStub{stubProvider: stubProvider{name: "petitlyrics", err: petitlyrics.ErrRateLimited}}
+	cb := circuit.New(60*time.Second, 30*time.Minute)
+	l := NewProviderLane(p, cb)
+
+	_, _ = l.FindLyrics(context.Background(), models.Track{}, "")
+
+	if p.throttles != 1 {
+		t.Errorf("pacer ratcheted %d time(s) on an explicit 429; want exactly 1", p.throttles)
+	}
+}
+
+// ClassifyOutcome is the telemetry-and-queue twin of providerClassifier: the
+// worker branches on it (worker.go:1187) to decide how a work item is RELEASED.
+// It enumerated only the musixmatch sentinels, so every petitlyrics error fell to
+// OutcomeTransport -- meaning the two provider lanes disagreed about what a miss
+// even is, and a petitlyrics outage was indistinguishable from a network blip.
+func TestClassifyOutcome_PetitLyricsSentinels(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want OutcomeClass
+		why  string
+	}{
+		{
+			"clean miss", petitlyrics.ErrNotFound, OutcomeBenignMiss,
+			"a miss is a successful round trip; classing it as transport makes the " +
+				"queue release the item on a different path than an identical musixmatch miss",
+		},
+		{
+			"undecodable tier", petitlyrics.ErrUnsupportedTier, OutcomeBenignMiss,
+			"lyricsType 2 arrived and parsed; only its payload is undecodable, " +
+				"which is a per-track gap on a healthy lane",
+		},
+		{
+			"revoked application id", petitlyrics.ErrUnauthorized, OutcomeAuthRateLimit,
+			"an auth rejection must release the item without recording a stable miss, " +
+				"exactly as the musixmatch 401 does",
+		},
+		{
+			"throttled", petitlyrics.ErrRateLimited, OutcomeAuthRateLimit,
+			"an explicit 429 is the same class of outcome for either provider",
+		},
+		{
+			"sustained zero results", petitlyrics.ErrProviderUnavailable, OutcomeAuthRateLimit,
+			"a revoked application id reached through the zero-result path is the same " +
+				"OUTCOME as one reached through a 401, however differently it was detected",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyOutcome(tc.err); got != tc.want {
+				t.Errorf("ClassifyOutcome(%v) = %v; want %v.\n%s", tc.err, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+func TestClassifyOutcome_PetitLyricsForbiddenIsNotAuth(t *testing.T) {
+	// 403 is a refused request SHAPE, not a credential or throttle problem, so it
+	// must NOT be folded into the auth/rate-limit class. Bucketing it there would
+	// reproduce the #495 misdiagnosis, where a User-Agent denylist rejection read
+	// as a rate limit and sent the investigation after a phantom throttle.
+	if got := ClassifyOutcome(petitlyrics.ErrForbidden); got == OutcomeAuthRateLimit {
+		t.Error("403 classified as auth/rate-limit; it is a client-shape defect " +
+			"that no amount of waiting or credential rotation will fix")
+	}
+}

--- a/internal/orchestrator/petitlyrics_lane_test.go
+++ b/internal/orchestrator/petitlyrics_lane_test.go
@@ -1,0 +1,126 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/circuit"
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/petitlyrics"
+)
+
+// The petitlyrics lane had NO error policy at all before #607: providerClassifier
+// referenced only the musixmatch sentinels, so every petitlyrics failure fell
+// through to the "transport / unexpected error" branch that deliberately leaves
+// the breaker untouched.
+//
+// The consequence was a lane that could never trip. A revoked credential (401), a
+// refused request shape (403), and provider throttling (429) all read as ordinary
+// transport noise: no breaker trip, no pacer ratchet, and none of the diagnostic
+// warnings the musixmatch lane gets for the same conditions. Meanwhile a genuine
+// miss never reset the ramp, because petitlyrics.ErrNotFound is not in
+// musixmatch.IsBenignMiss's vocabulary either.
+//
+// These tests pin the policy per sentinel. They are the regression net for the
+// asymmetry: whatever musixmatch does for a condition, petitlyrics must do the
+// analogous thing, or the second provider lane is silently unmanaged.
+
+func TestPetitLyricsUnauthorizedTripsBreaker(t *testing.T) {
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrUnauthorized}
+	l, cb := newTestLane(p)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrUnauthorized) {
+		t.Fatalf("err = %v; want ErrUnauthorized preserved for ranking", err)
+	}
+	if cb.Allow() != circuit.StateOpen {
+		t.Error("a 401 left the breaker CLOSED. The clientAppId is a hardcoded " +
+			"constant shared by every install, so a revocation is exactly the " +
+			"outage this must surface rather than absorb as transport noise.")
+	}
+}
+
+func TestPetitLyricsForbiddenTripsBreaker(t *testing.T) {
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrForbidden}
+	l, cb := newTestLane(p)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrForbidden) {
+		t.Fatalf("err = %v; want ErrForbidden preserved for ranking", err)
+	}
+	if cb.Allow() != circuit.StateOpen {
+		t.Error("a 403 left the breaker CLOSED. Per internal/petitlyrics/errors.go " +
+			"a 403 is a REFUSED request shape (the #495 User-Agent denylist), not " +
+			"throttling: retrying an unchanged request cannot succeed.")
+	}
+}
+
+func TestPetitLyricsRateLimitedTripsBreaker(t *testing.T) {
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrRateLimited}
+	l, cb := newTestLane(p)
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrRateLimited) {
+		t.Fatalf("err = %v; want ErrRateLimited preserved for ranking", err)
+	}
+	if cb.Allow() != circuit.StateOpen {
+		t.Error("a 429 left the breaker CLOSED; an explicit throttle signal must " +
+			"open the lane, exactly as it does for musixmatch")
+	}
+}
+
+func TestPetitLyricsNotFoundIsBenignMiss(t *testing.T) {
+	// A clean miss proves the round trip worked, so it must RESET the throttle
+	// ramp rather than trip anything. Mirrors TestLaneBenignMissRecordsBenignMiss,
+	// including the clock advance: RecordBenignMiss clears the ramp but does not
+	// reopen an open window, so the miss has to actually reach the provider.
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrNotFound}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.Trip()
+	cb.Trip()
+	cb.SetClock(func() time.Time { return fixed.Add(2 * time.Hour) })
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrNotFound) {
+		t.Fatalf("err = %v; want ErrNotFound preserved", err)
+	}
+	if cb.Trips() != 0 {
+		t.Errorf("trips = %d; want 0. A successful round trip that simply found "+
+			"nothing must reset the ramp, not leave the lane ratcheting toward "+
+			"a longer backoff.", cb.Trips())
+	}
+	if cb.EverSucceeded() {
+		t.Error("a benign miss must NOT set EverSucceeded: the round trip worked " +
+			"but no lyric was matched")
+	}
+}
+
+func TestPetitLyricsUnsupportedTierIsBenignMiss(t *testing.T) {
+	// lyricsType 2 (the encrypted LSY blob) is undecodable today. The response
+	// ARRIVED and parsed fine; only its payload tier is unsupported. That is a
+	// per-track capability gap on a healthy lane, so it resets the ramp exactly
+	// like a miss and must never be mistaken for a lane fault.
+	p := &stubProvider{name: "petitlyrics", err: petitlyrics.ErrUnsupportedTier}
+	l, cb := newTestLane(p)
+	fixed := time.Now()
+	cb.SetClock(func() time.Time { return fixed })
+	cb.Trip()
+	cb.Trip()
+	cb.SetClock(func() time.Time { return fixed.Add(2 * time.Hour) })
+
+	_, err := l.FindLyrics(context.Background(), models.Track{}, "")
+	if !errors.Is(err, petitlyrics.ErrUnsupportedTier) {
+		t.Fatalf("err = %v; want ErrUnsupportedTier preserved", err)
+	}
+	if cb.Trips() != 0 {
+		t.Errorf("trips = %d; want 0. An undecodable tier is a healthy round "+
+			"trip, so it must reset the ramp rather than ratchet it.", cb.Trips())
+	}
+	if cb.EverSucceeded() {
+		t.Error("an undecodable tier must NOT set EverSucceeded: no lyric was written")
+	}
+}

--- a/internal/orchestrator/resolve.go
+++ b/internal/orchestrator/resolve.go
@@ -87,6 +87,28 @@ func providerClassifier(l *Lane, err error) error {
 	// failure fell through to the transport branch below and left the breaker
 	// untouched. The lane could not trip on any condition.
 	switch {
+	// ORDER IS LOAD-BEARING: ErrProviderUnavailable WRAPS ErrNotFound (so that
+	// existing callers bucketing a miss as benign keep working), which means it
+	// also satisfies the benign-miss case further down. Tested after it, a
+	// sustained outage would RESET the ramp instead of opening the lane -- the
+	// exact silent degradation #607 exists to end.
+	case errors.Is(err, petitlyrics.ErrProviderUnavailable):
+		// Deliberate decision (#607 asks for this to be chosen, not inherited):
+		// the sentinel TRIPS the breaker. A sustained run of zero-result
+		// responses almost certainly means the hardcoded application id was
+		// revoked, and continuing to fire paced requests at a provider that
+		// answers nothing is pure waste against a shared egress. The breaker's
+		// backoff re-probes periodically, so a transient cause still recovers
+		// with no operator action.
+		//
+		// It does NOT ratchet the pacer: a dead credential is not a throttle, and
+		// slowing a lane that is not being rate limited would persist after the
+		// credential is restored.
+		res := l.breaker.Trip()
+		slog.Warn("lane circuit opened: provider returned no results for a sustained run of lookups; the application id may have been revoked",
+			"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		return err
+
 	case errors.Is(err, petitlyrics.ErrUnauthorized):
 		res := l.breaker.Trip()
 		slog.Warn("lane circuit opened: provider rejected the client application id; the lane is down until it is restored",

--- a/internal/orchestrator/resolve.go
+++ b/internal/orchestrator/resolve.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sydlexius/canticle/internal/circuit"
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/musixmatch"
+	"github.com/sydlexius/canticle/internal/petitlyrics"
 	"github.com/sydlexius/canticle/internal/providers"
 )
 
@@ -70,6 +71,58 @@ func providerClassifier(l *Lane, err error) error {
 		if errors.Is(err, musixmatch.ErrRateLimited) ||
 			(errors.Is(err, musixmatch.ErrUnauthorized) && l.breaker.EverSucceeded()) {
 			l.notifyThrottle()
+		}
+		return err
+	}
+
+	// Petit Lyrics fault sentinels. These are handled separately from the
+	// musixmatch block above rather than folded into it, because the two
+	// providers do not share a throttle model: musixmatch distinguishes a
+	// never-succeeded 401 (a bad token) from a post-success 401 (an egress
+	// throttle) and ratchets the adaptive pacer only in the latter case, while
+	// petitlyrics has no token at all -- its 401 means the hardcoded clientAppId
+	// was rejected, which is never a throttle and must never ratchet the pacer.
+	//
+	// Before #607 none of these were classified here, so every petitlyrics
+	// failure fell through to the transport branch below and left the breaker
+	// untouched. The lane could not trip on any condition.
+	switch {
+	case errors.Is(err, petitlyrics.ErrUnauthorized):
+		res := l.breaker.Trip()
+		slog.Warn("lane circuit opened: provider rejected the client application id; the lane is down until it is restored",
+			"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		return err
+
+	case errors.Is(err, petitlyrics.ErrForbidden):
+		// A refused request SHAPE, not throttling (internal/petitlyrics/errors.go
+		// keeps 403 distinct from 429 for exactly this reason -- see #495, where a
+		// User-Agent denylist rejection read as a phantom rate limit and sent the
+		// investigation after the wrong cause). Retrying an unchanged request
+		// cannot succeed, so open the lane rather than spend requests on it.
+		res := l.breaker.Trip()
+		slog.Warn("lane circuit opened: provider refused the request shape (not throttling); a client change is required",
+			"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		return err
+
+	case errors.Is(err, petitlyrics.ErrRateLimited):
+		res := l.breaker.Trip()
+		slog.Warn("lane circuit opened: provider throttling",
+			"provider", l.Name(), "trips", res.Trips, "cause", err, "backoff", res.Window, "next_retry", res.OpenUntil)
+		// An explicit 429 is an unambiguous throttle signal, so it ratchets the
+		// pacer -- unlike the 401 above.
+		l.notifyThrottle()
+		return err
+
+	case errors.Is(err, petitlyrics.ErrNotFound), errors.Is(err, petitlyrics.ErrUnsupportedTier):
+		// Both are healthy round trips. ErrNotFound is a clean miss;
+		// ErrUnsupportedTier means the response arrived fine and its payload was
+		// an undecodable tier (lyricsType 2, the encrypted LSY blob). Neither says
+		// anything about lane health, so both reset the ramp.
+		//
+		// EverSucceeded is deliberately NOT set, matching the musixmatch branch: a
+		// miss is a successful round trip but not a genuine lyric match.
+		if l.breaker.RecordBenignMiss() {
+			slog.Info("lane circuit closed; provider recovered", "provider", l.Name())
 		}
 		return err
 	}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -101,33 +101,48 @@ type Client struct {
 // reached the escalation threshold. Called for a response that parsed cleanly and
 // simply carried no songs -- never for a transport or status failure, which say
 // nothing about whether the application id still works.
+// The log emission is deliberately OUTSIDE the critical section. slog handlers
+// can block on I/O and take locks of their own, and this mutex also paces every
+// outbound request, so logging under it would serialize concurrent lookups on
+// the handler -- worst at exactly the moment an outage transition fires. The
+// pacer at pace() already follows this shape; match it.
 func (c *Client) recordZeroResult() bool {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.consecutiveZero++
-	if c.consecutiveZero < ZeroResultThreshold {
-		return false
-	}
-	if !c.zeroReported {
+	count := c.consecutiveZero
+	reached := count >= ZeroResultThreshold
+	// Latch INSIDE the lock so exactly one goroutine can win the transition and
+	// emit the warning, even though the emission happens after the unlock.
+	transitioned := reached && !c.zeroReported
+	if transitioned {
 		c.zeroReported = true
-		slog.Warn("petitlyrics: provider has returned no results for a sustained run of lookups; the application id may have been revoked",
-			"consecutive", c.consecutiveZero, "threshold", ZeroResultThreshold)
 	}
-	return true
+	c.mu.Unlock()
+
+	if transitioned {
+		slog.Warn("petitlyrics: provider has returned no results for a sustained run of lookups; the application id may have been revoked",
+			"consecutive", count, "threshold", ZeroResultThreshold)
+	}
+	return reached
 }
 
 // recordNonZeroResult clears the outage counter. Any response carrying at least
 // one song proves the application id is still accepted, whatever the client then
 // makes of the payload.
+// The recovery log is emitted after the unlock, for the same reason as the
+// warning in recordZeroResult.
 func (c *Client) recordNonZeroResult() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.zeroReported {
-		slog.Info("petitlyrics: provider returned results again; the sustained zero-result run has ended",
-			"after", c.consecutiveZero)
-		c.zeroReported = false
-	}
+	recovered := c.zeroReported
+	after := c.consecutiveZero
+	c.zeroReported = false
 	c.consecutiveZero = 0
+	c.mu.Unlock()
+
+	if recovered {
+		slog.Info("petitlyrics: provider returned results again; the sustained zero-result run has ended",
+			"after", after)
+	}
 }
 
 // NewClient creates a new Petit Lyrics client.

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -78,11 +78,56 @@ type Client struct {
 	clientAppID string
 
 	// pacer fields -- zero value means no pacing (minInterval == 0).
+	//
+	// mu also guards the zero-result outage counter below. One mutex covers both
+	// because the client is shared across worker goroutines and the two pieces of
+	// state are touched on the same request path; a second lock would buy nothing
+	// but a lock-ordering hazard.
 	mu          sync.Mutex
 	minInterval time.Duration
 	lastRequest time.Time
 	now         func() time.Time
 	sleep       func(ctx context.Context, d time.Duration) bool
+
+	// consecutiveZero counts back-to-back zero-result responses (#607). Reset by
+	// any response carrying at least one song.
+	consecutiveZero int
+	// zeroReported latches the transition so the outage is logged ONCE rather
+	// than on every request past the threshold. Cleared on recovery.
+	zeroReported bool
+}
+
+// recordZeroResult counts a zero-song response and reports whether the run has
+// reached the escalation threshold. Called for a response that parsed cleanly and
+// simply carried no songs -- never for a transport or status failure, which say
+// nothing about whether the application id still works.
+func (c *Client) recordZeroResult() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consecutiveZero++
+	if c.consecutiveZero < ZeroResultThreshold {
+		return false
+	}
+	if !c.zeroReported {
+		c.zeroReported = true
+		slog.Warn("petitlyrics: provider has returned no results for a sustained run of lookups; the application id may have been revoked",
+			"consecutive", c.consecutiveZero, "threshold", ZeroResultThreshold)
+	}
+	return true
+}
+
+// recordNonZeroResult clears the outage counter. Any response carrying at least
+// one song proves the application id is still accepted, whatever the client then
+// makes of the payload.
+func (c *Client) recordNonZeroResult() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.zeroReported {
+		slog.Info("petitlyrics: provider returned results again; the sustained zero-result run has ended",
+			"after", c.consecutiveZero)
+		c.zeroReported = false
+	}
+	c.consecutiveZero = 0
 }
 
 // NewClient creates a new Petit Lyrics client.
@@ -416,7 +461,19 @@ func (c *Client) request(ctx context.Context, track models.Track, tier int) ([]a
 		return nil, fmt.Errorf("petitlyrics: decode XML response: %w", err)
 	}
 	if len(parsed.Songs) == 0 {
+		// A clean HTTP 200 carrying no songs. Individually this is an ordinary
+		// miss; sustained, it is the fingerprint of a revoked application id,
+		// since the service keeps answering normally rather than returning 401
+		// (#607).
+		if c.recordZeroResult() {
+			return nil, ErrProviderUnavailable
+		}
 		return nil, fmt.Errorf("petitlyrics: no songs in response: %w", ErrNotFound)
 	}
+	// At least one song came back, which proves the application id is still
+	// accepted. Reset regardless of what the client then makes of the payload: a
+	// candidate that loses selection, or a tier this client cannot decode, is a
+	// per-track outcome and says nothing about credential health.
+	c.recordNonZeroResult()
 	return parsed.Songs, nil
 }

--- a/internal/petitlyrics/errors.go
+++ b/internal/petitlyrics/errors.go
@@ -1,6 +1,9 @@
 package petitlyrics
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Sentinel errors returned by the Petit Lyrics client. Callers should use
 // errors.Is to test for these classes rather than string-matching the message.
@@ -31,3 +34,37 @@ var (
 	// rather than failing the track outright.
 	ErrUnsupportedTier = errors.New("petitlyrics: unsupported lyrics tier")
 )
+
+// ErrProviderUnavailable indicates a sustained run of zero-result responses:
+// the request shape is valid and the API keeps answering HTTP 200 with
+// well-formed XML, but every response carries no songs at all (#607).
+//
+// This exists because a revoked clientAppId does NOT produce a 401. The service
+// keeps replying normally with an empty song list, which is byte-identical to a
+// genuine miss -- so a total lane outage would otherwise present as "the
+// provider suddenly has none of my tracks", indefinitely, with the lane looking
+// healthy the whole time.
+//
+// It WRAPS ErrNotFound deliberately. Every existing caller that buckets a miss
+// as benign keeps working unchanged; only code that explicitly tests for this
+// sentinel sees the escalation. That mirrors how musixmatch.ErrTokenRenewalRequired
+// also satisfies errors.Is(_, ErrUnauthorized).
+var ErrProviderUnavailable = fmt.Errorf(
+	"petitlyrics: provider returned no results for %d consecutive lookups (application id revoked?): %w",
+	ZeroResultThreshold, ErrNotFound)
+
+// ZeroResultThreshold is how many CONSECUTIVE zero-result lookups escalate to
+// ErrProviderUnavailable.
+//
+// Sizing: this lane runs as a fallback, so it only ever sees tracks the primary
+// provider already missed, and its measured coverage on that population is low
+// (roughly 1 in 4). A run of 8 consecutive misses is therefore entirely ordinary
+// -- at a 25% hit rate it happens about 10% of the time -- while 20 in a row is
+// under 0.4%, improbable enough to be worth a warning without being so rare that
+// a real outage goes unreported for hours. At the client's 30s pacing floor, 20
+// lookups is about 10 minutes to detection.
+//
+// The counter is CONSECUTIVE, never cumulative: any single non-zero response
+// clears it. A cumulative count would eventually escalate on any long-lived
+// client no matter how healthy the provider is.
+const ZeroResultThreshold = 20

--- a/internal/petitlyrics/errors.go
+++ b/internal/petitlyrics/errors.go
@@ -59,10 +59,22 @@ var ErrProviderUnavailable = fmt.Errorf(
 // Sizing: this lane runs as a fallback, so it only ever sees tracks the primary
 // provider already missed, and its measured coverage on that population is low
 // (roughly 1 in 4). A run of 8 consecutive misses is therefore entirely ordinary
-// -- at a 25% hit rate it happens about 10% of the time -- while 20 in a row is
-// under 0.4%, improbable enough to be worth a warning without being so rare that
-// a real outage goes unreported for hours. At the client's 30s pacing floor, 20
-// lookups is about 10 minutes to detection.
+// -- at a 25% hit rate any given 8-lookup window is all-misses about 10% of the
+// time -- while a given 20-lookup window is under 0.4%. At the client's 30s
+// pacing floor, 20 lookups is about 10 minutes to detection.
+//
+// Read that per-WINDOW figure correctly: it is not the false-positive rate over
+// a long run. Some run of 20 is expected roughly every 1,250 lookups at that hit
+// rate, or about half a day of sustained fallback traffic, so a large library
+// scan should expect to trip this occasionally without any provider fault.
+//
+// That is tolerable because recovery is HIT-DRIVEN, not count-driven: the first
+// non-zero response clears the counter and the latch outright. But note the
+// counter keeps climbing past the threshold, so every further zero-result
+// re-trips the breaker and ramps its geometric backoff toward the 30-minute cap.
+// A long genuine dry spell therefore escalates to a real lane pause, which is
+// the correct behavior for an actual outage and merely conservative for a dry
+// spell -- the lane is returning nothing either way.
 //
 // The counter is CONSECUTIVE, never cumulative: any single non-zero response
 // clears it. A cumulative count would eventually escalate on any long-lived

--- a/internal/petitlyrics/unavailable_test.go
+++ b/internal/petitlyrics/unavailable_test.go
@@ -1,0 +1,113 @@
+package petitlyrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// A revoked clientAppId does NOT produce a 401. The API keeps answering: HTTP
+// 200, well-formed XML, zero songs. The client maps that to ErrNotFound, which
+// is byte-identical to what a genuine miss looks like.
+//
+// So a total lane outage would present as "petitlyrics suddenly has none of my
+// tracks", indefinitely, with the lane appearing healthy and returning honest
+// misses. That is the failure #607 exists to make diagnosable, and it is why a
+// 401 branch alone is not sufficient cover.
+//
+// The signal is CONSECUTIVE, not cumulative: a real dry spell is common on a
+// fallback lane that only sees what the primary provider missed, so any single
+// non-zero response has to clear the count.
+
+// emptyResponse is a well-formed API envelope carrying no songs -- exactly what
+// a revoked application id is reported to return.
+const emptyResponse = `<?xml version="1.0" encoding="UTF-8"?><response><songs></songs></response>`
+
+func serveEmpty() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write([]byte(emptyResponse))
+	}
+}
+
+func TestZeroResults_BelowThresholdStaysNotFound(t *testing.T) {
+	c, _ := newTestClient(t, serveEmpty())
+
+	// One short of the threshold: still indistinguishable from bad luck, so the
+	// client must not escalate.
+	for i := 0; i < ZeroResultThreshold-1; i++ {
+		_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("lookup %d: err = %v; want ErrNotFound below the threshold", i, err)
+		}
+		if errors.Is(err, ErrProviderUnavailable) {
+			t.Fatalf("lookup %d escalated early; %d consecutive misses is a plausible "+
+				"dry spell on a fallback lane and must not be reported as an outage", i, i+1)
+		}
+	}
+}
+
+func TestZeroResults_CrossingThresholdSurfacesSentinel(t *testing.T) {
+	c, _ := newTestClient(t, serveEmpty())
+
+	var err error
+	for i := 0; i < ZeroResultThreshold; i++ {
+		_, err = c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+	}
+	if !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("after %d consecutive zero-result lookups err = %v; want "+
+			"ErrProviderUnavailable. Without it a dead clientAppId is "+
+			"indistinguishable from a library the provider simply lacks.",
+			ZeroResultThreshold, err)
+	}
+	// It must ALSO still satisfy ErrNotFound, so every existing caller that
+	// treats a miss as benign keeps working unchanged.
+	if !errors.Is(err, ErrNotFound) {
+		t.Error("ErrProviderUnavailable must still satisfy errors.Is(_, ErrNotFound): " +
+			"callers that bucket a miss as benign must not break on the escalation")
+	}
+}
+
+func TestZeroResults_SuccessMidRunResets(t *testing.T) {
+	// Serve empties until told otherwise, then one real hit, then empties again.
+	// The counter must restart from zero after the hit.
+	hit := false
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		if hit {
+			body, err := os.ReadFile(filepath.Join("testdata", "type1_unsynced.xml"))
+			if err != nil {
+				t.Errorf("read fixture: %v", err)
+				return
+			}
+			_, _ = w.Write(body)
+			return
+		}
+		_, _ = w.Write([]byte(emptyResponse))
+	})
+
+	for i := 0; i < ZeroResultThreshold-1; i++ {
+		_, _ = c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+	}
+
+	hit = true
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"}); err != nil {
+		t.Fatalf("the reset lookup should have succeeded: %v", err)
+	}
+	hit = false
+
+	// One more empty. If the reset worked this is count 1, nowhere near the
+	// threshold; if it did not, this is the crossing.
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+	if errors.Is(err, ErrProviderUnavailable) {
+		t.Error("a successful lookup did not reset the consecutive-zero counter. " +
+			"The signal is CONSECUTIVE: a provider that answered once is not down, " +
+			"and a cumulative counter would eventually escalate on any long-lived " +
+			"client no matter how healthy.")
+	}
+}

--- a/internal/petitlyrics/unavailable_test.go
+++ b/internal/petitlyrics/unavailable_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/models"
@@ -76,10 +78,18 @@ func TestZeroResults_CrossingThresholdSurfacesSentinel(t *testing.T) {
 func TestZeroResults_SuccessMidRunResets(t *testing.T) {
 	// Serve empties until told otherwise, then one real hit, then empties again.
 	// The counter must restart from zero after the hit.
-	hit := false
+	//
+	// hit is an atomic.Bool, not a plain bool: newTestClient serves on an
+	// httptest goroutine, so the handler READS this flag while the test WRITES
+	// it. The writes happen between sequential FindLyrics calls, so in practice
+	// the handler has finished before each write and -race does not currently
+	// flag it -- but nothing GUARANTEES that ordering (a kept-alive connection or
+	// a handler still unwinding would break it), so the safety is made explicit
+	// rather than left to timing.
+	var hit atomic.Bool
 	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
-		if hit {
+		if hit.Load() {
 			body, err := os.ReadFile(filepath.Join("testdata", "type1_unsynced.xml"))
 			if err != nil {
 				t.Errorf("read fixture: %v", err)
@@ -95,11 +105,11 @@ func TestZeroResults_SuccessMidRunResets(t *testing.T) {
 		_, _ = c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
 	}
 
-	hit = true
+	hit.Store(true)
 	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"}); err != nil {
 		t.Fatalf("the reset lookup should have succeeded: %v", err)
 	}
-	hit = false
+	hit.Store(false)
 
 	// One more empty. If the reset worked this is count 1, nowhere near the
 	// threshold; if it did not, this is the crossing.
@@ -109,5 +119,52 @@ func TestZeroResults_SuccessMidRunResets(t *testing.T) {
 			"The signal is CONSECUTIVE: a provider that answered once is not down, " +
 			"and a cumulative counter would eventually escalate on any long-lived " +
 			"client no matter how healthy.")
+	}
+}
+
+// TestZeroResultLatchIsExactlyOnceUnderConcurrency defends the invariant that the
+// logging fix depends on. The transition warning is emitted AFTER the mutex is
+// released (so a blocking slog handler cannot serialize outbound requests), which
+// means the "have I already reported this?" latch has to be claimed INSIDE the
+// lock. Claim it outside and every goroutine crossing the threshold together
+// would each emit the warning -- turning a one-line outage signal into a flood,
+// which is exactly what the once-on-transition requirement exists to prevent.
+func TestZeroResultLatchIsExactlyOnceUnderConcurrency(t *testing.T) {
+	c := NewClient()
+	total := ZeroResultThreshold * 2
+
+	var wg sync.WaitGroup
+	reached := make([]bool, total)
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			reached[idx] = c.recordZeroResult()
+		}(i)
+	}
+	wg.Wait()
+
+	c.mu.Lock()
+	got, latched := c.consecutiveZero, c.zeroReported
+	c.mu.Unlock()
+
+	if got != total {
+		t.Errorf("consecutiveZero = %d; want %d. A lost increment means the counter "+
+			"is racy and the threshold could be reached late or never.", got, total)
+	}
+	if !latched {
+		t.Error("zeroReported was not latched after crossing the threshold; the " +
+			"recovery log would then never fire either")
+	}
+
+	n := 0
+	for _, r := range reached {
+		if r {
+			n++
+		}
+	}
+	if n != ZeroResultThreshold+1 {
+		t.Errorf("%d calls reported reached; want %d (every call at or past the "+
+			"threshold reports, and none before it)", n, ZeroResultThreshold+1)
 	}
 }


### PR DESCRIPTION
## Summary

- The petitlyrics lane had **no error policy at all**. `providerClassifier` referenced only the musixmatch sentinels, so a rejected application id (401), a refused request shape (403), and provider throttling (429) all fell through to the branch that deliberately leaves the breaker untouched. The lane could not trip on any condition, and a clean miss never reset its throttle ramp either.
- Adds `ErrProviderUnavailable` for the failure #607 actually describes: a revoked `clientAppId` does **not** produce a 401. The API keeps answering HTTP 200 with well-formed XML and zero songs, which maps to `ErrNotFound` and is indistinguishable from a genuine miss. Escalates after 20 consecutive zero-result lookups; any response carrying a song clears the count.
- **Look at this first:** the pre-push review found this PR also fixes an unrelated live bug, now filed as #748. `ClassifyOutcome` had zero petitlyrics references, so a routine miss classified as `OutcomeTransport` (precedence 3), which outranks a benign miss (precedence 1). On an ordinary double-miss the worker therefore recorded a queue **failure** against the row: `attempts++`, geometric backoff, marching toward retirement. Ordinary misses were burning retry budget.

No user-visible behavior change to lyric output. The change is to lane health, breaker behavior, and how the queue releases an item.

## Linked issue

Closes #607

Part of #748 (the class fix -- an enumeration test so a third provider cannot reproduce this silently -- is tracked there, not here).

## Design decisions worth reviewing

- **`ErrProviderUnavailable` wraps `ErrNotFound`**, so existing callers that bucket a miss as benign keep working unchanged. That makes case **order load-bearing** in both `providerClassifier` and `ClassifyOutcome`: tested after the benign-miss case, a credential outage would reset the ramp and record a stable miss against every track it touched. Both sites carry a comment saying so, and a test pins it.
- **The sentinel trips the breaker** (a deliberate choice, per #607's own request that this be chosen rather than inherited). Firing paced requests at a provider answering nothing is waste against a shared egress, and the backoff re-probes so a transient cause recovers unattended. It does **not** ratchet the pacer -- a dead credential is not a throttle, and the slowdown would persist after restoration.
- **`ErrForbidden` stays out of the auth class.** A 403 is a refused request shape that no waiting or rotation fixes; bucketing it with throttling would repeat the #495 misdiagnosis, where a User-Agent denylist rejection read as a phantom rate limit.
- **The reset fires on any returned song, before candidate selection.** The signal is "is the credential still accepted", not "did we like the result". Moving it behind selection would open the breaker on a demonstrably working credential whenever match quality was poor.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), re-run after the review fixes.
- [x] Code review pass complete; no critical or important findings. Three minor: two fixed, one declined with the reasoning recorded in `d630bba`.
- [ ] Commits squashed into one -- **deliberately not squashed.** Three distinct concerns: the pre-existing hole, the new sentinel, and the review response. Squashed, the pre-existing bug reads as part of the new feature.
- [x] Label set.
- [ ] UAT -- not performed. The escalation path needs a revoked credential to exercise live; it is covered by tests at the client and classifier level instead. See Test plan.
- [x] No web-UI change (no screenshot applicable).
- [x] No `.templ` or CSS source changed.
- [x] No migration needed (no schema or data change).

## Test plan

- [x] `make gate` passes locally, re-run at `d630bba`.
- [x] New tests were confirmed to **fail against unfixed code** before the fix was written. All five lane-policy tests failed at their assertions with the empty-policy diagnostic; the three zero-result tests failed as undefined symbols, then at assertions once defined.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Which surface this fixes:** lane breaker state and worker item-release policy, not a reporting surface. Verified through `circuit.Breaker.Allow()` and `ClassifyOutcome` directly rather than through `/metrics` or the dashboard, neither of which this touches.
- [x] Independently re-verified by the pre-push reviewer via mutation: reordering the wrapper case, dropping it from the auth class, deleting the counter reset, and deleting the pacer notification each reddened **at an assertion**, not at a build error.
- [ ] Manual UAT steps:
  - [ ] Not applicable -- exercising the escalation live requires a revoked application id.
- [ ] Reviewer follow-ups:
  - [ ] The threshold of 20 is sized from a measured ~25% hit rate on this lane's population. The comment now notes some run of 20 is expected roughly every 1,250 lookups, so a large scan may trip it occasionally without provider fault; recovery is hit-driven, so it self-clears. Sanity-check that tradeoff.
  - [ ] #748's prod exposure is unmeasured. Worth checking the queue for rows whose `attempts` were inflated by the misclassification, and whether it relates to #655 -- same subsystem, deliberately not asserted either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyric search reliability when PetitLyrics returns repeated empty results.
  * Temporary provider outages are now distinguished from songs that simply cannot be found.
  * Authentication, rate-limit, and service availability issues are handled more accurately to support recovery.
  * Successful lookups restore normal provider behavior after a period of empty results.
* **Tests**
  * Added coverage for provider errors, repeated misses, rate limiting, recovery, and breaker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->