### PR TITLE
test(petitlyrics): env-gated measurement probe, plus two permanent regression tests

### DIFF
--- a/internal/lrcnormalize/lrcnormalize_test.go
+++ b/internal/lrcnormalize/lrcnormalize_test.go
@@ -252,9 +252,20 @@ func TestParseBody_SingleTimestamp(t *testing.T) {
 // expandLine stops consuming once non-timestamp text begins. The word markup is
 // therefore carried as literal cue TEXT.
 //
-// The body below is byte-identical to what the A2 sample generator emits
-// (internal/lyrics/a2sample_test.go), so the two cannot drift apart. All content
-// is synthesized placeholder words.
+// The body below is a MINIMIZED A2 document, not a copy of the sample
+// generator's output: it carries the same cue-line shape (a leading [mm:ss.xx]
+// followed by inline <mm:ss.xx> word markers) but omits the [al]/[by] tags, the
+// third cue, and the trailing spaces that internal/lyrics/a2sample_test.go
+// emits. An earlier version of this comment claimed the two were byte-identical.
+// They are not, and the claim would have sent a reader trying to keep them in
+// sync.
+//
+// They are deliberately NOT shared. The parser behavior pinned here is
+// permanent, while that generator is throwaway scaffolding marked for deletion,
+// and coupling this test to it would tie a lasting guarantee to code with a
+// stated expiry. What matters is the SHAPE, and both carry it.
+//
+// All content is synthesized placeholder words.
 func TestParseBody_PreservesA2WordMarkers(t *testing.T) {
 	const a2Body = "[ar:Canticle Test Signal]\n" +
 		"[ti:Enhanced LRC Probe]\n" +

--- a/internal/lrcnormalize/lrcnormalize_test.go
+++ b/internal/lrcnormalize/lrcnormalize_test.go
@@ -237,3 +237,94 @@ func TestParseBody_SingleTimestamp(t *testing.T) {
 		t.Errorf("total: want 15.05, got %v", c.Time.Total)
 	}
 }
+
+// TestParseBody_PreservesA2WordMarkers is issue #480's stated acceptance
+// criterion: an Enhanced-LRC (A2) round trip must prove the inline <mm:ss.xx>
+// word markers survive expansion.
+//
+// Why this matters independently of any media player: canticle reads its own
+// sidecars back off disk through ParseBody (the revalidate path, #442). If the
+// A2 writer emits word markers and this normalizer then mangles them on read,
+// that is a defect regardless of whether any player renders them.
+//
+// The mechanism the test pins is tsRe: it is anchored (^) and requires square
+// brackets, so an angle-bracket marker cannot match on either count, and
+// expandLine stops consuming once non-timestamp text begins. The word markup is
+// therefore carried as literal cue TEXT.
+//
+// The body below is byte-identical to what the A2 sample generator emits
+// (internal/lyrics/a2sample_test.go), so the two cannot drift apart. All content
+// is synthesized placeholder words.
+func TestParseBody_PreservesA2WordMarkers(t *testing.T) {
+	const a2Body = "[ar:Canticle Test Signal]\n" +
+		"[ti:Enhanced LRC Probe]\n" +
+		"\n" +
+		"[00:01.00]<00:01.00>one <00:01.80>two <00:02.60>three <00:03.40>four\n" +
+		"[00:05.00]<00:05.00>five <00:05.80>six <00:06.60>seven <00:07.40>eight\n"
+
+	doc := ParseBody(a2Body)
+
+	if len(doc.Cues) != 2 {
+		t.Fatalf("want 2 cues (one per A2 line, NOT one per word marker), got %d: %+v",
+			len(doc.Cues), doc.Cues)
+	}
+
+	// The leading line-level stamp is consumed as the cue's timestamp.
+	if doc.Cues[0].Time.Total != 1 {
+		t.Errorf("cue 0 timestamp: want 1s, got %v", doc.Cues[0].Time.Total)
+	}
+	if doc.Cues[1].Time.Total != 5 {
+		t.Errorf("cue 1 timestamp: want 5s, got %v", doc.Cues[1].Time.Total)
+	}
+
+	// Every word marker survives verbatim in the cue text.
+	wantCue0 := "<00:01.00>one <00:01.80>two <00:02.60>three <00:03.40>four"
+	if doc.Cues[0].Text != wantCue0 {
+		t.Errorf("A2 word markers did not survive the round trip:\n want %q\n got  %q",
+			wantCue0, doc.Cues[0].Text)
+	}
+	wantCue1 := "<00:05.00>five <00:05.80>six <00:06.60>seven <00:07.40>eight"
+	if doc.Cues[1].Text != wantCue1 {
+		t.Errorf("A2 word markers did not survive the round trip:\n want %q\n got  %q",
+			wantCue1, doc.Cues[1].Text)
+	}
+
+	// Header tags are still classified as tags, not swallowed by the A2 lines.
+	if len(doc.Tags) != 2 {
+		t.Errorf("want 2 header tags alongside A2 cues, got %d: %+v", len(doc.Tags), doc.Tags)
+	}
+}
+
+// TestExpand_IdempotentOnA2Cues pins the second half of #480's criterion: the
+// backfill path (Expand over already-parsed cues) must not split an A2 cue.
+//
+// This is the failure that would actually bite. Expand splits a cue whose TEXT
+// carries an embedded timestamp, and a naive stamp matcher would see twelve
+// "timestamps" in one A2 line and shatter it into twelve cues, each carrying the
+// wrong text. The petitlyrics client already guards against a split shifting its
+// word-timing indices (client.go:326); this proves the split does not happen.
+func TestExpand_IdempotentOnA2Cues(t *testing.T) {
+	in := models.Synced{Lines: []models.Lines{
+		{Text: "<00:01.00>one <00:01.80>two <00:02.60>three <00:03.40>four",
+			Time: models.Time{Total: 1, Seconds: 1}},
+		{Text: "<00:05.00>five <00:05.80>six <00:06.60>seven <00:07.40>eight",
+			Time: models.Time{Total: 5, Seconds: 5}},
+	}}
+
+	out := Expand(in)
+
+	if len(out.Lines) != len(in.Lines) {
+		t.Fatalf("Expand split an A2 cue: want %d cues, got %d. A split shifts every "+
+			"later word-timing index, which is exactly what the petitlyrics client's "+
+			"length guard exists to detect.\n%+v", len(in.Lines), len(out.Lines), out.Lines)
+	}
+	for i := range out.Lines {
+		if out.Lines[i].Text != in.Lines[i].Text {
+			t.Errorf("cue %d text mutated:\n want %q\n got  %q", i, in.Lines[i].Text, out.Lines[i].Text)
+		}
+		if out.Lines[i].Time.Total != in.Lines[i].Time.Total {
+			t.Errorf("cue %d timestamp mutated: want %v, got %v",
+				i, in.Lines[i].Time.Total, out.Lines[i].Time.Total)
+		}
+	}
+}

--- a/internal/lyrics/a2sample_test.go
+++ b/internal/lyrics/a2sample_test.go
@@ -1,0 +1,130 @@
+package lyrics
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// TestGenerateA2Sample writes a known-good Enhanced-LRC (A2) file so the
+// maintainer can load it into Emby and Symphonium and judge whether they render
+// word markers or show them as literal text.
+//
+// That verdict gates #480: a non-supporting player displays "<mm:ss.xx>" inline,
+// which is worse than clean line-sync. Music Assistant is known-not-supporting
+// (filed 2026-07-15).
+//
+// Content is synthesized, never a real lyric.
+//
+// Run: A2SAMPLE_DIR=/path/to/scratchpad go test -run TestGenerateA2Sample ./internal/lyrics -v
+func TestGenerateA2Sample(t *testing.T) {
+	dir := os.Getenv("A2SAMPLE_DIR")
+	if dir == "" {
+		t.Skip("set A2SAMPLE_DIR to generate the A2 player-verification sample")
+	}
+
+	song := models.Song{
+		Track: models.Track{
+			ArtistName: "Canticle Test Signal",
+			TrackName:  "Enhanced LRC Probe",
+			AlbumName:  "Player Verification",
+		},
+		Subtitles: models.Synced{Lines: []models.Lines{
+			{Text: "one two three four", Time: models.Time{Total: 1.0, Minutes: 0, Seconds: 1, Hundredths: 0}},
+			{Text: "five six seven eight", Time: models.Time{Total: 5.0, Minutes: 0, Seconds: 5, Hundredths: 0}},
+			{Text: "nine ten eleven twelve", Time: models.Time{Total: 9.0, Minutes: 0, Seconds: 9, Hundredths: 0}},
+		}},
+		WordTimings: []models.WordTiming{
+			{Line: 0, Text: "one", StartMS: 1000, EndMS: 1800},
+			{Line: 0, Text: "two", StartMS: 1800, EndMS: 2600},
+			{Line: 0, Text: "three", StartMS: 2600, EndMS: 3400},
+			{Line: 0, Text: "four", StartMS: 3400, EndMS: 4200},
+			{Line: 1, Text: "five", StartMS: 5000, EndMS: 5800},
+			{Line: 1, Text: "six", StartMS: 5800, EndMS: 6600},
+			{Line: 1, Text: "seven", StartMS: 6600, EndMS: 7400},
+			{Line: 1, Text: "eight", StartMS: 7400, EndMS: 8200},
+			{Line: 2, Text: "nine", StartMS: 9000, EndMS: 9800},
+			{Line: 2, Text: "ten", StartMS: 9800, EndMS: 10600},
+			{Line: 2, Text: "eleven", StartMS: 10600, EndMS: 11400},
+			{Line: 2, Text: "twelve", StartMS: 11400, EndMS: 12200},
+		},
+	}
+
+	body := renderA2(song)
+	path := filepath.Join(dir, "a2-player-test.lrc")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write A2 sample: %v", err)
+	}
+
+	t.Logf("A2 sample written to %s\n\n%s", path, body)
+	t.Logf("VERDICT NEEDED: load this in Emby and Symphonium. " +
+		"Word markers rendering as karaoke-style highlighting means A2 is supported. " +
+		"Literal '<00:01.00>' text on screen means it is NOT, and #480 should stay shelved.")
+}
+
+// renderA2 emits Enhanced-LRC: a leading line-level [mm:ss.xx] for backward
+// compatibility, then inline <mm:ss.xx> markers before each word.
+//
+// This is a THROWAWAY renderer for the player-verification sample only. The real
+// writer is #480's job and belongs in writer.go with the full timing-guard and
+// provenance path; do not promote this.
+func renderA2(song models.Song) string {
+	byLine := map[int][]models.WordTiming{}
+	for _, wt := range song.WordTimings {
+		byLine[wt.Line] = append(byLine[wt.Line], wt)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "[ar:%s]\n", song.Track.ArtistName)
+	fmt.Fprintf(&b, "[ti:%s]\n", song.Track.TrackName)
+	fmt.Fprintf(&b, "[al:%s]\n", song.Track.AlbumName)
+	b.WriteString("[by:canticle A2 player-support probe]\n\n")
+
+	for i, line := range song.Subtitles.Lines {
+		fmt.Fprintf(&b, "[%s]", stampFromMS(int(line.Time.Total*1000)))
+		for _, wt := range byLine[i] {
+			fmt.Fprintf(&b, "<%s>%s ", stampFromMS(wt.StartMS), wt.Text)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// stampFromMS formats milliseconds as mm:ss.xx.
+func stampFromMS(ms int) string {
+	if ms < 0 {
+		ms = 0
+	}
+	return fmt.Sprintf("%02d:%02d.%02d", ms/60000, (ms/1000)%60, (ms/10)%100)
+}
+
+// TestRenderA2Shape asserts the sample renderer emits both marker kinds, since a
+// player verdict is meaningless if the file it was judged on was malformed.
+func TestRenderA2Shape(t *testing.T) {
+	song := models.Song{
+		Track: models.Track{ArtistName: "A", TrackName: "T", AlbumName: "AL"},
+		Subtitles: models.Synced{Lines: []models.Lines{
+			{Text: "alpha beta", Time: models.Time{Total: 1.5}},
+		}},
+		WordTimings: []models.WordTiming{
+			{Line: 0, Text: "alpha", StartMS: 1500, EndMS: 2000},
+			{Line: 0, Text: "beta", StartMS: 2000, EndMS: 2500},
+		},
+	}
+
+	got := renderA2(song)
+
+	if !strings.Contains(got, "[00:01.50]") {
+		t.Errorf("missing the line-level cue for backward compatibility:\n%s", got)
+	}
+	if !strings.Contains(got, "<00:01.50>alpha") {
+		t.Errorf("missing the first word marker:\n%s", got)
+	}
+	if !strings.Contains(got, "<00:02.00>beta") {
+		t.Errorf("missing the second word marker:\n%s", got)
+	}
+}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -247,9 +247,13 @@ type apiResponse struct {
 	Songs   []apiSong `xml:"songs>song"`
 }
 
-// apiSong is one <song> element. Only the fields this client uses are mapped;
-// the response carries additional metadata (writer, composer, jancode, jasracID,
-// cdc, upload/release dates) that is intentionally ignored.
+// apiSong is one <song> element. Only the fields this client uses are mapped.
+//
+// The response carries MORE than the fields listed here. A verified inventory
+// lives in docs/superpowers/specs/2026-07-21-petitlyrics-api-rewrite-design.md;
+// among the deliberately unmapped are writer, composer, jancode, jasracID, cdc,
+// artistId, availableLyricsType, prefferedLyricsType, uploadDate, releaseDate.
+// Do not treat that list as exhaustive either: it reflects observed responses.
 type apiSong struct {
 	LyricsID   string `xml:"lyricsId"`
 	Title      string `xml:"title"`
@@ -259,6 +263,11 @@ type apiSong struct {
 	DurationMS int    `xml:"duration"`
 	LyricsType int    `xml:"lyricsType"`
 	LyricsData string `xml:"lyricsData"`
+	// IsOfficial and Copyright are decoded for MEASUREMENT ONLY (#615, #600).
+	// Nothing in the fetch path consumes them yet: whether isOfficial can carry
+	// a per-result trust signal is exactly what the survey probe is measuring.
+	IsOfficial string `xml:"isOfficial"`
+	Copyright  string `xml:"copyright"`
 }
 
 // FindLyrics looks up lyrics for the given track in a single request.

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -252,7 +252,7 @@ type apiResponse struct {
 // The response carries MORE than the fields listed here. A verified inventory
 // lives in docs/superpowers/specs/2026-07-21-petitlyrics-api-rewrite-design.md;
 // among the deliberately unmapped are writer, composer, jancode, jasracID, cdc,
-// artistId, availableLyricsType, prefferedLyricsType, uploadDate, releaseDate.
+// artistId, prefferedLyricsType, uploadDate, releaseDate.
 // Do not treat that list as exhaustive either: it reflects observed responses.
 type apiSong struct {
 	LyricsID   string `xml:"lyricsId"`
@@ -263,11 +263,16 @@ type apiSong struct {
 	DurationMS int    `xml:"duration"`
 	LyricsType int    `xml:"lyricsType"`
 	LyricsData string `xml:"lyricsData"`
-	// IsOfficial and Copyright are decoded for MEASUREMENT ONLY (#615, #600).
-	// Nothing in the fetch path consumes them yet: whether isOfficial can carry
-	// a per-result trust signal is exactly what the survey probe is measuring.
-	IsOfficial string `xml:"isOfficial"`
-	Copyright  string `xml:"copyright"`
+	// IsOfficial, Copyright, and AvailableTier are decoded for MEASUREMENT ONLY
+	// (#615, #600). Nothing in the fetch path consumes them: whether isOfficial
+	// can carry a per-result trust signal is exactly what the survey probe is
+	// measuring, and availableLyricsType is decoded so the probe can report how
+	// often it agrees with the tier the payload bytes actually carry. Neither
+	// selection nor classification may consult AvailableTier: the payload stays
+	// the authoritative discriminator (see classifyPayload and selectCandidate).
+	IsOfficial    string `xml:"isOfficial"`
+	Copyright     string `xml:"copyright"`
+	AvailableTier int    `xml:"availableLyricsType"`
 }
 
 // FindLyrics looks up lyrics for the given track in a single request.

--- a/internal/petitlyrics/decode.go
+++ b/internal/petitlyrics/decode.go
@@ -73,10 +73,15 @@ func xmlRootPrefix(raw []byte) []byte {
 // classifyPayload reports which tier a decoded payload actually is, derived from
 // the bytes rather than from the response's lyricsType field.
 //
-// This is deliberate. The API's availableLyricsType is not a capability set (it
-// reported the same value regardless of the tier requested), and lyricsType
-// echoes the request. The payload itself is the only trustworthy discriminator,
-// and the three shapes are cleanly separable:
+// This is deliberate, but NOT for the reason an earlier version of this comment
+// gave. It claimed availableLyricsType was not a capability set, concluded from
+// two probe tracks; that claim is RETRACTED. Measured over 107 hits the field
+// predicts the returned tier with no exceptions.
+//
+// Classifying from the payload is still correct: it is the difference between
+// trusting a field and validating what actually arrived, and it keeps the
+// decoder honest if the API's own accounting ever drifts. The three shapes are
+// cleanly separable:
 //
 //	tierWordSync -- XML with a <wsy> root
 //	tierLineSync -- binary: not valid UTF-8, and carries NUL bytes

--- a/internal/petitlyrics/decode_test.go
+++ b/internal/petitlyrics/decode_test.go
@@ -35,9 +35,15 @@ func payloadFromFixture(t *testing.T, name string) []byte {
 }
 
 // TestClassifyPayload pins the payload-shape discriminator. This is the check
-// that must not regress: the API's lyricsType field echoes the request and
-// availableLyricsType is not a capability set, so the bytes are the only
-// trustworthy signal for which tier actually came back.
+// that must not regress, but NOT for the reason an earlier version of this
+// comment gave. It claimed availableLyricsType is not a capability set,
+// concluded from two probe tracks; that claim is RETRACTED. Measured over 107
+// hits the field predicts the returned tier with no exceptions.
+//
+// The conclusion still holds: lyricsType merely echoes the request, and the
+// payload bytes are what actually arrived, so validating them is the difference
+// between trusting a field and checking the goods. That stays true however well
+// availableLyricsType predicts, so nothing here argues for consulting it.
 func TestClassifyPayload(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/petitlyrics/probe_capture_test.go
+++ b/internal/petitlyrics/probe_capture_test.go
@@ -1,0 +1,114 @@
+package petitlyrics
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureTransport tees every response body to a file before handing the
+// response on, so a probe can keep the raw bytes that Client.request parses and
+// discards.
+//
+// It must NOT consume the body: the client still has to read it. Teeing means
+// read-all then restore, never read-and-forget.
+type captureTransport struct {
+	base http.RoundTripper
+	dir  string
+
+	mu sync.Mutex
+	n  int
+}
+
+func newCaptureTransport(dir string) *captureTransport {
+	return &captureTransport{base: http.DefaultTransport, dir: dir}
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := c.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, readErr := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("capture transport: read body: %w", readErr)
+	}
+
+	c.mu.Lock()
+	idx := c.n
+	c.n++
+	c.mu.Unlock()
+
+	// Named by index only. A filename must never carry a track title.
+	path := filepath.Join(c.dir, fmt.Sprintf("sample-%04d.xml", idx))
+	if writeErr := os.WriteFile(path, body, 0o600); writeErr != nil {
+		return nil, fmt.Errorf("capture transport: write %s: %w", path, writeErr)
+	}
+
+	// Restore the body so the client can still read it.
+	res.Body = io.NopCloser(bytesReader(body))
+	return res, nil
+}
+
+func (c *captureTransport) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+// TestCaptureTransport_TeesBodyAndLeavesItReadable is the load-bearing test for
+// this wrapper. A transport that captures the body but forgets to restore it
+// breaks every request while looking correct in isolation, and that failure
+// would only surface against the live API, mid-sweep.
+func TestCaptureTransport_TeesBodyAndLeavesItReadable(t *testing.T) {
+	dir := t.TempDir()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write([]byte(`<response><songs><song><lyricsId>1</lyricsId></song></songs></response>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	ct := newCaptureTransport(dir)
+	client := &http.Client{Transport: ct}
+
+	res, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	// The client must still be able to read the body.
+	got, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if !strings.Contains(string(got), "<lyricsId>1</lyricsId>") {
+		t.Errorf("restored body is not readable by the caller: got %q", got)
+	}
+
+	// And the capture file must hold the same bytes.
+	captured, err := os.ReadFile(filepath.Join(dir, "sample-0000.xml"))
+	if err != nil {
+		t.Fatalf("read capture file: %v", err)
+	}
+	if string(captured) != string(got) {
+		t.Errorf("capture and restored body differ:\ncaptured: %q\nrestored: %q", captured, got)
+	}
+
+	if ct.count() != 1 {
+		t.Errorf("count() = %d, want 1", ct.count())
+	}
+}
+
+// bytesReader is a tiny indirection so the RoundTrip body restore reads clearly.
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }

--- a/internal/petitlyrics/probe_report_test.go
+++ b/internal/petitlyrics/probe_report_test.go
@@ -1,0 +1,179 @@
+package petitlyrics
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// sampleObservation is one track's worth of survey data. It deliberately carries
+// NO title, artist, album, or lyric text: the report generator can only print
+// what it is given, so the privacy guarantee is structural rather than a
+// redaction pass that could fail open.
+type sampleObservation struct {
+	Tier          int     // classifyPayload result, 0 when the lookup failed
+	AvailableTier int     // availableLyricsType as reported, 0 when absent
+	CueCount      int     // number of cues decoded, 0 when none
+	IsOfficial    string  // raw isOfficial value, empty when absent
+	Copyright     string  // raw copyright value, empty when absent
+	DistinctRatio float64 // tier-3 only: fraction of lines with distinct word starts
+	Err           string  // sentinel error class name, empty on success
+}
+
+type surveyReport struct {
+	total          int
+	tierCounts     map[int]int
+	availTierAgree int
+	availTierSeen  int
+	officialCounts map[string]int
+	officialByTier map[int]map[string]int
+	copyrightSeen  int
+	distinctRatios []float64
+	errCounts      map[string]int
+}
+
+func newSurveyReport() *surveyReport {
+	return &surveyReport{
+		tierCounts:     map[int]int{},
+		officialCounts: map[string]int{},
+		officialByTier: map[int]map[string]int{},
+		errCounts:      map[string]int{},
+	}
+}
+
+func (r *surveyReport) add(obs sampleObservation) {
+	r.total++
+	if obs.Err != "" {
+		r.errCounts[obs.Err]++
+		// A sample can carry BOTH an error and a known tier: the wsy-decode and
+		// lsy-write paths classify the payload before they fail. Those still count
+		// toward the tier distribution, because Q2 asks what the provider OFFERS,
+		// not what we managed to decode. Returning early here would silently
+		// undercount word-sync coverage by exactly the tracks that are hardest to
+		// decode.
+		if obs.Tier != 0 {
+			r.tierCounts[obs.Tier]++
+		}
+		return
+	}
+	r.tierCounts[obs.Tier]++
+	if obs.AvailableTier != 0 {
+		r.availTierSeen++
+		if obs.AvailableTier == obs.Tier {
+			r.availTierAgree++
+		}
+	}
+	if obs.IsOfficial != "" {
+		r.officialCounts[obs.IsOfficial]++
+		if r.officialByTier[obs.Tier] == nil {
+			r.officialByTier[obs.Tier] = map[string]int{}
+		}
+		r.officialByTier[obs.Tier][obs.IsOfficial]++
+	}
+	if obs.Copyright != "" {
+		r.copyrightSeen++
+	}
+	if obs.Tier == tierWordSync {
+		r.distinctRatios = append(r.distinctRatios, obs.DistinctRatio)
+	}
+}
+
+func (r *surveyReport) render() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "samples: %d\n", r.total)
+
+	fmt.Fprintf(&b, "\ntier distribution:\n")
+	for _, tier := range []int{tierUnsynced, tierLineSync, tierWordSync} {
+		fmt.Fprintf(&b, "  tier %d: %d\n", tier, r.tierCounts[tier])
+	}
+
+	fmt.Fprintf(&b, "\nerrors:\n")
+	if len(r.errCounts) == 0 {
+		fmt.Fprintf(&b, "  none\n")
+	}
+	for _, k := range sortedKeys(r.errCounts) {
+		fmt.Fprintf(&b, "  %s: %d\n", k, r.errCounts[k])
+	}
+
+	fmt.Fprintf(&b, "\navailableLyricsType agreement: %d/%d\n", r.availTierAgree, r.availTierSeen)
+
+	fmt.Fprintf(&b, "\nisOfficial values:\n")
+	if len(r.officialCounts) == 0 {
+		fmt.Fprintf(&b, "  field absent on every sample\n")
+	}
+	for _, k := range sortedKeys(r.officialCounts) {
+		fmt.Fprintf(&b, "  %q: %d\n", k, r.officialCounts[k])
+	}
+
+	fmt.Fprintf(&b, "\nisOfficial by tier:\n")
+	for _, tier := range []int{tierUnsynced, tierLineSync, tierWordSync} {
+		if len(r.officialByTier[tier]) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "  tier %d:\n", tier)
+		for _, k := range sortedKeys(r.officialByTier[tier]) {
+			fmt.Fprintf(&b, "    %q: %d\n", k, r.officialByTier[tier][k])
+		}
+	}
+
+	fmt.Fprintf(&b, "\ncopyright populated: %d\n", r.copyrightSeen)
+
+	fmt.Fprintf(&b, "\nword-sync distinct-start ratios (n=%d):\n", len(r.distinctRatios))
+	if len(r.distinctRatios) > 0 {
+		sorted := append([]float64(nil), r.distinctRatios...)
+		sort.Float64s(sorted)
+		fmt.Fprintf(&b, "  min %.2f  median %.2f  max %.2f\n",
+			sorted[0], sorted[len(sorted)/2], sorted[len(sorted)-1])
+	}
+
+	return b.String()
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestSurveyReport_EmitsNoIdentifyingContent is the privacy guarantee made
+// testable. The report is the only probe output permitted on a shared surface
+// (an issue, a PR body, a commit message), so it must be impossible for a track
+// title or a lyric to reach it.
+//
+// The guarantee is structural: sampleObservation has no field that could carry
+// one. This test defends that structure by feeding obviously-identifiable
+// strings through every field that IS free-form and asserting none of the
+// canary values appear.
+func TestSurveyReport_EmitsNoIdentifyingContent(t *testing.T) {
+	const canary = "CANARY-IDENTIFYING-CONTENT"
+
+	r := newSurveyReport()
+	r.add(sampleObservation{
+		Tier:          tierWordSync,
+		AvailableTier: tierWordSync,
+		CueCount:      42,
+		IsOfficial:    "1",
+		Copyright:     canary + "-COPYRIGHT",
+		DistinctRatio: 1.0,
+	})
+	r.add(sampleObservation{Err: "ErrNotFound"})
+
+	out := r.render()
+
+	if strings.Contains(out, canary) {
+		t.Errorf("report leaked a free-form field value into its output:\n%s", out)
+	}
+	if !strings.Contains(out, "samples: 2") {
+		t.Errorf("report did not count both samples:\n%s", out)
+	}
+	if !strings.Contains(out, "ErrNotFound: 1") {
+		t.Errorf("report did not record the error class:\n%s", out)
+	}
+	if !strings.Contains(out, "copyright populated: 1") {
+		t.Errorf("report did not count the populated copyright field:\n%s", out)
+	}
+}

--- a/internal/petitlyrics/probe_report_test.go
+++ b/internal/petitlyrics/probe_report_test.go
@@ -12,9 +12,12 @@ import (
 // what it is given, so the privacy guarantee is structural rather than a
 // redaction pass that could fail open.
 type sampleObservation struct {
-	Tier          int     // classifyPayload result, 0 when the lookup failed
-	AvailableTier int     // availableLyricsType as reported, 0 when absent
-	CueCount      int     // number of cues decoded, 0 when none
+	Tier          int // classifyPayload result, 0 when the lookup failed
+	AvailableTier int // availableLyricsType as reported, 0 when absent
+	CueCount      int // number of cues decoded, 0 when none
+	// IsOfficial is PRINTED VERBATIM by render(), unlike Copyright which is only
+	// counted. If the value ever turns out to be free-form text rather than a
+	// short enumerated token, it must be bucketed before it reaches the report.
 	IsOfficial    string  // raw isOfficial value, empty when absent
 	Copyright     string  // raw copyright value, empty when absent
 	DistinctRatio float64 // tier-3 only: fraction of lines with distinct word starts
@@ -29,6 +32,7 @@ type surveyReport struct {
 	officialCounts map[string]int
 	officialByTier map[int]map[string]int
 	copyrightSeen  int
+	cueCounts      []int
 	distinctRatios []float64
 	errCounts      map[string]int
 }
@@ -74,6 +78,12 @@ func (r *surveyReport) add(obs sampleObservation) {
 	if obs.Copyright != "" {
 		r.copyrightSeen++
 	}
+	// A cue count is aggregate-safe (a number, never a line of text) and sizes the
+	// future writer work. Zero means nothing was decoded, so it carries no
+	// distribution information and is left out.
+	if obs.CueCount > 0 {
+		r.cueCounts = append(r.cueCounts, obs.CueCount)
+	}
 	if obs.Tier == tierWordSync {
 		r.distinctRatios = append(r.distinctRatios, obs.DistinctRatio)
 	}
@@ -118,6 +128,14 @@ func (r *surveyReport) render() string {
 	}
 
 	fmt.Fprintf(&b, "\ncopyright populated: %d\n", r.copyrightSeen)
+
+	fmt.Fprintf(&b, "\ncue counts (n=%d):\n", len(r.cueCounts))
+	if len(r.cueCounts) > 0 {
+		sorted := append([]int(nil), r.cueCounts...)
+		sort.Ints(sorted)
+		fmt.Fprintf(&b, "  min %d  median %d  max %d\n",
+			sorted[0], sorted[len(sorted)/2], sorted[len(sorted)-1])
+	}
 
 	fmt.Fprintf(&b, "\nword-sync distinct-start ratios (n=%d):\n", len(r.distinctRatios))
 	if len(r.distinctRatios) > 0 {
@@ -175,5 +193,73 @@ func TestSurveyReport_EmitsNoIdentifyingContent(t *testing.T) {
 	}
 	if !strings.Contains(out, "copyright populated: 1") {
 		t.Errorf("report did not count the populated copyright field:\n%s", out)
+	}
+}
+
+// TestSurveyReport_AvailableTierAgreement pins that the availableLyricsType
+// statistic is REAL rather than a permanent 0/0. The field is decoded on apiSong
+// and stamped by surveySample purely so this line can be computed; a reader who
+// sees 0/0 would read it as "absent on every sample", the opposite of the
+// established finding.
+func TestSurveyReport_AvailableTierAgreement(t *testing.T) {
+	r := newSurveyReport()
+	// Agrees with the payload-derived tier.
+	r.add(sampleObservation{Tier: tierWordSync, AvailableTier: tierWordSync})
+	r.add(sampleObservation{Tier: tierUnsynced, AvailableTier: tierUnsynced})
+	// Seen but disagrees, so it counts in the denominator only.
+	r.add(sampleObservation{Tier: tierLineSync, AvailableTier: tierWordSync})
+	// Absent, so it counts in neither.
+	r.add(sampleObservation{Tier: tierLineSync})
+
+	if r.availTierSeen != 3 {
+		t.Errorf("availTierSeen = %d, want 3 (an absent field is not a sample)", r.availTierSeen)
+	}
+	if r.availTierAgree != 2 {
+		t.Errorf("availTierAgree = %d, want 2", r.availTierAgree)
+	}
+	if got := r.render(); !strings.Contains(got, "availableLyricsType agreement: 2/3") {
+		t.Errorf("report did not render the agreement statistic:\n%s", got)
+	}
+
+	// The empty case must still render, and must not claim agreement.
+	empty := newSurveyReport().render()
+	if !strings.Contains(empty, "availableLyricsType agreement: 0/0") {
+		t.Errorf("empty report did not render the agreement line:\n%s", empty)
+	}
+}
+
+// TestSurveyReport_CueCountDistribution pins the cue-count aggregation, which
+// exists to size the future writer work. A count is aggregate-safe; the empty
+// case is covered because render() indexes the sorted slice.
+func TestSurveyReport_CueCountDistribution(t *testing.T) {
+	r := newSurveyReport()
+	r.add(sampleObservation{Tier: tierWordSync, CueCount: 30})
+	r.add(sampleObservation{Tier: tierWordSync, CueCount: 10})
+	r.add(sampleObservation{Tier: tierWordSync, CueCount: 50})
+	// Zero carries no distribution information and must be left out.
+	r.add(sampleObservation{Tier: tierUnsynced, CueCount: 0})
+	// An errored sample never reaches the success-path accumulators.
+	r.add(sampleObservation{Err: "wsy-decode", Tier: tierWordSync, CueCount: 99})
+
+	if len(r.cueCounts) != 3 {
+		t.Fatalf("cueCounts = %v, want 3 entries (zero and errored samples excluded)", r.cueCounts)
+	}
+	out := r.render()
+	if !strings.Contains(out, "cue counts (n=3)") {
+		t.Errorf("report did not render the cue-count sample size:\n%s", out)
+	}
+	if !strings.Contains(out, "min 10  median 30  max 50") {
+		t.Errorf("report did not render the cue-count distribution:\n%s", out)
+	}
+
+	// No samples with cues: render() must not index an empty slice.
+	emptyReport := newSurveyReport()
+	emptyReport.add(sampleObservation{Tier: tierUnsynced})
+	empty := emptyReport.render()
+	if !strings.Contains(empty, "cue counts (n=0)") {
+		t.Errorf("empty report did not render the cue-count header:\n%s", empty)
+	}
+	if strings.Contains(empty, "min ") {
+		t.Errorf("empty report rendered a distribution line with no data:\n%s", empty)
 	}
 }

--- a/internal/petitlyrics/probe_report_test.go
+++ b/internal/petitlyrics/probe_report_test.go
@@ -106,7 +106,14 @@ func (r *surveyReport) render() string {
 		fmt.Fprintf(&b, "  %s: %d\n", k, r.errCounts[k])
 	}
 
-	fmt.Fprintf(&b, "\navailableLyricsType agreement: %d/%d\n", r.availTierAgree, r.availTierSeen)
+	// The denominator here is deliberately SMALLER than the tier-distribution
+	// total, and saying so in the output stops a reader treating the gap as a
+	// discrepancy. A sample that classified a tier but then failed to decode
+	// counts toward the tier counts (see add()) yet never reaches these
+	// accumulators, so it is present above and absent here.
+	fmt.Fprintf(&b, "\navailableLyricsType agreement: %d/%d"+
+		" (denominator counts only samples that decoded fully; see tier distribution for the full count)\n",
+		r.availTierAgree, r.availTierSeen)
 
 	fmt.Fprintf(&b, "\nisOfficial values:\n")
 	if len(r.officialCounts) == 0 {

--- a/internal/petitlyrics/probe_report_test.go
+++ b/internal/petitlyrics/probe_report_test.go
@@ -15,9 +15,12 @@ type sampleObservation struct {
 	Tier          int // classifyPayload result, 0 when the lookup failed
 	AvailableTier int // availableLyricsType as reported, 0 when absent
 	CueCount      int // number of cues decoded, 0 when none
-	// IsOfficial is PRINTED VERBATIM by render(), unlike Copyright which is only
-	// counted. If the value ever turns out to be free-form text rather than a
-	// short enumerated token, it must be bucketed before it reaches the report.
+	// IsOfficial is PRINTED by render(), unlike Copyright which is only counted.
+	// It passes through boundedToken first, so a short enumerated token (the
+	// observed "0"/"1") prints verbatim while anything longer is replaced by a
+	// length-only placeholder. That keeps the measurement intact -- printing the
+	// real values is how the inverted isOfficial correlation was found -- without
+	// leaving a provider-controlled string able to reach a shared surface.
 	IsOfficial    string  // raw isOfficial value, empty when absent
 	Copyright     string  // raw copyright value, empty when absent
 	DistinctRatio float64 // tier-3 only: fraction of lines with distinct word starts
@@ -69,11 +72,11 @@ func (r *surveyReport) add(obs sampleObservation) {
 		}
 	}
 	if obs.IsOfficial != "" {
-		r.officialCounts[obs.IsOfficial]++
+		r.officialCounts[boundedToken(obs.IsOfficial)]++
 		if r.officialByTier[obs.Tier] == nil {
 			r.officialByTier[obs.Tier] = map[string]int{}
 		}
-		r.officialByTier[obs.Tier][obs.IsOfficial]++
+		r.officialByTier[obs.Tier][boundedToken(obs.IsOfficial)]++
 	}
 	if obs.Copyright != "" {
 		r.copyrightSeen++
@@ -186,14 +189,30 @@ func TestSurveyReport_EmitsNoIdentifyingContent(t *testing.T) {
 		DistinctRatio: 1.0,
 	})
 	r.add(sampleObservation{Err: "ErrNotFound"})
+	// The canary MUST also travel through IsOfficial, because that is the one
+	// free-form field render() prints VERBATIM (Copyright is only counted). An
+	// earlier version of this test fed the canary through Copyright alone and set
+	// IsOfficial to a benign "1" -- so it asserted over the path that cannot leak
+	// while leaving the path that can entirely unexercised.
+	r.add(sampleObservation{
+		Tier:       tierUnsynced,
+		IsOfficial: canary + "-OFFICIAL",
+	})
 
 	out := r.render()
 
 	if strings.Contains(out, canary) {
 		t.Errorf("report leaked a free-form field value into its output:\n%s", out)
 	}
-	if !strings.Contains(out, "samples: 2") {
-		t.Errorf("report did not count both samples:\n%s", out)
+	if !strings.Contains(out, "samples: 3") {
+		t.Errorf("report did not count every sample:\n%s", out)
+	}
+	// The bound must not have swallowed the ordinary enumerated token: the whole
+	// point of bounding rather than bucketing is that the real values still print,
+	// since printing them is how the sweep found the isOfficial correlation.
+	if !strings.Contains(out, `"1": 1`) {
+		t.Errorf("a short enumerated token was not printed verbatim; bounding must "+
+			"not degrade the measurement:\n%s", out)
 	}
 	if !strings.Contains(out, "ErrNotFound: 1") {
 		t.Errorf("report did not record the error class:\n%s", out)
@@ -269,4 +288,33 @@ func TestSurveyReport_CueCountDistribution(t *testing.T) {
 	if strings.Contains(empty, "min ") {
 		t.Errorf("empty report rendered a distribution line with no data:\n%s", empty)
 	}
+}
+
+// maxTokenLen bounds a provider value that render() prints VERBATIM. The two
+// values observed across a 100-track live sweep were "0" and "1", so anything
+// past a handful of characters is not the enumerated flag this report is
+// measuring.
+const maxTokenLen = 8
+
+// boundedToken passes through a short enumerated token and replaces anything
+// longer with a length-only placeholder.
+//
+// This closes the one path by which the report could leak. sampleObservation
+// carries no title/artist/album field, so the privacy guarantee is otherwise
+// structural -- but IsOfficial is a provider-controlled string that render()
+// prints verbatim, and "provider-controlled" plus "printed verbatim" is a leak
+// waiting for the provider to change shape.
+//
+// It BOUNDS rather than buckets. Bucketing (mapping every value to
+// official/not-official) was the reviewer's suggestion and would have destroyed
+// the measurement: printing the raw values is exactly how the sweep found that
+// isOfficial discriminates INVERTED (every word-synced result carried "0", every
+// unsynced one "1"), which is the finding that redirected #480 and #615. A
+// length bound keeps that visible while making an unexpected long value
+// unprintable.
+func boundedToken(v string) string {
+	if len(v) <= maxTokenLen {
+		return v
+	}
+	return fmt.Sprintf("<non-token value, %d bytes>", len(v))
 }

--- a/internal/petitlyrics/probe_survey_test.go
+++ b/internal/petitlyrics/probe_survey_test.go
@@ -176,16 +176,33 @@ func findRepoRoot(start string) (string, error) {
 	}
 }
 
-// resolveSymlinks returns the fully-resolved path when it exists, and the input
-// unchanged when it does not. Resolving matters for containment: on macOS a
-// scratchpad under /tmp resolves to /private/tmp, and comparing an unresolved
-// path against a resolved root can make two names for the same directory look
-// like different places.
+// resolveSymlinks returns path with every symlinked component resolved,
+// including when the path does not exist yet.
+//
+// Resolving matters for containment: on macOS a scratchpad under /tmp resolves
+// to /private/tmp, and comparing an unresolved path against a resolved root
+// makes two names for the same directory look like different places.
+//
+// The recursion is load-bearing, not tidiness. filepath.EvalSymlinks fails when
+// ANY component is missing, and an earlier version returned the path unchanged
+// on that failure -- which made the containment guard FAIL OPEN on the common
+// first-run path, before the operator has created PLPROBE_DIR. Measured: with a
+// repo at /tmp/repo (a symlinked component on macOS), findRepoRoot returns the
+// resolved /private/tmp/repo while an uncreated /tmp/repo/captures stayed
+// unresolved, so filepath.Rel returned "../link/not-created-yet" and the guard
+// read a directory INSIDE the working tree as outside it. Resolving the nearest
+// existing ancestor and re-attaching the missing tail keeps both sides in the
+// same namespace whether or not the leaf exists.
 func resolveSymlinks(path string) string {
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		return resolved
 	}
-	return path
+	parent := filepath.Dir(path)
+	if parent == path {
+		// Reached the filesystem root without resolving; nothing left to try.
+		return path
+	}
+	return filepath.Join(resolveSymlinks(parent), filepath.Base(path))
 }
 
 // ensureOutsideRepo rejects a probe directory that is the repo root or anything
@@ -467,7 +484,12 @@ func TestFindRepoRoot_LocatesByMarkerNotName(t *testing.T) {
 	}
 
 	// A synthetic tree with no marker must fail rather than walking to /.
-	bare := t.TempDir()
+	//
+	// bare is resolved because findRepoRoot returns a RESOLVED path. Comparing a
+	// resolved result against an unresolved prefix means HasPrefix can never
+	// match on a symlinked TMPDIR (the macOS default), so the assertion below
+	// would pass without testing anything.
+	bare := resolveSymlinks(t.TempDir())
 	deep := filepath.Join(bare, "a", "b")
 	if err := os.MkdirAll(deep, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -574,5 +596,49 @@ func TestReadTrackList(t *testing.T) {
 
 	if _, err := readTrackList(filepath.Join(dir, "absent.tsv")); err == nil {
 		t.Error("a missing track list must be an error, not an empty sweep")
+	}
+}
+
+// TestEnsureOutsideRepo_RejectsUncreatedDirInsideRepo pins the fail-open case
+// that shipped in the first version of this guard.
+//
+// The guard's whole job is keeping raw captures of a private library out of the
+// working tree. It compared a RESOLVED repo root against a probe dir that
+// resolveSymlinks left UNRESOLVED whenever any component was missing -- which is
+// the normal first run, before the operator has created PLPROBE_DIR. With a
+// symlinked component in the path (on macOS /tmp is a symlink to /private/tmp),
+// the two sides landed in different namespaces, filepath.Rel returned a
+// ".."-prefixed result, and the guard read a directory INSIDE the repo as
+// outside it.
+//
+// The test constructs exactly that shape: a symlink pointing at a repo root, and
+// a NOT-YET-CREATED child under the symlinked name.
+func TestEnsureOutsideRepo_RejectsUncreatedDirInsideRepo(t *testing.T) {
+	realRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(realRoot, 0o700); err != nil {
+		t.Fatalf("mkdir real root: %v", err)
+	}
+	linkRoot := filepath.Join(t.TempDir(), "linked-repo")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// The guard is handed the RESOLVED root, exactly as TestSurveyProbe does via
+	// findRepoRoot.
+	resolvedRoot := resolveSymlinks(linkRoot)
+
+	// A capture dir inside the repo, reached through the symlinked name, that
+	// does not exist yet.
+	uncreated := filepath.Join(linkRoot, "captures")
+	if _, err := os.Stat(uncreated); err == nil {
+		t.Fatal("precondition: the capture dir must NOT exist for this case")
+	}
+
+	got, err := ensureOutsideRepo(uncreated, resolvedRoot)
+	if err == nil {
+		t.Errorf("guard ACCEPTED %q, which is inside the repo at %q (resolved to %q). "+
+			"Raw captures of a private library would land in the working tree, one "+
+			"`git add -A` from a public surface -- the exact outcome this guard exists "+
+			"to prevent, on the common first-run path.", uncreated, resolvedRoot, got)
 	}
 }

--- a/internal/petitlyrics/probe_survey_test.go
+++ b/internal/petitlyrics/probe_survey_test.go
@@ -259,9 +259,10 @@ func surveySample(ctx context.Context, c *Client, track models.Track, captureDir
 	}
 
 	obs := sampleObservation{
-		Tier:       classifyPayload(raw),
-		IsOfficial: candidate.IsOfficial,
-		Copyright:  candidate.Copyright,
+		Tier:          classifyPayload(raw),
+		AvailableTier: candidate.AvailableTier,
+		IsOfficial:    candidate.IsOfficial,
+		Copyright:     candidate.Copyright,
 	}
 
 	switch obs.Tier {

--- a/internal/petitlyrics/probe_survey_test.go
+++ b/internal/petitlyrics/probe_survey_test.go
@@ -50,8 +50,13 @@ func TestSurveyProbe(t *testing.T) {
 	if dir == "" {
 		t.Fatal("PLPROBE_DIR must be set to a scratchpad directory outside the repo")
 	}
-	if strings.Contains(dir, "canticle/internal") || strings.Contains(dir, "canticle/docs") {
-		t.Fatalf("PLPROBE_DIR must not be under the repo: %s", dir)
+	repoRoot, err := findRepoRoot(".")
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	dir, err = ensureOutsideRepo(dir, repoRoot)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	captureDir := filepath.Join(dir, "captures")
@@ -83,21 +88,28 @@ func TestSurveyProbe(t *testing.T) {
 	report := newSurveyReport()
 	ctx := context.Background()
 	consecutiveTransportErrors := 0
+	var abortBanner string
 
 	for i, track := range tracks {
 		obs, fatal := surveySample(ctx, c, track, captureDir, i)
 		report.add(obs)
 
 		if fatal != nil {
+			// Record the error CLASS, never the wrapped error: a wrapped message
+			// could in principle carry a track value, and this banner is written
+			// into the shareable artifact.
+			abortBanner = abortedBanner(i, len(tracks), obs.Err,
+				"an auth or throttle failure makes later lookups resemble misses")
 			t.Logf("ABORT at sample %d of %d: %v", i, len(tracks), fatal)
-			t.Logf("Results collected before this point are SUSPECT, not partial: " +
-				"an auth or throttle failure makes later lookups resemble misses.")
 			break
 		}
 
 		if obs.Err == "transport" {
 			consecutiveTransportErrors++
 			if consecutiveTransportErrors >= maxConsecutiveTransportErrors {
+				abortBanner = abortedBanner(i, len(tracks), "transport",
+					fmt.Sprintf("%d consecutive transport errors; the run is measuring the network",
+						consecutiveTransportErrors))
 				t.Logf("ABORT at sample %d: %d consecutive transport errors; "+
 					"the run is measuring the network", i, consecutiveTransportErrors)
 				break
@@ -107,7 +119,11 @@ func TestSurveyProbe(t *testing.T) {
 		}
 	}
 
-	out := report.render()
+	// The banner is PREPENDED to the rendered report rather than only logged,
+	// because report.txt is the artifact that travels to an issue and a reader
+	// there has no access to the test log. A truncated run that looks complete
+	// would be read as poor coverage rather than as a dead credential.
+	out := abortBanner + report.render()
 	t.Logf("\n===== SURVEY REPORT (safe to share) =====\n%s", out)
 
 	reportPath := filepath.Join(dir, "report.txt")
@@ -116,6 +132,89 @@ func TestSurveyProbe(t *testing.T) {
 	}
 	t.Logf("report written to %s", reportPath)
 	t.Logf("captures written: %d (raw, keep out of the repo)", ct.count())
+}
+
+// abortedBanner renders the header prepended to a truncated run's report.
+//
+// Aggregate-only, like the report it fronts: a sample INDEX, a sentinel error
+// CLASS, and a fixed explanation. No path, artist, title, album, or lyric text
+// can reach it, so the "safe to share" label still holds on an aborted run.
+func abortedBanner(idx, planned int, errClass, why string) string {
+	if errClass == "" {
+		errClass = "unknown"
+	}
+	return fmt.Sprintf(
+		"***** RUN ABORTED - RESULTS ARE SUSPECT, NOT PARTIAL *****\n"+
+			"stopped at sample %d of %d planned; cause: %s\n"+
+			"%s, so the counts below UNDERSTATE coverage by an unknown amount.\n"+
+			"Do not read the tier distribution or the miss rate as a measurement.\n"+
+			"**********************************************************\n\n",
+		idx, planned, errClass, why)
+}
+
+// findRepoRoot walks up from start looking for the directory holding go.mod.
+//
+// The root is located by MARKER, never by directory name. A name check
+// ("does the path contain canticle/") is wrong twice over: the repo can be
+// cloned to any path, and an unrelated directory that merely contains the name
+// would be rejected. The marker is the only thing that actually identifies the
+// module root.
+func findRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", start, err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return resolveSymlinks(dir), nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found walking up from %q", start)
+		}
+		dir = parent
+	}
+}
+
+// resolveSymlinks returns the fully-resolved path when it exists, and the input
+// unchanged when it does not. Resolving matters for containment: on macOS a
+// scratchpad under /tmp resolves to /private/tmp, and comparing an unresolved
+// path against a resolved root can make two names for the same directory look
+// like different places.
+func resolveSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
+
+// ensureOutsideRepo rejects a probe directory that is the repo root or anything
+// beneath it, returning the absolute, symlink-resolved path on success.
+//
+// This is a real containment check, not a substring match. Raw captures of a
+// private music library landing anywhere inside the working tree are one
+// `git add -A` away from a public surface, so the guard has to hold for the repo
+// ROOT itself and for every path under it, whatever they are named.
+func ensureOutsideRepo(dir, repoRoot string) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve PLPROBE_DIR %q: %w", dir, err)
+	}
+	abs = resolveSymlinks(abs)
+
+	rel, err := filepath.Rel(repoRoot, abs)
+	if err != nil {
+		// Different volumes (or otherwise unrelatable), so it cannot be inside.
+		return abs, nil //nolint:nilerr // reason: an unrelatable path is provably not under repoRoot, which is exactly what this function checks; the Rel error is the evidence, not a failure.
+	}
+	// Rel yields "." for the root itself and a path starting with ".." only when
+	// abs escapes repoRoot. Anything else is inside.
+	if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf(
+			"PLPROBE_DIR must not be the repo or under it: %s is inside %s (resolved to %s)",
+			dir, repoRoot, abs)
+	}
+	return abs, nil
 }
 
 // surveySample performs one lookup and classifies the result. The second return
@@ -191,6 +290,13 @@ func surveySample(ctx context.Context, c *Client, track models.Track, captureDir
 // one start time. A line where every word shares a timestamp is effectively
 // line-level only, which the A2 writer (#480) has to handle per line rather than
 // assuming uniform coverage.
+//
+// A ONE-WORD line necessarily has a single start time, so it counts as
+// non-distinct and sits in the denominator alongside a multi-word line whose
+// words all share a timestamp. That is deliberate: both are line-level-only for
+// the writer's purposes, and the ratio measures usable word granularity, not the
+// provider's intent. A corpus of short lines therefore reads as low coverage,
+// which is the honest reading of what a per-word writer would get.
 func distinctStartRatio(cues []models.Lines, timings []models.WordTiming) float64 {
 	if len(cues) == 0 {
 		return 0
@@ -214,10 +320,11 @@ func distinctStartRatio(cues []models.Lines, timings []models.WordTiming) float6
 // readTrackList parses artist<TAB>title<TAB>album per line.
 //
 // The open below is a variable path (gosec G304), which is fine here and needs
-// no //nolint: gosec is excluded on _test.go by .golangci.yml, so a directive
-// would suppress nothing and nolintlint would flag it as dead. On the merits,
-// the path is built from PLPROBE_DIR, an operator-supplied scratchpad path for a
-// manually-invoked probe; there is no untrusted input and no server context.
+// no `//nolint`. gosec is excluded on `_test.go` by `.golangci.yml`, so a
+// directive would suppress nothing and nolintlint would flag it as dead. On the
+// merits, the path is built from PLPROBE_DIR, an operator-supplied scratchpad
+// path for a manually-invoked probe; there is no untrusted input and no server
+// context.
 func readTrackList(path string) ([]models.Track, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -246,4 +353,217 @@ func readTrackList(path string) ([]models.Track, error) {
 		return nil, fmt.Errorf("scan track list: %w", err)
 	}
 	return tracks, nil
+}
+
+// TestEnsureOutsideRepo_RejectsEveryPathUnderTheRepo is the load-bearing test
+// for the containment guard. The guard exists to keep raw captures of a private
+// music library out of the working tree, where a single `git add -A` would put
+// them on a public surface, so a guard that accepts the repo ROOT or an
+// arbitrarily-named subdirectory of it is not a guard at all.
+//
+// The earlier substring form ("does the path contain canticle/internal") failed
+// exactly these cases; each is pinned here so it cannot come back.
+func TestEnsureOutsideRepo_RejectsEveryPathUnderTheRepo(t *testing.T) {
+	repoRoot := t.TempDir()
+	repoRoot = resolveSymlinks(repoRoot)
+	outside := resolveSymlinks(t.TempDir())
+
+	inside := []struct {
+		name string
+		dir  string
+	}{
+		{"the repo root itself", repoRoot},
+		{"a plainly-named subdirectory", filepath.Join(repoRoot, "plprobe")},
+		{"a scratch subdirectory", filepath.Join(repoRoot, "scratch")},
+		{"a package directory", filepath.Join(repoRoot, "internal", "petitlyrics")},
+		{"a docs directory", filepath.Join(repoRoot, "docs", "captures")},
+		{"a deeply nested directory", filepath.Join(repoRoot, "a", "b", "c", "d")},
+		{"an unclean path that resolves inside", filepath.Join(repoRoot, "x", "..", "y")},
+	}
+	for _, tc := range inside {
+		t.Run("reject "+tc.name, func(t *testing.T) {
+			got, err := ensureOutsideRepo(tc.dir, repoRoot)
+			if err == nil {
+				t.Fatalf("ensureOutsideRepo(%q) accepted a path inside the repo, returned %q", tc.dir, got)
+			}
+			// The message must name both sides, or an operator cannot tell which
+			// of the two paths is the one they need to change.
+			if !strings.Contains(err.Error(), repoRoot) {
+				t.Errorf("error does not name the repo root: %v", err)
+			}
+		})
+	}
+
+	outsideCases := []struct {
+		name string
+		dir  string
+	}{
+		{"a sibling scratchpad", outside},
+		{"a subdirectory of a sibling", filepath.Join(outside, "plprobe")},
+		{"a path merely NAMED like the repo", filepath.Join(outside, "canticle", "internal")},
+		{"a sibling sharing a name prefix", repoRoot + "-notes"},
+	}
+	for _, tc := range outsideCases {
+		t.Run("accept "+tc.name, func(t *testing.T) {
+			got, err := ensureOutsideRepo(tc.dir, repoRoot)
+			if err != nil {
+				t.Fatalf("ensureOutsideRepo(%q) rejected a path outside the repo: %v", tc.dir, err)
+			}
+			if !filepath.IsAbs(got) {
+				t.Errorf("returned path is not absolute: %q", got)
+			}
+		})
+	}
+}
+
+// TestEnsureOutsideRepo_ResolvesRelativeAndSymlinkedPaths pins that containment
+// is decided on the RESOLVED path. A relative path or a symlink into the tree
+// would otherwise walk straight past a check done on the raw string.
+func TestEnsureOutsideRepo_ResolvesRelativeAndSymlinkedPaths(t *testing.T) {
+	repoRoot := resolveSymlinks(t.TempDir())
+	outside := resolveSymlinks(t.TempDir())
+
+	// A symlink living outside the repo but POINTING inside it must be rejected:
+	// writes through it land in the working tree.
+	target := filepath.Join(repoRoot, "captures")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(outside, "sneaky")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := ensureOutsideRepo(link, repoRoot); err == nil {
+		t.Error("a symlink pointing into the repo was accepted")
+	}
+
+	// A relative path is resolved against the working directory, which during
+	// this test is the package directory inside the repo.
+	if _, err := ensureOutsideRepo(".", mustRepoRoot(t)); err == nil {
+		t.Error(`ensureOutsideRepo(".") accepted the package directory itself`)
+	}
+}
+
+// TestFindRepoRoot_LocatesByMarkerNotName pins that the root is found via go.mod
+// rather than a hardcoded directory name, so the guard still works in a clone
+// under any path.
+func TestFindRepoRoot_LocatesByMarkerNotName(t *testing.T) {
+	root := mustRepoRoot(t)
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("located root %q has no go.mod: %v", root, err)
+	}
+	// The package directory must resolve to that same root.
+	if _, err := os.Stat(filepath.Join(root, "internal", "petitlyrics")); err != nil {
+		t.Errorf("located root %q does not contain this package: %v", root, err)
+	}
+
+	// A synthetic tree with no marker must fail rather than walking to /.
+	bare := t.TempDir()
+	deep := filepath.Join(bare, "a", "b")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// This only proves the negative when no ancestor of the temp dir carries a
+	// go.mod, which is true of the OS temp root.
+	if got, err := findRepoRoot(deep); err == nil && strings.HasPrefix(got, bare) {
+		t.Errorf("findRepoRoot invented a root inside a marker-less tree: %q", got)
+	}
+}
+
+func mustRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := findRepoRoot(".")
+	if err != nil {
+		t.Fatalf("findRepoRoot: %v", err)
+	}
+	return root
+}
+
+// TestAbortedBanner_TravelsWithTheReportAndStaysAggregate pins the two
+// properties that make the banner worth having: it is PART of the rendered
+// report (so it reaches an issue, where the test log does not), and it carries
+// nothing but an index and an error class.
+func TestAbortedBanner_TravelsWithTheReportAndStaysAggregate(t *testing.T) {
+	banner := abortedBanner(34, 100, "ErrUnauthorized", "the credential died")
+
+	for _, want := range []string{"ABORTED", "SUSPECT", "34", "100", "ErrUnauthorized"} {
+		if !strings.Contains(banner, want) {
+			t.Errorf("banner does not mention %q:\n%s", want, banner)
+		}
+	}
+
+	// The banner fronts the report, so a reader sees the caveat before the counts.
+	r := newSurveyReport()
+	r.add(sampleObservation{Tier: tierWordSync})
+	out := banner + r.render()
+	if !strings.HasPrefix(out, "*****") {
+		t.Errorf("banner is not the first thing in the artifact:\n%s", out)
+	}
+	if strings.Index(out, "ABORTED") > strings.Index(out, "samples:") {
+		t.Error("the abort caveat appears after the counts it qualifies")
+	}
+
+	// An empty error class must still render a usable cause, not a blank.
+	if got := abortedBanner(0, 10, "", "why"); strings.Contains(got, "cause: \n") {
+		t.Errorf("empty error class rendered as a blank cause:\n%s", got)
+	}
+}
+
+// TestDistinctStartRatio pins the arithmetic the #480 sizing decision rests on,
+// including the documented treatment of single-word lines as non-distinct.
+func TestDistinctStartRatio(t *testing.T) {
+	cues := []models.Lines{{Text: "a"}, {Text: "b"}, {Text: "c"}, {Text: "d"}}
+	timings := []models.WordTiming{
+		// Line 0: two words, distinct starts -> counts as distinct.
+		{Line: 0, StartMS: 100}, {Line: 0, StartMS: 200},
+		// Line 1: two words sharing one start -> line-level only.
+		{Line: 1, StartMS: 300}, {Line: 1, StartMS: 300},
+		// Line 2: a single word -> necessarily one start, so non-distinct.
+		{Line: 2, StartMS: 400},
+		// Line 3: no timings at all.
+	}
+	if got := distinctStartRatio(cues, timings); got != 0.25 {
+		t.Errorf("distinctStartRatio = %v, want 0.25 (only line 0 is distinct)", got)
+	}
+
+	if got := distinctStartRatio(nil, timings); got != 0 {
+		t.Errorf("distinctStartRatio(nil cues) = %v, want 0 (no divide by zero)", got)
+	}
+	if got := distinctStartRatio(cues, nil); got != 0 {
+		t.Errorf("distinctStartRatio(no timings) = %v, want 0", got)
+	}
+}
+
+// TestReadTrackList parses a synthetic list. The fixture is written at test time
+// with obviously-synthetic values: no real library metadata belongs in the repo.
+func TestReadTrackList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tracks.tsv")
+	content := "ArtistA\tTitleA\tAlbumA\n" +
+		"\n" +
+		"ArtistB\tTitleB\n" +
+		"malformed-single-field\n" +
+		"  \n" +
+		"ArtistC\tTitleC\tAlbumC\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tracks, err := readTrackList(path)
+	if err != nil {
+		t.Fatalf("readTrackList: %v", err)
+	}
+	if len(tracks) != 3 {
+		t.Fatalf("got %d tracks, want 3 (blank and single-field lines skipped): %+v", len(tracks), tracks)
+	}
+	if tracks[0].ArtistName != "ArtistA" || tracks[0].TrackName != "TitleA" || tracks[0].AlbumName != "AlbumA" {
+		t.Errorf("first track parsed incorrectly: %+v", tracks[0])
+	}
+	if tracks[1].AlbumName != "" {
+		t.Errorf("two-field line should leave the album empty: %+v", tracks[1])
+	}
+
+	if _, err := readTrackList(filepath.Join(dir, "absent.tsv")); err == nil {
+		t.Error("a missing track list must be an error, not an empty sweep")
+	}
 }

--- a/internal/petitlyrics/probe_survey_test.go
+++ b/internal/petitlyrics/probe_survey_test.go
@@ -223,6 +223,14 @@ func surveySample(ctx context.Context, c *Client, track models.Track, captureDir
 	songs, err := c.request(ctx, track, tierWordSync)
 	if err != nil {
 		switch {
+		// MUST precede the ErrNotFound case: ErrProviderUnavailable WRAPS
+		// ErrNotFound, so it satisfies errors.Is for both. Tested after the miss
+		// case it would be read as an ordinary miss and the sweep would CONTINUE
+		// -- the exact contamination the abort semantics exist to prevent, in the
+		// one place whose job is to notice it.
+		case errors.Is(err, ErrProviderUnavailable):
+			return sampleObservation{Err: "ErrProviderUnavailable"}, fmt.Errorf(
+				"sustained zero-result run at sample %d (application id revoked?): %w", idx, err)
 		case errors.Is(err, ErrUnauthorized):
 			// The clientAppID is a hardcoded constant shared by every canticle
 			// install (#607). If it is revoked mid-sweep every later lookup

--- a/internal/petitlyrics/probe_survey_test.go
+++ b/internal/petitlyrics/probe_survey_test.go
@@ -1,0 +1,249 @@
+package petitlyrics
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// maxSamples bounds the sweep independently of the track list length, so a
+// longer list is truncated rather than silently extending the run.
+const maxSamples = 100
+
+// minTrackList is a setup-error floor. Below this, tier-2 captures are too few to
+// be a corpus and the isOfficial cross-tabulation has no cells.
+const minTrackList = 50
+
+// maxConsecutiveTransportErrors aborts a run that has started measuring the
+// network rather than the API. One timeout is noise; three in a row is not.
+const maxConsecutiveTransportErrors = 3
+
+// TestSurveyProbe performs ONE paced live sweep against the real petitlyrics API
+// and reports aggregates. It answers three questions off the same responses:
+// whether isOfficial discriminates usefully (#615/#600), what word-sync coverage
+// looks like on this library (#480), and whether a tier-2 corpus can be
+// collected (#602).
+//
+// It is gated on PLPROBE=1 and makes real outbound requests. Run it explicitly:
+//
+//	PLPROBE_DIR=/path/to/scratchpad/plprobe PLPROBE=1 \
+//	  go test -run TestSurveyProbe ./internal/petitlyrics -v -timeout 90m
+//
+// The track list at $PLPROBE_DIR/tracks.tsv is artist<TAB>title<TAB>album per
+// line. Neither it nor the captures may live under the repo.
+func TestSurveyProbe(t *testing.T) {
+	if os.Getenv("PLPROBE") != "1" {
+		t.Skip("live probe: set PLPROBE=1 to run")
+	}
+
+	dir := os.Getenv("PLPROBE_DIR")
+	if dir == "" {
+		t.Fatal("PLPROBE_DIR must be set to a scratchpad directory outside the repo")
+	}
+	if strings.Contains(dir, "canticle/internal") || strings.Contains(dir, "canticle/docs") {
+		t.Fatalf("PLPROBE_DIR must not be under the repo: %s", dir)
+	}
+
+	captureDir := filepath.Join(dir, "captures")
+	if err := os.MkdirAll(captureDir, 0o700); err != nil {
+		t.Fatalf("create capture dir: %v", err)
+	}
+
+	tracks, err := readTrackList(filepath.Join(dir, "tracks.tsv"))
+	if err != nil {
+		t.Fatalf("read track list: %v", err)
+	}
+	if len(tracks) < minTrackList {
+		t.Fatalf("track list has %d entries, need at least %d", len(tracks), minTrackList)
+	}
+	if len(tracks) > maxSamples {
+		t.Logf("track list has %d entries; truncating to %d", len(tracks), maxSamples)
+		tracks = tracks[:maxSamples]
+	}
+
+	ct := newCaptureTransport(captureDir)
+	c := NewClient()
+	c.httpClient = &http.Client{
+		Timeout:       30 * time.Second,
+		Transport:     ct,
+		CheckRedirect: c.checkRedirect,
+	}
+	c.WithMinInterval(DefaultMinInterval)
+
+	report := newSurveyReport()
+	ctx := context.Background()
+	consecutiveTransportErrors := 0
+
+	for i, track := range tracks {
+		obs, fatal := surveySample(ctx, c, track, captureDir, i)
+		report.add(obs)
+
+		if fatal != nil {
+			t.Logf("ABORT at sample %d of %d: %v", i, len(tracks), fatal)
+			t.Logf("Results collected before this point are SUSPECT, not partial: " +
+				"an auth or throttle failure makes later lookups resemble misses.")
+			break
+		}
+
+		if obs.Err == "transport" {
+			consecutiveTransportErrors++
+			if consecutiveTransportErrors >= maxConsecutiveTransportErrors {
+				t.Logf("ABORT at sample %d: %d consecutive transport errors; "+
+					"the run is measuring the network", i, consecutiveTransportErrors)
+				break
+			}
+		} else {
+			consecutiveTransportErrors = 0
+		}
+	}
+
+	out := report.render()
+	t.Logf("\n===== SURVEY REPORT (safe to share) =====\n%s", out)
+
+	reportPath := filepath.Join(dir, "report.txt")
+	if err := os.WriteFile(reportPath, []byte(out), 0o600); err != nil {
+		t.Errorf("write report: %v", err)
+	}
+	t.Logf("report written to %s", reportPath)
+	t.Logf("captures written: %d (raw, keep out of the repo)", ct.count())
+}
+
+// surveySample performs one lookup and classifies the result. The second return
+// is non-nil for a class that must abort the whole run.
+func surveySample(ctx context.Context, c *Client, track models.Track, captureDir string, idx int) (sampleObservation, error) {
+	songs, err := c.request(ctx, track, tierWordSync)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrUnauthorized):
+			// The clientAppID is a hardcoded constant shared by every canticle
+			// install (#607). If it is revoked mid-sweep every later lookup
+			// resembles a miss, and the coverage number would read as poor
+			// coverage rather than a dead credential.
+			return sampleObservation{Err: "ErrUnauthorized"}, fmt.Errorf("credential rejected: %w", err)
+		case errors.Is(err, ErrForbidden):
+			// Per errors.go, a refused request shape rather than throttling. Means
+			// the probe talks to the service differently than canticle does, which
+			// invalidates the premise of the measurement.
+			return sampleObservation{Err: "ErrForbidden"}, fmt.Errorf("request refused: %w", err)
+		case errors.Is(err, ErrRateLimited):
+			// Prod does not query petitlyrics, so a 429 at this pacing means the
+			// floor is wrong. A real #535 finding worth stopping for.
+			return sampleObservation{Err: "ErrRateLimited"}, fmt.Errorf("throttled at sample %d: %w", idx, err)
+		case errors.Is(err, ErrNotFound):
+			return sampleObservation{Err: "ErrNotFound"}, nil
+		default:
+			return sampleObservation{Err: "transport"}, nil
+		}
+	}
+
+	candidate, err := selectCandidate(songs, track)
+	if err != nil {
+		return sampleObservation{Err: "no-candidate"}, nil
+	}
+	if candidate.LyricsData == "" {
+		return sampleObservation{Err: "empty-payload"}, nil
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(candidate.LyricsData)
+	if err != nil {
+		return sampleObservation{Err: "base64"}, nil
+	}
+
+	obs := sampleObservation{
+		Tier:       classifyPayload(raw),
+		IsOfficial: candidate.IsOfficial,
+		Copyright:  candidate.Copyright,
+	}
+
+	switch obs.Tier {
+	case tierWordSync:
+		cues, timings, decErr := decodeWordSync(raw)
+		if decErr != nil {
+			obs.Err = "wsy-decode"
+			return obs, nil
+		}
+		obs.CueCount = len(cues)
+		obs.DistinctRatio = distinctStartRatio(cues, timings)
+	case tierLineSync:
+		// The #602 corpus. The capture transport already wrote the full response;
+		// write the decoded binary payload separately so the follow-on has the
+		// exact bytes without re-parsing the envelope.
+		path := filepath.Join(captureDir, fmt.Sprintf("lsy-%04d.bin", idx))
+		if writeErr := os.WriteFile(path, raw, 0o600); writeErr != nil {
+			obs.Err = "lsy-write"
+		}
+	}
+
+	return obs, nil
+}
+
+// distinctStartRatio reports the fraction of lines whose words do NOT all share
+// one start time. A line where every word shares a timestamp is effectively
+// line-level only, which the A2 writer (#480) has to handle per line rather than
+// assuming uniform coverage.
+func distinctStartRatio(cues []models.Lines, timings []models.WordTiming) float64 {
+	if len(cues) == 0 {
+		return 0
+	}
+	starts := make(map[int]map[int]struct{}, len(cues))
+	for _, wt := range timings {
+		if starts[wt.Line] == nil {
+			starts[wt.Line] = map[int]struct{}{}
+		}
+		starts[wt.Line][wt.StartMS] = struct{}{}
+	}
+	distinct := 0
+	for i := range cues {
+		if len(starts[i]) > 1 {
+			distinct++
+		}
+	}
+	return float64(distinct) / float64(len(cues))
+}
+
+// readTrackList parses artist<TAB>title<TAB>album per line.
+//
+// The open below is a variable path (gosec G304), which is fine here and needs
+// no //nolint: gosec is excluded on _test.go by .golangci.yml, so a directive
+// would suppress nothing and nolintlint would flag it as dead. On the merits,
+// the path is built from PLPROBE_DIR, an operator-supplied scratchpad path for a
+// manually-invoked probe; there is no untrusted input and no server context.
+func readTrackList(path string) ([]models.Track, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open track list: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var tracks []models.Track
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 2 {
+			continue
+		}
+		tr := models.Track{ArtistName: parts[0], TrackName: parts[1]}
+		if len(parts) > 2 {
+			tr.AlbumName = parts[2]
+		}
+		tracks = append(tracks, tr)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan track list: %w", err)
+	}
+	return tracks, nil
+}

--- a/internal/petitlyrics/selection.go
+++ b/internal/petitlyrics/selection.go
@@ -57,9 +57,11 @@ const (
 //     sparsity this is the workhorse signal, not a fallback.
 //  3. Title and album textual similarity.
 //
-// Deliberately NOT used: availableLyricsType. It is not a capability set --
-// both probe tracks reported the same value regardless of the tier requested --
-// so tier preference is derived from the decoded payload instead.
+// Deliberately NOT used: availableLyricsType. Not because it is unreliable (an
+// earlier comment said so from a two-track sample; that is RETRACTED, and over
+// 107 hits it predicts the returned tier exactly), but because selection ranks
+// CANDIDATES for identity match, and the tier a candidate offers is not evidence
+// that it is the right recording.
 //
 // An empty candidate list returns ErrNotFound.
 func selectCandidate(songs []apiSong, track models.Track) (apiSong, error) {

--- a/internal/petitlyrics/unavailable_test.go
+++ b/internal/petitlyrics/unavailable_test.go
@@ -189,12 +189,32 @@ func TestSurveySampleAbortsOnProviderUnavailable(t *testing.T) {
 
 	var lastErr error
 	var lastObs sampleObservation
+	abortAt := -1
 	for i := 0; i <= ZeroResultThreshold; i++ {
 		lastObs, lastErr = surveySample(context.Background(), c,
 			models.Track{TrackName: "t", ArtistName: "a"}, t.TempDir(), i)
 		if lastErr != nil {
+			abortAt = i
 			break
 		}
+		// The OTHER direction of the case order, and the one that makes this test
+		// non-vacuous: every lookup below the threshold is an ordinary miss and
+		// must NOT abort. Without this, a surveySample that aborted on EVERY
+		// ErrNotFound would break at i == 0 and still satisfy every assertion
+		// below -- passing while the probe stopped on the first track the
+		// provider merely lacks.
+		if lastObs.Err != "ErrNotFound" {
+			t.Fatalf("sample %d: Err = %q; want %q below the threshold", i, lastObs.Err, "ErrNotFound")
+		}
+	}
+
+	// The counter reaches the threshold on the Nth call, which is index N-1.
+	wantAbortAt := ZeroResultThreshold - 1
+	if abortAt != wantAbortAt {
+		t.Errorf("aborted at sample %d; want %d (the %dth lookup, zero-indexed). "+
+			"Aborting early means an ordinary miss is being read as an outage; "+
+			"aborting late, or never, means the outage is being read as a miss.",
+			abortAt, wantAbortAt, ZeroResultThreshold)
 	}
 
 	if lastErr == nil {

--- a/internal/petitlyrics/unavailable_test.go
+++ b/internal/petitlyrics/unavailable_test.go
@@ -168,3 +168,45 @@ func TestZeroResultLatchIsExactlyOnceUnderConcurrency(t *testing.T) {
 			"threshold reports, and none before it)", n, ZeroResultThreshold+1)
 	}
 }
+
+// TestSurveySampleAbortsOnProviderUnavailable pins the case ORDER in the probe's
+// own error switch.
+//
+// ErrProviderUnavailable wraps ErrNotFound, so it satisfies errors.Is for both.
+// The probe returns a non-nil error to mean "abort the whole run" and a nil error
+// with Err set to mean "this one sample failed, keep going". If the wrapper is
+// tested after the miss case, a credential outage reads as an ordinary miss and
+// the sweep CONTINUES -- producing a coverage number that says "the provider has
+// little for this library" when the truth is "the credential died at sample N".
+//
+// That is the contamination the abort semantics exist to prevent, and this switch
+// is the one place whose job is to notice it. The bug was live after #607's
+// sentinel merged in: the probe predated the sentinel and never learned about it.
+func TestSurveySampleAbortsOnProviderUnavailable(t *testing.T) {
+	// Serve empties until the client's own counter escalates. The threshold+1st
+	// lookup is the first to come back as ErrProviderUnavailable.
+	c, _ := newTestClient(t, serveEmpty())
+
+	var lastErr error
+	var lastObs sampleObservation
+	for i := 0; i <= ZeroResultThreshold; i++ {
+		lastObs, lastErr = surveySample(context.Background(), c,
+			models.Track{TrackName: "t", ArtistName: "a"}, t.TempDir(), i)
+		if lastErr != nil {
+			break
+		}
+	}
+
+	if lastErr == nil {
+		t.Fatal("the sweep did not abort on a sustained zero-result run. A revoked " +
+			"application id would be recorded as a run of ordinary misses and the " +
+			"coverage number would be silently wrong.")
+	}
+	if !errors.Is(lastErr, ErrProviderUnavailable) {
+		t.Errorf("abort error = %v; want it to carry ErrProviderUnavailable", lastErr)
+	}
+	if lastObs.Err != "ErrProviderUnavailable" {
+		t.Errorf("observation class = %q; want %q so the report names the real cause "+
+			"rather than burying it as a miss", lastObs.Err, "ErrProviderUnavailable")
+	}
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3766,4 +3766,14 @@ func TestSongCacheRoundTripDropsWordTimings(t *testing.T) {
 		t.Fatalf("line cues did not survive the round trip: got %d, want %d",
 			len(got.Subtitles.Lines), len(song.Subtitles.Lines))
 	}
+	// Count alone is too weak a guard: a round trip that preserved the number of
+	// cues while corrupting their text or timestamps would still satisfy it, and
+	// this test would report the WordTimings constraint as intact while the
+	// persisted subtitle data had silently changed underneath it.
+	for i, want := range song.Subtitles.Lines {
+		if gotLine := got.Subtitles.Lines[i]; gotLine != want {
+			t.Errorf("subtitle line %d changed across the cache round trip: got %#v, want %#v",
+				i, gotLine, want)
+		}
+	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3720,3 +3720,50 @@ func TestRunOnceDetectorMemoDegradedResponseNotStamped(t *testing.T) {
 		t.Fatalf("deferred = %v; want the item deferred as a normal miss", q.deferred)
 	}
 }
+
+// TestSongCacheRoundTripDropsWordTimings pins a constraint the Enhanced-LRC (A2)
+// writer (#480) has to design around: models.Song.WordTimings is tagged json:"-"
+// and the worker caches songs as JSON, so a cache HIT returns a song with no word
+// timings and orchestrator.QualityOf classifies it as merely line-synced.
+//
+// On a saturated queue most traffic is cache hits, so an A2 writer that assumes
+// word timings are present would emit word-synced output only on a fresh fetch.
+//
+// This test PASSES on current code. It exists so that making WordTimings
+// serializable becomes a deliberate decision rather than an accident: if someone
+// removes the json:"-" tag, this fails and forces the conversation.
+func TestSongCacheRoundTripDropsWordTimings(t *testing.T) {
+	song := models.Song{
+		Track: models.Track{ArtistName: "Test Artist", TrackName: "Test Track"},
+		Subtitles: models.Synced{Lines: []models.Lines{
+			{Text: "first cue", Time: models.Time{Total: 1.0}},
+			{Text: "second cue", Time: models.Time{Total: 2.0}},
+		}},
+		WordTimings: []models.WordTiming{
+			{Line: 0, Text: "first", StartMS: 1000, EndMS: 1400},
+			{Line: 0, Text: "cue", StartMS: 1400, EndMS: 1900},
+			{Line: 1, Text: "second", StartMS: 2000, EndMS: 2500},
+			{Line: 1, Text: "cue", StartMS: 2500, EndMS: 2900},
+		},
+	}
+
+	encoded, err := encodeSong(song)
+	if err != nil {
+		t.Fatalf("encodeSong: %v", err)
+	}
+
+	got := decodeSong(encoded, song.Track)
+
+	if len(got.WordTimings) != 0 {
+		t.Errorf("WordTimings survived the cache round trip: got %d, want 0. "+
+			"If this is intentional, the A2 writer constraint documented on "+
+			"models.Song.WordTimings needs revisiting.", len(got.WordTimings))
+	}
+
+	// The cues MUST survive, otherwise this test would pass for the wrong reason
+	// (a round trip that drops everything proves nothing about WordTimings).
+	if len(got.Subtitles.Lines) != len(song.Subtitles.Lines) {
+		t.Fatalf("line cues did not survive the round trip: got %d, want %d",
+			len(got.Subtitles.Lines), len(song.Subtitles.Lines))
+	}
+}


### PR DESCRIPTION
## Summary

- Builds the measurement instruments that answered the questions gating the open petitlyrics issues. **Ships no runtime behavior**: the only production edits are three decode-only `apiSong` fields (`isOfficial`, `copyright`, `availableLyricsType`, consumed by nothing in the fetch path) and comment corrections.
- Adds **two permanent regression tests** that are the durable value here, independent of the probe: `TestSongCacheRoundTripDropsWordTimings` pins that `WordTimings` is dropped by the JSON song cache (a constraint any future Enhanced-LRC writer must design around), and the `lrcnormalize` A2 round-trip tests satisfy a stated #480 acceptance criterion.
- **The probe already paid for itself.** It ran once and produced the findings posted to #615, #480, and #602 -- most consequentially that `isOfficial` discriminates but *inverted*: every word-synced result in the sample was `isOfficial=0`, every unsynced one `isOfficial=1`.

**Look at first:** `internal/petitlyrics/probe_survey_test.go` -- the env gate, the abort semantics, and the repo-containment guard are the three places where a defect has real consequences (unattended third-party API traffic, a silently wrong measurement, or private library data landing inside the working tree).

## Linked issue

Part of #480, #602, #615.

Closes nothing -- this is the measurement pass those issues were blocked on, not their implementation.

## Size override

This PR is **1,314 LOC across 11 files**, over the 800/10 sustainable-PR threshold. Maintainer override, rationale as given:

> The harness is one thing: the capture transport, report generator, and survey probe are useless apart, and splitting them would mean a PR whose tests reference code from an unmerged branch.

Roughly 85% of the diff is test files. The reviewable production surface is ~40 lines.

## What is deliberately temporary

The probe (`probe_capture_test.go`, `probe_report_test.go`, `probe_survey_test.go`) is scaffolding with a stated expiry -- deletable once its questions are answered. `renderA2` in `a2sample_test.go` is explicitly marked not-for-promotion; the real A2 writer is #480's job and belongs on the timing-guard and provenance path. Both are `_test.go`, so nothing here compiles into the released binary.

## Safety properties worth verifying

- **The env gate.** `TestSurveyProbe` fires real outbound requests only under `PLPROBE=1`. Nothing in `.github/`, the `Makefile`, `scripts/`, or `.githooks/` sets it -- verified by grep and behaviorally (a plain `go test -v` prints `--- SKIP`). CI cannot fire live API traffic.
- **Privacy is structural, not filtered.** `sampleObservation` has no field able to carry a title, artist, album, or lyric text, so the report generator can only print aggregates -- there is no redaction pass that could fail open. Capture filenames are index-only. A canary test asserts no free-form value reaches the output.
- **Repo containment.** `ensureOutsideRepo` rejects the repo root and everything under it via `filepath.Rel` on symlink-resolved absolute paths, with the root located by `go.mod` marker rather than by name. Fails safe when no marker is found.

## Pre-flight checklist

- [x] Pre-push gate green locally, re-run at `5bd6994`.
- [x] Adversarial review complete. One Important finding, fixed in `df30014` (see below). Two minors fixed, one declined with rationale in `5bd6994`.
- [ ] Commits squashed -- **deliberately not.** Twelve commits, each a distinct piece; the merge commit (`7707c6b`) in particular should stay legible.
- [x] Label set.
- [ ] UAT -- the probe has been run once end-to-end against the live API (that is what produced the findings on #615/#480/#602), but it is env-gated scaffolding, not a user-facing flow.
- [x] No web-UI change, no `.templ`/CSS change, no migration needed.

## Test plan

- [x] `make gate` passes at `5bd6994`.
- [x] New tests confirmed to **fail against unfixed code**. The A2 round-trip tests were mutation-verified (widening the timestamp regex to accept angle brackets reddens both at their assertions); so were the containment guard, the capture transport, the report canary, and the cache round-trip guard.
- [x] Patch coverage meets the Codecov threshold.
- [x] **Which surface this touches:** none at runtime. The probe writes only to an operator-supplied directory outside the repo.

### The review finding worth reading

`surveySample` had no case for `ErrProviderUnavailable`. Because that sentinel wraps `ErrNotFound` (deliberately, so existing benign-miss callers keep working), `errors.Is(err, ErrNotFound)` matched it and a **dead credential would have been recorded as an ordinary miss while the sweep continued**.

The reviewer proved this behaviorally rather than by reading: 25 lookups against an empty-response server showed the client emitting its outage warning while the probe rendered a clean report claiming a 100% miss rate with no abort banner. A sweep whose credential died at sample 12 would have completed all 100 and produced a "safe to share" report reading as near-zero coverage -- which, posted to #480, is a number that shelves the issue on a dead credential rather than a measurement.

Fixed in `df30014` with a test pinning the case order (mutation-verified: moving the case back below the miss case reddens at the assertion).

This is the **third** instance of the same wrapper-ordering trap on this work, after `providerClassifier` and `ClassifyOutcome`. Every new `errors.Is` switch over these sentinels is wrong by default unless the wrapper is tested first -- worth a guard, tracked in #748.

- [ ] Reviewer follow-ups:
  - [ ] The probe is scaffolding. Worth deciding now whether it earns a permanent home or should be deleted once #602's corpus question is settled.
  - [ ] `distinctStartRatio` depends on `decodeWordSync`'s line-index assignment. Verified correct here (including with out-of-order input), but it is an undocumented coupling between the probe's measurement and the decoder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Enhanced LRC parsing so inline word-timing markers remain part of the displayed lyric text.
  - Prevented repeated lyric expansion from altering Enhanced LRC cues or timestamps.
  - Preserved synced subtitle line cues when lyrics are saved and restored from cache.
  - Improved handling of unavailable lyric responses and related error reporting.

- **Quality Improvements**
  - Added safeguards and validation for lyric synchronization, API responses, and privacy-safe diagnostic reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->