### PR TITLE
test(orchestrator): fail when a provider sentinel is not classified

### DIFF
--- a/internal/orchestrator/sentinel_enumeration_test.go
+++ b/internal/orchestrator/sentinel_enumeration_test.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -35,11 +36,30 @@ import (
 // It shipped exactly once (petitlyrics, fixed in #607). The guard below makes
 // the NEXT provider fail at test time instead of silently on prod.
 
-// providerPackages are the lyric-provider packages whose exported error
-// sentinels must be accounted for by ClassifyOutcome.
-var providerPackages = []string{
-	"../musixmatch",
-	"../petitlyrics",
+// providerPackages returns the lyric-provider package directories whose
+// exported error sentinels must be accounted for by ClassifyOutcome.
+//
+// The paths are derived from THIS FILE's location via runtime.Caller rather
+// than written relative to the working directory. `go test` happens to run each
+// package in its own source directory, so a bare "../musixmatch" works today --
+// but that is a property of the harness, not a guarantee: a compiled test binary
+// run from elsewhere, or any harness that sets a different cwd, would resolve
+// those paths somewhere else. This guard's whole value is failing when a
+// sentinel goes unclassified, and a scan that cannot find the source files
+// fails for the wrong reason.
+//
+// Returns a fresh slice per call so no test can mutate what another test reads.
+func providerPackages(t *testing.T) []string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not resolve this test file's path; the AST scan cannot locate the provider packages")
+	}
+	internalDir := filepath.Dir(filepath.Dir(thisFile)) // .../internal
+	return []string{
+		filepath.Join(internalDir, "musixmatch"),
+		filepath.Join(internalDir, "petitlyrics"),
+	}
 }
 
 // classifiedSentinels maps every exported provider sentinel to its value, so
@@ -54,38 +74,49 @@ var providerPackages = []string{
 // authoritative name set; anything it finds that is missing HERE fails the
 // test, so a newly added sentinel cannot slip through by being forgotten in
 // two places at once.
-var classifiedSentinels = map[string]error{
-	"musixmatch.ErrUnauthorized":         musixmatch.ErrUnauthorized,
-	"musixmatch.ErrRateLimited":          musixmatch.ErrRateLimited,
-	"musixmatch.ErrNotFound":             musixmatch.ErrNotFound,
-	"musixmatch.ErrNoLyrics":             musixmatch.ErrNoLyrics,
-	"musixmatch.ErrTruncatedResponse":    musixmatch.ErrTruncatedResponse,
-	"musixmatch.ErrTokenRenewalRequired": musixmatch.ErrTokenRenewalRequired,
-	"musixmatch.ErrTokenMintRefused":     musixmatch.ErrTokenMintRefused,
-	"petitlyrics.ErrUnauthorized":        petitlyrics.ErrUnauthorized,
-	"petitlyrics.ErrRateLimited":         petitlyrics.ErrRateLimited,
-	"petitlyrics.ErrForbidden":           petitlyrics.ErrForbidden,
-	"petitlyrics.ErrNotFound":            petitlyrics.ErrNotFound,
-	"petitlyrics.ErrUnsupportedTier":     petitlyrics.ErrUnsupportedTier,
-	"petitlyrics.ErrProviderUnavailable": petitlyrics.ErrProviderUnavailable,
+//
+// Built fresh per call rather than held in a package variable, so one test
+// cannot mutate the set another test reads.
+func classifiedSentinels() map[string]error {
+	return map[string]error{
+		"musixmatch.ErrUnauthorized":         musixmatch.ErrUnauthorized,
+		"musixmatch.ErrRateLimited":          musixmatch.ErrRateLimited,
+		"musixmatch.ErrNotFound":             musixmatch.ErrNotFound,
+		"musixmatch.ErrNoLyrics":             musixmatch.ErrNoLyrics,
+		"musixmatch.ErrTruncatedResponse":    musixmatch.ErrTruncatedResponse,
+		"musixmatch.ErrTokenRenewalRequired": musixmatch.ErrTokenRenewalRequired,
+		"musixmatch.ErrTokenMintRefused":     musixmatch.ErrTokenMintRefused,
+		"petitlyrics.ErrUnauthorized":        petitlyrics.ErrUnauthorized,
+		"petitlyrics.ErrRateLimited":         petitlyrics.ErrRateLimited,
+		"petitlyrics.ErrForbidden":           petitlyrics.ErrForbidden,
+		"petitlyrics.ErrNotFound":            petitlyrics.ErrNotFound,
+		"petitlyrics.ErrUnsupportedTier":     petitlyrics.ErrUnsupportedTier,
+		"petitlyrics.ErrProviderUnavailable": petitlyrics.ErrProviderUnavailable,
+	}
 }
 
 // transportExemptions are sentinels that are CORRECT to classify as
 // OutcomeTransport, each with the reason it is not the #748 defect. An
 // exemption must be a deliberate decision recorded somewhere in the tree, never
 // a way to quiet this test.
-var transportExemptions = map[string]string{
-	// A 403 is a refused request SHAPE, not a credential or throttle condition,
-	// and no amount of waiting or rotation fixes it. Bucketing it with the
-	// auth/throttle signals would repeat the #495 misdiagnosis, where a
-	// User-Agent denylist rejection read as a phantom rate limit. Transport is
-	// the correct class; internal/orchestrator/errors.go says so explicitly.
-	"petitlyrics.ErrForbidden": "a refused request shape, deliberately not an auth/throttle signal (#495)",
-	// Bootstrap-path only: returned by the token mint in internal/musixmatch/
-	// token.go and handled in internal/commands/token_bootstrap.go. It is never
-	// produced by a lyric lookup, so it cannot reach a lane and therefore cannot
-	// reach ClassifyOutcome at all.
-	"musixmatch.ErrTokenMintRefused": "token-bootstrap path only; never returned by a lookup, so it never reaches a lane",
+//
+// Built fresh per call, for the same reason as classifiedSentinels: an
+// exemption list a test could mutate is an exemption list that can be widened
+// by accident.
+func transportExemptions() map[string]string {
+	return map[string]string{
+		// A 403 is a refused request SHAPE, not a credential or throttle condition,
+		// and no amount of waiting or rotation fixes it. Bucketing it with the
+		// auth/throttle signals would repeat the #495 misdiagnosis, where a
+		// User-Agent denylist rejection read as a phantom rate limit. Transport is
+		// the correct class; internal/orchestrator/errors.go says so explicitly.
+		"petitlyrics.ErrForbidden": "a refused request shape, deliberately not an auth/throttle signal (#495)",
+		// Bootstrap-path only: returned by the token mint in internal/musixmatch/
+		// token.go and handled in internal/commands/token_bootstrap.go. It is never
+		// produced by a lyric lookup, so it cannot reach a lane and therefore cannot
+		// reach ClassifyOutcome at all.
+		"musixmatch.ErrTokenMintRefused": "token-bootstrap path only; never returned by a lookup, so it never reaches a lane",
+	}
 }
 
 // TestEveryProviderSentinelIsClassified is the #748 guard: every exported error
@@ -96,9 +127,11 @@ var transportExemptions = map[string]string{
 // failure alone (an explicit acceptance criterion of #748).
 func TestEveryProviderSentinelIsClassified(t *testing.T) {
 	found := exportedSentinelsFromSource(t)
+	classified := classifiedSentinels()
+	exemptions := transportExemptions()
 
 	for _, name := range found {
-		sentinel, ok := classifiedSentinels[name]
+		sentinel, ok := classified[name]
 		if !ok {
 			t.Errorf("provider sentinel %s is not covered by this test.\n"+
 				"Add it to classifiedSentinels, then make sure ClassifyOutcome handles it.\n"+
@@ -113,7 +146,7 @@ func TestEveryProviderSentinelIsClassified(t *testing.T) {
 		if got != OutcomeTransport {
 			continue
 		}
-		if reason, exempt := transportExemptions[name]; exempt {
+		if reason, exempt := exemptions[name]; exempt {
 			t.Logf("%s classifies as transport by design: %s", name, reason)
 			continue
 		}
@@ -134,12 +167,12 @@ func TestSentinelExemptionsAreLive(t *testing.T) {
 	for _, name := range exportedSentinelsFromSource(t) {
 		live[name] = true
 	}
-	for name := range transportExemptions {
+	for name := range transportExemptions() {
 		if !live[name] {
 			t.Errorf("transportExemptions names %s, which no provider package declares; remove the stale entry", name)
 		}
 	}
-	for name := range classifiedSentinels {
+	for name := range classifiedSentinels() {
 		if !live[name] {
 			t.Errorf("classifiedSentinels names %s, which no provider package declares; remove the stale entry", name)
 		}
@@ -160,7 +193,7 @@ func exportedSentinelsFromSource(t *testing.T) []string {
 	t.Helper()
 
 	var out []string
-	for _, dir := range providerPackages {
+	for _, dir := range providerPackages(t) {
 		pkgName := filepath.Base(dir)
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -191,7 +224,15 @@ func exportedSentinelsFromSource(t *testing.T) []string {
 						continue
 					}
 					for i, ident := range vs.Names {
-						if !ident.IsExported() || !strings.HasPrefix(ident.Name, "Err") {
+						// Exported-ness is the only NAME condition. An earlier
+						// version also required an "Err" prefix, which was a hole:
+						// an exported `NoLyrics = errors.New(...)` would have been
+						// skipped on its name alone and could restore the very
+						// unclassified-transport fallback this guard exists to
+						// prevent. declaresAnError below is the real filter -- it
+						// checks the TYPE and INITIALIZER, which is what actually
+						// makes something a sentinel.
+						if !ident.IsExported() {
 							continue
 						}
 						if !declaresAnError(vs, i) {

--- a/internal/orchestrator/sentinel_enumeration_test.go
+++ b/internal/orchestrator/sentinel_enumeration_test.go
@@ -1,0 +1,257 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/musixmatch"
+	"github.com/sydlexius/canticle/internal/petitlyrics"
+)
+
+// This file is the durable guard for #748.
+//
+// ClassifyOutcome enumerates provider sentinels by hand and falls to
+// `default: OutcomeTransport` for anything it does not recognize. Transport
+// outranks a benign miss in precedence(), so an UNENUMERATED miss wins the
+// cross-lane ranking on an ordinary double-miss -- the common case for a
+// saturated queue, where the fallback lane only ever sees what the primary
+// already missed. The worker then records a queue FAILURE against the row:
+// attempts++, geometric backoff, marching toward retirement. Ordinary misses
+// burn retry budget.
+//
+// That is invisible from either end. The provider really did return nothing, so
+// a miss is the honest outcome, and the row is still retried -- just against a
+// budget it should never have spent. Nothing logs a misclassification. It also
+// only bites when BOTH lanes miss, so any single-provider test classifies
+// correctly and stays green.
+//
+// It shipped exactly once (petitlyrics, fixed in #607). The guard below makes
+// the NEXT provider fail at test time instead of silently on prod.
+
+// providerPackages are the lyric-provider packages whose exported error
+// sentinels must be accounted for by ClassifyOutcome.
+var providerPackages = []string{
+	"../musixmatch",
+	"../petitlyrics",
+}
+
+// classifiedSentinels maps every exported provider sentinel to its value, so
+// the test can classify it rather than merely grep for its name. A name-only
+// scan would be wrong in both directions here: musixmatch's misses are
+// classified INDIRECTLY through IsBenignMiss(err) and never appear literally in
+// ClassifyOutcome (a false positive), while a sentinel could be named in a
+// comment without being classified (a false negative). Only calling
+// ClassifyOutcome settles it.
+//
+// This map is deliberately hand-maintained. The AST scan below is the
+// authoritative name set; anything it finds that is missing HERE fails the
+// test, so a newly added sentinel cannot slip through by being forgotten in
+// two places at once.
+var classifiedSentinels = map[string]error{
+	"musixmatch.ErrUnauthorized":         musixmatch.ErrUnauthorized,
+	"musixmatch.ErrRateLimited":          musixmatch.ErrRateLimited,
+	"musixmatch.ErrNotFound":             musixmatch.ErrNotFound,
+	"musixmatch.ErrNoLyrics":             musixmatch.ErrNoLyrics,
+	"musixmatch.ErrTruncatedResponse":    musixmatch.ErrTruncatedResponse,
+	"musixmatch.ErrTokenRenewalRequired": musixmatch.ErrTokenRenewalRequired,
+	"musixmatch.ErrTokenMintRefused":     musixmatch.ErrTokenMintRefused,
+	"petitlyrics.ErrUnauthorized":        petitlyrics.ErrUnauthorized,
+	"petitlyrics.ErrRateLimited":         petitlyrics.ErrRateLimited,
+	"petitlyrics.ErrForbidden":           petitlyrics.ErrForbidden,
+	"petitlyrics.ErrNotFound":            petitlyrics.ErrNotFound,
+	"petitlyrics.ErrUnsupportedTier":     petitlyrics.ErrUnsupportedTier,
+	"petitlyrics.ErrProviderUnavailable": petitlyrics.ErrProviderUnavailable,
+}
+
+// transportExemptions are sentinels that are CORRECT to classify as
+// OutcomeTransport, each with the reason it is not the #748 defect. An
+// exemption must be a deliberate decision recorded somewhere in the tree, never
+// a way to quiet this test.
+var transportExemptions = map[string]string{
+	// A 403 is a refused request SHAPE, not a credential or throttle condition,
+	// and no amount of waiting or rotation fixes it. Bucketing it with the
+	// auth/throttle signals would repeat the #495 misdiagnosis, where a
+	// User-Agent denylist rejection read as a phantom rate limit. Transport is
+	// the correct class; internal/orchestrator/errors.go says so explicitly.
+	"petitlyrics.ErrForbidden": "a refused request shape, deliberately not an auth/throttle signal (#495)",
+	// Bootstrap-path only: returned by the token mint in internal/musixmatch/
+	// token.go and handled in internal/commands/token_bootstrap.go. It is never
+	// produced by a lyric lookup, so it cannot reach a lane and therefore cannot
+	// reach ClassifyOutcome at all.
+	"musixmatch.ErrTokenMintRefused": "token-bootstrap path only; never returned by a lookup, so it never reaches a lane",
+}
+
+// TestEveryProviderSentinelIsClassified is the #748 guard: every exported error
+// sentinel a provider package declares must classify as something other than
+// the default transport bucket, or carry a documented exemption.
+//
+// The failure message names the missing sentinel so the fix is obvious from the
+// failure alone (an explicit acceptance criterion of #748).
+func TestEveryProviderSentinelIsClassified(t *testing.T) {
+	found := exportedSentinelsFromSource(t)
+
+	for _, name := range found {
+		sentinel, ok := classifiedSentinels[name]
+		if !ok {
+			t.Errorf("provider sentinel %s is not covered by this test.\n"+
+				"Add it to classifiedSentinels, then make sure ClassifyOutcome handles it.\n"+
+				"An unclassified sentinel falls to OutcomeTransport, which outranks a benign\n"+
+				"miss -- so an ordinary double-miss is recorded as a queue failure (#748).", name)
+			continue
+		}
+
+		// Wrap it, the way a lane returns it in production: ClassifyOutcome uses
+		// errors.Is throughout, so a bare sentinel would under-test the real path.
+		got := ClassifyOutcome(fmt.Errorf("lane: %w", sentinel))
+		if got != OutcomeTransport {
+			continue
+		}
+		if reason, exempt := transportExemptions[name]; exempt {
+			t.Logf("%s classifies as transport by design: %s", name, reason)
+			continue
+		}
+		t.Errorf("provider sentinel %s classifies as OutcomeTransport (the default arm).\n"+
+			"Transport outranks OutcomeBenignMiss in precedence(), so on an ordinary\n"+
+			"double-miss the worker records a queue FAILURE against the row: attempts++,\n"+
+			"geometric backoff, eventual retirement (#748).\n"+
+			"Add a case for it in ClassifyOutcome, or add a documented entry to\n"+
+			"transportExemptions saying why transport is correct.", name)
+	}
+}
+
+// TestSentinelExemptionsAreLive keeps the exemption lists honest: an entry
+// naming a sentinel that no longer exists is a stale carve-out that would go on
+// silently excusing a name nothing declares.
+func TestSentinelExemptionsAreLive(t *testing.T) {
+	live := map[string]bool{}
+	for _, name := range exportedSentinelsFromSource(t) {
+		live[name] = true
+	}
+	for name := range transportExemptions {
+		if !live[name] {
+			t.Errorf("transportExemptions names %s, which no provider package declares; remove the stale entry", name)
+		}
+	}
+	for name := range classifiedSentinels {
+		if !live[name] {
+			t.Errorf("classifiedSentinels names %s, which no provider package declares; remove the stale entry", name)
+		}
+	}
+}
+
+// exportedSentinelsFromSource parses the provider packages and returns every
+// exported package-level error sentinel as "<pkg>.<Name>". Parsing the source
+// is what makes this a real enumeration: reflection cannot list a package's
+// variables, so a hand-written list would drift exactly the way ClassifyOutcome
+// itself drifted.
+//
+// It recognizes both declaration forms the provider packages actually use:
+// `errors.New(...)` and `fmt.Errorf(...)` (petitlyrics.ErrProviderUnavailable
+// wraps ErrNotFound, so it must be an Errorf), and it accepts a var with an
+// explicit `error` type as well as an inferred one.
+func exportedSentinelsFromSource(t *testing.T) []string {
+	t.Helper()
+
+	var out []string
+	for _, dir := range providerPackages {
+		pkgName := filepath.Base(dir)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		fset := token.NewFileSet()
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			// ParseFile rather than the deprecated ParseDir (SA1019). Walking the
+			// directory ourselves is equivalent here and avoids pulling
+			// golang.org/x/tools/go/packages in for a test that only needs
+			// top-level var declarations.
+			file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", filepath.Join(dir, name), err)
+			}
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.VAR {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					for i, ident := range vs.Names {
+						if !ident.IsExported() || !strings.HasPrefix(ident.Name, "Err") {
+							continue
+						}
+						if !declaresAnError(vs, i) {
+							continue
+						}
+						out = append(out, pkgName+"."+ident.Name)
+					}
+				}
+			}
+		}
+	}
+
+	// Self-check: a scan that silently finds nothing would make every assertion
+	// above vacuously true, which is the failure mode this whole file exists to
+	// prevent. The threshold is deliberately low -- it catches a broken scan, not
+	// a shrinking sentinel set.
+	if len(out) < 5 {
+		t.Fatalf("found only %d provider sentinels (%v); the AST scan is broken, so the #748 guard is not actually testing anything", len(out), out)
+	}
+	return out
+}
+
+// declaresAnError reports whether the i-th name in vs is an error-typed value.
+// It accepts an explicit `error` type annotation, or an initializer calling
+// errors.New / fmt.Errorf.
+func declaresAnError(vs *ast.ValueSpec, i int) bool {
+	if id, ok := vs.Type.(*ast.Ident); ok && id.Name == "error" {
+		return true
+	}
+	if i >= len(vs.Values) {
+		return false
+	}
+	call, ok := vs.Values[i].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return (pkg.Name == "errors" && sel.Sel.Name == "New") ||
+		(pkg.Name == "fmt" && sel.Sel.Name == "Errorf")
+}
+
+// TestUnenumeratedProviderMissLosesToTransport documents the ranking that makes
+// an unclassified sentinel harmful, so the guard above cannot be weakened
+// without this failing too. It asserts the precedence relationship #748 turns
+// on, using a stand-in for a provider whose sentinels were never enumerated.
+func TestUnenumeratedProviderMissLosesToTransport(t *testing.T) {
+	unenumerated := errors.New("someprovider: no results found")
+
+	if got := ClassifyOutcome(unenumerated); got != OutcomeTransport {
+		t.Fatalf("an unrecognized provider error classifies as %v; want OutcomeTransport (the default arm)", got)
+	}
+	if OutcomeTransport.precedence() <= OutcomeBenignMiss.precedence() {
+		t.Fatalf("transport precedence (%d) no longer outranks benign miss (%d); the #748 mechanism has changed and this guard needs revisiting",
+			OutcomeTransport.precedence(), OutcomeBenignMiss.precedence())
+	}
+}


### PR DESCRIPTION
## Summary

- `ClassifyOutcome` enumerates provider error sentinels by hand and falls to `default: OutcomeTransport` for anything unrecognized. Transport outranks a benign miss in `precedence()`, so an **unenumerated** miss wins the cross-lane ranking on an ordinary double-miss -- the common case for a saturated queue, where the fallback lane only ever sees what the primary already missed. The worker then records a queue FAILURE against the row: `attempts++`, geometric backoff, marching toward retirement. Ordinary misses were burning retry budget.
- That defect shipped once, for petitlyrics, and was fixed incidentally in #607. The **class** stayed open: adding a third provider without its sentinels reproduces it exactly, silently, with no test failure. This PR is the durable guard, and is **test-only -- no production code changes**.
- **Look at the exemption list first.** Two sentinels classify as transport *by design*, and each carries its reason inline: `petitlyrics.ErrForbidden` (a refused request SHAPE, deliberately not an auth/throttle signal -- bucketing it otherwise would repeat the #495 misdiagnosis) and `musixmatch.ErrTokenMintRefused` (bootstrap-path only, so it never reaches a lane). If either rationale is wrong, the guard is calibrated wrong.

## Linked issue

Part of #748

Deliberately `Part of`, not `Closes`. Two of #748's four acceptance criteria need production
database access and are NOT done here (see "Not covered"), so auto-closing the issue would
drop them silently. The issue stays open to track those two; close it once they are measured
and recorded there.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes (N/A -- test-only, no user-visible surface).
- [x] Screenshot attached for any web-UI change (N/A -- no web-UI change).
- [x] `make ui` re-run if any `.templ` or CSS source changed (N/A -- none changed).
- [x] Migration added under `internal/db/migrations/` (N/A -- no schema or data change).

## Test plan

- [x] `make gate` passes locally, read from its output rather than its exit code.
- [x] New tests were confirmed to **fail against unfixed code** before being accepted.
      This is the central claim of a test-only PR, so all three mutations are recorded here.
      Each mutant **compiled cleanly** and failed at an **assertion**, not at the build --
      a mutant that fails to compile proves nothing:
      1. **Reproduce the original #748 defect.** Removed the `petitlyrics.ErrNotFound` arm
         from `ClassifyOutcome`'s benign-miss case:
         > `provider sentinel petitlyrics.ErrNotFound classifies as OutcomeTransport (the default arm).`
      2. **Break the scanner.** Changed the AST scan's prefix filter so it matches nothing,
         simulating a silently-broken enumeration:
         > `found only 0 provider sentinels ([]); the AST scan is broken, so the #748 guard is not actually testing anything`
      3. **The actual future scenario.** Appended a new exported sentinel to
         `internal/petitlyrics/errors.go` that nothing classifies:
         > `provider sentinel petitlyrics.ErrNewlyAdded is not covered by this test.`

      Mutation 3 was re-run after the scanner was rewritten (see below), so the recorded
      evidence describes the code actually being shipped, not a superseded draft.
- [x] Patch coverage meets the Codecov threshold.
- [x] Which **surface** this change fixes is stated explicitly. The guard asserts on
      `ClassifyOutcome` in `internal/orchestrator/errors.go` -- the CROSS-LANE outcome
      classifier. It deliberately does **not** assert on `providerClassifier`
      (`internal/orchestrator/resolve.go`), which is the per-lane BREAKER policy and answers
      a different question. Both were wrong for petitlyrics before #607; only the former is
      guarded here.
- [x] Manual UAT steps: N/A (test-only).
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] **The test classifies rather than greps, deliberately.** A name-only source scan
        would be wrong in BOTH directions: musixmatch's misses are handled indirectly via
        `IsBenignMiss(err)` and never appear literally in `ClassifyOutcome` (false positive),
        while a sentinel named only in a comment would read as covered (false negative). So
        the guard calls `ClassifyOutcome` with each sentinel wrapped in `%w`, matching the
        production path, which is `errors.Is` throughout.
  - [ ] **Why the sentinel list is hand-maintained as well as AST-scanned.** The scan is the
        authoritative NAME set; anything it finds that is absent from the map fails the test.
        A sentinel therefore cannot slip through by being forgotten in two places at once,
        but it does mean a legitimately-new sentinel requires a deliberate two-line edit.
        That friction is the point; flag it if it reads as busywork.
  - [ ] **`parser.ParseFile` over an `os.ReadDir` walk**, not the deprecated
        `parser.ParseDir` (staticcheck SA1019). This avoids both a `//nolint` and pulling
        `golang.org/x/tools/go/packages` in for a test that only reads top-level `var`
        declarations. The tradeoff: the walk does not consider build tags, which is
        irrelevant here (neither provider package uses them) but would matter if one did.

## Not covered

- **Two of #748's acceptance criteria are unmet, both requiring production data.** The issue
  asks for (a) the prod queue checked for rows whose `attempts` were inflated by this path,
  with the finding recorded on the issue, and (b) an explicit statement of whether #655 is
  related, **with evidence either way**. #748 is emphatic that the #655 link must not be
  assumed without measuring, so neither is guessed at here. Both need a prod DB query.
- **The guard covers `ClassifyOutcome` only.** `providerClassifier` in `resolve.go` has the
  same by-hand enumeration shape and the same silent-default risk, and is NOT guarded by
  this PR. It is a strictly larger job (per-lane breaker policy has no single correct
  default the way "not transport" works here) and would want its own issue.
- **The wrapped-sentinel ordering trap is not directly guarded.**
  `petitlyrics.ErrProviderUnavailable` WRAPS `ErrNotFound`, which makes case ORDER
  load-bearing in every `errors.Is` switch over these sentinels -- it shipped wrong at three
  separate sites in one day. This guard would catch a sentinel that is entirely absent, but
  a correctly-listed sentinel tested in the WRONG ORDER still classifies plausibly. An
  order-sensitivity test is a separate piece of work.
- **No live-traffic or prod verification of the worker path.** The precedence relationship is
  asserted directly (`OutcomeTransport.precedence() > OutcomeBenignMiss.precedence()`); the
  downstream `w.fail` vs `requeueDeferred` behavior in `internal/worker` is not re-tested
  here and relies on its existing coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression coverage for provider error classification.
  * Verified exported provider errors are correctly classified, documented transport exceptions remain valid, and stale entries are detected.
  * Added coverage for wrapped and unrecognized errors, including fallback behavior and classification precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->