### PR TITLE
chore: bump Go toolchain 1.26.5 -> 1.26.6

### DIFF
--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -40,7 +40,7 @@ mxlrc-go/
 │   └── dependabot.yml
 ├── .planning/                  # Planning documents
 │   └── codebase/               # Codebase analysis docs
-├── go.mod                      # Module: github.com/doxazo-net/canticle, Go 1.26.5
+├── go.mod                      # Module: github.com/sydlexius/canticle, Go 1.26.6
 ├── go.sum
 ├── Makefile
 ├── README.md
@@ -107,7 +107,7 @@ mxlrc-go/
 - `cmd/mxlrcgo-svc/main.go`: CLI entry point. `func main()` — token resolution, wires all dependencies, calls `App.Run(ctx)`.
 
 **Configuration:**
-- `go.mod`: Module path `github.com/doxazo-net/canticle`, Go 1.25
+- `go.mod`: Module path `github.com/sydlexius/canticle`, Go 1.26.6
 - `.golangci.yml`: Linter rules (errcheck, govet, staticcheck, gosec, revive, etc.)
 - `.goreleaser.yml`: Cross-platform build matrix — binary name `mxlrcgo-svc`, build path `./cmd/mxlrcgo-svc`
 - `Makefile`: Build/test/lint/format commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sydlexius/canticle
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

- Go 1.26.6 is out, and 1.26.5 now carries published stdlib advisories. The image scan runs grype with `only-fixed: true` and a HIGH+ fail cutoff, so **every build on 1.26.5 fails it** -- seven HIGH stdlib findings against `/usr/local/bin/canticle`. This is not a code regression; it is the vulnerability database moving under an unchanged pin.
- **This unblocks #752**, which is currently red on `Image Scan` for exactly this reason and cannot fix itself -- its diff touches no dependency or image input.
- **Look at the Dockerfile digest first.** The two build inputs are not equivalent edits: `go.mod` is a one-line change from which all of CI resolves its toolchain, but the Dockerfile is pinned **by digest**, and the digest must be re-resolved from the registry rather than hand-edited.

## Linked issue

Closes #751

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes (N/A -- no user-visible behavior change; the
      binary's observable surface is identical, only its stdlib version moves).
- [x] Screenshot attached for any web-UI change (N/A -- no web-UI change).
- [x] `make ui` re-run if any `.templ` or CSS source changed (N/A -- none changed).
- [x] Migration added under `internal/db/migrations/` (N/A -- no schema or data change).

## Test plan

- [x] `make gate` passes locally on the new toolchain, read from its output rather than its
      exit code. A Go minor bump can surface new vet or analyzer findings that were not
      reachable before; **none appeared** -- `go build`, `go vet`, race tests, coverage
      floors, golangci-lint, actionlint, and govulncheck are all clean.
- [x] New tests confirmed to fail against unfixed code: **N/A, and deliberately so.** This
      change adds no tests. A toolchain bump is verified by the existing suite passing on the
      new toolchain, not by new assertions; a test written to "prove" a version number would
      restate `go.mod` rather than exercise behavior.
- [x] Patch coverage meets the Codecov threshold (no Go source changed, so nothing in scope).
- [x] Which **surface** this change fixes is stated explicitly, and was verified by looking at
      that surface. The failing surface is the **image scan**, which asks whether the shipped
      package VERSION is vulnerable. That is a different question from `govulncheck`, which
      asks whether vulnerable code paths are actually CALLED -- govulncheck was green
      throughout, on both the old and new toolchain, which is why the gate never caught this
      and only the image scan did.
- [x] Manual UAT steps (list the specific flows exercised):
  - [x] Resolved the `1.26.6-alpine` digest from the registry and confirmed it is an OCI
        **image index** (`application/vnd.oci.image.index.v1+json`, linux/amd64 + arm
        variants), matching the media type of the pin it replaces. Pinning a single-platform
        manifest instead would silently break multi-arch builds.
  - [x] Confirmed no `1.26.5` string remains in either build input.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] **`docs/DEVELOPER.md` is deliberately untouched.** It says "Requires Go 1.26.2 or
        newer" -- a FLOOR, not a pin. It stays true after this bump, and mechanically raising
        it to match would exclude contributors for no reason. Flag if you'd rather it move.
  - [ ] **The CI scan gap this exposed.** `nightly.yml` runs no image scan, and `ci.yml`'s
        scan job is gated on code changes, so main last scanned on 2026-08-12 and has been
        passing its nightly ever since while these advisories landed. Nothing would have
        surfaced this until the next code PR happened to trip it -- which is what occurred.
        A periodic scan of `main` would turn "a random PR goes red" into "the nightly tells
        you". Worth its own issue; not fixed here.

## Not covered

- **The `libssh` finding is untouched.** The scan also reports `CVE-2026-59843` (medium) in
  the Alpine `libssh` package. It sits below the HIGH+ fail cutoff so it does not gate the
  build, and it comes from the runtime base image rather than the Go toolchain -- a different
  bump entirely.
- **No verification that the image scan actually goes green.** That runs in CI on this PR;
  the local gate has no image-scan step, so the claim here is "the toolchain no longer
  carries the seven HIGH advisories", not "grype confirmed clean". Read the `Image Scan`
  check on this PR before trusting it, and treat the check -- not this body -- as the
  authority.
- **Whether the new stdlib introduces behavior changes** beyond the security fixes. The full
  race suite passes, which is meaningful coverage, but a patch release's own release notes
  were not audited line by line against this codebase.
