### PR TITLE
fix(timing): catch degenerate LRCs whose cues all share one timestamp

### DIFF
--- a/internal/commands/revalidate.go
+++ b/internal/commands/revalidate.go
@@ -195,8 +195,8 @@ func applyRevalidate(out io.Writer, cfg config.Config, args RevalidateCmd, plan 
 // printRevalidateCounts emits the aggregate distribution. Counts only: no path,
 // no artist, no title, no lyric text.
 func printRevalidateCounts(out io.Writer, c revalidate.Counts, apply bool) {
-	_, _ = fmt.Fprintf(out, "revalidate: scanned=%d ok=%d MisSynced=%d categorical=%d unknown-duration=%d no-audio=%d errored=%d%s\n",
-		c.Scanned, c.Ok, c.MisSynced, c.Categorical, c.UnknownDuration, c.NoAudio, c.Errored, suffixRevalidateDryRun(apply))
+	_, _ = fmt.Fprintf(out, "revalidate: scanned=%d ok=%d MisSynced=%d categorical=%d degenerate=%d unknown-duration=%d no-audio=%d errored=%d%s\n",
+		c.Scanned, c.Ok, c.MisSynced, c.Categorical, c.Degenerate, c.UnknownDuration, c.NoAudio, c.Errored, suffixRevalidateDryRun(apply))
 	if c.UnknownDuration > 0 {
 		// Name a remedy that actually works for THESE files. Before #684 a scan
 		// short-circuited on any file that already had a sidecar before it ever

--- a/internal/commands/revalidate.go
+++ b/internal/commands/revalidate.go
@@ -231,7 +231,12 @@ func writeRevalidateTail(path string, findings []revalidate.Finding) error {
 	}
 	defer func() { _ = f.Close() }()
 	for _, fd := range findings {
-		if fd.Outcome != timing.MisSynced && fd.Outcome != timing.Categorical {
+		// The REMEDIABLE verdicts, enumerated by hand. A verdict the sweep will
+		// act on but the tail never prints is the worst combination here:
+		// revalidate is dry-run by default, and this file is the only per-file
+		// view an operator gets, so an omission reads as "nothing will happen to
+		// that file". Degenerate joins the list for that reason (#673).
+		if fd.Outcome != timing.MisSynced && fd.Outcome != timing.Categorical && fd.Outcome != timing.Degenerate {
 			continue
 		}
 		if _, werr := fmt.Fprintf(f, "%s\t%s\tduration=%ds\toverrun=%.2fs\tratio=%.3f\taction=%s\n",

--- a/internal/commands/revalidate_test.go
+++ b/internal/commands/revalidate_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/sydlexius/canticle/internal/db"
 	"github.com/sydlexius/canticle/internal/library"
 	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/realign"
+	"github.com/sydlexius/canticle/internal/revalidate"
 	"github.com/sydlexius/canticle/internal/scanner"
+	"github.com/sydlexius/canticle/internal/timing"
 )
 
 // revalidateFixture builds a config + database + library root holding one audio
@@ -385,5 +388,42 @@ func TestRevalidateBadConfigPathIsAnError(t *testing.T) {
 	var out bytes.Buffer
 	if code := runRevalidate(t.Context(), &out, RevalidateCmd{ConfigPath: bad}); code != 1 {
 		t.Errorf("exit = %d, want 1: %s", code, out.String())
+	}
+}
+
+// TestRevalidateTailIncludesDegenerate covers the #673 report filter. The tail
+// enumerates outcomes by hand, so a new remediable verdict is silently DROPPED
+// from the operator's only per-file view unless it is added here.
+//
+// That matters more than a missing line: the tail is where an operator confirms
+// what a dry run would touch, and revalidate is dry-run by default. A file the
+// sweep will demote but never mentions is exactly the surprise the dry run
+// exists to prevent.
+func TestRevalidateTailIncludesDegenerate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tail.tsv")
+	findings := []revalidate.Finding{
+		{Path: "/lib/a.lrc", Outcome: timing.Degenerate, Duration: 240, Action: realign.KindDemote},
+		{Path: "/lib/b.lrc", Outcome: timing.MisSynced, Duration: 100, Action: realign.KindDemote},
+		{Path: "/lib/c.lrc", Outcome: timing.Ok, Duration: 100},
+	}
+
+	if err := writeRevalidateTail(path, findings); err != nil {
+		t.Fatalf("writeRevalidateTail: %v", err)
+	}
+	body, err := os.ReadFile(path) //nolint:gosec // test path from t.TempDir
+	if err != nil {
+		t.Fatalf("read tail: %v", err)
+	}
+	got := string(body)
+
+	if !strings.Contains(got, string(timing.Degenerate)) {
+		t.Errorf("tail omits the degenerate finding; got %q", got)
+	}
+	if !strings.Contains(got, "/lib/a.lrc") {
+		t.Errorf("tail omits the degenerate file path; got %q", got)
+	}
+	// The existing filter must be unchanged: Ok is not remediable and stays out.
+	if strings.Contains(got, "/lib/c.lrc") {
+		t.Errorf("tail includes a compliant file; got %q", got)
 	}
 }

--- a/internal/commands/revalidate_test.go
+++ b/internal/commands/revalidate_test.go
@@ -410,7 +410,7 @@ func TestRevalidateTailIncludesDegenerate(t *testing.T) {
 	if err := writeRevalidateTail(path, findings); err != nil {
 		t.Fatalf("writeRevalidateTail: %v", err)
 	}
-	body, err := os.ReadFile(path) //nolint:gosec // test path from t.TempDir
+	body, err := os.ReadFile(path) //nolint:gosec // reason: test path from t.TempDir
 	if err != nil {
 		t.Fatalf("read tail: %v", err)
 	}
@@ -425,5 +425,34 @@ func TestRevalidateTailIncludesDegenerate(t *testing.T) {
 	// The existing filter must be unchanged: Ok is not remediable and stays out.
 	if strings.Contains(got, "/lib/c.lrc") {
 		t.Errorf("tail includes a compliant file; got %q", got)
+	}
+}
+
+// TestPrintRevalidateCountsIncludesDegenerate covers the aggregate summary
+// (#673 review). The tail file is opt-in via --tail, so this one line is what
+// a plain `revalidate` run actually shows an operator -- and revalidate is
+// dry-run by default, which means a planned demotion that never appears in the
+// summary is invisible at exactly the moment it matters.
+//
+// Nothing pinned this line before, which is why the omission survived: the
+// counts printer enumerates fields by hand, so a new Counts field is silently
+// absent rather than a compile error.
+func TestPrintRevalidateCountsIncludesDegenerate(t *testing.T) {
+	var buf bytes.Buffer
+	printRevalidateCounts(&buf, revalidate.Counts{
+		Scanned: 9, Ok: 4, MisSynced: 1, Categorical: 1, Degenerate: 2,
+		UnknownDuration: 1, NoAudio: 0, Errored: 0,
+	}, false)
+
+	got := buf.String()
+	if !strings.Contains(got, "degenerate=2") {
+		t.Errorf("summary omits the degenerate count; got %q", got)
+	}
+	// The pre-existing fields must survive the edit: a reordered or dropped
+	// counter would be a regression this test should also catch.
+	for _, want := range []string{"scanned=9", "ok=4", "MisSynced=1", "categorical=1", "unknown-duration=1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary lost %q; got %q", want, got)
+		}
 	}
 }

--- a/internal/lyrics/timing_guard.go
+++ b/internal/lyrics/timing_guard.go
@@ -75,6 +75,18 @@ func DecidePromotion(song models.Song) (PromotionDecision, timing.TimingOutcome,
 	switch outcome {
 	case timing.MisSynced:
 		return DemoteToUnsynced, outcome, mag
+	case timing.Degenerate:
+		// Every cue shares one timestamp, so the file is not synced at all
+		// (#673). Demote rather than quarantine: only the TIMING is fabricated
+		// -- the words are typically correct, and are exactly what a .txt is
+		// for. Quarantining would discard usable text over a defect that
+		// costs nothing to downgrade.
+		//
+		// This arm is why the outcome exists. Without it the default below
+		// fails open and a degenerate lyric is PROMOTED as synced, which is
+		// the pre-#673 behavior: timing.Evaluate returned Ok for this shape,
+		// so nothing rejected it anywhere on the path.
+		return DemoteToUnsynced, outcome, mag
 	case timing.Categorical:
 		return Quarantine, outcome, mag
 	case timing.Ok, timing.UnknownDuration:

--- a/internal/lyrics/timing_guard_test.go
+++ b/internal/lyrics/timing_guard_test.go
@@ -338,7 +338,7 @@ func TestWriteLRC_TimingGuard_DegenerateWritesTxt(t *testing.T) {
 	txt := filepath.Join(dir, "song.txt")
 	mustExist(t, txt)
 
-	data, err := os.ReadFile(txt) //nolint:gosec // test path from t.TempDir
+	data, err := os.ReadFile(txt) //nolint:gosec // reason: test path from t.TempDir
 	if err != nil {
 		t.Fatalf("reading demoted .txt: %v", err)
 	}

--- a/internal/lyrics/timing_guard_test.go
+++ b/internal/lyrics/timing_guard_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/timing"
 )
 
 // guardSong builds a synced song with the given audio duration and cues.
@@ -305,5 +306,74 @@ func TestDecidePromotion(t *testing.T) {
 				t.Errorf("DecidePromotion() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestWriteLRC_TimingGuard_DegenerateWritesTxt covers #673 at accept time: an
+// .lrc whose cues all share one timestamp is not synced, so it must never be
+// written as one. The words are typically correct -- only the timing is
+// fabricated -- so this demotes to .txt exactly as MisSynced does, rather than
+// discarding.
+//
+// The pre-fix behavior was a silent PROMOTION: timing.Evaluate returned Ok for
+// this shape (an all-zero file has max 0, so it never overruns), and
+// DecidePromotion's default arm fails open by design. A new outcome that nobody
+// maps therefore ships as "write the bad file", which is the failure mode this
+// test pins.
+func TestWriteLRC_TimingGuard_DegenerateWritesTxt(t *testing.T) {
+	dir := t.TempDir()
+	// The #673 production shape: many cues, one distinct timestamp.
+	song := guardSong(240,
+		cue(0, "first line"),
+		cue(0, "second line"),
+		cue(0, "third line"),
+	)
+
+	w := NewLRCWriter()
+	if err := w.WriteLRC(song, "song.lrc", dir); err != nil {
+		t.Fatalf("WriteLRC: %v", err)
+	}
+
+	mustNotExist(t, filepath.Join(dir, "song.lrc"))
+	txt := filepath.Join(dir, "song.txt")
+	mustExist(t, txt)
+
+	data, err := os.ReadFile(txt) //nolint:gosec // test path from t.TempDir
+	if err != nil {
+		t.Fatalf("reading demoted .txt: %v", err)
+	}
+	body := string(data)
+	// The words survive the demotion -- that is the whole point of demoting
+	// rather than quarantining.
+	for _, want := range []string{"first line", "second line", "third line"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("demoted .txt is missing %q; got %q", want, body)
+		}
+	}
+	// And the fake timing does not.
+	if strings.Contains(body, "[00:") {
+		t.Errorf("demoted .txt must not carry LRC timestamps; got %q", body)
+	}
+}
+
+// TestDecidePromotion_DegenerateDemotes pins the decision directly, without the
+// filesystem. The writer test above proves the end-to-end effect; this proves
+// the mapping itself, so a regression is attributable to the arm rather than to
+// any write-path change.
+func TestDecidePromotion_DegenerateDemotes(t *testing.T) {
+	song := guardSong(240, cue(0, "a"), cue(0, "b"))
+
+	decision, outcome, mag := DecidePromotion(song)
+
+	if decision != DemoteToUnsynced {
+		t.Errorf("decision = %v; want %v -- a degenerate lyric must never be promoted as synced", decision, DemoteToUnsynced)
+	}
+	if outcome != timing.Degenerate {
+		t.Errorf("outcome = %q; want %q", outcome, timing.Degenerate)
+	}
+	// The magnitude derives from a timestamp the file does not honestly carry,
+	// so it must not be persisted as if it were measured.
+	if mag.Measured {
+		t.Error("degenerate decision reports Measured=true; the numbers are fabricated and would land in the metrics columns")
 	}
 }

--- a/internal/revalidate/revalidate.go
+++ b/internal/revalidate/revalidate.go
@@ -94,6 +94,7 @@ type Counts struct {
 	Ok              int
 	MisSynced       int
 	Categorical     int
+	Degenerate      int // every cue at one timestamp: not synced at all (#673)
 	UnknownDuration int // no exact duration: failed open, never remediated
 	NoAudio         int // a .lrc with no companion audio: realign's problem, not this one
 	Errored         int // unreadable file or duration-store failure
@@ -199,6 +200,24 @@ func (r *Revalidator) classify(ctx context.Context, root, path string, plan *Pla
 		plan.Counts.UnknownDuration++
 	case timing.MisSynced:
 		plan.Counts.MisSynced++
+		mv, mok := r.demotionMove(root, path, audio)
+		if mok {
+			f.Action = mv.Kind
+			plan.Moves = append(plan.Moves, mv)
+		}
+	case timing.Degenerate:
+		// Every cue shares one timestamp, so the file is not synced (#673).
+		// Demote exactly as MisSynced does -- same move, same backup trail --
+		// because the defect is identical in kind: the words are fine, the
+		// timing is not. Reusing demotionMove is what keeps this arm honest;
+		// a bespoke path here would drift from the settled-.txt and
+		// all-decorative rules that path already enforces.
+		//
+		// Note the overrun predicate CANNOT reach these files: an all-zero
+		// lyric has max 0, so it never overruns and classifies Ok. Before this
+		// arm the verdict fell to default and was counted Errored, which never
+		// remediates -- so the existing corpus would have stayed untouched.
+		plan.Counts.Degenerate++
 		mv, mok := r.demotionMove(root, path, audio)
 		if mok {
 			f.Action = mv.Kind

--- a/internal/revalidate/revalidate_test.go
+++ b/internal/revalidate/revalidate_test.go
@@ -555,3 +555,82 @@ func applyPlan(t *testing.T, plan Plan) []realign.Applied {
 	}
 	return applied
 }
+
+// TestDegenerateOnDiskIsDemoted covers the #673 repair path: a degenerate .lrc
+// ALREADY on disk (every cue at one timestamp) is found by this sweep and
+// demoted to .txt, keeping the words.
+//
+// The existing corpus is the reason this arm exists. The accept-time guard stops
+// new ones, but five such files were found on a production library before the
+// predicate existed, and nothing else walks .lrc files re-judging them. Before
+// this arm the outcome fell to classify's default, which counts an unrecognized
+// verdict as Errored and deliberately never remediates -- so the population
+// would have stayed exactly as it was, silently.
+func TestDegenerateOnDiskIsDemoted(t *testing.T) {
+	// Every cue at 00:00.00 -- the production shape. Well inside trackSeconds,
+	// so the overrun predicate reports Ok and cannot be what catches it.
+	root, lrc := lib(t, "[00:00.00]alpha\n[00:00.00]beta\n[00:00.00]gamma\n")
+	rv, quarantine := newRevalidator(t, root, fixedDuration(), nil)
+
+	plan, err := rv.Plan(t.Context())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Counts.Degenerate != 1 {
+		t.Fatalf("Degenerate = %d, want 1 (counts=%+v)", plan.Counts.Degenerate, plan.Counts)
+	}
+	// It must NOT be miscounted as an error: an error is "we could not judge
+	// this", which would hide a file the sweep actually understands.
+	if plan.Counts.Errored != 0 {
+		t.Errorf("Errored = %d, want 0 -- a degenerate file is judged, not unreadable", plan.Counts.Errored)
+	}
+	if len(plan.Moves) != 1 {
+		t.Fatalf("moves = %d, want 1", len(plan.Moves))
+	}
+	if got := plan.Moves[0].Kind; got != realign.KindDemote {
+		t.Fatalf("kind = %q, want %q -- the words are correct, only the timing is fake", got, realign.KindDemote)
+	}
+
+	applyPlan(t, plan)
+
+	body, err := os.ReadFile(filepath.Join(root, "album", "track.txt"))
+	if err != nil {
+		t.Fatalf("demoted .txt missing: %v", err)
+	}
+	if got, want := string(body), "alpha\nbeta\ngamma\n"; got != want {
+		t.Errorf("demoted body = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(lrc); !os.IsNotExist(err) {
+		t.Errorf("the degenerate .lrc should have been moved aside: %v", err)
+	}
+	// Recoverable: this pass is backup-first like every other remediation here.
+	if _, err := os.Stat(filepath.Join(quarantine, "album", "track.lrc")); err != nil {
+		t.Errorf("the demoted .lrc is not recoverable from quarantine: %v", err)
+	}
+}
+
+// TestGenuinelySyncedIsNotDemotedAsDegenerate is the control this arm needs, and
+// an explicit #673 acceptance criterion: a real synced file must be untouched.
+// Without it the test above would also pass on a predicate that demoted
+// everything.
+func TestGenuinelySyncedIsNotDemotedAsDegenerate(t *testing.T) {
+	root, lrc := lib(t, "[00:10.00]alpha\n[00:25.00]beta\n[00:40.00]gamma\n")
+	rv, _ := newRevalidator(t, root, fixedDuration(), nil)
+
+	plan, err := rv.Plan(t.Context())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Counts.Degenerate != 0 {
+		t.Errorf("Degenerate = %d, want 0 -- distinct timestamps are a real sync", plan.Counts.Degenerate)
+	}
+	if plan.Counts.Ok != 1 {
+		t.Errorf("Ok = %d, want 1 (counts=%+v)", plan.Counts.Ok, plan.Counts)
+	}
+	if len(plan.Moves) != 0 {
+		t.Fatalf("moves = %d, want 0 -- a synced file must never be remediated", len(plan.Moves))
+	}
+	if _, err := os.Stat(lrc); err != nil {
+		t.Errorf("the synced .lrc must be left alone: %v", err)
+	}
+}

--- a/internal/scan/categorical_suppression_test.go
+++ b/internal/scan/categorical_suppression_test.go
@@ -288,3 +288,45 @@ func TestEnqueuePendingUnknownGenerationNeverSuppresses(t *testing.T) {
 		t.Fatalf("enqueued=%d; want 1 -- an unknown generation must not suppress", enqueued)
 	}
 }
+
+// Degenerate must NOT suppress, and the reason is the same one that spares
+// MisSynced rather than a new judgment (#673).
+//
+// Suppression exists for one shape: a verdict that writes NOTHING, leaving the
+// row indistinguishable from a track never fetched, so every scan re-fetches
+// and re-rejects it forever. Only Categorical does that.
+//
+// Degenerate demotes to a .txt exactly as MisSynced does, so #439's
+// settled-sidecar check already makes a later re-fetch a no-op: wasteful at
+// worst, never destructive. Suppressing it would hide a track that a future
+// provider generation could serve correctly, buying nothing.
+//
+// The current code reaches this outcome because shouldSuppress compares against
+// Categorical alone. This test exists so that stays a DECISION rather than an
+// accident: widening that comparison to "any non-Ok verdict" would silently
+// bury these rows.
+func TestEnqueuePendingDoesNotSuppressDegenerate(t *testing.T) {
+	ctx := context.Background()
+	store := &fakePendingStore{results: []models.ScanResult{{
+		ID:       1,
+		FilePath: "/music/degenerate.flac",
+		Track:    models.Track{ArtistName: "A", TrackName: "Degenerate"},
+	}}}
+	verdicts := &fakeTimingVerdicts{verdicts: map[string]scan.TimingVerdict{
+		"A\x00Degenerate": {Outcome: timing.Degenerate, ProvidersVersion: 3},
+	}}
+	work := &fakeWorkQueue{}
+
+	e := scan.Enqueuer{
+		Results: store, Cache: fakeLyricsCache{}, Queue: work,
+		Timing: verdicts, ProvidersVersion: 3,
+	}
+
+	enqueued, _, err := e.EnqueuePending(ctx, models.Library{ID: 7})
+	if err != nil {
+		t.Fatalf("EnqueuePending: %v", err)
+	}
+	if enqueued != 1 {
+		t.Fatalf("enqueued=%d; want 1 -- a degenerate row demotes to .txt and stays recoverable, so it must not be suppressed", enqueued)
+	}
+}

--- a/internal/timing/outcome_enumeration_test.go
+++ b/internal/timing/outcome_enumeration_test.go
@@ -1,0 +1,148 @@
+package timing
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// This file is the durable guard for the class of defect #673 exposed.
+//
+// TimingOutcome is consumed by hand-written switches and comparisons across
+// five packages, and EVERY ONE of them has a fail-open shape: an unrecognized
+// verdict promotes the write (internal/lyrics), skips remediation
+// (internal/revalidate), drops out of the operator's report
+// (internal/commands), or takes the benign branch (internal/worker,
+// internal/scan). That is the correct default for an UNKNOWN value and the
+// wrong one for a value someone just added, so adding an outcome without
+// visiting each site ships a silent no-op.
+//
+// Degenerate demonstrated it concretely: before this work it did not exist, and
+// the shape it describes classified as Ok, so a file whose every cue shared one
+// timestamp was written as a synced .lrc with nothing anywhere objecting.
+//
+// The guard below cannot verify that each site's HANDLING is correct -- that is
+// a judgment call per outcome, made in the code and its comments. What it can do
+// is force the question to be asked, by failing when the declared set of
+// outcomes drifts from the set this test knows about.
+
+// knownOutcomes is the hand-maintained roster of every TimingOutcome, paired
+// with the disposition decided for it. Adding a constant to timing.go without
+// adding it here fails the test, which is the point: the failure message is the
+// checklist of sites to visit.
+//
+// Deliberately duplicated rather than derived. A test that reads the same source
+// of truth as the code under test proves only that the file parses; the value
+// here is that a human had to write the second copy and, in doing so, decide
+// what the new outcome means at each consumer.
+var knownOutcomes = map[TimingOutcome]string{
+	Ok:              "compliant: promote, never remediate, no warn",
+	MisSynced:       "words correct, timing drifted: demote to .txt, do not suppress re-enqueue",
+	Categorical:     "timed to a different recording: quarantine, write nothing, suppress re-enqueue",
+	UnknownDuration: "no verdict possible: fail open everywhere, never remediate",
+	Degenerate:      "every cue at one timestamp, not synced at all: demote to .txt like MisSynced (#673)",
+}
+
+// TestEveryTimingOutcomeIsAccountedFor fails when timing.go declares an outcome
+// this test does not know about, or when the roster names one that no longer
+// exists.
+//
+// The failure message deliberately lists the consumer sites, because "add it to
+// the map" is NOT the fix -- visiting those sites is, and the map is only the
+// record that it happened.
+func TestEveryTimingOutcomeIsAccountedFor(t *testing.T) {
+	declared := declaredOutcomesFromSource(t)
+
+	for name, value := range declared {
+		if _, ok := knownOutcomes[value]; !ok {
+			t.Errorf("TimingOutcome %s (%q) is not accounted for.\n"+
+				"Adding it to knownOutcomes is the LAST step, not the fix. Every consumer\n"+
+				"below fails OPEN on an unrecognized verdict, so an unvisited site is a\n"+
+				"silent no-op rather than a compile error:\n"+
+				"  internal/lyrics/timing_guard.go   DecidePromotion -- default PROMOTES the write\n"+
+				"  internal/revalidate/revalidate.go classify        -- default counts Errored, never remediates\n"+
+				"  internal/commands/revalidate.go   writeRevalidateTail -- filter drops it from the report\n"+
+				"  internal/worker/worker.go         stampTimingOutcome  -- decides warn vs silence, and the wording\n"+
+				"  internal/scan/enqueuer.go         shouldSuppress      -- decides re-enqueue suppression",
+				name, value)
+		}
+	}
+
+	declaredValues := map[TimingOutcome]bool{}
+	for _, v := range declared {
+		declaredValues[v] = true
+	}
+	for value := range knownOutcomes {
+		if !declaredValues[value] {
+			t.Errorf("knownOutcomes names %q, which timing.go no longer declares; remove the stale entry", value)
+		}
+	}
+}
+
+// declaredOutcomesFromSource parses timing.go for every constant declared with
+// the TimingOutcome type, returning identifier -> value.
+//
+// Source-parsed rather than hand-listed for the same reason as the #748 sentinel
+// guard: Go has no runtime enumeration of a package's constants, so a hand-list
+// on BOTH sides could drift together and the test would pass while blind.
+func declaredOutcomesFromSource(t *testing.T) map[string]TimingOutcome {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not resolve this test file's path")
+	}
+	path := filepath.Join(filepath.Dir(thisFile), "timing.go")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	out := map[string]TimingOutcome{}
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, isVS := spec.(*ast.ValueSpec)
+			if !isVS {
+				continue
+			}
+			// Only constants explicitly typed TimingOutcome. The Tolerance /
+			// CategoricalRatio block in the same file is untyped and must not
+			// be swept in.
+			id, isIdent := vs.Type.(*ast.Ident)
+			if !isIdent || id.Name != "TimingOutcome" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, isLit := vs.Values[i].(*ast.BasicLit)
+				if !isLit || lit.Kind != token.STRING {
+					continue
+				}
+				out[name.Name] = TimingOutcome(strings.Trim(lit.Value, `"`))
+			}
+		}
+	}
+
+	// Self-check: a scan that silently finds nothing would make every assertion
+	// above vacuously true, which is the exact failure this file exists to
+	// prevent. The threshold catches a broken scan, not a shrinking set.
+	if len(out) < 4 {
+		t.Fatalf("found only %d TimingOutcome constants (%v); the AST scan is broken, so this guard is not testing anything", len(out), out)
+	}
+	return out
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -39,6 +39,18 @@ const (
 	// UnknownDuration means the audio duration was not known, so no judgment
 	// is possible. Always fail open: never reject on this.
 	UnknownDuration TimingOutcome = "unknown_duration"
+	// Degenerate means every text-bearing cue carries the SAME timestamp, so the
+	// file is not synced at all: each line would render simultaneously at that
+	// instant (in the observed population, all at 00:00.00). The words are
+	// typically correct -- only the timing is fabricated -- so callers demote to
+	// unsynced text rather than discarding, matching MisSynced's treatment.
+	//
+	// This is ORTHOGONAL to the overrun axis rather than a point on it, which is
+	// why it needs its own outcome. Evaluate judges by the MAXIMUM timestamp, so
+	// an all-zero file has max 0, an overrun of -duration and a ratio of 0 --
+	// maximally compliant by that measure. Measured on the #673 production shape:
+	// 65 cues at 00:00.00 against 240s audio returned Ok with ratio 0.00.
+	Degenerate TimingOutcome = "degenerate"
 )
 
 const (
@@ -88,6 +100,23 @@ func Evaluate(song models.Song, durationSeconds int) (TimingOutcome, Magnitude) 
 		return UnknownDuration, Magnitude{}
 	}
 
+	// Degeneracy is decided BEFORE the overrun arms below, and that boundary is
+	// load-bearing. A file whose cues all share one timestamp carries no honest
+	// timing, so its overrun and ratio are computed from a fabricated number: an
+	// all-zero file measures a -duration overrun and a 0.00 ratio, i.e. maximally
+	// compliant. Consulted only after those arms decide, the whole observed
+	// population would return Ok first and the degenerate verdict would be
+	// unreachable for exactly what it exists to catch; and a degenerate file that
+	// also overruns would name the symptom instead of the cause. Verified by
+	// mutation -- deferring it past the switch reddens the categorical case.
+	//
+	// Its position relative to correctedMaxSeconds below is NOT load-bearing
+	// (both orders give the same verdict); it sits first only to skip work that
+	// would be discarded.
+	if isDegenerate(song.Subtitles.Lines) {
+		return Degenerate, Magnitude{}
+	}
+
 	maxTS, ok := correctedMaxSeconds(song.Subtitles.Lines)
 	if !ok {
 		// Empty subtitles, nothing but decorative lines, or no cue with a usable
@@ -125,6 +154,62 @@ func Evaluate(song models.Song, durationSeconds int) (TimingOutcome, Magnitude) 
 // sticky in a running maximum, since every `s > NaN` comparison is false. A
 // single NaN on an early cue would otherwise swallow a genuinely categorical
 // overrun on a later one, making the verdict depend on cue order.
+// isDegenerate reports whether every text-bearing cue carries the SAME
+// timestamp -- a file that is not synced at all, since each line would render
+// simultaneously at that instant (#673).
+//
+// The rule is deliberately narrow: MORE THAN ONE text-bearing cue, and exactly
+// one distinct timestamp among them. Both halves matter.
+//
+//   - A single cue has one distinct timestamp by definition, so without the
+//     multi-cue requirement every legitimately short entry would be flagged.
+//   - "Distinct timestamps" is the whole signal. On the production population
+//     (#673) five files carried 10-70 cues at exactly one timestamp, while two
+//     genuinely-synced files in the same directory measured 67/67 and 63/63
+//     distinct. The discriminator is unambiguous, so it needs no threshold.
+//
+// NEAR-degenerate cases -- every cue inside a sub-second window, say -- are
+// deliberately NOT covered. The observed population is exactly-equal timestamps,
+// and inventing a tolerance here would risk demoting a real lyric whose opening
+// lines are genuinely close together, trading a confirmed defect for a
+// speculative one.
+//
+// Decorative lines are filtered on the SAME contract as correctedMaxSeconds,
+// via the shared isDecorative. That is not tidiness: counted, a single trailing
+// note-glyph marker at a different stamp would supply a second distinct
+// timestamp and mask a fully degenerate lyric. The two functions must agree on
+// which lines carry timing, or one can be fooled by input the other rejects.
+//
+// Non-finite timestamps are skipped per line, matching correctedMaxSeconds: a
+// NaN from a hostile or broken provider payload is not a real second distinct
+// value, and counting it would make a degenerate file read as synced.
+func isDegenerate(lines []models.Lines) bool {
+	var first float64
+	found, distinct := false, false
+	count := 0
+
+	for _, l := range lines {
+		if isDecorative(l.Text) {
+			continue
+		}
+		s := seconds(l.Time)
+		if math.IsNaN(s) || math.IsInf(s, 0) {
+			continue
+		}
+		count++
+		if !found {
+			first, found = s, true
+			continue
+		}
+		if s != first {
+			distinct = true
+			break
+		}
+	}
+
+	return count > 1 && !distinct
+}
+
 func correctedMaxSeconds(lines []models.Lines) (float64, bool) {
 	maxTS, found := 0.0, false
 	for _, l := range lines {

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -467,3 +467,119 @@ func TestThresholdsMatchCalibration(t *testing.T) {
 		t.Errorf("CategoricalRatio = %v, want 1.5", CategoricalRatio)
 	}
 }
+
+// TestEvaluate_DegenerateAllCuesShareOneTimestamp covers #673: an .lrc whose
+// cues all carry the SAME timestamp is not synced -- every line would render
+// simultaneously at playback start -- yet the overrun predicate cannot see it.
+//
+// The blind spot is structural, not an oversight. Evaluate compares the MAXIMUM
+// timestamp against the duration, so an all-zero file has max 0, an overrun of
+// -duration, and a ratio of 0: maximally "compliant" by that axis. Degeneracy is
+// ORTHOGONAL to overrun, which is why it needs its own arm rather than a
+// threshold tweak. Measured before the fix: 65 cues at 00:00.00 against 240s
+// audio returned Ok with ratio 0.00.
+func TestEvaluate_DegenerateAllCuesShareOneTimestamp(t *testing.T) {
+	tests := []struct {
+		name     string
+		song     models.Song
+		duration int
+		want     TimingOutcome
+	}{
+		{
+			// The production shape from #673: many cues, one distinct timestamp.
+			name:     "many cues all at zero is degenerate",
+			song:     song(line(0, "a"), line(0, "b"), line(0, "c"), line(0, "d")),
+			duration: 240,
+			want:     Degenerate,
+		},
+		{
+			// Degeneracy is about the timestamps being IDENTICAL, not about them
+			// being zero. A non-zero shared stamp is the same defect.
+			name:     "many cues all at the same non-zero stamp is degenerate",
+			song:     song(line(12, "a"), line(12, "b"), line(12, "c")),
+			duration: 240,
+			want:     Degenerate,
+		},
+		{
+			// A single cue has exactly one timestamp by definition. Calling that
+			// degenerate would flag every legitimately short entry, so the rule
+			// requires MORE THAN ONE text-bearing cue.
+			name:     "single cue is not degenerate",
+			song:     song(line(0, "a")),
+			duration: 240,
+			want:     Ok,
+		},
+		{
+			// Two cues is the smallest set where "all identical" is a real claim.
+			name:     "two identical cues is degenerate",
+			song:     song(line(5, "a"), line(5, "b")),
+			duration: 240,
+			want:     Degenerate,
+		},
+		{
+			name:     "two distinct cues is not degenerate",
+			song:     song(line(5, "a"), line(9, "b")),
+			duration: 240,
+			want:     Ok,
+		},
+		{
+			// Decorative lines are filtered before the distinctness test, exactly
+			// as they are for the max. Otherwise a single note-glyph marker at a
+			// different stamp would mask a fully degenerate lyric.
+			name:     "decorative line at another stamp does not rescue a degenerate lyric",
+			song:     song(line(0, "a"), line(0, "b"), line(30, "♪")),
+			duration: 240,
+			want:     Degenerate,
+		},
+		{
+			// The mirror case: real cues are distinct, so the file is fine even
+			// though a decorative line shares a stamp with one of them.
+			name:     "decorative line sharing a stamp does not make a synced lyric degenerate",
+			song:     song(line(10, "a"), line(40, "b"), line(40, "♪")),
+			duration: 240,
+			want:     Ok,
+		},
+		{
+			// Degeneracy is checked BEFORE the overrun comparison: a fake
+			// timestamp makes overrun and ratio meaningless, so a degenerate file
+			// that also overruns must report the cause, not the symptom.
+			name:     "degenerate wins over a categorical overrun",
+			song:     song(line(600, "a"), line(600, "b")),
+			duration: 100,
+			want:     Degenerate,
+		},
+		{
+			// Unknown duration still fails open first -- never reject on it.
+			name:     "degenerate with unknown duration stays UnknownDuration",
+			song:     song(line(0, "a"), line(0, "b")),
+			duration: 0,
+			want:     UnknownDuration,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := Evaluate(tt.song, tt.duration)
+			if got != tt.want {
+				t.Errorf("Evaluate = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEvaluate_DegenerateCarriesNoMagnitude pins that a degenerate verdict
+// reports Measured=false. The overrun and ratio are computed from a timestamp
+// the file does not honestly carry, so persisting them would put fabricated
+// numbers in the metrics columns -- worse than a NULL, because they look real.
+func TestEvaluate_DegenerateCarriesNoMagnitude(t *testing.T) {
+	outcome, mag := Evaluate(song(line(0, "a"), line(0, "b")), 240)
+	if outcome != Degenerate {
+		t.Fatalf("outcome = %q; want %q", outcome, Degenerate)
+	}
+	if mag.Measured {
+		t.Error("degenerate magnitude reports Measured=true; the numbers derive from a fake timestamp and must not be persisted")
+	}
+	if mag.OverrunSeconds != 0 || mag.Ratio != 0 {
+		t.Errorf("degenerate magnitude carries data: %+v", mag)
+	}
+}

--- a/internal/worker/timing_outcome_test.go
+++ b/internal/worker/timing_outcome_test.go
@@ -220,3 +220,49 @@ func TestStampTimingOutcome_LogsOnlyNonCompliant(t *testing.T) {
 		})
 	}
 }
+
+// TestStampTimingOutcome_DegenerateLogsAccurately covers the worker half of
+// #673. A degenerate result IS worth a warn -- it is non-compliant and
+// actionable -- but the existing sibling warn says the lyric "overruns the
+// audio", which is FALSE for this shape: a degenerate file has no honest timing
+// to overrun, and its overrun/ratio fields are zero.
+//
+// So this pins two things at once: that the event is not silently swallowed,
+// and that what it says about the file is true. A warn whose text contradicts
+// its own numeric fields is how an operator gets sent after the wrong cause.
+func TestStampTimingOutcome_DegenerateLogsAccurately(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	q := &fakeQueue{}
+	w := &Worker{queue: q, now: func() time.Time { return testNow }}
+	// Two cues at the same stamp, well inside a 100s track: the overrun
+	// predicate reports nothing, so only the degeneracy check can catch it.
+	song := syncedSong(tLine(0, "a"), tLine(0, "b"))
+
+	w.stampTimingOutcome(t.Context(), queue.WorkItem{ID: 11,
+		Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "T"}}}, song, 100)
+
+	// The verdict is persisted like any other.
+	rec, ok := q.timingOutcomes[11]
+	if !ok {
+		t.Fatal("no timing outcome stamped for a degenerate result")
+	}
+	if rec.Outcome != string(timing.Degenerate) {
+		t.Errorf("Outcome = %q, want %q", rec.Outcome, timing.Degenerate)
+	}
+
+	log := buf.String()
+	if log == "" {
+		t.Fatal("a degenerate result logged nothing; it is non-compliant and actionable")
+	}
+	// The claim must match the defect.
+	if strings.Contains(log, "overruns the audio") {
+		t.Errorf("degenerate warn claims an overrun, which this file does not have: %q", log)
+	}
+	if !strings.Contains(log, "outcome=degenerate") {
+		t.Errorf("degenerate warn is missing outcome=degenerate: %q", log)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1014,10 +1014,18 @@ func (w *Worker) stampTimingOutcome(ctxNoCancel context.Context, item queue.Work
 		// unknown-duration case is a routine fail-open, not an anomaly.
 		return
 	}
+	// The message must match the defect. A degenerate lyric does NOT overrun --
+	// every cue shares one timestamp, so overrun_seconds and ratio are both 0 --
+	// and the overrun wording beside those zeros would send an operator after
+	// the wrong cause (#673).
+	msg := "worker: synced lyric timing overruns the audio"
+	if rec.Outcome == string(timing.Degenerate) {
+		msg = "worker: lyric is not really synced; every cue shares one timestamp"
+	}
 	// Artist and track name identify the row for an operator reading their own
 	// logs, matching every sibling warn here. They stay in the log line only and
 	// are never routed to a metric label or any shared surface.
-	slog.Warn("worker: synced lyric timing overruns the audio",
+	slog.Warn(msg,
 		"id", item.ID,
 		"outcome", rec.Outcome,
 		"overrun_seconds", rec.Magnitude,


### PR DESCRIPTION
## Summary

- An `.lrc` whose cue lines all carry the **same** timestamp was accepted, written, and counted as a synced result. It is not synced -- every line renders simultaneously at playback start. Found on a production library: five files carrying 10-70 cues at exactly one timestamp, while two genuinely-synced files in the same directory measured 67/67 and 63/63 distinct.
- **The existing timing work could not see it, and that is structural.** `timing.Evaluate` models an OVERRUN -- it compares the MAXIMUM timestamp against the audio duration. An all-zero file has max 0, so it measures a `-duration` overrun and a `0.00` ratio: maximally compliant by that axis. Measured before the fix, 65 cues at `00:00.00` against 240s audio returned `Ok`. Degeneracy is **orthogonal** to overrun, so it needs its own arm rather than a threshold tweak.
- **Look at the five consumer arms first** -- they are the substance of this change, not the predicate. Every `TimingOutcome` consumer fails OPEN on an unrecognized verdict, so a new outcome ships as a silent no-op unless each site is visited deliberately.

## Linked issue

Closes #673

## The five consumers, and why each decision went the way it did

| Site | Decision | What the fail-open default would have done |
|---|---|---|
| `lyrics.DecidePromotion` | demote to `.txt` | **PROMOTED the bad file** -- the pre-fix behavior, reproduced by mutation |
| `revalidate.classify` | demote via existing `demotionMove` | counted `Errored`, never remediated -- the existing corpus stays untouched |
| `commands.writeRevalidateTail` | include it | dropped from the report; revalidate is dry-run by default and this is the only per-file view an operator gets |
| `worker.stampTimingOutcome` | warn, but **not** with the overrun wording | claimed "overruns the audio" beside `overrun_seconds=0 ratio=0` -- a self-contradicting log that sends an operator after the wrong cause |
| `scan.shouldSuppress` | do **not** suppress | already correct, but by accident rather than decision -- now pinned |

The disposition is **demote**, matching `MisSynced`: only the timing is fabricated, the words are typically correct, and a `.txt` is exactly what correct-words-no-timing means. Quarantining would discard usable text over a defect that costs nothing to downgrade.

The suppression decision follows the rule already written in `shouldSuppress`, not a new judgment: suppression exists for verdicts that write **nothing** (leaving a row indistinguishable from never-fetched, so every scan re-fetches forever). `Degenerate` writes a `.txt`, so #439's settled-sidecar check already makes a re-fetch a harmless no-op.

## No new package, no new subcommand

`internal/revalidate` already walks on-disk `.lrc` files, re-judges each through `lyrics.EvaluateLRCFile` -> `timing.Evaluate`, and remediates via `realign.Apply` behind the dry-run-by-default `revalidate` command. So the repair path for the existing corpus is **one case arm**, and the CLI is unchanged.

CodeRabbit's issue plan proposed a new `internal/degeneratelrc` package plus a `reconcile-degenerate-lrc` subcommand. That was read and deliberately not taken: it duplicates working machinery and adds a command where a flag-free reuse exists.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes -- see the measured before/after in Test plan.
- [x] Screenshot attached for any web-UI change (N/A -- no web-UI change).
- [x] `make ui` re-run if any `.templ` or CSS source changed (N/A -- none changed).
- [x] Migration added under `internal/db/migrations/` (N/A). `timing_outcome` is plain TEXT with no CHECK constraint (migration 034), verified, so a new value needs no schema change. Rows written before this change keep their old verdict; the revalidate sweep is what re-judges them.

## Test plan

- [x] `make gate` passes locally, read from its output rather than its exit code: **patch coverage 100.00% (63/63)**, all coverage floors held, golangci-lint 0 issues, actionlint clean, govulncheck clean.
- [x] New tests were confirmed to **fail against unfixed code**, at an ASSERTION rather than a build error. The predicate was written test-first; every other arm was verified by valid mutation (each mutant compiled cleanly):
  - drop the multi-cue guard (`count > 1` -> `count > 0`) -> `single cue is not degenerate` reddens
  - drop the shared decorative filter -> a note-glyph marker at another stamp masks a degenerate lyric
  - defer the check past the overrun arms -> `degenerate wins over a categorical overrun` reddens
  - remove the `lyrics` arm -> the writer logs `kind=synced` and writes the bad `.lrc` (the original bug)
  - remove the `revalidate` arm -> `Degenerate = 0 ... Errored:1`, no remediation
  - swap `demotionMove` for `removalMove` -> `kind = "quarantine", want "demote"` (pins words-are-kept, not merely that something happens)
  - widen `shouldSuppress` to "any non-Ok verdict" -> both the degenerate and the existing MisSynced guard redden
- [x] Patch coverage meets the Codecov threshold (100.00%).
- [x] Which **surface** this change fixes is stated explicitly and was verified at each one. Five consumers, five separate arms, each with its own test -- a DB-level or single-package check would not have caught the other four.
- [x] Manual UAT steps (list the specific flows exercised):
  - [x] Measured the blind spot before fixing: 65 cues at `00:00.00` vs 240s audio -> `Ok`, ratio `0.00`. Same shape after -> `Degenerate`.
  - [x] Control, both before and after: 60 distinct cues -> `Ok`, untouched by the sweep and never demoted.
  - [x] End-to-end write path: a degenerate song writes `song.txt` with the words and no `song.lrc`; the fake timestamps do not appear in the demoted body.
  - [x] End-to-end repair path: a degenerate `.lrc` on disk is demoted, the words survive in `.txt`, and the original is recoverable from quarantine.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] **PR size override.** 12 files exceeds the 10-file prep-pr threshold (524 insertions, well under the 800 LOC limit). Maintainer-approved rather than split: landing the predicate alone would ship an outcome that every consumer silently ignores -- a knowingly-inert intermediate state, which is the exact defect this PR fixes.
  - [ ] **Near-degenerate is deliberately out of scope.** All cues inside a sub-second window is NOT flagged. The observed population is exactly-equal timestamps, and inventing a tolerance risks demoting a real lyric whose opening lines are genuinely close -- trading a confirmed defect for a speculative one. Easy to add later if a corpus census justifies it.
  - [ ] **The enumeration guard's roster is duplicated on purpose.** It could derive the known set from the same source it parses, but then it would only prove the file parses. The second copy exists so a human has to write it and, in doing so, decide what a new outcome means at each of the five sites.

## Not covered

- **No corpus census was run.** #673 notes one would size the problem; this ships the detector and the repair without knowing how many files are affected library-wide. `revalidate` is dry-run by default, so the first real run reports the count before touching anything -- that is the census, and it is worth reading before applying.
- **Provenance is still unknown.** Whether a provider lane is actively emitting these, or whether they predate current write paths, was not established. The accept-time guard now stops new ones either way, so this determines urgency rather than correctness.
- **The `[length:]` heuristic is untouched.** #585 covers mis-disambiguated files detected via the length tag; that is a different signal and a different defect.
- **No prod verification.** The five production files that motivated the issue were not re-checked against this build -- the fixtures reproduce their shape (many cues, one distinct timestamp), but the actual library was not swept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for lyric files whose timed lines all share the same timestamp.
  * These files are demoted to untimed text while preserving lyric content and remaining recoverable.
  * Revalidation reports these files separately from other timing issues.
* **Bug Fixes**
  * Prevented degenerate timing from being incorrectly treated as synchronized.
  * Added clearer warnings that distinguish shared-timestamp issues from audio timing overruns.
  * Ensured affected files are reprocessed rather than suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->