### PR TITLE
fix(timing): treat A2 word markers as markup when judging a cue

### DIFF
--- a/internal/lyrics/lrcfile.go
+++ b/internal/lyrics/lrcfile.go
@@ -68,7 +68,13 @@ func EvaluateLRCFile(path string, durationSeconds int) (timing.TimingOutcome, ti
 func PlainBody(synced models.Synced) string {
 	var b strings.Builder
 	for _, l := range synced.Lines {
-		text := strings.TrimSpace(l.Text)
+		// Strip A2 word markers before anything else. These cues may have been
+		// read back off disk from a file canticle itself wrote with word sync
+		// enabled (#480), and a .txt is by definition the plain words -- persisting
+		// `<00:01.50>alpha` there writes timestamp garbage into the user's
+		// lyrics, unrecoverably. IsDecorative strips them too, so a marked
+		// decorative cue is still dropped.
+		text := strings.TrimSpace(timing.StripWordMarkers(l.Text))
 		if timing.IsDecorative(text) {
 			continue
 		}

--- a/internal/lyrics/lrcfile_test.go
+++ b/internal/lyrics/lrcfile_test.go
@@ -162,3 +162,28 @@ func TestPlainBody_AllDecorativeIsEmpty(t *testing.T) {
 		t.Errorf("PlainBody = %q, want empty", got)
 	}
 }
+
+// TestPlainBody_StripsWordMarkers is the C2 fix (#480 prerequisite).
+//
+// PlainBody flattens cues read back OFF DISK, so once canticle writes A2 word
+// markers those cues carry them. Without stripping, a demotion persists
+// timestamp garbage into the user's plain-lyrics .txt -- and that is not
+// recoverable from the .txt afterwards.
+//
+// This is independent of what triggers the demotion: any A2 file that demotes
+// for any legitimate reason (a genuine overrun) hits it. Only the disk-read
+// path is affected -- the accept-time demotion flattens song.Subtitles, which
+// is unmarked -- and the disk-read path is the one that runs over the whole
+// library.
+func TestPlainBody_StripsWordMarkers(t *testing.T) {
+	got := PlainBody(models.Synced{Lines: []models.Lines{
+		{Text: "<00:01.50>alpha <00:02.00>beta"},
+		{Text: "<05:00.00>♪"}, // decorative even when marked: dropped
+		{Text: "<00:03.00>gamma"},
+	}})
+
+	want := "alpha beta\ngamma\n"
+	if got != want {
+		t.Errorf("PlainBody = %q; want %q -- a demoted .txt must carry words, never timestamps", got, want)
+	}
+}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -8,6 +8,7 @@ package timing
 
 import (
 	"math"
+	"regexp"
 	"strings"
 
 	"github.com/sydlexius/canticle/internal/models"
@@ -227,6 +228,31 @@ func correctedMaxSeconds(lines []models.Lines) (float64, bool) {
 	return maxTS, found
 }
 
+// wordMarkerRe matches one Enhanced-LRC (A2) inline word marker, `<mm:ss.xx>`.
+//
+// Deliberately anchored to the STAMP SHAPE rather than to any `<...>` run: a
+// lyric line may legitimately contain angle brackets, and eating those would be
+// silent text loss. Minutes are 1+ digits because a track past an hour renders
+// `70:00.00` rather than wrapping.
+var wordMarkerRe = regexp.MustCompile(`<\d{1,}:\d{2}\.\d{2}>`)
+
+// StripWordMarkers removes Enhanced-LRC (A2) inline word markers from a cue,
+// leaving the words. Text carrying no marker is returned unchanged.
+//
+// It exists because canticle now WRITES those markers (#480) and re-reads its
+// own sidecars on the revalidate path. Without stripping, a decorative cue that
+// gained a marker (`<05:00.00>♪`) stopped being recognized as decorative, its
+// timestamp entered the corrected max, and a perfectly-synced file flipped from
+// Ok to MisSynced on re-read -- so the backlog pass would demote a file
+// canticle had just written correctly. The verdict must not depend on whether
+// markers are enabled.
+func StripWordMarkers(text string) string {
+	if !strings.Contains(text, "<") {
+		return text
+	}
+	return wordMarkerRe.ReplaceAllString(text, "")
+}
+
 // IsDecorative reports whether a lyric line carries no actual lyric text: blank,
 // a run of music-note glyphs (including the "♪ Instrumental ♪" marker form), or
 // an [key:value] metadata tag.
@@ -242,7 +268,9 @@ func IsDecorative(text string) bool {
 // run of music-note glyphs (including the "♪ Instrumental ♪" marker form), or
 // an [key:value] metadata tag.
 func isDecorative(text string) bool {
-	t := strings.TrimSpace(text)
+	// Strip A2 word markers first: a marked decorative cue is still decorative,
+	// and classifying by the marked text would defeat the whole filter (#480).
+	t := strings.TrimSpace(StripWordMarkers(text))
 	if t == "" {
 		return true
 	}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -233,8 +233,11 @@ func correctedMaxSeconds(lines []models.Lines) (float64, bool) {
 // Deliberately anchored to the STAMP SHAPE rather than to any `<...>` run: a
 // lyric line may legitimately contain angle brackets, and eating those would be
 // silent text loss. Minutes are 1+ digits because a track past an hour renders
-// `70:00.00` rather than wrapping.
-var wordMarkerRe = regexp.MustCompile(`<\d{1,}:\d{2}\.\d{2}>`)
+// `70:00.00` rather than wrapping, but SECONDS are bounded to 00-59: `<00:60.00>`
+// is not a valid mm:ss.xx stamp, so it falls under the same preserve-malformed
+// rule as any other marker-ish text. That distinction is load-bearing because
+// PlainBody persists this text verbatim into a user-visible .txt.
+var wordMarkerRe = regexp.MustCompile(`<\d+:[0-5]\d\.\d{2}>`)
 
 // StripWordMarkers removes Enhanced-LRC (A2) inline word markers from a cue,
 // leaving the words. Text carrying no marker is returned unchanged.

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -583,3 +583,61 @@ func TestEvaluate_DegenerateCarriesNoMagnitude(t *testing.T) {
 		t.Errorf("degenerate magnitude carries data: %+v", mag)
 	}
 }
+
+// TestStripWordMarkers covers the A2-marker stripper (#480 prerequisite).
+func TestStripWordMarkers(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"<05:00.00>♪", "♪"},
+		{"<00:01.50>alpha <00:02.00>beta", "alpha beta"},
+		{"plain line", "plain line"},
+		{"", ""},
+		// A malformed or partial marker is NOT a marker: leave it alone rather
+		// than guessing, so text that merely looks marker-ish is never eaten.
+		{"<not a stamp>alpha", "<not a stamp>alpha"},
+		{"a < b > c", "a < b > c"},
+		// An hour-length track's stamp still has the mm:ss.xx shape.
+		{"<70:00.00>alpha", "alpha"},
+	} {
+		if got := StripWordMarkers(tc.in); got != tc.want {
+			t.Errorf("StripWordMarkers(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestIsDecorative_MarkedNoteStillDecorative is the C1 fix.
+//
+// A decorative cue that gained an A2 word marker (`<05:00.00>♪`) was no longer
+// recognized as decorative, so its timestamp entered correctedMaxSeconds and a
+// perfectly-synced file re-read from disk flipped from Ok to MisSynced --
+// exactly the ~33% false-demotion class this package exists to prevent,
+// reintroduced by the writer. revalidate would then demote a correct file.
+func TestIsDecorative_MarkedNoteStillDecorative(t *testing.T) {
+	for _, s := range []string{"♪", "<05:00.00>♪", "<00:00.00>♪ ♪"} {
+		if !IsDecorative(s) {
+			t.Errorf("IsDecorative(%q) = false; a marked decorative cue is still decorative", s)
+		}
+	}
+	// A marked REAL lyric must stay text-bearing, or the fix would silently
+	// filter every marked line out of the verdict.
+	if IsDecorative("<00:01.50>alpha") {
+		t.Error("IsDecorative marked a real lyric as decorative")
+	}
+}
+
+// TestEvaluate_MarkedTrailingMarkerDoesNotOverrun is the same fix at the
+// Evaluate level: the verdict must not depend on whether markers were written.
+func TestEvaluate_MarkedTrailingMarkerDoesNotOverrun(t *testing.T) {
+	plain := song(line(1, "alpha"), line(300, "♪"))
+	marked := song(
+		models.Lines{Text: "<00:01.00>alpha", Time: models.Time{Total: 1}},
+		models.Lines{Text: "<05:00.00>♪", Time: models.Time{Total: 300}},
+	)
+	po, _ := Evaluate(plain, 240)
+	mo, _ := Evaluate(marked, 240)
+	if po != mo {
+		t.Errorf("verdict depends on markers: plain=%q marked=%q; want identical", po, mo)
+	}
+	if mo != Ok {
+		t.Errorf("marked file verdict = %q; want ok", mo)
+	}
+}

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -597,6 +597,13 @@ func TestStripWordMarkers(t *testing.T) {
 		{"a < b > c", "a < b > c"},
 		// An hour-length track's stamp still has the mm:ss.xx shape.
 		{"<70:00.00>alpha", "alpha"},
+		// Seconds are 00-59. A value past that is not a valid mm:ss.xx stamp, so
+		// it falls under the same preserve-malformed rule as "<not a stamp>":
+		// stripping it would delete user-visible text, and PlainBody persists
+		// exactly this text into a .txt.
+		{"<00:59.99>alpha", "alpha"},
+		{"<00:60.00>alpha", "<00:60.00>alpha"},
+		{"<00:99.99>alpha", "<00:99.99>alpha"},
 	} {
 		if got := StripWordMarkers(tc.in); got != tc.want {
 			t.Errorf("StripWordMarkers(%q) = %q; want %q", tc.in, got, tc.want)


### PR DESCRIPTION
## Summary

- canticle re-reads its own `.lrc` sidecars on the revalidate path, and `timing.IsDecorative` classifies a cue by its **text**. Once the Enhanced-LRC writer (#480) emits A2 word markers, a decorative cue becomes `<05:00.00>♪` -- which `isNoteOnly` no longer recognizes -- so the line turns text-bearing and its timestamp enters `correctedMaxSeconds`. That is the ~33% false-demotion class `internal/timing` exists to prevent, reintroduced through the writer.
- **This lands underneath the A2 writer, not with it.** Shipping the writer without this arms a destructive backlog pass against its own output, so the prerequisite goes first and separately.
- Found by adversarial pre-push review of the writer branch, before that branch was pushed.

## Linked issue

Part of #480

## The measured failure

Same song, same 240s audio, written twice -- the canonical #438 shape (one lyric cue plus a trailing decorative marker at 5:00), re-read through `lyrics.EvaluateLRCFile`:

```
wordSync=false -> verdict=ok          overrun=-238.5  ratio=0.006
wordSync=true  -> verdict=mis_synced  overrun=  60.0  ratio=1.250

IsDecorative("♪") = true      IsDecorative("<05:00.00>♪") = false
```

The verdict depends on whether markers were written, which it must not.

**The accept-time guard does not catch it.** That judges `song.Subtitles`, which is unmarked, so the file passes on write and fails on re-read -- and `internal/revalidate` then classifies `MisSynced`, takes `demotionMove`, and replaces a correct `.lrc` with a `.txt`. canticle would write a correct file and destroy it on the next backlog pass.

It flips the #673 degenerate verdict the same way: an unfiltered glyph line makes `isDegenerate`'s `count > 1` hold, so a two-cue file reads as degenerate purely because markers were enabled.

## The second half: `PlainBody` persisted the markers

`PlainBody` flattens cues read **off disk**, so once those cues carry markers a demotion wrote timestamp text into the user's plain-lyrics `.txt`:

```
PlainBody, before:  "<00:01.50>alpha <00:02.00>beta\n<00:03.00>gamma\n"
```

Not recoverable from the `.txt` afterwards. This is independent of the trigger above -- any A2 file demoting for any legitimate reason (a genuine overrun) hits it. Only the disk-read path is affected; the accept-time demotion flattens `song.Subtitles`, which is unmarked. The disk-read path is the one that runs over the whole library.

## The fix

One exported `timing.StripWordMarkers`, shared by both call sites rather than two copies that could drift -- the same reasoning that made `IsDecorative` exported in the first place.

The regex is anchored to the **stamp shape** (`<\d{1,}:\d{2}\.\d{2}>`), not to any `<...>` run, because a lyric may legitimately contain angle brackets and eating those would be silent text loss. Minutes are `1+` digits so a track past an hour (`70:00.00`) still matches.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), or run via `/prep-pr` which invokes it.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT performed for user-visible changes. **N/A today, by construction**: nothing in the repo writes A2 markers yet, so no existing sidecar contains one and no verdict changes for any current file. This is a guard installed ahead of its trigger.
- [x] Screenshot attached for any web-UI change (N/A).
- [x] `make ui` re-run if any `.templ` or CSS source changed (N/A).
- [x] Migration added under `internal/db/migrations/` (N/A -- no schema or data change).

## Test plan

- [x] `make gate` passes locally, read from its output rather than its exit code: **patch coverage 100.00% (15/15)**, all coverage floors held, golangci-lint 0 issues, actionlint and govulncheck clean.
- [x] New tests were confirmed to **fail against unfixed code**, at an assertion rather than a build error. Mutation-verified, each mutant compiling cleanly:
  - revert `isDecorative`'s strip -> 2 failures (`IsDecorative` on a marked note, and the Evaluate-level verdict-parity test)
  - revert `PlainBody`'s strip -> returns the raw markers again
  - loosen the regex to `<[^>]*>` -> eats `<not a stamp>alpha` and turns `a < b > c` into `a  c`
- [x] Patch coverage meets the Codecov threshold (100%).
- [x] Which **surface** this change affects is stated explicitly: cue classification (`timing.IsDecorative`, and therefore `timing.Evaluate`'s corrected max and `isDegenerate`) and the demotion body (`lyrics.PlainBody`). No provider, queue, scan, or write-path behavior changes.
- [x] Manual UAT steps:
  - [x] Reproduced the failure independently of the review that reported it, driving the real `LRCWriter` with `SetWordSync` on and off and re-reading through `EvaluateLRCFile` -- the verdict table above is that run's output.
  - [x] Confirmed the decorative-line drop in `PlainBody` comes from the shared `IsDecorative` fix propagating, not from a second code path.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] **The regex is the load-bearing judgment call.** Anchoring to the stamp shape means a genuinely malformed marker (say `<0:1.5>`) is left in the text rather than stripped. That is the deliberate direction -- fail toward keeping text -- but if petitlyrics ever emits a non-conforming stamp, those files would classify by marked text again. Worth a second opinion on the tolerance.
  - [ ] **`StripWordMarkers` lives in `timing`, not `lrcnormalize`.** `lrcnormalize` owns A2 syntax and would be the intuitive home, but `timing` is what both consumers already import and moving it there would invert the dependency. Flag if you would rather it lived with the parser.

## Not covered

- **No file on disk carries a marker today**, so this fixes nothing currently broken -- it prevents the writer from breaking things. The value is entirely forward-looking, and it is only verifiable against the writer branch (where the reproduction above came from).
- **`ReadSyncedLRC` still returns marked cue text.** Stripping happens at classification and flattening, not at read, so any future consumer of `ReadSyncedLRC` must strip for itself. That is deliberate -- a re-reader that wants the markers (a future round-trip or upgrade scorer) should still see them -- but it is a sharp edge worth knowing about.
- **The remaining review findings are NOT in this PR.** An empty-cue substitution bypass, a newline-in-word truncation (verified: `ParseBody` yields one cue and silently drops everything after the newline), and the dead `a2sample_test.go` scaffolding all belong to the writer branch and land there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Enhanced LRC word-timing markers from generated plain lyrics.
  * Prevented timestamp markers in decorative cues from affecting lyric timing evaluation.
  * Preserved ordinary lyric text and spacing while ignoring malformed markers safely.

* **Tests**
  * Added coverage for word-marker removal, decorative cue handling, and timing evaluation with marked lyrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->