### PR TITLE
feat(petitlyrics): decode the LSY line-sync tier (lyricsType 2)

### DIFF
--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -364,12 +364,22 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 // passed to the zipper: pairing timings with bytes that are not the words is a
 // route to confident-looking wrong output, which is the failure this whole path
 // is written to avoid.
-func (c *Client) lookupUnsyncedText(ctx context.Context, track models.Track) (string, error) {
+//
+// PINNED TO lyricsID, and that is the load-bearing part. An earlier version
+// re-ran selectCandidate against the tier-1 response, which scores on ISRC,
+// duration, and title text and never consults the lyrics id. The second request
+// could therefore settle on a DIFFERENT recording than the one that supplied
+// the timings -- a live cut, a remaster, a cover. When that other recording
+// happens to carry the same line count, zipLineSync sees a well-formed pair and
+// emits an .lrc whose every cue belongs to a different performance. Nothing
+// downstream can detect it. Selecting the exact id the tier-2 payload came from
+// makes the two responses provably the same song, and its absence a typed miss.
+func (c *Client) lookupUnsyncedText(ctx context.Context, track models.Track, lyricsID string) (string, error) {
 	songs, err := c.request(ctx, track, tierUnsynced)
 	if err != nil {
 		return "", fmt.Errorf("petitlyrics: line-sync text lookup: %w", err)
 	}
-	candidate, err := selectCandidate(songs, track)
+	candidate, err := selectByLyricsID(songs, lyricsID)
 	if err != nil {
 		return "", fmt.Errorf("petitlyrics: line-sync text lookup, no candidate matched: %w", err)
 	}
@@ -456,7 +466,7 @@ func (c *Client) lookup(ctx context.Context, track models.Track, tier int) (mode
 		if err != nil {
 			return models.Song{}, err
 		}
-		text, err := c.lookupUnsyncedText(ctx, track)
+		text, err := c.lookupUnsyncedText(ctx, track, candidate.LyricsID)
 		if err != nil {
 			return models.Song{}, err
 		}

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -352,6 +352,45 @@ func (c *Client) FindLyrics(ctx context.Context, track models.Track) (models.Son
 	return c.lookup(ctx, track, tierWordSync)
 }
 
+// lookupUnsyncedText fetches the plain lyric text for a track at tier 1.
+//
+// It exists for the line-sync path: an LSY payload carries timings but no
+// usable words, so a tier-2 result is a JOIN of two responses. Routed through
+// c.request so the second call is paced like any other, and so a credential or
+// throttle failure surfaces as the same typed sentinel rather than a bespoke
+// error this lane's classifier would not recognize.
+//
+// A tier-1 request that answers with a non-text payload is refused rather than
+// passed to the zipper: pairing timings with bytes that are not the words is a
+// route to confident-looking wrong output, which is the failure this whole path
+// is written to avoid.
+func (c *Client) lookupUnsyncedText(ctx context.Context, track models.Track) (string, error) {
+	songs, err := c.request(ctx, track, tierUnsynced)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup: %w", err)
+	}
+	candidate, err := selectCandidate(songs, track)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup, no candidate matched: %w", err)
+	}
+	if candidate.LyricsData == "" {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup returned no payload: %w", ErrNotFound)
+	}
+	raw, err := base64.StdEncoding.DecodeString(candidate.LyricsData)
+	if err != nil {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup, base64 decode: %w", err)
+	}
+	if got := classifyPayload(raw); got != tierUnsynced {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup returned tier %d, want plain text: %w",
+			got, ErrNotFound)
+	}
+	text := decodeUnsynced(raw)
+	if strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("petitlyrics: line-sync text lookup returned empty text: %w", ErrNotFound)
+	}
+	return text, nil
+}
+
 // lookup performs one API request at the given tier and decodes the result.
 func (c *Client) lookup(ctx context.Context, track models.Track, tier int) (models.Song, error) {
 	songs, err := c.request(ctx, track, tier)
@@ -409,7 +448,27 @@ func (c *Client) lookup(ctx context.Context, track models.Track, tier int) (mode
 		return song, nil
 
 	case tierLineSync:
-		return models.Song{}, fmt.Errorf("petitlyrics: lyricsType 2 (encrypted LSY): %w", ErrUnsupportedTier)
+		// Tier 2 carries timings ONLY, so a line-synced result costs a second
+		// request for the words. That request goes through c.request, which
+		// paces itself, rather than issuing a raw POST that would bypass the
+		// configured floor (#535).
+		timings, err := decodeLineSyncTimings(raw)
+		if err != nil {
+			return models.Song{}, err
+		}
+		text, err := c.lookupUnsyncedText(ctx, track)
+		if err != nil {
+			return models.Song{}, err
+		}
+		cues, err := zipLineSync(timings, text)
+		if err != nil {
+			return models.Song{}, err
+		}
+		// Same normalizer as every other write path (#470), so this lane holds
+		// the one-cue-per-line model too. No word timings exist at this tier, so
+		// unlike the word-sync branch there is no index-stability concern.
+		song.Subtitles = lrcnormalize.Expand(models.Synced{Lines: cues})
+		return song, nil
 
 	default:
 		text := decodeUnsynced(raw)

--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -321,19 +321,78 @@ func TestFindLyrics_MissCostsOneRequest(t *testing.T) {
 	}
 }
 
-// TestFindLyrics_LineSyncIsUnsupported pins the deliberate gap: the line-sync
-// payload is an encrypted binary blob, so it must surface as a typed tier miss
-// rather than being mistaken for lyrics.
-func TestFindLyrics_LineSyncIsUnsupported(t *testing.T) {
-	c, _ := newTestClient(t, serveFixture(t, "type2_linesync.xml"))
-	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
-	if err == nil {
-		t.Fatal("an encrypted line-sync payload must not be reported as success")
+// TestFindLyrics_LineSyncJoinsTwoResponses pins the two-request flow that tier 2
+// requires. The LSY blob carries timings but no usable words, so a line-synced
+// result is a JOIN: the timings come from the tier-2 payload and the text from a
+// SECOND request at tier 1.
+//
+// This replaces TestFindLyrics_LineSyncIsUnsupported, which asserted the
+// deliberate gap this change closes.
+//
+// Both requests must go through the client (hence its pacer), which is why the
+// request count and the per-request lyricsType are asserted rather than just the
+// decoded output.
+func TestFindLyrics_LineSyncJoinsTwoResponses(t *testing.T) {
+	timings := []int{100, 250, 400}
+	blob := buildLSY(t, 0xdc18, true, timings)
+
+	// Filler stands in for lyric text: three lines to match three timings.
+	text := "alpha\nbeta\ngamma\n"
+
+	c, fs := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		if r.PostForm.Get("lyricsType") == "1" {
+			_, _ = w.Write(tierEnvelope(t, []byte(text)))
+			return
+		}
+		_, _ = w.Write(tierEnvelope(t, blob))
+	})
+
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
 	}
-	// The single request returns the track's actual tier, so a line-sync-only
-	// track surfaces the typed tier error directly -- no retry involved.
-	if !errors.Is(err, ErrUnsupportedTier) {
-		t.Errorf("want ErrUnsupportedTier, got %v", err)
+
+	if n := len(song.Subtitles.Lines); n != len(timings) {
+		t.Fatalf("got %d cues, want %d", n, len(timings))
+	}
+	if got := song.Subtitles.Lines[0].Text; got != "alpha" {
+		t.Errorf("first cue text = %q, want the tier-1 text", got)
+	}
+	// 400 cs = 4.0 s. A wrong scale here is the silent-drift failure mode.
+	if got := song.Subtitles.Lines[2].Time.Total; got < 3.99 || got > 4.01 {
+		t.Errorf("last cue = %v s, want ~4.0 s (centiseconds wrongly scaled?)", got)
+	}
+
+	reqs := fs.snapshot()
+	if len(reqs) != 2 {
+		t.Fatalf("a line-sync result must cost exactly 2 requests, got %d", len(reqs))
+	}
+	if reqs[1].form["lyricsType"] != "1" {
+		t.Errorf("the second request must ask for tier 1 text, got lyricsType=%q", reqs[1].form["lyricsType"])
+	}
+}
+
+// TestFindLyrics_LineSyncRefusesAMismatchedJoin pins the guard against the worst
+// output this lane can produce. If the tier-1 text does not have exactly as many
+// lines as there are timings, every later cue would be attributed to the wrong
+// moment -- an .lrc that looks correct and drifts. It must fail instead.
+func TestFindLyrics_LineSyncRefusesAMismatchedJoin(t *testing.T) {
+	blob := buildLSY(t, 0xdc18, true, []int{100, 250, 400})
+
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		if r.PostForm.Get("lyricsType") == "1" {
+			_, _ = w.Write(tierEnvelope(t, []byte("alpha\nbeta\n"))) // 2 lines, 3 timings
+			return
+		}
+		_, _ = w.Write(tierEnvelope(t, blob))
+	})
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"}); err == nil {
+		t.Fatal("a timing/text count mismatch must fail, never emit misaligned cues")
 	}
 }
 

--- a/internal/petitlyrics/decode.go
+++ b/internal/petitlyrics/decode.go
@@ -2,6 +2,7 @@ package petitlyrics
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/xml"
 	"fmt"
 	"sort"
@@ -14,7 +15,7 @@ import (
 // Lyrics tiers advertised by the API's lyricsType parameter and field.
 const (
 	tierUnsynced = 1 // base64 plain UTF-8 text
-	tierLineSync = 2 // base64 encrypted LSY binary; not yet decodable
+	tierLineSync = 2 // base64 obfuscated LSY binary; timings only, words come from tier 1
 	tierWordSync = 3 // base64 <wsy> XML with per-word timings
 )
 
@@ -94,6 +95,176 @@ func classifyPayload(raw []byte) int {
 		return tierLineSync
 	}
 	return tierUnsynced
+}
+
+// LSY container offsets. The tier-2 payload is a two-chunk binary: an
+// MHDROBJT header followed by an MLRCOBJT payload. Verified against real
+// captures -- every offset below held on all of them, and the size identity
+// lsyPayloadStart + 2*lineCount + lineLength*lineCount == len(payload) was
+// exact, which is what makes a truncated or wrongly parsed blob detectable rather
+// than silently producing plausible garbage.
+const (
+	lsyKeySwitchFlagOff = 0x19 // u8: nonzero means the key is permuted once
+	lsyProtectionIDOff  = 0x1a // u16 LE: the raw key before permutation
+	lsyLineCountOff     = 0x38 // u32 LE: number of timed lines
+	lsyLineLengthOff    = 0x42 // u16 LE: bytes per text slot (64 observed)
+	lsyPayloadStart     = 0xcc // start of the u16 LE timestamp array
+	lsyMinHeaderLen     = lsyPayloadStart
+
+	// lsyMaxLines bounds a declared line count before it is used to size a
+	// slice, so a corrupt or hostile u32 cannot drive a huge allocation. No
+	// observed payload came close; a lyric with more lines than this is not a
+	// lyric.
+	lsyMaxLines = 10000
+
+	// lsyWrapCS is the u16 rollover in centiseconds. A timestamp is stored in
+	// 16 bits, so a track longer than ~10.9 minutes wraps and the decoder has
+	// to unwrap it.
+	lsyWrapCS = 65536
+)
+
+// deriveLSYKey reproduces the provider's key schedule: the protection id is
+// used directly, or -- when the switch flag at 0x19 is set -- permuted once by
+// a fixed mask/shift schedule that swaps adjacent bit PAIRS within each nibble
+// while leaving the outermost pair of each byte in place.
+//
+// This is a ONE-TIME permutation of a single per-payload key, not a per-line
+// rotation. Both the timestamps and the payload's text region use the result.
+//
+// Verified: on four real captures the flag was set and this reproduced, exactly,
+// the key independently recovered from each payload's text by frequency
+// analysis. That agreement between two unrelated derivations is the evidence
+// this schedule is right -- the issue that specified it flagged the bit
+// manipulation as suspect on read, and it is not.
+func deriveLSYKey(protectionID uint16, switchFlag bool) uint16 {
+	if !switchFlag {
+		return protectionID
+	}
+	// Computed in uint16 rather than widening to uint32 and converting back.
+	// Every left-shifted term is masked first, so none can carry past bit 15
+	// (0x000c<<2 == 0x0030, 0x00c0<<2 == 0x0300, 0x0c00<<2 == 0x3000): the
+	// arithmetic is exact at this width, and staying here means there is no
+	// narrowing conversion to justify or suppress.
+	k := protectionID
+	return (k & 0x0003) |
+		(k&0x000c)<<2 |
+		(k&0x0030)>>2 |
+		(k&0x00c0)<<2 |
+		(k&0x0300)>>2 |
+		(k&0x0c00)<<2 |
+		(k&0x3000)>>2 |
+		(k & 0xc000)
+}
+
+// decodeLineSyncTimings extracts the per-line cue times, in centiseconds, from
+// an LSY (tier 2) payload.
+//
+// It returns ONLY the timings: the tier-2 blob does not carry usable lyric
+// text. Its text region decodes to a partially-legible mix that never resolves
+// cleanly under the payload key, so the words come from a separate
+// lyricsType=1 request and are zipped against these timings by the caller.
+// Attempting to recover text from this blob was measured and abandoned; do not
+// retry it without new evidence.
+//
+// Timestamps are stored as u16 centiseconds and therefore ROLL OVER at ~10.9
+// minutes. A decrease from one line to the next is read as a rollover and
+// unwrapped. Note that the public reference implementation gets this wrong: its
+// wrap counter is derived from the already-offset accumulator, so it can never
+// increment and a long track decodes with every post-rollover cue ~10.9 minutes
+// early. Unwrapping on the raw sequence is the fix.
+func decodeLineSyncTimings(raw []byte) ([]int, error) {
+	if len(raw) < lsyMinHeaderLen {
+		return nil, fmt.Errorf("petitlyrics: line-sync payload is %d bytes, need at least %d: %w",
+			len(raw), lsyMinHeaderLen, ErrNotFound)
+	}
+
+	lineCount := int(binary.LittleEndian.Uint32(raw[lsyLineCountOff:]))
+	if lineCount <= 0 {
+		return nil, fmt.Errorf("petitlyrics: line-sync payload declares %d lines: %w", lineCount, ErrNotFound)
+	}
+	if lineCount > lsyMaxLines {
+		return nil, fmt.Errorf("petitlyrics: line-sync payload declares %d lines, over the %d cap: %w",
+			lineCount, lsyMaxLines, ErrNotFound)
+	}
+
+	// The timestamp array must be fully present. Checked BEFORE indexing so a
+	// truncated payload is a typed miss rather than a panic.
+	end := lsyPayloadStart + 2*lineCount
+	if len(raw) < end {
+		return nil, fmt.Errorf("petitlyrics: line-sync payload is %d bytes, need %d for %d timestamps: %w",
+			len(raw), end, lineCount, ErrNotFound)
+	}
+
+	// Cross-check the declared geometry against the actual length. The payload
+	// is a timestamp array followed by lineCount fixed-width text slots, so
+	// this identity holds exactly on a well-formed blob (verified on every real
+	// capture). A mismatch means the shape is not what this decoder parses --
+	// treat it as a miss rather than trusting timestamps read from it. Advisory
+	// only when lineLength is absent: some field being zero is not proof of
+	// corruption, but a nonzero one that disagrees is.
+	if lineLength := int(binary.LittleEndian.Uint16(raw[lsyLineLengthOff:])); lineLength > 0 {
+		want := lsyPayloadStart + 2*lineCount + lineLength*lineCount
+		if len(raw) != want {
+			return nil, fmt.Errorf(
+				"petitlyrics: line-sync payload is %d bytes, geometry says %d (%d lines x %d-byte slots): %w",
+				len(raw), want, lineCount, lineLength, ErrNotFound)
+		}
+	}
+
+	key := deriveLSYKey(
+		binary.LittleEndian.Uint16(raw[lsyProtectionIDOff:]),
+		raw[lsyKeySwitchFlagOff] != 0,
+	)
+
+	out := make([]int, 0, lineCount)
+	var wraps, prev int
+	for i := range lineCount {
+		cs := int(binary.LittleEndian.Uint16(raw[lsyPayloadStart+2*i:]) ^ key)
+		if i > 0 && cs < prev {
+			wraps++
+		}
+		prev = cs
+		out = append(out, cs+wraps*lsyWrapCS)
+	}
+	return out, nil
+}
+
+// zipLineSync pairs decoded cue times with the lyric text fetched separately at
+// tier 1.
+//
+// A count mismatch is a hard error, never a truncation to the shorter side.
+// Zipping mismatched sequences yields an .lrc whose every later line is
+// attributed to the wrong moment -- output that looks correct and is silently
+// wrong, which is worse than no output at all.
+//
+// Trailing blank lines are dropped first: a text payload conventionally ends
+// with a newline, and that alone must not fail an otherwise-aligned pair.
+// Interior blanks are NOT dropped, because a blank between verses may or may
+// not be a timed line, and guessing is exactly how misalignment gets in.
+func zipLineSync(timings []int, text string) ([]models.Lines, error) {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if len(lines) != len(timings) {
+		return nil, fmt.Errorf(
+			"petitlyrics: line-sync timing/text mismatch: %d timestamps, %d text lines: %w",
+			len(timings), len(lines), ErrNotFound)
+	}
+
+	// Ranging over timings and indexing lines (rather than the reverse) keeps the
+	// bound visible: lines was just proven to be the same length, and reslicing it
+	// to that length states the relationship for a reader and an analyzer alike.
+	lines = lines[:len(timings)]
+	cues := make([]models.Lines, 0, len(timings))
+	for i, cs := range timings {
+		cues = append(cues, models.Lines{
+			Text: strings.TrimSpace(lines[i]),
+			Time: msToTime(cs * 10),
+		})
+	}
+	return cues, nil
 }
 
 // decodeUnsynced returns plain lyric text from an unsynced payload.

--- a/internal/petitlyrics/linesync_test.go
+++ b/internal/petitlyrics/linesync_test.go
@@ -1,10 +1,15 @@
 package petitlyrics
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
 )
 
 // buildLSY constructs a synthetic tier-2 payload with the container geometry of
@@ -193,7 +198,7 @@ func TestZipLineSync_RefusesAMismatch(t *testing.T) {
 	}
 }
 
-func TestZipLineSync_PairsInOrderAndTolregatesTrailingNewline(t *testing.T) {
+func TestZipLineSync_PairsInOrderAndToleratesTrailingNewline(t *testing.T) {
 	// A trailing newline is conventional and must not fail an aligned pair.
 	cues, err := zipLineSync([]int{0, 150, 1234}, "alpha\nbeta\ngamma\n")
 	if err != nil {
@@ -226,4 +231,117 @@ func isNonDecreasing(v []int) bool {
 		}
 	}
 	return true
+}
+
+// TestZipLineSync_KeepsInteriorBlankLines pins a behavior zipLineSync documents
+// but nothing previously tested. An interior blank is a timed line as far as
+// this lane is concerned; dropping one would shift every later cue onto the
+// wrong moment.
+//
+// The count-mismatch guard cannot catch that regression: dropping an interior
+// blank removes one line AND one pairing together, so the counts still agree
+// and the zip succeeds while the alignment is wrong. That is exactly the silent
+// drift this lane is written to prevent, which is why it needs its own test.
+func TestZipLineSync_KeepsInteriorBlankLines(t *testing.T) {
+	cues, err := zipLineSync([]int{0, 100, 200}, "alpha\n\ngamma\n")
+	if err != nil {
+		t.Fatalf("zipLineSync: %v", err)
+	}
+	if len(cues) != 3 {
+		t.Fatalf("got %d cues, want 3 (interior blank dropped?)", len(cues))
+	}
+	if cues[1].Text != "" {
+		t.Errorf("interior blank cue text = %q, want empty", cues[1].Text)
+	}
+	if cues[2].Text != "gamma" {
+		t.Errorf("cue[2] = %q, want \"gamma\" -- a dropped interior blank shifts every later cue", cues[2].Text)
+	}
+	if got := cues[2].Time.Total; got < 1.99 || got > 2.01 {
+		t.Errorf("cue[2] time = %v s, want ~2.0 s", got)
+	}
+}
+
+// songXML builds one <song> element with an explicit lyrics id. Synthetic
+// filler only -- no provider content.
+func songXML(lyricsID, title string, payload []byte) string {
+	return `<song><lyricsId>` + lyricsID + `</lyricsId><title>` + title +
+		`</title><lyricsType>1</lyricsType><lyricsData>` +
+		base64.StdEncoding.EncodeToString(payload) + `</lyricsData></song>`
+}
+
+// TestLineSync_TextLookupPinsTheLyricsID is the regression test for the defect
+// CodeRabbit caught on this PR.
+//
+// The tier-1 continuation used to re-run selectCandidate, which scores on ISRC,
+// duration, and title text and never consults the lyrics id. So the second
+// request could settle on a DIFFERENT recording than the one that supplied the
+// timings. When that other recording carries the SAME LINE COUNT, zipLineSync
+// sees a well-formed pair and emits an .lrc whose every cue belongs to another
+// performance -- undetectable downstream.
+//
+// The fixture is built to reproduce exactly that: the decoy is listed FIRST and
+// is given the title that scores best against the requested track, so a
+// scoring selector prefers it, and it carries the same number of lines so the
+// count guard cannot save us. Only pinning the id yields the right text.
+func TestLineSync_TextLookupPinsTheLyricsID(t *testing.T) {
+	const wantID, decoyID = "222", "111"
+	blob := buildLSY(t, 0xdc18, true, []int{100, 250, 400})
+
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		if r.PostForm.Get("lyricsType") == "1" {
+			// Decoy first, and titled to out-score the real one.
+			_, _ = w.Write([]byte(`<response><songs>` +
+				songXML(decoyID, "Lorem Ipsum", []byte("wrong1\nwrong2\nwrong3\n")) +
+				songXML(wantID, "Lorem Ipsum (Live)", []byte("right1\nright2\nright3\n")) +
+				`</songs></response>`))
+			return
+		}
+		// The tier-2 response identifies which record the timings came from.
+		_, _ = w.Write([]byte(`<response><songs>` +
+			`<song><lyricsId>` + wantID + `</lyricsId><title>Lorem Ipsum (Live)</title>` +
+			`<lyricsType>2</lyricsType><lyricsData>` +
+			base64.StdEncoding.EncodeToString(blob) +
+			`</lyricsData></song></songs></response>`))
+	})
+
+	song, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
+	if err != nil {
+		t.Fatalf("FindLyrics: %v", err)
+	}
+	if len(song.Subtitles.Lines) != 3 {
+		t.Fatalf("got %d cues, want 3", len(song.Subtitles.Lines))
+	}
+	if got := song.Subtitles.Lines[0].Text; got != "right1" {
+		t.Errorf("cue[0] = %q, want %q -- the text lookup did not pin the tier-2 lyrics id", got, "right1")
+	}
+}
+
+// TestLineSync_RefusesWhenTheLyricsIDIsAbsent pins the other half: if the
+// tier-1 response does not carry the id the timings came from, there is no
+// provably-matching text, so the lane must refuse rather than fall back to a
+// scored guess.
+func TestLineSync_RefusesWhenTheLyricsIDIsAbsent(t *testing.T) {
+	blob := buildLSY(t, 0xdc18, true, []int{100, 250, 400})
+
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		if r.PostForm.Get("lyricsType") == "1" {
+			_, _ = w.Write([]byte(`<response><songs>` +
+				songXML("999", "Lorem Ipsum", []byte("a\nb\nc\n")) +
+				`</songs></response>`))
+			return
+		}
+		_, _ = w.Write([]byte(`<response><songs>` +
+			`<song><lyricsId>222</lyricsId><title>Lorem Ipsum</title>` +
+			`<lyricsType>2</lyricsType><lyricsData>` +
+			base64.StdEncoding.EncodeToString(blob) +
+			`</lyricsData></song></songs></response>`))
+	})
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"}); err == nil {
+		t.Fatal("a missing lyrics id must refuse, not fall back to a scored candidate")
+	}
 }

--- a/internal/petitlyrics/linesync_test.go
+++ b/internal/petitlyrics/linesync_test.go
@@ -1,0 +1,229 @@
+package petitlyrics
+
+import (
+	"encoding/binary"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// buildLSY constructs a synthetic tier-2 payload with the container geometry of
+// a real one. No provider bytes are vendored: the timestamps are supplied by the
+// caller and the text region is filler, which is all the decoder reads.
+//
+// The text region is deliberately filler rather than lorem-ipsum words. The
+// decoder does not read it -- tier 2's words come from a separate tier-1
+// request -- so putting plausible lyric text here would imply a coupling that
+// does not exist.
+func buildLSY(t *testing.T, protectionID uint16, switchFlag bool, timingsCS []int) []byte {
+	t.Helper()
+
+	const lineLength = 64
+	n := len(timingsCS)
+	buf := make([]byte, lsyPayloadStart+2*n+lineLength*n)
+
+	copy(buf[0:], "MHDROBJT")
+	binary.LittleEndian.PutUint32(buf[0x08:], 44)
+	copy(buf[0x0c:], "2.00")
+	if switchFlag {
+		buf[lsyKeySwitchFlagOff] = 1
+	}
+	binary.LittleEndian.PutUint16(buf[lsyProtectionIDOff:], protectionID)
+	copy(buf[0x2c:], "MLRCOBJT")
+	binary.LittleEndian.PutUint32(buf[0x34:], uint32(len(buf)-0x2c))
+	binary.LittleEndian.PutUint32(buf[lsyLineCountOff:], uint32(n))
+	binary.LittleEndian.PutUint16(buf[lsyLineLengthOff:], lineLength)
+
+	key := deriveLSYKey(protectionID, switchFlag)
+	for i, cs := range timingsCS {
+		// The wire format stores centiseconds in 16 bits and WRAPS; truncating
+		// here is the encoder reproducing that, which is the rollover behavior
+		// the decoder is tested against. Masking explicitly rather than
+		// converting states that intent and needs no suppression.
+		binary.LittleEndian.PutUint16(buf[lsyPayloadStart+2*i:], uint16(cs&0xffff)^key)
+	}
+	return buf
+}
+
+// TestDeriveLSYKey_ReproducesObservedKeys pins the key schedule against values
+// measured from real captures.
+//
+// These four (protection id -> key) pairs are the load-bearing evidence that the
+// permutation is right. Each key was FIRST recovered independently from its
+// payload's own text region by frequency analysis, then found to equal what this
+// schedule computes from the header. Two unrelated derivations agreeing is why
+// the schedule is trusted; the issue specifying it flagged the bit manipulation
+// as suspect on read, and this is the check that settles it.
+//
+// The pairs are opaque integers -- no lyric content, no track identity.
+func TestDeriveLSYKey_ReproducesObservedKeys(t *testing.T) {
+	cases := []struct {
+		protectionID uint16
+		want         uint16
+	}{
+		{0xdc18, 0xf424},
+		{0xdd1c, 0xf474},
+		{0xdc01, 0xf401},
+		{0xdc1b, 0xf427},
+	}
+	for _, tc := range cases {
+		if got := deriveLSYKey(tc.protectionID, true); got != tc.want {
+			t.Errorf("deriveLSYKey(%#04x, true) = %#04x, want %#04x", tc.protectionID, got, tc.want)
+		}
+	}
+
+	// With the flag clear the id is used verbatim. No capture exercises this
+	// branch, so it is pinned by construction rather than by measurement -- and
+	// that gap is deliberate: inventing a permuted expectation here would encode
+	// a guess as a fact.
+	if got := deriveLSYKey(0xdc18, false); got != 0xdc18 {
+		t.Errorf("deriveLSYKey with flag clear = %#04x, want the id unchanged", got)
+	}
+}
+
+func TestDecodeLineSyncTimings_RoundTrip(t *testing.T) {
+	// Exercised across several real protection ids, and with the key-switch flag
+	// both set and clear. A single id would let a decoder that ignored the header
+	// and hardcoded one key pass -- the ids below derive to four DIFFERENT keys,
+	// so only reading the header actually works.
+	cases := []struct {
+		name         string
+		protectionID uint16
+		switchFlag   bool
+	}{
+		{"observed id A, flag set", 0xdc18, true},
+		{"observed id B, flag set", 0xdd1c, true},
+		{"observed id C, flag set", 0xdc01, true},
+		{"flag clear, id used verbatim", 0xdc18, false},
+	}
+	want := []int{1883, 2110, 2446, 2966, 3413}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decodeLineSyncTimings(buildLSY(t, tc.protectionID, tc.switchFlag, want))
+			if err != nil {
+				t.Fatalf("decodeLineSyncTimings: %v", err)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("got %d timings, want %d", len(got), len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("timing[%d] = %d, want %d", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeLineSyncTimings_UnwrapsRollover is the case the public reference
+// implementation gets wrong. Timestamps are u16 centiseconds, so they roll over
+// at ~10.9 minutes; a decoder that does not unwrap emits every post-rollover cue
+// roughly 10.9 minutes early, which on a long track is silently, confidently
+// wrong output rather than a visible failure.
+func TestDecodeLineSyncTimings_UnwrapsRollover(t *testing.T) {
+	// Third value wraps: 70000 cs does not fit in u16 and lands at 4464.
+	want := []int{60000, 65000, 70000, 75000}
+	got, err := decodeLineSyncTimings(buildLSY(t, 0xdc18, true, want))
+	if err != nil {
+		t.Fatalf("decodeLineSyncTimings: %v", err)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("timing[%d] = %d, want %d (rollover not unwrapped)", i, got[i], want[i])
+		}
+	}
+	if !isNonDecreasing(got) {
+		t.Errorf("unwrapped timings are not monotonic: %v", got)
+	}
+}
+
+func TestDecodeLineSyncTimings_RejectsMalformed(t *testing.T) {
+	good := buildLSY(t, 0xdc18, true, []int{100, 200, 300})
+
+	t.Run("truncated header", func(t *testing.T) {
+		if _, err := decodeLineSyncTimings(good[:0x40]); !errors.Is(err, ErrNotFound) {
+			t.Errorf("want ErrNotFound for a short header, got %v", err)
+		}
+	})
+
+	t.Run("truncated timestamp array", func(t *testing.T) {
+		// Header intact, payload cut inside the timestamps. Must be a typed miss,
+		// never a panic -- this is the shape a partial network read produces.
+		short := append([]byte(nil), good[:lsyPayloadStart+2]...)
+		if _, err := decodeLineSyncTimings(short); !errors.Is(err, ErrNotFound) {
+			t.Errorf("want ErrNotFound for a truncated array, got %v", err)
+		}
+	})
+
+	t.Run("zero lines", func(t *testing.T) {
+		z := append([]byte(nil), good...)
+		binary.LittleEndian.PutUint32(z[lsyLineCountOff:], 0)
+		if _, err := decodeLineSyncTimings(z); !errors.Is(err, ErrNotFound) {
+			t.Errorf("want ErrNotFound for a zero line count, got %v", err)
+		}
+	})
+
+	t.Run("absurd line count is capped, not allocated", func(t *testing.T) {
+		z := append([]byte(nil), good...)
+		binary.LittleEndian.PutUint32(z[lsyLineCountOff:], 0xffffffff)
+		if _, err := decodeLineSyncTimings(z); !errors.Is(err, ErrNotFound) {
+			t.Errorf("want ErrNotFound for an over-cap line count, got %v", err)
+		}
+	})
+
+	t.Run("geometry disagrees with length", func(t *testing.T) {
+		z := append([]byte(nil), good...)
+		binary.LittleEndian.PutUint16(z[lsyLineLengthOff:], 128) // real slots are 64
+		if _, err := decodeLineSyncTimings(z); !errors.Is(err, ErrNotFound) {
+			t.Errorf("want ErrNotFound when declared geometry contradicts the length, got %v", err)
+		}
+	})
+}
+
+// TestZipLineSync_RefusesAMismatch is the guard against the worst outcome this
+// lane can produce. Zipping unequal sequences would attribute every later line
+// to the wrong moment: an .lrc that looks right and drifts. Failing loudly is
+// strictly better than emitting it.
+func TestZipLineSync_RefusesAMismatch(t *testing.T) {
+	if _, err := zipLineSync([]int{100, 200, 300}, "alpha\nbeta"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound when text is shorter than timings, got %v", err)
+	}
+	if _, err := zipLineSync([]int{100}, "alpha\nbeta\ngamma"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound when text is longer than timings, got %v", err)
+	}
+}
+
+func TestZipLineSync_PairsInOrderAndTolregatesTrailingNewline(t *testing.T) {
+	// A trailing newline is conventional and must not fail an aligned pair.
+	cues, err := zipLineSync([]int{0, 150, 1234}, "alpha\nbeta\ngamma\n")
+	if err != nil {
+		t.Fatalf("zipLineSync: %v", err)
+	}
+	if len(cues) != 3 {
+		t.Fatalf("got %d cues, want 3", len(cues))
+	}
+	if cues[0].Text != "alpha" || cues[2].Text != "gamma" {
+		t.Errorf("cue text out of order: %q .. %q", cues[0].Text, cues[2].Text)
+	}
+	// 1234 cs = 12.34 s.
+	if got := cues[2].Time.Total; got < 12.33 || got > 12.35 {
+		t.Errorf("cue[2] time = %v s, want ~12.34 s (centiseconds wrongly scaled?)", got)
+	}
+	// CRLF must not leave a stray carriage return welded to the text.
+	crlf, err := zipLineSync([]int{0, 100}, "alpha\r\nbeta\r\n")
+	if err != nil {
+		t.Fatalf("zipLineSync with CRLF: %v", err)
+	}
+	if strings.ContainsRune(crlf[0].Text, '\r') {
+		t.Errorf("CRLF survived into cue text: %q", crlf[0].Text)
+	}
+}
+
+func isNonDecreasing(v []int) bool {
+	for i := 1; i < len(v); i++ {
+		if v[i] < v[i-1] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/petitlyrics/selection.go
+++ b/internal/petitlyrics/selection.go
@@ -1,6 +1,7 @@
 package petitlyrics
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sydlexius/canticle/internal/models"
@@ -78,6 +79,31 @@ func selectCandidate(songs []apiSong, track models.Track) (apiSong, error) {
 		}
 	}
 	return songs[best], nil
+}
+
+// selectByLyricsID picks the candidate whose lyrics id matches exactly, with no
+// scoring and no fallback.
+//
+// This is deliberately NOT selectCandidate. Scoring answers "which of these is
+// most likely the right recording", which is the correct question for a first
+// lookup and the WRONG one for a continuation: the line-sync path already knows
+// exactly which record it wants, because the tier-2 payload came from it. Any
+// heuristic here could substitute a different recording, and a substitution that
+// happens to share a line count produces cues from the wrong performance with
+// nothing downstream able to notice.
+//
+// An absent id is a typed miss rather than a best-effort pick. Refusing costs
+// one lyric; guessing corrupts one silently.
+func selectByLyricsID(songs []apiSong, lyricsID string) (apiSong, error) {
+	if lyricsID == "" {
+		return apiSong{}, fmt.Errorf("petitlyrics: no lyrics id to pin the text lookup to: %w", ErrNotFound)
+	}
+	for _, s := range songs {
+		if s.LyricsID == lyricsID {
+			return s, nil
+		}
+	}
+	return apiSong{}, fmt.Errorf("petitlyrics: lyrics id %q absent from the text response: %w", lyricsID, ErrNotFound)
 }
 
 // scoreCandidate ranks one candidate against the local track. Higher is better.


### PR DESCRIPTION
## Summary

- Routes `tierLineSync` to a real decoder instead of returning `ErrUnsupportedTier`, so a track whose best available tier is line-sync now yields an `.lrc` rather than falling back to plain text.
- **Look at the key schedule first.** The issue documented a mask/shift permutation of the protection id and flagged its own bit manipulation as suspect on read. It is correct: on four real captures it reproduces, exactly, the key independently recovered from each payload by frequency analysis. Two unrelated derivations agreeing is the evidence, and it means the key is derivable from the header - there was never a corpus blocker.
- **This also fixes a bug present in the public reference implementation** (see below), so do not "correct" the rollover handling back toward it.
- No user-visible change for existing lanes; word-sync and unsynced paths are untouched.

## Linked issue

Closes #602.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push (single commit).
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes - **NOT DONE, and this is the main gap.** See "Not covered".
- [ ] Screenshot attached for any web-UI change - **N/A**, no web-UI change.
- [ ] `make ui` re-run - **N/A**, no `.templ` or CSS source changed.
- [ ] Migration added - **N/A**, no data correction.

## Test plan

- [x] `make gate` passes locally (conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, govulncheck).
- [x] New tests confirmed to **fail against unfixed code**, and to fail again when the fix is removed:
  - Removing the rollover unwrap yields `4464` where `70000` is correct. The first attempt at this mutation failed to COMPILE, which proves nothing - it was redone so it fails at the assertion.
  - Neutering the key permutation fails `TestDeriveLSYKey_ReproducesObservedKeys` with the exact observed values.
- [x] Patch coverage meets the threshold; coverage floor satisfied.
- [x] Which **surface** this change fixes is stated explicitly: `Client.FindLyrics` for a track whose best tier is 2. It does not touch the word-sync path, the writer, or serve mode.
- [x] Manual verification performed:
  - [x] The geometry identity `0xcc + 2*count + lineLength*count == len` holds EXACTLY on all four real captures.
  - [x] Decoded timings on all four captures are strictly monotonic, in centiseconds, spanning 2.2-4.0 minutes with 1-9s inter-line gaps - i.e. plausible song structure.
  - [x] The second (text) request goes through `Client.request` and therefore the existing pacer (#535), asserted by request count and per-request `lyricsType` rather than by inspection.
- [ ] Reviewer follow-ups:
  - [ ] The `zipLineSync` equality rule is the highest-risk design decision here. It demands the tier-1 text have exactly as many lines as there are timings. If real payloads routinely differ by a title row or a blank, this lane refuses every track. Worth a second opinion on whether refusing is right versus a bounded tolerance.

## Not covered

- **No test runs against a live tier-2 response.** The container geometry and key schedule are pinned against four REAL captures, but every end-to-end fixture is synthetic. "Tested" and "proven in the field" are different claims and this PR only supports the first.
- **Whether real tier-1 text reliably has the same line count as its tier-2 timings is UNMEASURED.** This is the concrete risk: on a mismatch the lane fails loudly rather than emitting misaligned cues - the safe direction - but it would read as the lane being broken rather than as a data mismatch. One live verification run against likely-tier-2 material settles it.
- **Text recovery from the tier-2 blob was attempted and abandoned, deliberately.** Its text region never resolves cleanly under the payload key (25-35% of units land in private-use and surrogate ranges; a per-segment key leaves only 12/44 segments clean). Hence the second request. Do not retry this without new evidence.
- **The four captures backing the key schedule all carry the same key-switch flag value.** The flag-clear branch is exercised by construction in the round-trip test, not by measurement.
- **The `lineLength` geometry check is advisory when the field is zero.** A zero there is not proof of corruption, so it is skipped rather than treated as a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying line-synchronized lyrics.
  * Combines timing data with lyric text to produce accurately aligned lyric cues.
  * Supports varied payload formats and timestamp rollover handling.

* **Bug Fixes**
  * Rejects malformed, incomplete, or mismatched lyric data instead of showing misaligned lyrics.
  * Normalizes line endings and removes unnecessary trailing blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->