### PR TITLE
fix(test): assert the sentinel on the line-sync mismatch guard

### DIFF
--- a/internal/petitlyrics/client_test.go
+++ b/internal/petitlyrics/client_test.go
@@ -391,8 +391,19 @@ func TestFindLyrics_LineSyncRefusesAMismatchedJoin(t *testing.T) {
 		_, _ = w.Write(tierEnvelope(t, blob))
 	})
 
-	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"}); err == nil {
+	_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Lorem Ipsum"})
+	if err == nil {
 		t.Fatal("a timing/text count mismatch must fail, never emit misaligned cues")
+	}
+	// Assert the SENTINEL, not merely a non-nil error. Several unrelated stages
+	// in this path also return an error (the tier check in lookupUnsyncedText, a
+	// base64 failure), so a bare nil-check would still pass if the count guard
+	// stopped working and something else failed instead. The orchestrator
+	// classifies on the sentinel, so what matters is that it survives the whole
+	// client path to the caller -- not just the unit path TestZipLineSync_
+	// RefusesAMismatch already covers.
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound for a count mismatch, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Follow-up to #763: applies the one CodeRabbit finding from that review whose fix did not reach the merge. The commit existed locally but its push FAILED (`failed to push some refs`), so it was never on the branch when #763 merged. Everything else from that review did land.
- `TestFindLyrics_LineSyncRefusesAMismatchedJoin` accepted ANY error. Several unrelated stages in the line-sync path also return an error at that call - the tier check in `lookupUnsyncedText`, a base64 failure - so the test would still pass if the count guard in `zipLineSync` stopped working and a different stage failed instead.
- Now asserts `errors.Is(err, ErrNotFound)`, proving the sentinel survives the whole client path to the caller. That matters because the orchestrator classifies on the sentinel, and the unit-level guard (`TestZipLineSync_RefusesAMismatch`) only covers the direct path.

Test-only. One file, 12 lines added.

## Linked issue

Part of #602 (the issue itself is closed by #763; this is a follow-up to a review finding on that PR, not a reopening).

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`).
- [x] Code review pass complete.
- [x] Single clean commit, cherry-picked onto current `main` (`e80c54c`) rather than carried on the merged branch.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed - **N/A**, test-only change with no runtime behavior.
- [ ] Screenshot - **N/A**.
- [ ] `make ui` re-run - **N/A**, no `.templ` or CSS change.
- [ ] Migration - **N/A**.

## Test plan

- [x] `make gate` passes locally.
- [x] The assertion was confirmed to have teeth, AFTER rebasing onto merged `main`: removing the `ErrNotFound` wrap from the mismatch error in `zipLineSync` fails the test at the new assertion (`want ErrNotFound for a count mismatch, got petitlyrics: line-sync timing/text mismatch: 3 timestamps, 2 text lines`). The mutant COMPILES, so the failure is at the assertion rather than the build - a mutant that fails to compile would prove nothing. The previous bare nil-check passed that same mutant.
- [x] Patch coverage: test-only diff, no non-test Go source changed.
- [x] Which surface this covers is stated explicitly: the sentinel's survival across `Client.FindLyrics`, not the unit-level guard already covered elsewhere.
- [ ] Reviewer follow-ups: none.

## Not covered

- This changes no runtime behavior. It closes a gap in what the existing tests can DETECT, not a defect in the shipped code - the count guard in `zipLineSync` was and is correct.
- The live-verification gap noted on #763 is unchanged and still open: no test in this package runs against a real tier-2 response, and whether real tier-1 text reliably matches its tier-2 line count remains unmeasured.
