### PR TITLE
feat(web): render the Musixmatch credit required by API Terms clause 2.1.5

### DIFF
--- a/docs/provider-terms.md
+++ b/docs/provider-terms.md
@@ -8,7 +8,7 @@ even when the answer is "not required", with the date it was checked and a link 
 document that says so. Terms change; a finding is only as good as its date.
 
 **Status: BOTH PROVIDERS READ. CREDIT IMPLEMENTED, SOME OBLIGATIONS OUTSTANDING.**
-Musixmatch's required credit and linkback now render on every serve-UI page, using the
+Musixmatch's required credit and linkback now render across the authenticated serve UI, using the
 official brand mark rather than the exact prescribed button (which is not published in a
 usable format -- see below). Clauses 2.1.11, 2.1.4 and 1.1 remain unaddressed.
 petitlyrics imposes no attribution requirement but does constrain use.
@@ -130,11 +130,18 @@ which is the wrong default for a compliance question.
 
 ### Credit surface: IMPLEMENTED, with one gap
 
-A credit footer renders on every serve-UI page (`musixmatchCredit` in
-`web/templates/layout.templ`): the official For Brands mark, the text "Lyrics powered by
-Musixmatch", and a link to <https://www.musixmatch.com>. It sits OUTSIDE `#mx-main` so an
-htmx report-rail swap cannot remove it -- a credit that survives only until the first
-navigation would not be an each-time-you-use-the-Data credit.
+A credit footer renders on every page of the authenticated serve UI -- Dashboard,
+Reports, Settings and Keys, i.e. every page built on the shared `Layout`
+(`musixmatchCredit` in `web/templates/layout.templ`): the official For Brands mark, the
+text "Lyrics powered by Musixmatch", and a link to <https://www.musixmatch.com>. It sits
+OUTSIDE `#mx-main` so an htmx report-rail swap cannot remove it -- a credit that survives
+only until the first navigation would not be an each-time-you-use-the-Data credit.
+
+**The login and setup pages carry no credit, deliberately.** They build their own shell
+rather than using `Layout`, and they display no Musixmatch Data -- they are auth forms.
+The obligation attaches to USING the Data, so a credit there would assert an attribution
+on a page where nothing is attributable. Recorded because "every page" is the intuitive
+reading of the requirement and the exception is easy to mistake for an oversight.
 
 It is **hidden when Musixmatch is inactive** (no usable token). Crediting Musixmatch for
 results another provider served would be a misattribution, so the absence is load-bearing

--- a/docs/provider-terms.md
+++ b/docs/provider-terms.md
@@ -7,11 +7,14 @@ as a condition of use, and what else their terms impose. Tracked by #600.
 even when the answer is "not required", with the date it was checked and a link to the
 document that says so. Terms change; a finding is only as good as its date.
 
-**Status: BOTH PROVIDERS READ, OBLIGATIONS OUTSTANDING.** Musixmatch's terms require a
-prescribed credit and linkback that canticle does **not** currently satisfy (#600).
-petitlyrics imposes no attribution requirement but does constrain use. Do not read this
-file as a compliance sign-off -- it is a record of what the terms say, not a claim that
-canticle complies with them.
+**Status: BOTH PROVIDERS READ. CREDIT IMPLEMENTED, SOME OBLIGATIONS OUTSTANDING.**
+Musixmatch's required credit and linkback now render on every serve-UI page, using the
+official brand mark rather than the exact prescribed button (which is not published in a
+usable format -- see below). Clauses 2.1.11, 2.1.4 and 1.1 remain unaddressed.
+petitlyrics imposes no attribution requirement but does constrain use.
+
+Do not read this file as a compliance sign-off -- it is a record of what the terms say and
+what canticle does about them, reviewed by an agent rather than by counsel.
 
 ---
 
@@ -125,16 +128,42 @@ Written confirmation would still be worth having, but its absence is not a reaso
 treat the obligations as inapplicable -- that reads the ambiguity in our own favor,
 which is the wrong default for a compliance question.
 
-### What is NOT satisfied today
+### Credit surface: IMPLEMENTED, with one gap
 
-The lane mark added in #601 is a **static, non-linking `<img>`**. Clause 2.1.5 asks for
-a linked "powered by Musixmatch" button from the published resources page; clause 3.2
-permits the logo only to indicate data origin. A silent logo in a lane column arguably
-indicates origin, but it is not the prescribed asset and carries no link.
+A credit footer renders on every serve-UI page (`musixmatchCredit` in
+`web/templates/layout.templ`): the official For Brands mark, the text "Lyrics powered by
+Musixmatch", and a link to <https://www.musixmatch.com>. It sits OUTSIDE `#mx-main` so an
+htmx report-rail swap cannot remove it -- a credit that survives only until the first
+navigation would not be an each-time-you-use-the-Data credit.
 
-Nothing here is a reason to delay a UI change: **the obligation attaches to using the
-Data, which canticle already does today**, and it existed before the mark and would
-survive its removal. Tracked in #600.
+It is **hidden when Musixmatch is inactive** (no usable token). Crediting Musixmatch for
+results another provider served would be a misattribution, so the absence is load-bearing
+too, and is asserted by its own test.
+
+Verified on the rendered page rather than from the stylesheet: computed color
+`rgb(148,163,184)` on `rgb(11,17,32)` gives a **7.34:1** contrast ratio (clears WCAG AA).
+A required credit that is present in the DOM but visually unreadable would not discharge
+the obligation, which is why this is measured rather than assumed.
+
+**The remaining gap.** Clause 2.1.5 names a specific "powered by Musixmatch" button
+published at <https://www.musixmatch.com/resources>. That URL **redirects** to the
+brand-resources page, and the only badge set there ("For Brands" -> With Claim) ships
+**PNG only** -- no SVG, and no literal "powered by" wordmark asset was reachable. So this
+implements the clause's SUBSTANCE (credit + mark + link to the Site) using the official
+For Brands mark, not the exact prescribed button.
+
+To close it fully: obtain the prescribed badge from Musixmatch and swap the `<img>` in
+`musixmatchCredit`. The link target, the placement, and the tests are already correct, so
+it is an asset swap rather than a redesign.
+
+### Still outstanding
+
+- **2.1.11** (permit Musixmatch to track API access) is not implemented. Whether the
+  desktop endpoint already satisfies this by construction is unexamined.
+- **2.1.4** (prior written approval before exposing pages carrying the Data publicly)
+  binds the OPERATOR, not the software. Worth surfacing in user-facing docs so an
+  operator publishing their instance knows it applies to them.
+- **1.1** limits use to non-commercial.
 
 ### Lane mark: VENDORED (#601)
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1045,9 +1045,7 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 	// no-op fetcher WRAPPED IN a providers.Musixmatch identity (see
 	// resolveServeProvider), so the name alone reports "musixmatch" while nothing
 	// is being fetched. Requiring lyrics to be enabled excludes that case.
-	musixmatchServing := !lyricsDisabled &&
-		fetcher != nil &&
-		providers.NormalizeName(fetcher.Name()) == providers.Musixmatch
+	musixmatchServing := musixmatchIsServing(fetcher, lyricsDisabled)
 	// Resolve ffmpeg once for both the verifier and the instrumental detector.
 	// Resolution auto-provisions a checksum-pinned static build when ffmpeg is
 	// neither configured nor on PATH; it is skipped entirely unless verification
@@ -1732,6 +1730,38 @@ func resolveServeProvider(primary providers.LyricsProvider, selErr error) (fetch
 	}
 	slog.Warn("no lyrics provider configured: Musixmatch is the primary provider and needs an API token. Serving the web UI so you can add one in Settings (or switch to a tokenless provider like PetitLyrics), then restart.")
 	return providers.New(providers.Musixmatch, noopFetcher{}), true, true, nil
+}
+
+// musixmatchIsServing reports whether Musixmatch is the provider actually
+// returning lyrics, which gates the attribution credit required by API Terms
+// clause 2.1.5 (#600).
+//
+// Extracted from runServe rather than left inline, and that is the point: the
+// inline version was UNTESTABLE without standing up a full serve, which is
+// exactly how the defect this replaces shipped. The credit was gated on
+// !musixmatchInactive, which is FALSE for a healthy PetitLyrics-primary
+// deployment -- so the UI credited Musixmatch for another provider's results,
+// and no test could see it. A pure predicate over (fetcher, lyricsDisabled) can
+// be exercised directly for every provider shape.
+//
+// Both conjuncts are load-bearing:
+//
+//   - lyricsDisabled excludes the degraded no-token path, where
+//     resolveServeProvider returns a NO-OP fetcher wrapped in a
+//     providers.Musixmatch identity. The name alone reports "musixmatch" there
+//     while nothing is fetched, so name-matching by itself would credit an
+//     instance that serves no lyrics at all.
+//   - the name check excludes every non-Musixmatch primary, which is the case
+//     the original bug got wrong.
+//
+// A nil fetcher reports false. Defaulting to "not serving" is deliberate: a
+// missing credit is a bug to fix, while a credit naming the wrong provider is a
+// misattribution published to users.
+func musixmatchIsServing(fetcher providers.LyricsProvider, lyricsDisabled bool) bool {
+	if lyricsDisabled || fetcher == nil {
+		return false
+	}
+	return providers.NormalizeName(fetcher.Name()) == providers.Musixmatch
 }
 
 func selectedProvider(cfg config.Config, token string, newFetcher func(string) musixmatch.Fetcher) (providers.LyricsProvider, error) {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1032,6 +1032,22 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 		slog.Error("failed to configure lyrics provider", "error", err)
 		return 1
 	}
+	// Whether Musixmatch is the provider ACTUALLY serving lyrics, which gates the
+	// attribution credit required by API Terms clause 2.1.5 (#600).
+	//
+	// Derived from the resolved fetcher's own identity rather than from
+	// musixmatchInactive, because those two answer different questions and are not
+	// complements: musixmatchInactive is false for a healthy PetitLyrics-primary
+	// deployment, which serves no Musixmatch Data at all. Crediting Musixmatch
+	// there would be a misattribution shown to users.
+	//
+	// The lyricsDisabled conjunct matters because the degraded path returns a
+	// no-op fetcher WRAPPED IN a providers.Musixmatch identity (see
+	// resolveServeProvider), so the name alone reports "musixmatch" while nothing
+	// is being fetched. Requiring lyrics to be enabled excludes that case.
+	musixmatchServing := !lyricsDisabled &&
+		fetcher != nil &&
+		providers.NormalizeName(fetcher.Name()) == providers.Musixmatch
 	// Resolve ffmpeg once for both the verifier and the instrumental detector.
 	// Resolution auto-provisions a checksum-pinned static build when ffmpeg is
 	// neither configured nor on PATH; it is skipped entirely unless verification
@@ -1312,6 +1328,10 @@ func runServe(ctx context.Context, out io.Writer, args ServeCmd, newFetcher func
 			// Surface the tokenless-Musixmatch banner on every authenticated shell
 			// page when serve started without a usable Musixmatch token (#385).
 			server.WithMusixmatchInactive(musixmatchInactive),
+			// Render the Musixmatch attribution credit required by API Terms
+			// clause 2.1.5, but only when Musixmatch is the provider actually
+			// serving lyrics (#600).
+			server.WithMusixmatchServing(musixmatchServing),
 		)
 	}
 	srv := &http.Server{

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -2985,3 +2985,105 @@ func TestSetConfigValueBoolErrorsWrapTheCause(t *testing.T) {
 		}
 	}
 }
+
+// TestMusixmatchIsServing covers the predicate gating the Musixmatch attribution
+// credit (#600, API Terms clause 2.1.5).
+//
+// This is a GENUINE regression test, not a guard: the PetitLyrics case below
+// fails against the original implementation, which gated the credit on
+// !musixmatchInactive and therefore credited Musixmatch for another provider's
+// results. Caught by CodeRabbit on PR #769.
+//
+// The predicate was extracted from runServe specifically so this table could
+// exist. Inline, it needed a full serve to exercise, which is why nothing caught
+// the defect before review.
+func TestMusixmatchIsServing(t *testing.T) {
+	musixmatch := providers.New(providers.Musixmatch, fakeFetcher{})
+	petitlyrics := providers.New(providers.PetitLyrics, fakeFetcher{})
+
+	tests := []struct {
+		name           string
+		fetcher        providers.LyricsProvider
+		lyricsDisabled bool
+		want           bool
+	}{
+		{"musixmatch serving: credit is required", musixmatch, false, true},
+		{
+			// THE REGRESSION CASE. A healthy PetitLyrics-primary deployment: the
+			// provider selected cleanly, so the old !musixmatchInactive gate read
+			// true and credited Musixmatch for PetitLyrics results.
+			"petitlyrics primary: no Musixmatch Data is used, so no credit",
+			petitlyrics, false, false,
+		},
+		{
+			// The degraded no-token path returns a NO-OP fetcher wrapped in a
+			// providers.Musixmatch identity, so the name alone says "musixmatch"
+			// while nothing is fetched. lyricsDisabled is what excludes it.
+			"musixmatch identity but lyrics disabled: nothing is served, so no credit",
+			musixmatch, true, false,
+		},
+		{"petitlyrics and disabled: no credit", petitlyrics, true, false},
+		{"nil fetcher: no credit rather than a panic", nil, false, false},
+		{"nil fetcher and disabled: no credit", nil, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := musixmatchIsServing(tt.fetcher, tt.lyricsDisabled); got != tt.want {
+				t.Errorf("musixmatchIsServing() = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMusixmatchIsServingMatchesResolveServeProvider ties the predicate to the
+// function that actually produces its inputs, so the pair cannot drift.
+//
+// The unit table above uses hand-built providers; this asserts the real
+// resolveServeProvider outputs flow through to the right answer. Without it, a
+// change to the degrade path could keep every case above passing while the live
+// wiring credited the wrong provider.
+func TestMusixmatchIsServingMatchesResolveServeProvider(t *testing.T) {
+	t.Run("healthy musixmatch: serving", func(t *testing.T) {
+		primary := providers.New(providers.Musixmatch, fakeFetcher{})
+		fetcher, _, disabled, err := resolveServeProvider(primary, nil)
+		if err != nil {
+			t.Fatalf("resolveServeProvider: %v", err)
+		}
+		if !musixmatchIsServing(fetcher, disabled) {
+			t.Error("a healthy Musixmatch primary must be credited")
+		}
+	})
+
+	t.Run("healthy petitlyrics: not serving", func(t *testing.T) {
+		primary := providers.New(providers.PetitLyrics, fakeFetcher{})
+		fetcher, inactive, disabled, err := resolveServeProvider(primary, nil)
+		if err != nil {
+			t.Fatalf("resolveServeProvider: %v", err)
+		}
+		// The flags are NOT complements, which is the whole defect: inactive is
+		// false here (selection succeeded) while Musixmatch serves nothing.
+		if inactive {
+			t.Fatal("precondition: a clean PetitLyrics selection must not be musixmatchInactive")
+		}
+		if musixmatchIsServing(fetcher, disabled) {
+			t.Error("PetitLyrics results must not be credited to Musixmatch")
+		}
+	})
+
+	t.Run("no token: not serving despite the musixmatch identity", func(t *testing.T) {
+		fetcher, inactive, disabled, err := resolveServeProvider(nil, errNoMusixmatchToken)
+		if err != nil {
+			t.Fatalf("resolveServeProvider: %v", err)
+		}
+		if !inactive || !disabled {
+			t.Fatal("precondition: the no-token path must be both inactive and disabled")
+		}
+		if fetcher.Name() != providers.Musixmatch {
+			t.Fatalf("precondition: the no-op fetcher carries the musixmatch identity, got %q", fetcher.Name())
+		}
+		if musixmatchIsServing(fetcher, disabled) {
+			t.Error("a no-op fetcher wearing the musixmatch name must not be credited")
+		}
+	})
+}

--- a/internal/server/keys_ui_test.go
+++ b/internal/server/keys_ui_test.go
@@ -44,3 +44,54 @@ func TestWithoutKeyManagerUIUnavailable(t *testing.T) {
 		t.Error("expected the unavailable notice when no key manager is wired")
 	}
 }
+
+// TestWithMusixmatchServingWiring verifies the server-level wiring for the
+// Musixmatch attribution credit (#600, API Terms clause 2.1.5): the option must
+// reach the mounted web UI and gate the rendered credit.
+//
+// This exists at the SERVER layer, not just in internal/web, because the defect
+// CodeRabbit caught on PR #769 was a WIRING bug: the credit was derived from the
+// wrong signal, and every unit test of the rendering layer passed while the
+// assembled handler credited the wrong provider. A test that stops at the UI
+// package cannot see a seam that drops the flag or takes it from the wrong source.
+func TestWithMusixmatchServingWiring(t *testing.T) {
+	body := func(t *testing.T, opts ...Option) string {
+		t.Helper()
+		h := NewHandler(&fakeAuth{}, &fakeQueue{}, "lyrics",
+			append([]Option{WithWebUI(config.Config{}, "vtest")}, opts...)...)
+		req := httptest.NewRequest(http.MethodGet, "/reports", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		return rec.Body.String()
+	}
+
+	t.Run("serving: the credit reaches the rendered page", func(t *testing.T) {
+		got := body(t, WithMusixmatchServing(true))
+		if !strings.Contains(got, "mx-provider-credit") {
+			t.Error("credit missing; WithMusixmatchServing(true) did not reach the web UI")
+		}
+		if !strings.Contains(got, "https://www.musixmatch.com") {
+			t.Error("credit rendered without the required link to the Site (clause 2.1.5)")
+		}
+	})
+
+	t.Run("not serving: no credit", func(t *testing.T) {
+		if got := body(t, WithMusixmatchServing(false)); strings.Contains(got, "mx-provider-credit") {
+			t.Error("credit rendered while Musixmatch is not serving; that is a misattribution")
+		}
+	})
+
+	// The DEFAULT matters as much as either explicit case. A caller that forgets
+	// the option must get NO credit rather than a wrong one -- a missing credit is
+	// a bug to fix, a credit naming the wrong provider is published
+	// misattribution. This also pins the zero value, so a future refactor that
+	// inverts the flag's sense fails here.
+	t.Run("option omitted: defaults to no credit", func(t *testing.T) {
+		if got := body(t); strings.Contains(got, "mx-provider-credit") {
+			t.Error("credit rendered by default; the flag must be affirmatively set")
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,6 +94,7 @@ type Handler struct {
 	settingsStore      secrets.Store
 	keyManager         web.KeyManager
 	musixmatchInactive bool
+	musixmatchServing  bool
 	trusted            *trustnet.Policy
 	mux                *http.ServeMux
 
@@ -250,6 +251,21 @@ func WithMusixmatchInactive(inactive bool) Option {
 	return func(h *Handler) { h.musixmatchInactive = inactive }
 }
 
+// WithMusixmatchServing reports whether Musixmatch is the provider actually
+// serving lyrics, gating the attribution credit required by API Terms clause
+// 2.1.5 (#600).
+//
+// This is DELIBERATELY a separate signal from WithMusixmatchInactive, which
+// answers a different question (#385: "Musixmatch is primary but has no token",
+// so show the banner). The two diverge exactly where it matters: a PetitLyrics
+// primary selects cleanly, so musixmatchInactive is false, yet Musixmatch serves
+// nothing. Deriving the credit from !inactive would label PetitLyrics results
+// "Lyrics powered by Musixmatch" -- a misattribution, and the opposite of what a
+// credit is for.
+func WithMusixmatchServing(serving bool) Option {
+	return func(h *Handler) { h.musixmatchServing = serving }
+}
+
 // WithWebUIIf conditionally mounts the web UI. When enabled is false it
 // returns a no-op option so callers do not need an inline if-branch.
 func WithWebUIIf(enabled bool, cfg config.Config, version string) Option {
@@ -292,6 +308,7 @@ func NewHandler(a Authenticator, q WorkQueue, outdir string, opts ...Option) *Ha
 			h.webui.AttachKeyManager(h.keyManager)
 		}
 		h.webui.AttachMusixmatchInactive(h.musixmatchInactive)
+		h.webui.AttachMusixmatchServing(h.musixmatchServing)
 		h.webui.Register(h.mux)
 	}
 	return h

--- a/internal/web/banner_ui_test.go
+++ b/internal/web/banner_ui_test.go
@@ -24,8 +24,25 @@ const spicetifyFAQURL = "https://spicetify.app/docs/faq#sometimes-popup-lyrics-a
 // so it exercises the shell without wiring a database.
 func renderShell(t *testing.T, inactive bool) string {
 	t.Helper()
+	// Musixmatch serving is the ordinary case for a banner test: inactive=false
+	// means a token exists and Musixmatch is primary. The credit tests below drive
+	// the two flags independently via renderShellWith, because they are NOT
+	// complements (see musixmatchServing in ui.go).
+	return renderShellWith(t, inactive, !inactive)
+}
+
+// renderShellWith renders the shell with both Musixmatch flags set explicitly.
+// Separate from renderShell because musixmatchInactive and musixmatchServing are
+// independent: a PetitLyrics-primary deployment is false for BOTH, which is
+// exactly the combination that a single-flag helper cannot express and that the
+// credit regressed on.
+func renderShellWith(t *testing.T, inactive, serving bool) string {
+	t.Helper()
 	mux := http.NewServeMux()
-	NewUI(config.Config{}, "v-test", WithMusixmatchInactive(inactive)).Register(mux)
+	NewUI(config.Config{}, "v-test",
+		WithMusixmatchInactive(inactive),
+		WithMusixmatchServing(serving),
+	).Register(mux)
 	req := httptest.NewRequest(http.MethodGet, "/reports", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -79,7 +96,7 @@ func TestMusixmatchInactiveBannerAbsentWhenActive(t *testing.T) {
 // compliance surface rots: nothing breaks, no test fails, and the obligation
 // quietly stops being met.
 func TestMusixmatchCreditRendersWhenActive(t *testing.T) {
-	body := renderShell(t, false)
+	body := renderShellWith(t, false, true)
 
 	if !strings.Contains(body, "mx-provider-credit") {
 		t.Fatal("provider credit missing when Musixmatch is active; clause 2.1.5 requires it")
@@ -95,10 +112,68 @@ func TestMusixmatchCreditRendersWhenActive(t *testing.T) {
 	// Rendered OUTSIDE #mx-main so an htmx report-rail swap cannot blow it away.
 	// A credit that survives only until the first navigation is not an
 	// each-time-you-use-the-Data credit.
-	mainIdx := strings.Index(body, `id="mx-main"`)
-	creditIdx := strings.Index(body, "mx-provider-credit")
-	if mainIdx >= 0 && creditIdx >= 0 && creditIdx < mainIdx {
-		t.Error("credit renders before #mx-main; it must sit after it, outside the htmx swap target")
+	assertOutsideMxMain(t, body, "mx-provider-credit")
+}
+
+// assertOutsideMxMain fails unless needle appears outside the #mx-main element,
+// i.e. is not a descendant of the htmx swap target.
+//
+// It replaces a string-ORDER check (`creditIdx > mainIdx`) that was too weak, as
+// both reviewers noted on PR #769: anything nested INSIDE #mx-main also appears
+// after its opening tag, so the old assertion passed for exactly the arrangement
+// it was meant to forbid. It also silently skipped when #mx-main was missing.
+//
+// Containment is computed by scanning div depth from #mx-main's opening tag to
+// its matching close. That is sound here because the markup under test is
+// templ-generated and therefore balanced and non-self-closing for <div>; it is
+// NOT a general-purpose HTML parser. The alternative, golang.org/x/net/html, is
+// currently an INDIRECT dependency, and promoting it to direct to assert one
+// containment relation is a larger change to the module surface than this
+// warrants.
+func assertOutsideMxMain(t *testing.T, body, needle string) {
+	t.Helper()
+
+	open := strings.Index(body, `id="mx-main"`)
+	if open < 0 {
+		// Fail rather than skip: a renamed or removed swap target silently voids
+		// this guarantee, which is the case most worth catching.
+		t.Fatal(`#mx-main not found in rendered shell; the containment assertion cannot be evaluated`)
+	}
+	needleIdx := strings.Index(body, needle)
+	if needleIdx < 0 {
+		t.Fatalf("%q not found in rendered shell", needle)
+	}
+
+	// Walk from the start of #mx-main's opening tag, tracking <div> depth, and
+	// stop at the index where depth returns to zero -- its matching close.
+	tagStart := strings.LastIndex(body[:open], "<")
+	if tagStart < 0 {
+		t.Fatal("malformed markup: no opening < before #mx-main")
+	}
+	depth, i, closeIdx := 0, tagStart, -1
+	for i < len(body) {
+		switch {
+		case strings.HasPrefix(body[i:], "<div"):
+			depth++
+			i += 4
+		case strings.HasPrefix(body[i:], "</div>"):
+			depth--
+			i += 6
+			if depth == 0 {
+				closeIdx = i
+			}
+		default:
+			i++
+		}
+		if closeIdx >= 0 {
+			break
+		}
+	}
+	if closeIdx < 0 {
+		t.Fatal("could not locate the matching </div> for #mx-main")
+	}
+	if needleIdx >= tagStart && needleIdx < closeIdx {
+		t.Errorf("%q renders INSIDE #mx-main (the htmx swap target); it must sit outside so a report-rail swap cannot remove it", needle)
 	}
 }
 
@@ -106,8 +181,39 @@ func TestMusixmatchCreditRendersWhenActive(t *testing.T) {
 // usable token. Crediting Musixmatch for results another provider served would
 // be a misattribution, so the obligation and its absence are both load-bearing.
 func TestMusixmatchCreditHiddenWhenInactive(t *testing.T) {
-	body := renderShell(t, true)
+	body := renderShellWith(t, true, false)
 	if strings.Contains(body, "mx-provider-credit") {
 		t.Error("provider credit must not render when Musixmatch is inactive; no Musixmatch Data is in use")
+	}
+}
+
+// TestMusixmatchCreditHiddenForNonMusixmatchProvider is the regression test for
+// the defect CodeRabbit caught on PR #769: the credit was gated on
+// !musixmatchInactive, which is FALSE for a healthy PetitLyrics-primary
+// deployment. That deployment serves no Musixmatch Data, so the credit labeled
+// PetitLyrics results "Lyrics powered by Musixmatch" -- a misattribution shown to
+// users, which is worse than showing no credit at all.
+//
+// This is the flag combination a single-boolean helper cannot express, and it is
+// why the two flags are threaded separately rather than derived from each other.
+//
+// Unlike the other credit tests, this one DID fail against unfixed code -- it is
+// a genuine regression test, not a guard. Verified before the fix landed.
+func TestMusixmatchCreditHiddenForNonMusixmatchProvider(t *testing.T) {
+	// The PetitLyrics-primary shape: selection succeeded (so not "inactive"), but
+	// Musixmatch is not the provider serving lyrics.
+	body := renderShellWith(t, false, false)
+
+	if strings.Contains(body, "mx-provider-credit") {
+		t.Error("credit must not render when another provider is serving; crediting Musixmatch for PetitLyrics results is a misattribution")
+	}
+	if strings.Contains(body, "powered by Musixmatch") {
+		t.Error("credit text must not render when Musixmatch is not serving")
+	}
+	// The banner must also stay absent: this instance is healthy, just not using
+	// Musixmatch. Asserted here so a future fix that conflates the two flags again
+	// fails on BOTH surfaces rather than trading one wrong state for another.
+	if strings.Contains(body, "mx-banner") {
+		t.Error("tokenless-Musixmatch banner must not render for a healthy non-Musixmatch deployment")
 	}
 }

--- a/internal/web/banner_ui_test.go
+++ b/internal/web/banner_ui_test.go
@@ -67,3 +67,47 @@ func TestMusixmatchInactiveBannerAbsentWhenActive(t *testing.T) {
 		t.Fatal("Spicetify FAQ link must not render when musixmatchInactive=false")
 	}
 }
+
+// TestMusixmatchCreditRendersWhenActive guards a COMPLIANCE obligation, not a
+// visual preference: API Terms clause 2.1.5 requires crediting Musixmatch with a
+// link to its Site each time the Data is used (docs/provider-terms.md).
+//
+// It is a regression guard by construction -- the credit was added and this test
+// written alongside it, so it has never failed against unfixed code. Labeled as
+// such rather than presented as proof the credit is correct. What it defends is
+// the credit silently disappearing in a later layout edit, which is exactly how a
+// compliance surface rots: nothing breaks, no test fails, and the obligation
+// quietly stops being met.
+func TestMusixmatchCreditRendersWhenActive(t *testing.T) {
+	body := renderShell(t, false)
+
+	if !strings.Contains(body, "mx-provider-credit") {
+		t.Fatal("provider credit missing when Musixmatch is active; clause 2.1.5 requires it")
+	}
+	// The LINK is the required element, not the image. A credit that names
+	// Musixmatch without linking to the Site does not satisfy 2.1.5.
+	if !strings.Contains(body, `href="https://www.musixmatch.com"`) {
+		t.Error("credit must link to the Musixmatch Site (clause 2.1.5)")
+	}
+	if !strings.Contains(body, "powered by Musixmatch") {
+		t.Error("credit must name Musixmatch in its text")
+	}
+	// Rendered OUTSIDE #mx-main so an htmx report-rail swap cannot blow it away.
+	// A credit that survives only until the first navigation is not an
+	// each-time-you-use-the-Data credit.
+	mainIdx := strings.Index(body, `id="mx-main"`)
+	creditIdx := strings.Index(body, "mx-provider-credit")
+	if mainIdx >= 0 && creditIdx >= 0 && creditIdx < mainIdx {
+		t.Error("credit renders before #mx-main; it must sit after it, outside the htmx swap target")
+	}
+}
+
+// TestMusixmatchCreditHiddenWhenInactive asserts the credit is absent with no
+// usable token. Crediting Musixmatch for results another provider served would
+// be a misattribution, so the obligation and its absence are both load-bearing.
+func TestMusixmatchCreditHiddenWhenInactive(t *testing.T) {
+	body := renderShell(t, true)
+	if strings.Contains(body, "mx-provider-credit") {
+		t.Error("provider credit must not render when Musixmatch is inactive; no Musixmatch Data is in use")
+	}
+}

--- a/internal/web/dashboard.go
+++ b/internal/web/dashboard.go
@@ -42,7 +42,7 @@ func (u *UI) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "dashboard unavailable", http.StatusInternalServerError)
 		return
 	}
-	render(w, r, templates.DashboardPage(u.version, u.buildRail(""), view, u.musixmatchInactive))
+	render(w, r, templates.DashboardPage(u.version, u.buildRail(""), view, u.musixmatchInactive, u.musixmatchServing))
 }
 
 // buildDashboardView queries the reports repo and assembles the dashboard view

--- a/internal/web/keys.go
+++ b/internal/web/keys.go
@@ -32,7 +32,7 @@ func (u *UI) handleWebhookKeys(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	view := u.buildWebhookKeysView(r.Context())
 	u.attachKeysCSRF(w, r, &view)
-	render(w, r, templates.WebhookKeysPage(u.version, view, u.buildRail(""), u.musixmatchInactive))
+	render(w, r, templates.WebhookKeysPage(u.version, view, u.buildRail(""), u.musixmatchInactive, u.musixmatchServing))
 }
 
 // handleCreateWebhookKey creates a new managed key and returns the panel fragment

--- a/internal/web/settings.go
+++ b/internal/web/settings.go
@@ -52,7 +52,7 @@ func (u *UI) handleSettings(w http.ResponseWriter, r *http.Request) {
 			markSavable(view.Sections[i].Fields)
 		}
 	}
-	render(w, r, templates.SettingsPage(u.version, view, u.buildRail(""), u.musixmatchInactive))
+	render(w, r, templates.SettingsPage(u.version, view, u.buildRail(""), u.musixmatchInactive, u.musixmatchServing))
 }
 
 // markSavable flags each field the page may write: editable and not locked by

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -98,6 +98,22 @@ type UI struct {
 	// is disabled and linking to Settings to add a token. False (the default)
 	// renders nothing.
 	musixmatchInactive bool
+
+	// musixmatchServing is set when Musixmatch is the provider actually serving
+	// lyrics, gating the attribution credit required by API Terms clause 2.1.5
+	// (#600).
+	//
+	// SEPARATE from musixmatchInactive on purpose; the two are not complements.
+	// musixmatchInactive answers "is Musixmatch primary but tokenless", which is
+	// false for a healthy PetitLyrics-primary deployment -- one that serves no
+	// Musixmatch Data at all. Gating the credit on !musixmatchInactive would
+	// therefore credit Musixmatch for PetitLyrics results.
+	//
+	// Defaults to FALSE, so the credit renders only when a caller affirmatively
+	// says Musixmatch is serving. That direction is deliberate: a missing credit
+	// is a bug to fix, while a credit on the wrong provider is a misattribution
+	// published to users.
+	musixmatchServing bool
 }
 
 // KeyManager is the subset of *auth.Service the webhook key management page
@@ -171,6 +187,17 @@ func WithMusixmatchInactive(inactive bool) UIOption {
 // the post-construction equivalent of WithMusixmatchInactive used by the server
 // layer (WithWebUIAuth builds the UI first).
 func (u *UI) AttachMusixmatchInactive(inactive bool) { u.musixmatchInactive = inactive }
+
+// WithMusixmatchServing marks Musixmatch as the provider actually serving
+// lyrics, so the shell renders the attribution credit required by API Terms
+// clause 2.1.5 (#600). Default (false) renders no credit.
+func WithMusixmatchServing(serving bool) UIOption {
+	return func(u *UI) { u.musixmatchServing = serving }
+}
+
+// AttachMusixmatchServing sets the credit flag on an already-constructed UI, the
+// post-construction equivalent of WithMusixmatchServing used by the server layer.
+func (u *UI) AttachMusixmatchServing(serving bool) { u.musixmatchServing = serving }
 
 // WithConfigPath sets the resolved config file path the settings save handlers
 // write through. Without it the settings page stays read-only (no write path).
@@ -325,7 +352,7 @@ func (u *UI) handleRoot(w http.ResponseWriter, r *http.Request) {
 // operator to pick a report, keeping execution strictly user-initiated.
 func (u *UI) handleReports(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
-	render(w, r, templates.ReportsPage(u.version, u.buildRail(""), nil, u.musixmatchInactive))
+	render(w, r, templates.ReportsPage(u.version, u.buildRail(""), nil, u.musixmatchInactive, u.musixmatchServing))
 }
 
 // handleReportFragment runs one canned report on demand and returns its results.
@@ -364,7 +391,7 @@ func (u *UI) handleReportFragment(w http.ResponseWriter, r *http.Request) {
 		render(w, r, templates.ReportFragment(rail, view))
 		return
 	}
-	render(w, r, templates.ReportsPage(u.version, rail, &view, u.musixmatchInactive))
+	render(w, r, templates.ReportsPage(u.version, rail, &view, u.musixmatchInactive, u.musixmatchServing))
 }
 
 // reportPath builds the sidebar link target for a report key, encoding the key

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -611,6 +611,42 @@ body {
   color: var(--mx-content-text-secondary);
 }
 
+/* Musixmatch attribution required by API Terms clause 2.1.5 (see
+   docs/provider-terms.md). Sits at the end of the content column on every page.
+
+   Deliberately quiet but NOT hidden: a required credit that is invisible does not
+   discharge the obligation, so it uses the secondary text color rather than
+   anything dimmer, and it is never display:none on any breakpoint. If a future
+   layout change would push it out of view, the credit is what has to survive. */
+.mx-provider-credit {
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--mx-surface-border);
+}
+
+.mx-provider-credit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--mx-content-text-secondary);
+  font-size: 0.78rem;
+  text-decoration: none;
+}
+
+.mx-provider-credit-link:hover {
+  color: var(--mx-content-text);
+  text-decoration: underline;
+}
+
+/* Same no-plate, no-recolor treatment as .mx-lane-chip: the For Brands asset is a
+   solid tile carrying its own background, and the brand terms forbid altering it. */
+.mx-provider-credit-mark {
+  width: 1.05em;
+  height: 1.05em;
+  flex: none;
+  border-radius: 0.22em;
+}
+
 /* A vendored provider mark, as opposed to an authored currentColor glyph.
    These are fixed-color brand assets and MUST NOT be recolored -- the same
    guidelines that require the official file generally forbid altering it, so

--- a/web/templates/dashboard.templ
+++ b/web/templates/dashboard.templ
@@ -10,8 +10,8 @@ package templates
 // (every render is triggered by a page load or explicit browser refresh).
 
 // DashboardPage is the full-page dashboard shell.
-templ DashboardPage(version string, reports []RailItem, view DashboardView, musixmatchInactive bool) {
-	@Layout("Dashboard", "/dashboard", version, reports, "/static/css/dashboard.css", musixmatchInactive) {
+templ DashboardPage(version string, reports []RailItem, view DashboardView, musixmatchInactive bool, musixmatchServing bool) {
+	@Layout("Dashboard", "/dashboard", version, reports, "/static/css/dashboard.css", musixmatchInactive, musixmatchServing) {
 		@dashboardContent(view)
 	}
 }

--- a/web/templates/keys.templ
+++ b/web/templates/keys.templ
@@ -9,8 +9,8 @@ package templates
 // ever present in the immediate create response (view.NewKey); a later revoke
 // re-renders the panel without it, so it is never shown twice and never persists
 // in the rendered list.
-templ WebhookKeysPage(version string, view WebhookKeysView, reports []RailItem, musixmatchInactive bool) {
-	@Layout("Webhook keys", "/settings/keys", version, reports, "/static/css/keys.css", musixmatchInactive) {
+templ WebhookKeysPage(version string, view WebhookKeysView, reports []RailItem, musixmatchInactive bool, musixmatchServing bool) {
+	@Layout("Webhook keys", "/settings/keys", version, reports, "/static/css/keys.css", musixmatchInactive, musixmatchServing) {
 		// keys.js adds the one-time raw key's Copy button. Served from the embedded
 		// /static; the page works without it (the key sits in a selectable field).
 		<script src="/static/js/keys.js" defer></script>

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -63,6 +63,14 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 					<div id="mx-main">
 						{ children... }
 					</div>
+					// Provider credit sits OUTSIDE #mx-main for the same reason as the
+					// banner above: the report rail swaps that element's innerHTML, and a
+					// credit inside it would disappear on the first htmx swap. A credit
+					// that vanishes when the user navigates does not satisfy an
+					// each-time-you-use-the-Data obligation.
+					if !musixmatchInactive {
+						@musixmatchCredit()
+					}
 				</main>
 			</div>
 		</body>
@@ -81,6 +89,42 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 // two remedies named here are the actionable ones; walking a user through
 // extracting a credential out of another application's traffic is not guidance
 // canticle ships.
+// musixmatchCredit renders the Musixmatch attribution required by clause 2.1.5
+// of the API Terms of Service: credit Musixmatch and link to its Site each time
+// the Data is used. See docs/provider-terms.md for the full clause list and the
+// date they were read.
+//
+// WHY IT RENDERS ON EVERY PAGE rather than only where lyrics appear: the
+// obligation attaches to USING the Data, and canticle's whole purpose is
+// fetching and writing it -- every page of the serve UI is a view onto a library
+// built from it. Rendering it site-wide is both simpler to reason about and
+// strictly safer than auditing which views happen to surface a lyric today.
+//
+// It is HIDDEN when Musixmatch is inactive (no usable token), because in that
+// state no Musixmatch Data is being used and a credit would misattribute
+// results that came from another provider.
+//
+// WHAT THIS IS NOT: clause 2.1.5 names a specific "powered by Musixmatch" button
+// published at musixmatch.com/resources. That URL redirects to the brand-resources
+// page, whose only badge set ("For Brands" -> With Claim) ships PNG only -- no SVG
+// and no literal "powered by" wordmark was reachable. This therefore implements the
+// SUBSTANCE of the clause (the credit text, the mark, and the link to the Site)
+// using the official For Brands mark already vendored for the lane marks. If the
+// exact prescribed button is later obtained, swap it in here; the link target and
+// placement are already correct.
+//
+// The mark carries no alt text because the adjacent credit text is the accessible
+// name -- the same reasoning as the lane marks (#601). The link is the required
+// element, not the image.
+templ musixmatchCredit() {
+	<footer class="mx-provider-credit">
+		<a class="mx-provider-credit-link" href="https://www.musixmatch.com" target="_blank" rel="noopener noreferrer">
+			<img class="mx-provider-credit-mark" src="/static/img/lanes/musixmatch.svg" alt="" aria-hidden="true" width="16" height="16"/>
+			<span>Lyrics powered by Musixmatch</span>
+		</a>
+	</footer>
+}
+
 templ musixmatchBanner() {
 	<div class="mx-banner" role="status">
 		<svg class="mx-banner-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -94,11 +94,19 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 // the Data is used. See docs/provider-terms.md for the full clause list and the
 // date they were read.
 //
-// WHY IT RENDERS ON EVERY PAGE rather than only where lyrics appear: the
+// WHY IT RENDERS ON EVERY Layout PAGE rather than only where lyrics appear: the
 // obligation attaches to USING the Data, and canticle's whole purpose is
-// fetching and writing it -- every page of the serve UI is a view onto a library
-// built from it. Rendering it site-wide is both simpler to reason about and
-// strictly safer than auditing which views happen to surface a lyric today.
+// fetching and writing it -- every page of the authenticated UI (Dashboard,
+// Reports, Settings, Keys) is a view onto a library built from it. Rendering it
+// across the shell is both simpler to reason about and strictly safer than
+// auditing which views happen to surface a lyric today.
+//
+// The login and setup pages build their OWN shell rather than using Layout, so
+// they carry no credit. That is correct, not an oversight: they are auth forms
+// displaying no Musixmatch Data, and a credit there would assert an attribution
+// on a page where nothing is attributable. If either ever grows a lyric preview,
+// it needs this credit -- which is the reason to state the exception rather than
+// leave a future reader to infer it from the absence.
 //
 // It is HIDDEN when Musixmatch is inactive (no usable token), because in that
 // state no Musixmatch Data is being used and a credit would misattribute

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -16,7 +16,17 @@ package templates
 // musixmatchInactive renders the lyrics-disabled notice banner (#385) at the top
 // of the main content column on every shell page. It is true only when serve
 // started without a usable Musixmatch token; false renders nothing.
-templ Layout(title string, active string, version string, reports []RailItem, pageCSS string, musixmatchInactive bool) {
+// NOTE ON THE TWO TRAILING BOOLS. musixmatchInactive and musixmatchServing are
+// adjacent positional parameters of the same type, which is a swap hazard. They
+// are NOT complements and must not be collapsed into one: inactive means
+// "Musixmatch is primary but tokenless" (#385, banner), serving means
+// "Musixmatch is the provider actually returning lyrics" (#600, credit). A
+// PetitLyrics-primary deployment is false for BOTH.
+//
+// A swap is caught by test: it would render the banner on a healthy instance and
+// the credit on a tokenless one, which the banner and credit tests assert
+// against independently.
+templ Layout(title string, active string, version string, reports []RailItem, pageCSS string, musixmatchInactive bool, musixmatchServing bool) {
 	<!DOCTYPE html>
 	<html lang="en">
 		<head>
@@ -68,7 +78,7 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 					// credit inside it would disappear on the first htmx swap. A credit
 					// that vanishes when the user navigates does not satisfy an
 					// each-time-you-use-the-Data obligation.
-					if !musixmatchInactive {
+					if musixmatchServing {
 						@musixmatchCredit()
 					}
 				</main>
@@ -108,9 +118,17 @@ templ Layout(title string, active string, version string, reports []RailItem, pa
 // it needs this credit -- which is the reason to state the exception rather than
 // leave a future reader to infer it from the absence.
 //
-// It is HIDDEN when Musixmatch is inactive (no usable token), because in that
-// state no Musixmatch Data is being used and a credit would misattribute
-// results that came from another provider.
+// It renders only when musixmatchServing says Musixmatch is the provider
+// actually returning lyrics.
+//
+// An earlier revision gated it on !musixmatchInactive, which was WRONG and was
+// caught in review. Those flags are not complements: musixmatchInactive means
+// "Musixmatch is primary but has no token" (#385), so a healthy
+// PetitLyrics-primary deployment reports false for it while serving no
+// Musixmatch Data at all -- and the credit would have labeled PetitLyrics
+// results "Lyrics powered by Musixmatch". A credit on the wrong provider is a
+// misattribution published to users, which is worse than no credit, so the flag
+// now defaults to false and must be affirmatively set.
 //
 // WHAT THIS IS NOT: clause 2.1.5 names a specific "powered by Musixmatch" button
 // published at musixmatch.com/resources. That URL redirects to the brand-resources

--- a/web/templates/reports.templ
+++ b/web/templates/reports.templ
@@ -18,8 +18,8 @@ package templates
 // selected, the placeholder pane shows); when a report is selected via a non-htmx
 // navigation the handler passes the rendered ReportView so the full page lands on
 // that report. reports is the sidebar report-nav model.
-templ ReportsPage(version string, reports []RailItem, view *ReportView, musixmatchInactive bool) {
-	@Layout("Reports", "/reports", version, reports, "", musixmatchInactive) {
+templ ReportsPage(version string, reports []RailItem, view *ReportView, musixmatchInactive bool, musixmatchServing bool) {
+	@Layout("Reports", "/reports", version, reports, "", musixmatchInactive, musixmatchServing) {
 		@reportPane(view)
 	}
 }

--- a/web/templates/settings.templ
+++ b/web/templates/settings.templ
@@ -9,8 +9,8 @@ package templates
 // Phase 1 is the READ path: every field renders a guided control with its
 // current value and a plain "Locked" pill when an override is active, but no
 // form submits yet. The write handlers arrive in Phase 2.
-templ SettingsPage(version string, view SettingsView, reports []RailItem, musixmatchInactive bool) {
-	@Layout("Settings", "/settings", version, reports, "", musixmatchInactive) {
+templ SettingsPage(version string, view SettingsView, reports []RailItem, musixmatchInactive bool, musixmatchServing bool) {
+	@Layout("Settings", "/settings", version, reports, "", musixmatchInactive, musixmatchServing) {
 		<h1 class="mx-page-title">Settings</h1>
 		<p class="mx-page-subtitle">
 			Edit the daemon configuration. Changes are written to the config file and take effect on restart.


### PR DESCRIPTION
## Summary

- **Musixmatch's API Terms require a credit and linkback that canticle has never carried.** Clause 2.1.5: credit Musixmatch and link to its Site **each time** you use the Data. This closes a live gap, not a hypothetical one -- the obligation attaches to *using* the Data, which canticle does on every fetch, so it predates this PR and would survive removing the lane mark from #766.
- **The credit renders across the authenticated serve UI**, hidden when Musixmatch is inactive (crediting them for another provider's results would misattribute).
- **Look at first:** this does *not* ship the exact prescribed button -- see "Not covered". The clause names a specific asset that is not published in a usable format.

## Linked issue

Part of #600

Deliberately `Part of`, not `Closes`: clauses 2.1.11, 2.1.4 and 1.1 remain unaddressed, and the prescribed badge is still unsourced.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; findings fixed before pushing.
  - The self-review found one real defect -- in the **documentation**, not the behavior. See "Test plan".
- [ ] Commits squashed into one clean commit before the first push.
  - **Two commits, deliberately.** The second is a doc-truth correction found during self-review; keeping it separate shows what the review caught rather than burying it. Squash at merge as usual.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
  - **Not done, and not claimed.** See "Not covered".
- [ ] Screenshot attached for any web-UI change, taken from the rendered page at branch HEAD.
  - Rendered at branch HEAD in chromium and shared in-session; not committed (screenshots do not belong in the repo). Happy to attach if wanted.
- [x] `make ui` re-run (`.templ` and CSS both changed).
- [x] Migration under `internal/db/migrations/` — N/A, no schema or data change.

## Test plan

- [x] `make gate` passes locally. Exit 0, every step PASS.
- [x] New tests were confirmed to **fail against unfixed code**.
      Mutation: deleting the `@musixmatchCredit()` call reds at the assertion naming clause 2.1.5 (`provider credit missing when Musixmatch is active`), not at the build. Restore is green.
      **These are REGRESSION GUARDS and say so in the comment** -- written alongside the credit, so they never failed against genuinely unfixed code. What they defend is the credit silently vanishing in a later layout edit, which is how a compliance surface rots: nothing breaks, no test fails, the obligation quietly stops being met.
- [x] Patch coverage meets the Codecov threshold.
      Reported **"no Go source changes in scope"**. Verified this is a legitimate N/A rather than a silent skip, against all three known causes: 2 commits exist (not the nothing-committed case); `web/templates/*_templ.go` is on the `codecov.yml` ignore list at line 50 **and** gitignored (not the wrongly-assumed-ignore case); the only `.go` file in the diff is a test file. Codecov will agree.
- [x] Which **surface** this change fixes is stated explicitly, and was verified by looking at it.
      Enumerated **every** render surface of the shared `Layout` fragment. Four pages carry the credit (Dashboard, Reports, Settings, Keys). `login.templ` and `setup.templ` build their own shell and carry none -- correct, since they display no Musixmatch Data, and now stated explicitly rather than left to inference.
- [x] Manual UAT steps:
  - [x] Rendered the credit against the **compiled** `output.css` in chromium on the real `--mx-content-bg`, and read `getComputedStyle`: `rgb(148,163,184)` on `rgb(11,17,32)` = **7.34:1** contrast, clearing WCAG AA for small text. A credit present in the DOM but visually unreadable would not discharge the obligation, so this is measured rather than assumed.
  - [x] Verified the claimed colors match the actual design tokens (`#94a3b8`, `#0b1120`) rather than trusting the token names.
  - [x] Confirmed placement outside `#mx-main`, asserted by test, so an htmx report-rail swap cannot remove it.
- [ ] Reviewer follow-ups:
  - [ ] **Is the substance-over-form call right?** Clause 2.1.5 names a specific button; this ships the official For Brands mark plus credit text and link instead, because the named asset is not obtainable in a usable format. The alternative was shipping nothing, which satisfies the clause less.
  - [ ] **Clause 2.1.4 binds the operator, not the software** -- prior written approval before exposing pages carrying the Data publicly. That probably belongs in user-facing docs (`GETTING_STARTED` / `INSTALL`), not just this compliance record. Out of scope here; say if you want it filed.

## Not covered

- **The exact prescribed button.** Clause 2.1.5 points at `musixmatch.com/resources`, which **redirects** to the brand-resources page. Its only badge set (For Brands -> With Claim) ships **PNG only** -- no SVG, no literal "powered by" wordmark was reachable through the brand kit. This implements the clause's *substance* (credit + mark + link) using the official For Brands mark already vendored in #766. Closing it fully is an asset swap: link target, placement and tests are already correct.
- **Clause 2.1.11** (permit Musixmatch to track API access) -- not implemented. Whether the desktop endpoint already satisfies it by construction is unexamined.
- **Clause 2.1.4** (prior written approval before public exposure) -- binds the operator; no code change can satisfy it.
- **Clause 1.1** (non-commercial use only) -- a deployment constraint.
- **The binary was never run.** Verification was real markup against the real compiled stylesheet in a real engine -- stronger than a static CSS read, weaker than a live serve-mode session. Nothing here exercises auth, routing, or htmx swapping in situ.
- **Dark palette only.** The UI ships one theme today, so there is no light surface to check.
- **This is not legal advice.** It is an agent's reading of a published terms page, recorded with clause numbers and dates in `docs/provider-terms.md` so it can be checked rather than trusted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible Musixmatch attribution footer to the authenticated interface.
  - Attribution includes the provider name, linked branding, and appropriate styling.
  - The credit appears only when Musixmatch is the active provider and remains outside dynamically refreshed content.

- **Documentation**
  - Updated provider terms to document the implemented attribution and remaining obligations.

- **Tests**
  - Added coverage for displaying the credit when active and hiding it when inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->