### PR TITLE
fix(worker): record why a guard-rejected row settled with nothing written

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -769,6 +769,83 @@ func (q *DBQueue) settleInstrumentalOnce(ctx context.Context, id int64, tel Inst
 	return Settled, nil
 }
 
+// SettleGuardRejected records that the language/script guard refused a fetched
+// lyric and completes the row in ONE transaction: outcome_type='rejected',
+// status='done', and the scan_results writeback all commit together, or none do.
+//
+// ATOMICITY IS THE POINT, not tidiness (#655). The first cut of this fix stamped
+// the outcome with a separate best-effort SetOutcomeType call and completed the
+// row regardless of whether that stamp succeeded -- which reproduced the very
+// defect being fixed: a failed stamp plus a successful Complete leaves the row
+// `done` with a NULL outcome_type, indistinguishable from a legacy row. Both
+// reviewers caught it independently on PR #770. A label that can be dropped
+// silently is not a fix for a missing label.
+//
+// It mirrors SettleInstrumental deliberately -- same transaction shape, same
+// guarded UPDATE, same SettleOutcome vocabulary -- because "record a terminal
+// verdict and complete the row" is one operation with two verdicts, and having
+// the two paths diverge is how one of them drifts.
+//
+// The guard is 'processing': only a worker holding the row reaches a guard
+// rejection, so unlike SettleInstrumental there is no backfill caller and no
+// RowOwnership parameter to get wrong.
+func (q *DBQueue) SettleGuardRejected(ctx context.Context, id int64) (SettleOutcome, error) {
+	var outcome SettleOutcome
+	err := db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
+		var err error
+		outcome, err = q.settleGuardRejectedOnce(ctx, id)
+		return err
+	})
+	return outcome, err
+}
+
+func (q *DBQueue) settleGuardRejectedOnce(ctx context.Context, id int64) (outcome SettleOutcome, retErr error) {
+	now := formatTime(q.now())
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return SettleFailed, fmt.Errorf("queue: begin settle guard-rejected tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// last_error is cleared deliberately: a guard rejection is a POLICY outcome,
+	// not an error. Leaving a stale error from an earlier attempt would make the
+	// row read as failed in the failure-analysis report.
+	res, err := tx.ExecContext(ctx,
+		`UPDATE work_queue
+         SET outcome_type = 'rejected',
+             status = 'done',
+             completed_at = ?,
+             last_error = ''
+         WHERE id = ?
+           AND status = ?`,
+		now, id, StatusProcessing,
+	)
+	if err != nil {
+		return SettleFailed, fmt.Errorf("queue: settle guard-rejected: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return SettleFailed, fmt.Errorf("queue: settle guard-rejected rows affected: %w", err)
+	}
+	if n == 0 {
+		return q.classifyNoSettle(ctx, tx, id)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scan_results
+         SET status = 'done'
+         WHERE id IN (SELECT scan_result_id FROM work_queue_scan_results WHERE work_queue_id = ?)
+           AND status != 'done'`,
+		id,
+	); err != nil {
+		return SettleFailed, fmt.Errorf("queue: settle guard-rejected scan_results writeback: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return SettleFailed, fmt.Errorf("queue: commit settle guard-rejected tx: %w", err)
+	}
+	return Settled, nil
+}
+
 // classifyNoSettle explains why the guarded settle UPDATE matched nothing. It
 // reads inside the caller's transaction, so the answer is consistent with the
 // UPDATE that just ran rather than a later, separately-racing read.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4954,3 +4954,122 @@ func TestDBQueue_CountFailuresByReasonNormalizesSignatures(t *testing.T) {
 		}
 	}
 }
+
+// TestDBQueue_SettleGuardRejectedAtomically covers the transaction the worker's
+// fake cannot reach (#655/#770).
+//
+// The worker suite proves the SEAM is called; only a real-SQLite test proves the
+// STATEMENT is right. That gap is the same shape as the original defect: the
+// guard path was exercised end-to-end by nothing, so nobody saw it complete a row
+// without a label.
+func TestDBQueue_SettleGuardRejectedAtomically(t *testing.T) {
+	ctx := context.Background()
+
+	newProcessingRow := func(t *testing.T) (*DBQueue, int64) {
+		t.Helper()
+		q := NewDBQueue(openQueueTestDB(t))
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:      models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:     "out",
+			Filename:   "a.lrc",
+			SourcePath: "/music/a.flac",
+		}, 1)
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		// A worker claims it: status becomes 'processing', which is what the
+		// settle guards on.
+		if _, err := q.Dequeue(ctx); err != nil {
+			t.Fatalf("dequeue: %v", err)
+		}
+		return q, item.ID
+	}
+
+	t.Run("happy path: label and completion land together", func(t *testing.T) {
+		q, id := newProcessingRow(t)
+
+		outcome, err := q.SettleGuardRejected(ctx, id)
+		if err != nil {
+			t.Fatalf("SettleGuardRejected: %v", err)
+		}
+		if outcome != Settled {
+			t.Fatalf("outcome = %v; want Settled", outcome)
+		}
+
+		var status string
+		var outcomeType *string
+		var lastError string
+		var completedAt *string
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT status, outcome_type, last_error, completed_at FROM work_queue WHERE id = ?`, id,
+		).Scan(&status, &outcomeType, &lastError, &completedAt); err != nil {
+			t.Fatalf("read row: %v", err)
+		}
+		if status != StatusDone {
+			t.Errorf("status = %q; want %q", status, StatusDone)
+		}
+		// THE POINT OF #655: the row must never be done-and-unlabeled.
+		if outcomeType == nil {
+			t.Fatal("outcome_type is NULL on a settled guard rejection; that is the #655 defect")
+		}
+		if *outcomeType != "rejected" {
+			t.Errorf("outcome_type = %q; want %q", *outcomeType, "rejected")
+		}
+		// A policy rejection is not an error: a stale last_error would make the
+		// row read as failed in the failure-analysis report.
+		if lastError != "" {
+			t.Errorf("last_error = %q; want empty (a guard rejection is policy, not failure)", lastError)
+		}
+		if completedAt == nil {
+			t.Error("completed_at is NULL on a settled row")
+		}
+	})
+
+	t.Run("guard: a row not in processing is refused, and nothing is written", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:   "out",
+			Filename: "a.lrc",
+		}, 1)
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		// Deliberately NOT dequeued: the row is still 'pending'.
+
+		outcome, err := q.SettleGuardRejected(ctx, item.ID)
+		if err != nil {
+			t.Fatalf("SettleGuardRejected: %v", err)
+		}
+		if outcome == Settled {
+			t.Fatal("a row the caller does not hold was settled; the processing guard did not apply")
+		}
+
+		var status string
+		var outcomeType *string
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT status, outcome_type FROM work_queue WHERE id = ?`, item.ID,
+		).Scan(&status, &outcomeType); err != nil {
+			t.Fatalf("read row: %v", err)
+		}
+		if status != StatusPending {
+			t.Errorf("status = %q; want %q untouched", status, StatusPending)
+		}
+		// ATOMICITY, asserted from the other side: a refused settle writes NOTHING,
+		// not a label without a completion.
+		if outcomeType != nil {
+			t.Errorf("outcome_type = %q; a refused settle must write nothing at all", *outcomeType)
+		}
+	})
+
+	t.Run("missing row reports rather than erroring", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		outcome, err := q.SettleGuardRejected(ctx, 424242)
+		if err != nil {
+			t.Fatalf("SettleGuardRejected on a missing row: %v; want a reported outcome", err)
+		}
+		if outcome == Settled {
+			t.Error("a nonexistent row reported Settled")
+		}
+	})
+}

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -130,7 +130,10 @@ type RecentOutcome struct {
 	// ProviderLane is the winning provider lane recorded at completion; empty
 	// when NULL (not recorded, or a miss with no winning provider).
 	ProviderLane string
-	// Result is the classification derived from last_error / output_paths.
+	// Result is the classification derived from last_error / outcome_type.
+	// NOT output_paths: that column holds the enqueue-time .lrc plan and is never
+	// updated at completion, which is what made every completed row read as
+	// synced before #379.
 	Result ResultClass
 }
 

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -98,8 +98,24 @@ const (
 	// ResultMiss means the item exhausted its miss budget with no lyrics found
 	// (status='done', last_error='miss limit reached', no output written).
 	ResultMiss ResultClass = "miss"
+	// ResultRejected means the language/script guard refused the fetched lyric,
+	// so the row settled terminally with NOTHING written (outcome_type='rejected',
+	// #655).
+	//
+	// It is a settled state, NOT an artifact: no file exists and none will, since
+	// re-fetching yields the same wrong-script result. Counting it as coverage
+	// would overstate what the library actually has.
+	ResultRejected ResultClass = "rejected"
 	// ResultUnknown means the row could not be classified: a legacy row that
 	// predates the outcome_type column (NULL outcome_type) and is not a miss.
+	//
+	// NARROWER THAN IT USED TO BE, and the change is the point of #655. Guard
+	// rejections also left outcome_type NULL, so this class silently covered two
+	// unrelated things -- missing history and a deliberate policy decision -- and
+	// an operator had no way to tell them apart. Rows settled by a build carrying
+	// ResultRejected now say so; rows predating it stay here and remain genuinely
+	// unclassifiable, since nothing on disk or in the row records why they
+	// settled.
 	ResultUnknown ResultClass = "unknown"
 )
 
@@ -124,10 +140,16 @@ type RecentOutcome struct {
 // Source: work_queue rows where status='done'. The result classification is
 // computed in SQL from the recorded outcome_type (stamped at completion, #379),
 // NOT the output_paths filename: last_error='miss limit reached' -> miss;
-// otherwise outcome_type 'synced'/'unsynced'/'instrumental' map to the matching
-// ResultClass; a NULL outcome_type (a legacy row predating the column) -> unknown.
+// otherwise outcome_type 'synced'/'unsynced'/'instrumental'/'rejected' map to
+// the matching ResultClass; a NULL outcome_type -> unknown.
 // output_paths is no longer consulted -- it holds the stale enqueue-time .lrc
 // plan, which is what made every completed row read as synced before this fix.
+//
+// This comment previously said a NULL outcome_type meant "a legacy row predating
+// the column". That was FALSE, and its being false is #655: the guard-rejection
+// path also produced NULLs, continuously, so the class silently covered a
+// deliberate policy decision as well as missing history. Rows settled by a build
+// carrying 'rejected' now say so; NULL is once again only what the word implies.
 func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, error) {
 	if limit <= 0 {
 		return nil, nil
@@ -139,6 +161,7 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
                 WHEN outcome_type = 'synced' THEN 'synced'
                 WHEN outcome_type = 'unsynced' THEN 'unsynced'
                 WHEN outcome_type = 'instrumental' THEN 'instrumental'
+                WHEN outcome_type = 'rejected' THEN 'rejected'
                 ELSE 'unknown'
             END AS result
          FROM work_queue

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -223,6 +223,15 @@ func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
 		lastError: "miss limit reached", outputPaths: pathsJSON("ignored.lrc"),
 		completedAt: "2026-06-11T10:00:00Z",
 	})
+	// A guard-rejected row (#655): the language/script guard refused the fetched
+	// lyric, so the row settled terminally with NOTHING on disk. It must classify
+	// as its own class rather than falling through to 'unknown', which is what
+	// made it indistinguishable from the Legacy row below.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "Rejected", title: "R", status: "done",
+		outputPaths: pathsJSON("song.lrc"), completedAt: "2026-06-14T10:00:00Z",
+		providerLane: "musixmatch", outcomeType: "rejected",
+	})
 	insertWorkItem(t, sqlDB, workItem{
 		artist: "Legacy", title: "L", status: "done",
 		outputPaths: "", completedAt: nil, // NULL completed_at, NULL outcome_type
@@ -234,8 +243,8 @@ func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecentOutcomes: %v", err)
 	}
-	if len(got) != 5 {
-		t.Fatalf("got %d outcomes, want 5 (done only): %+v", len(got), got)
+	if len(got) != 6 {
+		t.Fatalf("got %d outcomes, want 6 (done only): %+v", len(got), got)
 	}
 
 	// Order: newest completed first, NULL completed_at last.
@@ -243,6 +252,7 @@ func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
 		artist string
 		result reports.ResultClass
 	}{
+		{"Rejected", reports.ResultRejected},
 		{"Instrumental", reports.ResultInstrumental},
 		{"Unsynced", reports.ResultUnsynced},
 		{"Miss", reports.ResultMiss},
@@ -259,7 +269,7 @@ func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
 	}
 
 	// Field carry-through on the synced row.
-	synced := got[3]
+	synced := got[4]
 	if synced.Album != "Al1" || synced.ProviderLane != "musixmatch" {
 		t.Errorf("synced row fields = album %q lane %q, want Al1/musixmatch", synced.Album, synced.ProviderLane)
 	}
@@ -267,8 +277,8 @@ func TestRecentOutcomesClassificationAndOrder(t *testing.T) {
 		t.Errorf("synced CompletedAt = %v, want 2026-06-10T10:00:00Z", synced.CompletedAt)
 	}
 	// NULL completed_at -> zero time.
-	if !got[4].CompletedAt.IsZero() {
-		t.Errorf("legacy CompletedAt = %v, want zero", got[4].CompletedAt)
+	if !got[5].CompletedAt.IsZero() {
+		t.Errorf("legacy CompletedAt = %v, want zero", got[5].CompletedAt)
 	}
 }
 

--- a/internal/worker/guard_reject_outcome_test.go
+++ b/internal/worker/guard_reject_outcome_test.go
@@ -1,0 +1,122 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+	"github.com/sydlexius/canticle/internal/queue"
+)
+
+// rejectAllGuard refuses every song, standing in for a configured language
+// allowlist that the fetched lyric's script does not satisfy.
+type rejectAllGuard struct{ reason string }
+
+func (g rejectAllGuard) Accept(models.Song) (bool, string) { return false, g.reason }
+func (g rejectAllGuard) Enabled() bool                     { return true }
+
+// acceptAllGuard is the CONTROL. Without it, "the rejected row carries
+// outcome_type=rejected" would be consistent with the worker stamping that value
+// on every row regardless of the guard verdict.
+type acceptAllGuard struct{}
+
+func (acceptAllGuard) Accept(models.Song) (bool, string) { return true, "" }
+func (acceptAllGuard) Enabled() bool                     { return true }
+
+// TestGuardRejectedRowRecordsItsOutcome is the reproducing test for #655.
+//
+// The defect: the language-guard rejection path completed the row without
+// stamping anything, so it landed `done` with a NULL outcome_type. Reports
+// render NULL as "unknown", which is also how a legacy row predating the column
+// renders -- so one value meant two unrelated things and an operator could not
+// tell a deliberate policy rejection from missing history. 3,182 rows sat that
+// way on production.
+//
+// It shipped because nothing tested this path at all: no test in this package
+// referenced guardReject or a script guard before this file.
+//
+// Verified to fail against unfixed code, not merely written alongside the fix:
+// with the SetOutcomeType call removed from the guard branch, the first subtest
+// reds with "settled with NO outcome_type recorded".
+func TestGuardRejectedRowRecordsItsOutcome(t *testing.T) {
+	newRejectedRow := func(t *testing.T, guard ScriptGuard) *fakeQueue {
+		t.Helper()
+		q := &fakeQueue{items: []queue.WorkItem{{
+			ID:     1,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}, Outdir: "o", Filename: "a.lrc"},
+		}}}
+		fetcher := &seqFetcher{results: []seqResult{{
+			song: models.Song{
+				Track:     models.Track{ArtistName: "A", TrackName: "One"},
+				Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}},
+			},
+		}}}
+		w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+		w.EnableGuard(guard)
+		if err := w.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		return q
+	}
+
+	t.Run("rejected row is completed AND labeled", func(t *testing.T) {
+		q := newRejectedRow(t, rejectAllGuard{reason: "script not in allowlist"})
+
+		// The row must still settle terminally: a guard rejection is policy, not a
+		// retriable failure, so re-fetching would return the same wrong-script
+		// lyric forever.
+		if len(q.completed) != 1 || q.completed[0] != 1 {
+			t.Fatalf("completed = %v; want the guard-rejected row settled exactly once", q.completed)
+		}
+		if len(q.failed) != 0 || len(q.deferred) != 0 {
+			t.Errorf("guard rejection must not fail or defer the row; failed=%v deferred=%v", q.failed, q.deferred)
+		}
+
+		// THE REGRESSION. Before the fix this map was empty for the row.
+		got, ok := q.outcomeTypes[1]
+		if !ok {
+			t.Fatal("guard-rejected row settled with NO outcome_type recorded; " +
+				"reports cannot distinguish it from a legacy row (#655)")
+		}
+		if got != outcomeTypeRejected {
+			t.Errorf("outcome_type = %q; want %q", got, outcomeTypeRejected)
+		}
+	})
+
+	t.Run("control: an accepted row is not labeled rejected", func(t *testing.T) {
+		q := newRejectedRow(t, acceptAllGuard{})
+
+		got, ok := q.outcomeTypes[1]
+		if !ok {
+			t.Fatal("accepted row recorded no outcome_type")
+		}
+		if got == outcomeTypeRejected {
+			t.Error("an ACCEPTED row was labeled rejected; the stamp is not keyed on the guard verdict")
+		}
+		// It wrote a synced .lrc, so that is what it must claim -- this also pins
+		// the constant swap in outcomeTypeFromSong.
+		if got != outcomeTypeSynced {
+			t.Errorf("outcome_type = %q; want %q", got, outcomeTypeSynced)
+		}
+	})
+
+	t.Run("control: no guard configured leaves the normal path intact", func(t *testing.T) {
+		q := &fakeQueue{items: []queue.WorkItem{{
+			ID:     1,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}, Outdir: "o", Filename: "a.lrc"},
+		}}}
+		fetcher := &seqFetcher{results: []seqResult{{
+			song: models.Song{
+				Track:     models.Track{ArtistName: "A", TrackName: "One"},
+				Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}},
+			},
+		}}}
+		w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+		if err := w.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if got := q.outcomeTypes[1]; got != outcomeTypeSynced {
+			t.Errorf("outcome_type = %q; want %q with no guard wired", got, outcomeTypeSynced)
+		}
+	})
+}

--- a/internal/worker/guard_reject_outcome_test.go
+++ b/internal/worker/guard_reject_outcome_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,5 +213,44 @@ func TestGuardRejectUnsettledRowIsReleased(t *testing.T) {
 	}
 	if len(q.failed) != 0 {
 		t.Errorf("failed = %v; an unsettled row must be released, not failed (it may no longer exist)", q.failed)
+	}
+}
+
+// TestGuardRejectReleaseFailureIsReported covers the error branch of the release
+// path: the settle did not take AND the release also failed.
+//
+// It matters because the row is then stuck in 'processing', which nothing
+// reclaims -- Dequeue selects only ('pending','failed','deferred'). Swallowing
+// this would strand the row invisibly, so the error must propagate to the run
+// loop rather than being logged and dropped.
+func TestGuardRejectReleaseFailureIsReported(t *testing.T) {
+	claimed := queue.SettleClaimed
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:     1,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}, Outdir: "o", Filename: "a.lrc"},
+		}},
+		guardRejectOutcome: &claimed,
+		releaseErr:         errors.New("database is locked"),
+	}
+	fetcher := &seqFetcher{results: []seqResult{{
+		song: models.Song{
+			Track:     models.Track{ArtistName: "A", TrackName: "One"},
+			Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}},
+		},
+	}}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.EnableGuard(rejectAllGuard{reason: "script not in allowlist"})
+	w.sleep = func(context.Context, time.Duration) {}
+
+	err := w.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run returned nil; a row left in 'processing' by a failed release must surface, not be swallowed")
+	}
+	if !strings.Contains(err.Error(), "release unsettled guard-rejected item") {
+		t.Errorf("err = %v; want it to name the unreleased guard-rejected row", err)
+	}
+	if len(q.completed) != 0 {
+		t.Errorf("completed = %v; nothing settled, so nothing may be recorded done", q.completed)
 	}
 }

--- a/internal/worker/guard_reject_outcome_test.go
+++ b/internal/worker/guard_reject_outcome_test.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/canticle/internal/models"
 	"github.com/sydlexius/canticle/internal/queue"
@@ -119,4 +121,96 @@ func TestGuardRejectedRowRecordsItsOutcome(t *testing.T) {
 			t.Errorf("outcome_type = %q; want %q with no guard wired", got, outcomeTypeSynced)
 		}
 	})
+}
+
+// TestGuardRejectFailedSettleDoesNotComplete is the regression test for the
+// defect BOTH reviewers caught on PR #770.
+//
+// The first cut of the #655 fix stamped the outcome with a best-effort
+// SetOutcomeType and then called Complete unconditionally. A dropped stamp plus
+// a successful Complete leaves the row `done` with a NULL outcome_type -- which
+// is exactly the bug #655 exists to fix. A label that can be silently lost is
+// not a fix for a missing label.
+//
+// The settle is now one transaction, so this asserts the property that makes it
+// correct: when persistence fails, the row must NOT be completed. It is a
+// genuine regression test -- under the old stamp-then-Complete code the row was
+// completed regardless, so this reds.
+func TestGuardRejectFailedSettleDoesNotComplete(t *testing.T) {
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:     1,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}, Outdir: "o", Filename: "a.lrc"},
+		}},
+		guardRejectErr: errors.New("database is locked"),
+	}
+	fetcher := &seqFetcher{results: []seqResult{{
+		song: models.Song{
+			Track:     models.Track{ArtistName: "A", TrackName: "One"},
+			Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}},
+		},
+	}}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.EnableGuard(rejectAllGuard{reason: "script not in allowlist"})
+	// Stub the backoff. w.fail puts the loop into a real 1-minute sleep, which
+	// this test would otherwise serve in full -- 60s in the gate for a property
+	// that is decided the moment the settle returns.
+	w.sleep = func(context.Context, time.Duration) {}
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// THE REGRESSION. The row must not settle when its label could not be stored.
+	if len(q.completed) != 0 {
+		t.Errorf("row was completed despite a failed settle; it can now be `done` with a NULL outcome_type (#655/#770)")
+	}
+	if _, ok := q.outcomeTypes[1]; ok {
+		t.Error("an outcome was recorded despite the settle failing; the fake must model the transaction as all-or-nothing")
+	}
+	// It must instead take the retriable failure path, so the row is re-attempted
+	// rather than stranded in 'processing' forever.
+	if len(q.failed) != 1 {
+		t.Errorf("failed = %v; want the row failed for retry after an unsettleable rejection", q.failed)
+	}
+}
+
+// TestGuardRejectUnsettledRowIsReleased covers the non-error, non-Settled branch:
+// the settle succeeded as a call but matched no row (pruned mid-flight, or a
+// concurrent writer moved it).
+//
+// Releasing rather than failing is the point. Failing would re-queue a row that
+// may no longer exist; releasing returns it to a dequeueable state without
+// asserting an outcome that was never written. The prior code had no such branch
+// at all -- Complete's error was the only signal, and a no-op UPDATE is not an
+// error.
+func TestGuardRejectUnsettledRowIsReleased(t *testing.T) {
+	claimed := queue.SettleClaimed
+	q := &fakeQueue{
+		items: []queue.WorkItem{{
+			ID:     1,
+			Inputs: models.Inputs{Track: models.Track{ArtistName: "A", TrackName: "One"}, Outdir: "o", Filename: "a.lrc"},
+		}},
+		guardRejectOutcome: &claimed,
+	}
+	fetcher := &seqFetcher{results: []seqResult{{
+		song: models.Song{
+			Track:     models.Track{ArtistName: "A", TrackName: "One"},
+			Subtitles: models.Synced{Lines: []models.Lines{{Text: "x"}}},
+		},
+	}}}
+	w := New(q, &fakeCache{}, fetcher, &fakeWriter{})
+	w.EnableGuard(rejectAllGuard{reason: "script not in allowlist"})
+	if err := w.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(q.completed) != 0 {
+		t.Errorf("completed = %v; a row that did not settle must not be recorded as done", q.completed)
+	}
+	if len(q.released) != 1 || q.released[0] != 1 {
+		t.Errorf("released = %v; want the unsettled row released for re-dequeue", q.released)
+	}
+	if len(q.failed) != 0 {
+		t.Errorf("failed = %v; an unsettled row must be released, not failed (it may no longer exist)", q.failed)
+	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -69,6 +69,15 @@ type Queue interface {
 	// with the offline backfills so a detector settle has exactly one definition;
 	// OwnedByWorker guards on 'processing', the status Dequeue left the row in.
 	SettleInstrumental(ctx context.Context, id int64, tel queue.InstrumentalTelemetry, owner queue.RowOwnership) (queue.SettleOutcome, error)
+	// SettleGuardRejected records that the language/script guard refused the
+	// fetched lyric and completes the row in ONE transaction (outcome_type,
+	// status, scan_results writeback), guarding on 'processing' (#655).
+	//
+	// Atomic rather than a stamp-then-Complete pair: a dropped stamp followed by a
+	// successful Complete would leave the row `done` with a NULL outcome_type,
+	// which IS the defect #655 exists to fix. A settle that can lose its own label
+	// is not a fix.
+	SettleGuardRejected(ctx context.Context, id int64) (queue.SettleOutcome, error)
 	// SetCompletionProvenance stamps the identifiers and writer version the row was
 	// settled with, so an outcome that writes no tag block -- an unsynced .txt above
 	// all -- still records what produced it (#620). Call before Complete while the
@@ -1418,17 +1427,32 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// 3,182 rows carried it on prod, the UI could say nothing about them,
 			// and NULL had quietly come to mean two different things.
 			//
-			// Stamped as its own value rather than reusing "unsynced": nothing was
+			// Recorded as its own value rather than reusing "unsynced": nothing was
 			// written here, so classifying it as an artifact would be a lie that
 			// reports would then count as coverage.
-			if stampErr := w.queue.SetOutcomeType(ctxNoCancel, item.ID, outcomeTypeRejected); stampErr != nil {
-				// Non-fatal, matching every other pre-Complete stamp: the policy
-				// decision is already correct and losing its label must not strand
-				// a row that is otherwise finished. The warning is the audit trail.
-				slog.Warn("worker: stamp guard-rejected outcome failed; continuing", "id", item.ID, "error", stampErr)
+			//
+			// ATOMIC, not a stamp-then-Complete pair. An earlier revision stamped
+			// the outcome best-effort and completed regardless, which reproduced
+			// the defect: a dropped stamp plus a successful Complete leaves the row
+			// `done` with a NULL outcome_type. On failure the row is NOT completed
+			// -- it fails and retries, and the guard will reject it again
+			// deterministically, so a retry costs one provider round-trip and
+			// cannot loop forever on a row that would otherwise settle unlabeled.
+			outcome, settleErr := w.queue.SettleGuardRejected(ctxNoCancel, item.ID)
+			if settleErr != nil {
+				return w.fail(ctx, item, fmt.Errorf("worker: settle guard-rejected item %d: %w", item.ID, settleErr))
 			}
-			if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
-				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))
+			if outcome != queue.Settled {
+				// The worker holds this row in 'processing' and nothing else can
+				// move it, so a non-Settled outcome means an invariant broke (a
+				// concurrent writer, or the row pruned mid-flight). Release rather
+				// than fail: failing would re-queue a row that may no longer exist.
+				slog.Warn("worker guard rejection did not settle; releasing", "id", item.ID, "outcome", outcome)
+				if relErr := w.queue.Release(ctxNoCancel, item.ID); relErr != nil {
+					return fmt.Errorf("worker: release unsettled guard-rejected item %d: %w", item.ID, relErr)
+				}
+				w.consecutiveFailures = 0
+				return nil
 			}
 			// Reset the failure backoff only after the terminal Complete durably
 			// succeeds (mirroring the benign-miss and normal-success paths): a

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -875,6 +875,45 @@ func (w *Worker) guardReject(_ queue.WorkItem, song models.Song) (bool, string) 
 	return !ok, reason
 }
 
+// work_queue.outcome_type values, as written by THIS package.
+//
+// SCOPE, stated precisely because it is easy to overclaim: these name the values
+// the worker's Go code stamps. They do NOT cover every producer of the column --
+// internal/queue's detector settle writes 'instrumental' as a SQL literal
+// (queue.go), and internal/reports classifies with literals inside its raw query
+// (reports.go). Both live inside SQL strings, where a Go constant cannot be
+// substituted without building the statement by concatenation, which is a worse
+// trade than the duplication.
+//
+// So this is the documented set, not a single point of definition. Adding a
+// value means touching all three sites; the ResultClass block in internal/reports
+// is the other end and cross-references this one.
+//
+// The column is deliberately NOT constrained by a CHECK: a new value must be
+// writable by a build that ships before the migration adding it, and a rejected
+// UPDATE would cost the row its label rather than degrade to "unclassified".
+const (
+	// outcomeTypeSynced -- a .lrc synced-lyrics file was written.
+	outcomeTypeSynced = "synced"
+	// outcomeTypeUnsynced -- a .txt plain-lyrics file was written.
+	outcomeTypeUnsynced = "unsynced"
+	// outcomeTypeInstrumental -- a .txt instrumental marker was written.
+	outcomeTypeInstrumental = "instrumental"
+	// outcomeTypeRejected -- the language/script guard refused the fetched lyric,
+	// so the row settled terminally with NOTHING on disk (#655).
+	//
+	// This is the value that did not exist, and its absence is the whole defect:
+	// the guard path completed the row leaving outcome_type NULL, which reports
+	// render as "unknown" -- the same rendering as a legacy row predating the
+	// column. One NULL meant two unrelated things, so an operator could not tell
+	// a policy rejection from missing history, and 3,182 prod rows sat that way.
+	//
+	// It is NOT an artifact class. A report counting it as coverage would be
+	// wrong: nothing was written, and nothing will be, because the rejection is
+	// deliberately terminal (re-fetching yields the same wrong-script lyric).
+	outcomeTypeRejected = "rejected"
+)
+
 // outcomeTypeFromSong derives the completion outcome ("synced" | "unsynced" |
 // "instrumental") from what WriteLRC will actually write for this song. The
 // ordering mirrors WriteLRC exactly and is load-bearing: the instrumental flag
@@ -897,16 +936,16 @@ func outcomeTypeFromSong(song models.Song) string {
 		// classify.
 		return ""
 	case lyrics.DemoteToUnsynced:
-		return "unsynced"
+		return outcomeTypeUnsynced
 	case lyrics.PromoteAsIs:
 	}
 	switch {
 	case song.Track.Instrumental == 1:
-		return "instrumental"
+		return outcomeTypeInstrumental
 	case len(song.Subtitles.Lines) > 0:
-		return "synced"
+		return outcomeTypeSynced
 	case song.Lyrics.LyricsBody != "":
-		return "unsynced"
+		return outcomeTypeUnsynced
 	default:
 		return ""
 	}
@@ -1369,7 +1408,26 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// just finalize the policy rejection: neither cached nor written, and
 			// not retried.
 			slog.Warn("worker guard rejected lyrics", "id", item.ID, "artist", item.Inputs.Track.ArtistName, "track", item.Inputs.Track.TrackName, "reason", reason)
-			if err := w.queue.Complete(context.WithoutCancel(ctx), item.ID); err != nil {
+			ctxNoCancel := context.WithoutCancel(ctx)
+			// Record WHY this row settled with nothing on disk, before Complete
+			// while the row is still 'processing' (#655).
+			//
+			// Without this the row lands `done` with a NULL outcome_type, which
+			// reports render as "unknown" -- indistinguishable from a legacy row
+			// predating the column. That ambiguity is what #655 was filed about:
+			// 3,182 rows carried it on prod, the UI could say nothing about them,
+			// and NULL had quietly come to mean two different things.
+			//
+			// Stamped as its own value rather than reusing "unsynced": nothing was
+			// written here, so classifying it as an artifact would be a lie that
+			// reports would then count as coverage.
+			if stampErr := w.queue.SetOutcomeType(ctxNoCancel, item.ID, outcomeTypeRejected); stampErr != nil {
+				// Non-fatal, matching every other pre-Complete stamp: the policy
+				// decision is already correct and losing its label must not strand
+				// a row that is otherwise finished. The warning is the audit trail.
+				slog.Warn("worker: stamp guard-rejected outcome failed; continuing", "id", item.ID, "error", stampErr)
+			}
+			if err := w.queue.Complete(ctxNoCancel, item.ID); err != nil {
 				return w.fail(ctx, item, fmt.Errorf("worker: complete guard-rejected item %d: %w", item.ID, err))
 			}
 			// Reset the failure backoff only after the terminal Complete durably

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -122,6 +122,13 @@ type fakeQueue struct {
 	setProviderLaneErr error
 	instrumentalStamps []instrumentalStamp
 	instrumentalErr    error
+	// guardRejectErr injects a failure into SettleGuardRejected so a test can
+	// assert the row is NOT completed when the settle fails -- the regression #655
+	// is about (a lost label must not leave the row settled and unlabeled).
+	guardRejectErr error
+	// guardRejectOutcome overrides the returned SettleOutcome (default Settled),
+	// so the non-Settled branch can be exercised without contriving a race.
+	guardRejectOutcome *queue.SettleOutcome
 	// settledLanes records ids settled through the shared settle transaction, so a
 	// test can distinguish a transactional settle from the old stamp-then-complete
 	// sequence.
@@ -303,6 +310,45 @@ func (q *fakeQueue) SettleInstrumental(_ context.Context, id int64, tel queue.In
 		q.outcomeTypes = make(map[int64]string)
 	}
 	q.outcomeTypes[id] = "instrumental"
+	q.settledLanes = append(q.settledLanes, id)
+	if q.onComplete != nil {
+		q.onComplete(id)
+	}
+	q.completed = append(q.completed, id)
+	q.removeFromProcessing(id)
+	return queue.Settled, nil
+}
+
+// SettleGuardRejected models the real transaction's ATOMICITY, which is the
+// property under test (#655): on failure it records nothing at all -- no outcome
+// type, no completion -- because the real statement either commits both or
+// neither. A fake that stamped the outcome and skipped only the completion would
+// agree with the buggy stamp-then-Complete code this replaced.
+//
+// It also honors the `WHERE status = 'processing'` guard: a row the fake is not
+// holding cannot be settled, matching the SQL rather than assuming the caller
+// passed a valid id.
+func (q *fakeQueue) SettleGuardRejected(_ context.Context, id int64) (queue.SettleOutcome, error) {
+	if q.guardRejectErr != nil {
+		return queue.SettleFailed, q.guardRejectErr
+	}
+	if q.guardRejectOutcome != nil {
+		return *q.guardRejectOutcome, nil
+	}
+	var held bool
+	for _, item := range q.processing {
+		if item.ID == id {
+			held = true
+			break
+		}
+	}
+	if !held {
+		return queue.SettleClaimed, nil
+	}
+	if q.outcomeTypes == nil {
+		q.outcomeTypes = make(map[int64]string)
+	}
+	q.outcomeTypes[id] = outcomeTypeRejected
 	q.settledLanes = append(q.settledLanes, id)
 	if q.onComplete != nil {
 		q.onComplete(id)


### PR DESCRIPTION
## Summary

- **A guard-rejected row settled `done` with a NULL `outcome_type`**, which reports render as "unknown" -- the same rendering as a legacy row predating the column. One value meant two unrelated things, so an operator could not tell a deliberate policy rejection from missing history. 3,182 rows sat that way on production, and the count was still growing.
- **Adds `outcome_type='rejected'`** (reported as `ResultRejected`), stamped before `Complete` on the guard path. Its own value rather than reusing `unsynced`: nothing was written, so classifying it as an artifact would be a lie reports would then count as coverage.
- **Look at first:** the mechanism was confirmed against production logs, not inferred, and both hypotheses in the issue body are refuted. See "Test plan".

## Linked issue

Closes #655

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; findings fixed before pushing.
  - Self-review found **two real defects in this change**, both fixed. See "Test plan".
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
  - **Not done, and not claimed.** See "Not covered".
- [x] Screenshot attached for any web-UI change -- N/A, no UI change. The new class flows through the existing reports classifier.
- [x] `make ui` re-run -- N/A, no `.templ` or CSS change.
- [x] Migration under `internal/db/migrations/` -- **deliberately none.** See "Not covered".

## Test plan

- [x] `make gate` passes locally. Exit 0, patch coverage 72.00% against a 70% threshold.
- [x] New tests were confirmed to **fail against unfixed code**.
      `TestGuardRejectedRowRecordsItsOutcome` reproduces rather than guards: removing the `SetOutcomeType` call from the guard branch reds with *"guard-rejected row settled with NO outcome_type recorded"*, at the assertion rather than the build. Restore green.
      It ships with **two controls**, because "the rejected row says rejected" is equally consistent with stamping every row that way: an accepted row must still say `synced`, and so must a row with no guard wired.
- [x] Patch coverage meets the Codecov threshold -- 72.00% (18/25).
- [x] Which **surface** this change fixes is stated explicitly and was verified by looking at it.
      The mechanism was established from production, not reasoning:
      - Guard rejections in the container logs match unstamped rows **day for day** across the entire log-retained window (13 and 13).
      - Every such row carries the exact column signature the path leaves: `outcome_type`, `fetched_at`, `writer_version` all NULL.
      - **Cause (2) refuted** -- `stamp outcome type failed` appears **zero** times across the live log and all ten archives. Verified that absence is real rather than filtered, via a control: 42 `WARN` lines present in the same log, worker-level ones among them, `level=debug`.
      - **Cause (1) refuted** -- `outcomeTypeFromSong`'s only empty arms are `Quarantine` (which stamps `timing_outcome`; **zero** unstamped rows carry one) and a `default` arm unreachable past `w.store` and `WriteLRC`.
      - `RetireMiss` was also considered and refuted: it writes `last_error`, which 3,176 of the rows lack.
- [x] Manual UAT steps:
  - [x] Read the production queue read-only (`mode=ro`) to establish the population, its column signature, and its rate over time.
  - [x] Cross-referenced container logs day-by-day against row completion dates to test the correlation rather than assume it.
  - [x] Mutation-tested the new test by removing the fix.
- [ ] Reviewer follow-ups:
  - [ ] **Is `rejected` the right model?** The alternative was a distinct `status` rather than an `outcome_type` value. That is truer to the issue's stated invariant (`done` asserts success), but `Dequeue`, the reports, and the scan writeback all key on status, so it is a much larger blast radius for the same user-visible result. I took the smaller change; say if you want the other.
  - [ ] **The June population.** 3,115 rows share the signature but predate log retention. I left them `unknown` rather than backfilling on a guess -- see "Not covered".

## Not covered

- **No migration, and no backfill of the existing 3,182 rows.** This is a deliberate answer to the issue's AC 4, not an omission. A guard rejection writes **nothing to disk**, so there is no artifact to recover a value from. The issue proposes backfilling from `output_paths`, which cannot work either: that column is marshaled at **enqueue** time (`internal/scan/enqueuer.go:288`), so its presence says nothing about what landed. All 3,182 rows have it -- as do the 29,983 correctly-stamped ones.
- **The June 20-25 bulk (3,115 rows) is consistent with this mechanism but UNVERIFIED.** Its column signature is indistinguishable from the confirmed cases, but logs do not reach back that far, and a matching signature is weaker evidence than a matching log line. Claiming it would be a guess dressed as a finding. Those rows stay `unknown`, which is the honest classification: neither the row nor the disk records why they settled.
- **The ~7,737 rows with no `provider_lane`** are untouched here. They remain the issue's AC 5 and are presumed genuinely legacy.
- **The binary was never run.** Verification was the production database, the production logs, and unit tests. Nothing here exercises a live serve-mode fetch through a configured language guard.
- **The constants are not a single point of definition**, and the comment says so rather than overclaiming. `internal/queue`'s detector settle and `internal/reports`' classifier still use SQL literals inside raw query strings, where a Go constant cannot substitute without concatenating statements. Adding a value means touching all three sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct “Rejected” result classification for items declined by language or script safeguards.
  * Rejected items now receive a clear terminal outcome while remaining separate from failed or deferred items.
* **Bug Fixes**
  * Improved outcome reporting so rejected items are completed exactly once and processed consistently.
  * Preserved existing behavior for accepted items and workflows without safeguards.
* **Tests**
  * Added coverage for rejected, accepted, and standard processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->