### PR TITLE
fix(petitlyrics): confirm a suspected outage with a liveness probe, not a count

### DIFF
--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -124,42 +124,67 @@ type Client struct {
 // reached the escalation threshold. Called for a response that parsed cleanly and
 // simply carried no songs -- never for a transport or status failure, which say
 // nothing about whether the application id still works.
-// The log emission is deliberately OUTSIDE the critical section. slog handlers
-// can block on I/O and take locks of their own, and this mutex also paces every
-// outbound request, so logging under it would serialize concurrent lookups on
-// the handler -- worst at exactly the moment an outage transition fires. The
-// pacer at pace() already follows this shape; match it.
+//
+// It DOES NOT LOG. Reaching the threshold is only SUSPICION under #767, not a
+// finding: the probe in confirmOutage is what decides. An earlier revision warned
+// here, which meant a perfectly healthy credential still logged "the application
+// id may have been revoked" on every long run of obscure material -- the #767
+// false positive surviving in the log path after being removed from the error
+// path. Only reportConfirmedOutage logs, and only on evidence.
 func (c *Client) recordZeroResult() bool {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.consecutiveZero++
-	count := c.consecutiveZero
-	reached := count >= ZeroResultThreshold
-	// Latch INSIDE the lock so exactly one goroutine can win the transition and
-	// emit the warning, even though the emission happens after the unlock.
-	transitioned := reached && !c.zeroReported
-	if transitioned {
-		c.zeroReported = true
-	}
-	c.mu.Unlock()
-
-	if transitioned {
-		slog.Warn("petitlyrics: provider has returned no results for a sustained run of lookups; the application id may have been revoked",
-			"consecutive", count, "threshold", ZeroResultThreshold)
-	}
-	return reached
+	return c.consecutiveZero >= ZeroResultThreshold
 }
 
-// recordNonZeroResult clears the outage counter. Any response carrying at least
-// one song proves the application id is still accepted, whatever the client then
-// makes of the payload.
-// The recovery log is emitted after the unlock, for the same reason as the
-// warning in recordZeroResult.
-func (c *Client) recordNonZeroResult() {
+// reportConfirmedOutage latches and logs an outage the caller has CONFIRMED,
+// either by a failed liveness probe or by the no-control count fallback.
+//
+// The latch makes this log once per outage rather than on every request past the
+// threshold, and the emission sits outside the critical section: slog handlers
+// can block on I/O and take locks of their own, and this mutex also paces every
+// outbound request, so logging under it would serialize concurrent lookups at
+// exactly the moment an outage fires. pace() follows the same shape.
+func (c *Client) reportConfirmedOutage(probed bool) {
+	c.mu.Lock()
+	count := c.consecutiveZero
+	first := !c.zeroReported
+	c.zeroReported = true
+	c.mu.Unlock()
+
+	if first {
+		slog.Warn("petitlyrics: provider returned no results for a sustained run and a liveness check did not clear it; the application id may have been revoked",
+			"consecutive", count, "threshold", ZeroResultThreshold, "liveness_probed", probed)
+	}
+}
+
+// recordSuccess clears the outage run and records the track as the control for a
+// later liveness probe, IN ONE mutex-held transition (#767).
+//
+// Atomicity is load-bearing, not tidiness. These were two separate locked calls,
+// and CodeRabbit caught the race: between them a concurrent burst of misses could
+// reach the threshold, observe hasKnownGood == false, take the no-control path,
+// and report ErrProviderUnavailable on a credential that had JUST returned songs.
+// The failure mode was the exact false outage this change exists to prevent.
+//
+// A track with no artist or title is not stored as a control -- it would be
+// unfetchable as a probe -- but it still clears the run, because songs came back.
+//
+// The recovery log is emitted after the unlock, for the same reason as above. The
+// control track itself is NEVER logged: it is library metadata.
+func (c *Client) recordSuccess(track models.Track) {
+	usable := track.TrackName != "" && track.ArtistName != ""
+
 	c.mu.Lock()
 	recovered := c.zeroReported
 	after := c.consecutiveZero
 	c.zeroReported = false
 	c.consecutiveZero = 0
+	if usable {
+		c.knownGood = track
+		c.hasKnownGood = true
+	}
 	c.mu.Unlock()
 
 	if recovered {
@@ -573,23 +598,10 @@ func (c *Client) request(ctx context.Context, track models.Track, tier int) ([]a
 	// At least one song came back, which proves the application id is still
 	// accepted. Reset regardless of what the client then makes of the payload: a
 	// candidate that loses selection, or a tier this client cannot decode, is a
-	// per-track outcome and says nothing about credential health.
-	c.recordNonZeroResult()
-	c.rememberKnownGood(track)
+	// per-track outcome and says nothing about credential health. The same
+	// transition records the control track, atomically -- see recordSuccess.
+	c.recordSuccess(track)
 	return songs, nil
-}
-
-// rememberKnownGood records a track this credential just fetched successfully, so
-// a later liveness probe has a control the provider has demonstrably served
-// (#767). Held in memory only and never logged -- it is library metadata.
-func (c *Client) rememberKnownGood(track models.Track) {
-	if track.TrackName == "" || track.ArtistName == "" {
-		return
-	}
-	c.mu.Lock()
-	c.knownGood = track
-	c.hasKnownGood = true
-	c.mu.Unlock()
 }
 
 // confirmOutage decides whether a threshold-length miss run is a real provider
@@ -631,6 +643,7 @@ func (c *Client) confirmOutage(ctx context.Context) bool {
 		// Never had a hit on this credential, so there is nothing to test against
 		// and no way to do better than the count. This is the cold-start revoked
 		// credential #607 exists to catch.
+		c.reportConfirmedOutage(false)
 		return true
 	}
 	if busy {
@@ -652,6 +665,14 @@ func (c *Client) confirmOutage(ctx context.Context) bool {
 		// A transport or status failure says nothing about the credential; it is
 		// the ordinary network-flake case, and statusError already classifies a
 		// real 401/429.
+		//
+		// BACK THE COUNTER OFF rather than leaving it at the threshold. Otherwise
+		// recordZeroResult keeps returning true and EVERY subsequent miss launches
+		// another probe -- a retry storm of real paced requests during exactly the
+		// transient failure that caused it. Halving costs one more threshold's
+		// worth of misses before the next attempt, which is the right trade
+		// against hammering a provider that is already struggling.
+		c.backOffProbe()
 		slog.Debug("petitlyrics: liveness probe failed in transport; not treating as an outage", "error", err)
 		return false
 	}
@@ -659,11 +680,30 @@ func (c *Client) confirmOutage(ctx context.Context) bool {
 		// The credential works. The miss run was about the MATERIAL, which is the
 		// normal condition for a fallback lane. Clear it so the next run gets a
 		// fresh threshold rather than escalating on the very next miss.
-		c.recordNonZeroResult()
+		//
+		// The control is re-recorded here deliberately: it just proved itself
+		// again, and passing it keeps the reset and the store atomic.
+		c.recordSuccess(control)
 		slog.Debug("petitlyrics: liveness probe succeeded; sustained miss run is material, not a credential outage")
 		return false
 	}
+	// The provider served this track before and does not now. That is evidence.
+	c.reportConfirmedOutage(true)
 	return true
+}
+
+// backOffProbe halves the miss run after a probe that could not reach the API, so
+// the next attempt is a threshold away instead of on the very next miss (#767
+// review).
+//
+// Halving rather than zeroing: the misses were real, and discarding them entirely
+// would let a genuine outage hide behind repeated probe failures -- a credential
+// revoked at the same moment the network degrades would need two full runs to be
+// noticed. Halving keeps the evidence while spacing the retries.
+func (c *Client) backOffProbe() {
+	c.mu.Lock()
+	c.consecutiveZero /= 2
+	c.mu.Unlock()
 }
 
 // rawRequest performs the single form POST and decodes the XML envelope, without

--- a/internal/petitlyrics/client.go
+++ b/internal/petitlyrics/client.go
@@ -95,6 +95,29 @@ type Client struct {
 	// zeroReported latches the transition so the outage is logged ONCE rather
 	// than on every request past the threshold. Cleared on recovery.
 	zeroReported bool
+
+	// knownGood is the most recent track this credential successfully fetched at
+	// least one song for, and it is what makes the outage decision EVIDENCE-BASED
+	// rather than a guess (#767).
+	//
+	// A consecutive-miss count cannot distinguish "the provider has nothing for
+	// THIS material" from "the provider has nothing for ANYTHING", and those need
+	// opposite responses. A fallback lane sees exactly the obscure material the
+	// primary already failed on, so a long miss run is its NORMAL operating
+	// condition: measured at a 91% miss rate, a run of 20 had probability 0.742 of
+	// occurring by chance. The threshold was firing on the population it was meant
+	// to serve.
+	//
+	// Re-fetching a track the provider demonstrably had turns that into a real
+	// test: a hit proves the credential works and the misses were material, a miss
+	// proves the credential stopped working. Self-calibrating, because the control
+	// comes from this provider's own past behavior rather than a hardcoded canary
+	// that could itself be retired from the catalog.
+	knownGood    models.Track
+	hasKnownGood bool
+	// probeInFlight stops a burst of concurrent misses from each launching their
+	// own liveness probe. One probe answers the question for all of them.
+	probeInFlight bool
 }
 
 // recordZeroResult counts a zero-song response and reports whether the run has
@@ -518,8 +541,135 @@ func trackFromCandidate(s apiSong, local models.Track) models.Track {
 	return t
 }
 
-// request performs the single form POST and decodes the XML envelope.
+// request performs the single form POST, decodes the XML envelope, and maintains
+// the zero-result outage state (#607/#767).
+//
+// It wraps rawRequest so the liveness probe can reach the API WITHOUT feeding the
+// counter it exists to adjudicate: a probe that counted its own result would
+// either clear the suspicion it was sent to test, or deepen it, depending on
+// ordering. The probe calls rawRequest directly.
 func (c *Client) request(ctx context.Context, track models.Track, tier int) ([]apiSong, error) {
+	songs, err := c.rawRequest(ctx, track, tier)
+	if err != nil {
+		return nil, err
+	}
+	if len(songs) == 0 {
+		// A clean HTTP 200 carrying no songs. Individually this is an ordinary
+		// miss; sustained, it MIGHT be a revoked application id, since the service
+		// keeps answering normally rather than returning 401 (#607).
+		//
+		// "Might" is the whole correction in #767. A miss run is also what an
+		// obscure-material population looks like, so the count alone cannot decide.
+		// When the run reaches the threshold, ASK the provider a question it can
+		// only answer one way.
+		if !c.recordZeroResult() {
+			return nil, fmt.Errorf("petitlyrics: no songs in response: %w", ErrNotFound)
+		}
+		if c.confirmOutage(ctx) {
+			return nil, ErrProviderUnavailable
+		}
+		return nil, fmt.Errorf("petitlyrics: no songs in response: %w", ErrNotFound)
+	}
+	// At least one song came back, which proves the application id is still
+	// accepted. Reset regardless of what the client then makes of the payload: a
+	// candidate that loses selection, or a tier this client cannot decode, is a
+	// per-track outcome and says nothing about credential health.
+	c.recordNonZeroResult()
+	c.rememberKnownGood(track)
+	return songs, nil
+}
+
+// rememberKnownGood records a track this credential just fetched successfully, so
+// a later liveness probe has a control the provider has demonstrably served
+// (#767). Held in memory only and never logged -- it is library metadata.
+func (c *Client) rememberKnownGood(track models.Track) {
+	if track.TrackName == "" || track.ArtistName == "" {
+		return
+	}
+	c.mu.Lock()
+	c.knownGood = track
+	c.hasKnownGood = true
+	c.mu.Unlock()
+}
+
+// confirmOutage decides whether a threshold-length miss run is a real provider
+// outage, by re-fetching a track this credential previously succeeded on (#767).
+//
+// Returns true on POSITIVE evidence of an outage: the control track, which the
+// provider served before, now returns nothing. A hit means the credential works
+// and the misses were about the material, so the counter resets and the caller
+// reports an ordinary miss.
+//
+// WITH NO CONTROL IT FALLS BACK TO THE COUNT, which preserves #607. That case is
+// not a detail -- it is the ORIGINAL bug: a credential revoked before this
+// process ever saw a hit (a restart with a dead clientAppId) never earns a
+// control, so a probe-only design would leave that outage undetected FOREVER,
+// strictly worse than counting. An earlier draft of this function returned false
+// there and its comment claimed the next probe would catch it; there is no next
+// probe when no control can ever be recorded.
+//
+// The two cases separate cleanly, which is what makes this sound rather than a
+// compromise:
+//
+//   - A false positive (#767) happens on a lane that IS serving hits -- 6
+//     successful fetches preceded the run that misfired -- so a control exists
+//     and the probe adjudicates it.
+//   - A cold-start outage (#607) has no hits by definition, so no control exists
+//     and the count is the only signal available.
+//
+// A probe already in flight returns false: another goroutine is asking the same
+// question, and two probes cannot be more informative than one.
+func (c *Client) confirmOutage(ctx context.Context) bool {
+	c.mu.Lock()
+	control, have, busy := c.knownGood, c.hasKnownGood, c.probeInFlight
+	if have && !busy {
+		c.probeInFlight = true
+	}
+	c.mu.Unlock()
+
+	if !have {
+		// Never had a hit on this credential, so there is nothing to test against
+		// and no way to do better than the count. This is the cold-start revoked
+		// credential #607 exists to catch.
+		return true
+	}
+	if busy {
+		// Another goroutine is already probing. Do not claim an outage on no
+		// evidence; the in-flight probe will decide for the run.
+		return false
+	}
+	defer func() {
+		c.mu.Lock()
+		c.probeInFlight = false
+		c.mu.Unlock()
+	}()
+
+	// Deliberately rawRequest: the probe must not feed the counter it adjudicates.
+	// Tier 1 because every song with lyrics has it -- a tier-2/3 probe could miss
+	// on a healthy credential simply because that track has no higher tier.
+	songs, err := c.rawRequest(ctx, control, tierUnsynced)
+	if err != nil {
+		// A transport or status failure says nothing about the credential; it is
+		// the ordinary network-flake case, and statusError already classifies a
+		// real 401/429.
+		slog.Debug("petitlyrics: liveness probe failed in transport; not treating as an outage", "error", err)
+		return false
+	}
+	if len(songs) > 0 {
+		// The credential works. The miss run was about the MATERIAL, which is the
+		// normal condition for a fallback lane. Clear it so the next run gets a
+		// fresh threshold rather than escalating on the very next miss.
+		c.recordNonZeroResult()
+		slog.Debug("petitlyrics: liveness probe succeeded; sustained miss run is material, not a credential outage")
+		return false
+	}
+	return true
+}
+
+// rawRequest performs the single form POST and decodes the XML envelope, without
+// touching the outage counter. Callers that represent real lookup traffic should
+// use request instead.
+func (c *Client) rawRequest(ctx context.Context, track models.Track, tier int) ([]apiSong, error) {
 	form := url.Values{
 		"clientAppId":  {c.clientAppID},
 		"terminalType": {terminalType},
@@ -558,20 +708,8 @@ func (c *Client) request(ctx context.Context, track models.Track, tier int) ([]a
 	if err := xml.Unmarshal(body, &parsed); err != nil {
 		return nil, fmt.Errorf("petitlyrics: decode XML response: %w", err)
 	}
-	if len(parsed.Songs) == 0 {
-		// A clean HTTP 200 carrying no songs. Individually this is an ordinary
-		// miss; sustained, it is the fingerprint of a revoked application id,
-		// since the service keeps answering normally rather than returning 401
-		// (#607).
-		if c.recordZeroResult() {
-			return nil, ErrProviderUnavailable
-		}
-		return nil, fmt.Errorf("petitlyrics: no songs in response: %w", ErrNotFound)
-	}
-	// At least one song came back, which proves the application id is still
-	// accepted. Reset regardless of what the client then makes of the payload: a
-	// candidate that loses selection, or a tier this client cannot decode, is a
-	// per-track outcome and says nothing about credential health.
-	c.recordNonZeroResult()
+	// Zero-song handling and the outage counter live in request, the wrapper, so
+	// the liveness probe can call this without adjudicating itself (#767). An
+	// empty slice is returned as-is; the caller decides what it means.
 	return parsed.Songs, nil
 }

--- a/internal/petitlyrics/liveness_probe_test.go
+++ b/internal/petitlyrics/liveness_probe_test.go
@@ -1,0 +1,215 @@
+package petitlyrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
+
+// This file is the guard for #767.
+//
+// ZeroResultThreshold escalates a run of consecutive zero-result lookups to
+// ErrProviderUnavailable, on the reasoning that a revoked clientAppId keeps
+// answering HTTP 200 with no songs (#607). A fixed COUNT cannot make that
+// distinction, and the population it gets wrong is the one this lane exists to
+// serve: a fallback lane only sees what the primary already missed, so long miss
+// runs are its normal operating condition.
+//
+// Measured on a real paced sweep: a 91% miss rate, and an exact DP over the run
+// puts P(>=1 run of 20 misses in 78 lookups) at 0.742. The escalation was more
+// likely than not to fire on healthy material -- 6 lookups had succeeded on the
+// same credential earlier in that very run.
+//
+// The fix is a positive liveness probe: on reaching the threshold, re-fetch a
+// track this credential DEMONSTRABLY served before. A hit proves the credential
+// works and the misses were about the material; a miss is real evidence.
+
+// serveKnownGoodOnly answers requests for the control track ("Known") with a real
+// fixture and everything else with an empty envelope. It counts probe hits.
+//
+// This is the HEALTHY-CREDENTIAL model, and getting it right is the whole point:
+// the provider still HAS the track it served before, and simply lacks the obscure
+// ones. A count-based handler ("first N requests hit, then empty") would also
+// starve the probe's re-fetch, which models a DEAD credential instead -- the
+// opposite scenario.
+func serveKnownGoodOnly(t *testing.T) (http.HandlerFunc, *atomic.Int32) {
+	t.Helper()
+	hit := serveFixture(t, "type1_unsynced.xml")
+	var probes atomic.Int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil && r.FormValue("key_title") == "Known" {
+			probes.Add(1)
+			hit(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write([]byte(emptyResponse))
+	}, &probes
+}
+
+// serveHitThenEmpty answers the first n requests with a real fixture and every
+// later request with an empty envelope -- including the liveness probe's
+// re-fetch. That models a credential that WORKED and then genuinely died.
+func serveHitThenEmpty(t *testing.T, n int32) (http.HandlerFunc, *atomic.Int32) {
+	t.Helper()
+	hit := serveFixture(t, "type1_unsynced.xml")
+	var count atomic.Int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		if count.Add(1) <= n {
+			hit(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write([]byte(emptyResponse))
+	}, &count
+}
+
+// TestMissRunOnHealthyCredentialIsNotAnOutage is the #767 regression test: the
+// exact shape that misfired in production.
+//
+// A credential that has served hits, then hits a threshold-length run of misses
+// on obscure material, must NOT be reported as unavailable -- the liveness probe
+// re-fetches the known-good track, gets a hit, and the run is correctly read as
+// material rather than a credential failure.
+func TestMissRunOnHealthyCredentialIsNotAnOutage(t *testing.T) {
+	// The provider still has the control track; it simply lacks the obscure ones.
+	handler, _ := serveKnownGoodOnly(t)
+	c, _ := newTestClient(t, handler)
+
+	// The successful lookup that records the known-good track.
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Known", ArtistName: "Good"}); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+
+	// Now drive well past the threshold on obscure material. Under the old
+	// count-only rule this escalated at exactly ZeroResultThreshold.
+	var err error
+	for i := 0; i < ZeroResultThreshold+5; i++ {
+		_, err = c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"})
+		if errors.Is(err, ErrProviderUnavailable) {
+			t.Fatalf("miss %d reported ErrProviderUnavailable on a credential that is still serving; "+
+				"this is the #767 false positive (P=0.742 on the measured population)", i+1)
+		}
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v; want an ordinary ErrNotFound", err)
+	}
+}
+
+// TestColdStartRevokedCredentialStillEscalates guards the case a probe-only
+// design would BREAK, and it is the original #607 defect.
+//
+// A credential revoked before this process ever saw a hit never earns a control
+// track, so there is nothing to probe. Falling back to the count is the only
+// signal available; returning "not an outage" there would leave a dead
+// credential undetected forever -- strictly worse than the behavior #767
+// replaces.
+func TestColdStartRevokedCredentialStillEscalates(t *testing.T) {
+	c, _ := newTestClient(t, serveEmpty())
+
+	var err error
+	for i := 0; i < ZeroResultThreshold; i++ {
+		_, err = c.FindLyrics(context.Background(), models.Track{TrackName: "t", ArtistName: "a"})
+	}
+	if !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("a credential that never served a single hit did not escalate after %d misses; "+
+			"with no control track the count is the ONLY available signal (#607)", ZeroResultThreshold)
+	}
+	// It must still satisfy ErrNotFound so existing benign-miss callers work.
+	if !errors.Is(err, ErrNotFound) {
+		t.Error("ErrProviderUnavailable must still wrap ErrNotFound")
+	}
+}
+
+// TestLivenessProbeConfirmsRealOutage is the other half of the discrimination:
+// when the credential genuinely dies, the probe MISSES on the known-good track
+// and the outage is reported.
+//
+// Without this, "never escalates" would pass the test above and be useless.
+func TestLivenessProbeConfirmsRealOutage(t *testing.T) {
+	handler, _ := serveHitThenEmpty(t, 1)
+	c, _ := newTestClient(t, handler)
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Known", ArtistName: "Good"}); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+	// From here the server answers EVERYTHING with an empty envelope, including
+	// the probe's re-fetch of the known-good track. That is a real outage.
+	var err error
+	for i := 0; i < ZeroResultThreshold; i++ {
+		_, err = c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"})
+	}
+	if !errors.Is(err, ErrProviderUnavailable) {
+		t.Fatalf("err = %v; want ErrProviderUnavailable -- the probe re-fetched a track the "+
+			"credential had served and got nothing, which IS evidence of an outage", err)
+	}
+}
+
+// TestLivenessProbeResetsTheRunOnSuccess asserts the probe does not merely
+// suppress one escalation: a successful probe clears the counter, so the lane
+// gets a fresh threshold rather than re-escalating on the very next miss.
+//
+// Without the reset the probe would fire on every subsequent lookup, costing a
+// paced request each time -- turning a false alarm into a throughput problem.
+func TestLivenessProbeResetsTheRunOnSuccess(t *testing.T) {
+	handler, probes := serveKnownGoodOnly(t)
+	c, _ := newTestClient(t, handler)
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Known", ArtistName: "Good"}); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+	seeded := probes.Load()
+
+	// Two full threshold-length runs.
+	for i := 0; i < ZeroResultThreshold*2; i++ {
+		if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"}); errors.Is(err, ErrProviderUnavailable) {
+			t.Fatalf("miss %d escalated despite a live credential", i+1)
+		}
+	}
+
+	// Exactly two probes: one per completed run. More would mean the counter is
+	// not resetting and every miss past the threshold re-probes.
+	if got := probes.Load() - seeded; got != 2 {
+		t.Errorf("probe count = %d over two threshold runs; want 2 (a successful probe must reset the run)", got)
+	}
+}
+
+// TestConcurrentMissesProbeOnce asserts the in-flight guard: a burst of
+// concurrent misses crossing the threshold together must not each launch a
+// probe. Each probe is a real paced request, so N probes for one question is a
+// throughput cost with no extra information.
+func TestConcurrentMissesProbeOnce(t *testing.T) {
+	handler, probes := serveKnownGoodOnly(t)
+	c, _ := newTestClient(t, handler)
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Known", ArtistName: "Good"}); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+	seeded := probes.Load()
+
+	// Walk to one short of the threshold serially, so the burst below crosses it.
+	for i := 0; i < ZeroResultThreshold-1; i++ {
+		_, _ = c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"})
+		}()
+	}
+	wg.Wait()
+
+	// The exact count depends on scheduling, but it must be far below the number
+	// of concurrent missers -- the guard exists to collapse them.
+	if got := probes.Load() - seeded; got > 2 {
+		t.Errorf("probe count = %d for 8 concurrent misses; the in-flight guard should collapse them", got)
+	}
+}

--- a/internal/petitlyrics/liveness_probe_test.go
+++ b/internal/petitlyrics/liveness_probe_test.go
@@ -207,9 +207,77 @@ func TestConcurrentMissesProbeOnce(t *testing.T) {
 	}
 	wg.Wait()
 
-	// The exact count depends on scheduling, but it must be far below the number
-	// of concurrent missers -- the guard exists to collapse them.
-	if got := probes.Load() - seeded; got > 2 {
-		t.Errorf("probe count = %d for 8 concurrent misses; the in-flight guard should collapse them", got)
+	// EXACTLY one, and the exactness is provable rather than a hope about
+	// scheduling. The run sits at ZeroResultThreshold-1, so whichever goroutine
+	// increments first reaches the threshold and wins probeInFlight; every other
+	// goroutine either sees busy (returns false, no probe) or arrives after the
+	// successful probe reset the counter to 0, where 7 remaining misses cannot
+	// reach the threshold again.
+	//
+	// The earlier `got > 2` was wrong in the direction that matters: it also
+	// passed on ZERO probes, which is the guard blocking the probe entirely --
+	// precisely the failure this test exists to catch. Caught in review.
+	if got := probes.Load() - seeded; got != 1 {
+		t.Errorf("probe count = %d for 8 concurrent misses; want exactly 1 "+
+			"(0 means the in-flight guard suppressed the probe entirely, >1 means it failed to collapse them)", got)
+	}
+}
+
+// TestProbeTransportFailureDoesNotStorm covers the retry storm Copilot caught in
+// review on PR #771.
+//
+// When the probe cannot reach the API, the run is genuinely unadjudicated -- but
+// leaving the counter at the threshold means recordZeroResult keeps returning
+// true, so EVERY subsequent miss launches another probe. That is a burst of real
+// paced requests aimed at a provider that is already failing to answer.
+//
+// Backing the counter off spaces the retries out by roughly another threshold.
+func TestProbeTransportFailureDoesNotStorm(t *testing.T) {
+	hit := serveFixture(t, "type1_unsynced.xml")
+	var probes atomic.Int32
+	var breakProbe atomic.Bool
+
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil && r.FormValue("key_title") == "Known" {
+			probes.Add(1)
+			if breakProbe.Load() {
+				// Not a valid XML envelope: the probe fails in decode, which is
+				// the transport-ish failure class that says nothing about the
+				// credential.
+				w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+				_, _ = w.Write([]byte("}{ not xml"))
+				return
+			}
+			hit(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write([]byte(emptyResponse))
+	})
+
+	if _, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Known", ArtistName: "Good"}); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+	breakProbe.Store(true)
+	seeded := probes.Load()
+
+	// Drive a full threshold run plus a long tail of further misses. With no
+	// backoff every one of those tail misses probes again.
+	for i := 0; i < ZeroResultThreshold*2; i++ {
+		_, err := c.FindLyrics(context.Background(), models.Track{TrackName: "Obscure", ArtistName: "Artist"})
+		if errors.Is(err, ErrProviderUnavailable) {
+			t.Fatalf("miss %d escalated on a FAILED probe; a probe that could not reach "+
+				"the API is not evidence of a dead credential", i+1)
+		}
+	}
+
+	// Without the backoff this is ~21 probes (one per miss past the threshold).
+	// With it, the counter halves each time, so attempts are spaced out.
+	if got := probes.Load() - seeded; got > 4 {
+		t.Errorf("probe count = %d over %d misses after a failing probe; the backoff "+
+			"should space retries out rather than probing on every miss", got, ZeroResultThreshold*2)
+	}
+	if got := probes.Load() - seeded; got == 0 {
+		t.Error("no probe was attempted at all; the backoff must delay retries, not disable them")
 	}
 }

--- a/internal/petitlyrics/unavailable_test.go
+++ b/internal/petitlyrics/unavailable_test.go
@@ -129,6 +129,12 @@ func TestZeroResults_SuccessMidRunResets(t *testing.T) {
 // lock. Claim it outside and every goroutine crossing the threshold together
 // would each emit the warning -- turning a one-line outage signal into a flood,
 // which is exactly what the once-on-transition requirement exists to prevent.
+//
+// THE LATCH MOVED IN #767, AND SO DID HALF THIS TEST. Reaching the threshold is
+// now only SUSPICION -- the liveness probe decides -- so recordZeroResult no
+// longer latches or logs; reportConfirmedOutage does, on evidence. The invariant
+// is unchanged and still asserted here, just against the function that now owns
+// it. The counting half still exercises recordZeroResult.
 func TestZeroResultLatchIsExactlyOnceUnderConcurrency(t *testing.T) {
 	c := NewClient()
 	total := ZeroResultThreshold * 2
@@ -145,15 +151,38 @@ func TestZeroResultLatchIsExactlyOnceUnderConcurrency(t *testing.T) {
 	wg.Wait()
 
 	c.mu.Lock()
-	got, latched := c.consecutiveZero, c.zeroReported
+	got, latchedEarly := c.consecutiveZero, c.zeroReported
 	c.mu.Unlock()
 
 	if got != total {
 		t.Errorf("consecutiveZero = %d; want %d. A lost increment means the counter "+
 			"is racy and the threshold could be reached late or never.", got, total)
 	}
+	// Counting alone must NOT latch: that is the #767 correction. A latch here
+	// would mean a healthy credential had already been recorded as an outage
+	// before the probe ever ran.
+	if latchedEarly {
+		t.Error("zeroReported was latched by counting alone; reaching the threshold " +
+			"is only suspicion until the liveness probe confirms it (#767)")
+	}
+
+	// Now the confirmation path, concurrently: the latch must be claimed exactly
+	// once no matter how many goroutines confirm together.
+	var wg2 sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			c.reportConfirmedOutage(true)
+		}()
+	}
+	wg2.Wait()
+
+	c.mu.Lock()
+	latched := c.zeroReported
+	c.mu.Unlock()
 	if !latched {
-		t.Error("zeroReported was not latched after crossing the threshold; the " +
+		t.Error("zeroReported was not latched after a confirmed outage; the " +
 			"recovery log would then never fire either")
 	}
 


### PR DESCRIPTION
## Summary

- **A fixed consecutive-miss count cannot tell a revoked credential from obscure material**, and obscure material is exactly what a fallback lane sees -- the primary already served everything popular. Measured on a real paced sweep: a 91% miss rate, and an exact DP over the run puts **P(>=1 run of 20 misses in 78 lookups) at 0.742**. The escalation was more likely than not to fire on a healthy credential, and did.
- **Replaces the count with a positive liveness probe.** On reaching the threshold, re-fetch a track this credential demonstrably served before: a hit proves the credential works and the misses were about the material; a miss is real evidence of an outage.
- **Look at first:** the count is KEPT as the no-control fallback. That is not a hedge -- see "Test plan" for why removing it re-opens #607.

## Linked issue

Closes #767

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`.
- [x] Code review pass complete; findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
  - **Not done, and not claimed.** See "Not covered" -- this needs live provider traffic.
- [x] Screenshot -- N/A, no UI change.
- [x] `make ui` -- N/A, no `.templ` or CSS change.
- [x] Migration -- N/A, no schema or data change.

## Test plan

- [x] `make gate` passes locally. Exit 0, patch coverage **90.41%** against a 70% threshold.
- [x] New tests were confirmed to **fail against unfixed code** -- in BOTH directions, which is the property that matters here:

  | Mutation | Reds | Guards |
  |---|---|---|
  | Revert to count-only (no probe) | `TestMissRunOnHealthyCredentialIsNotAnOutage` | the #767 false positive |
  | Probe-only (drop the count fallback) | `TestColdStartRevokedCredentialStillEscalates` | the #607 cold-start outage |

  Neither half can be undone without a test noticing. Both failed at the assertion, not the build.

- [x] **The existing #607 tests caught a real flaw in the first draft**, and were left alone rather than adjusted to fit the new design. That draft returned "not an outage" whenever no control track existed -- but a credential revoked before the process ever sees a hit never earns a control, so a dead credential would have gone undetected **forever**: strictly worse than what it replaces. The draft's own comment claimed "the next probe catches it", which is false when no control can ever be recorded.
- [x] Patch coverage meets the Codecov threshold -- 90.41% (66/73).
- [x] Which **surface** this fixes is stated and was verified by looking at it:
  - `-race -count=2` on the concurrent probe path: **no data races**. This mattered because `c.mu` guards both the pacer and the outage counter, and the probe re-enters the request path -- `confirmOutage` releases the lock before any I/O, so it never nests with `pace()`.
  - The rename `request` -> `rawRequest` was checked caller-by-caller: the wrapper serves real lookup traffic (including the survey probe), `rawRequest` serves only the two internal callers that must not feed the counter.
  - **Privacy:** the control track is a library title. It is held in memory, never persisted, and never logged -- both probe log lines are `Debug` with no track identifiers.
- [x] Manual UAT steps:
  - [x] Ran the full `internal/petitlyrics` suite plus its consumers (`internal/orchestrator`, `internal/worker`) -- the lane's error sentinels feed both.
  - [x] Mutation-tested both directions (table above).
  - [x] Race-tested the concurrent burst path.
- [ ] Reviewer follow-ups:
  - [ ] **Is the no-control fallback the right call?** It means a cold-start revoked credential still escalates on count alone, at the same P=0.742 on obscure material. I judged an undetectable outage worse than a false positive in the one case where no better signal exists, but that is a judgment about which failure costs more.
  - [ ] **The probe spends one paced request** per completed miss run. A successful probe resets the run so it does not re-fire on every subsequent miss, and an in-flight guard collapses a concurrent burst -- but on a very obscure library it is a real if small cost.

## Not covered

- **No live provider traffic.** Every test here uses `httptest`. The behaviour this fixes was *measured* live (the aborted sweep), but the fix itself has not faced the real API -- that is the next step, and the reason this PR exists: it unblocks the tier-2 decoder verification sweep, which aborted at sample 78 of 100 on this exact false positive.
- **The threshold constant is unchanged at 20.** Raising it was considered and rejected: K would need to be **47** for P<5% on the measured population, and a more obscure library would misfire again. The shape of the signal was the problem, not its magnitude.
- **A genuinely revoked credential mid-run is detected one threshold later than before** in the worst case, because the probe must first miss on the control. That is the intended trade: the previous behaviour detected it instantly and also fired constantly on healthy lanes.
- **`isOfficial` / tier-2 corpus questions are untouched.** This is the unblocking step for #614's sweep, not the measurement itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of provider outages versus tracks with no available lyrics.
  * Prevented temporary empty results from being incorrectly reported as service outages.
  * Confirmed genuine outages continue to return appropriate unavailable errors.
  * Improved handling of concurrent requests and restored service availability more quickly after successful responses.

* **Tests**
  * Added coverage for healthy credentials, revoked credentials, outage detection, recovery, and concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->