### PR TITLE
fix(web): size inline SVGs by attribute, and name the retry-backoff count for its mechanism

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -507,16 +507,25 @@ func (r *Repo) UpNext(ctx context.Context, limit int) ([]UpNextItem, error) {
 }
 
 // QueueEligibility partitions the not-yet-done backlog by readiness: Eligible
-// rows are claimable now, Cooldown rows are waiting out a backoff/retry delay,
-// and Buffered is the eligible subset already stamped into the lookahead buffer.
+// rows are claimable now, RetryBackoff rows are waiting out a retry delay, and
+// Buffered is the eligible subset already stamped into the lookahead buffer.
 type QueueEligibility struct {
 	// Eligible counts rows the worker can claim now (status pending/failed/
 	// deferred, next_attempt_at <= now). This is the "of M eligible" header total.
 	Eligible int64
-	// Cooldown counts rows in the same statuses whose next_attempt_at is still in
-	// the future -- deferred/backoff rows not yet actionable. The empty state uses
-	// it to distinguish "nothing queued" from "everything waiting on cooldown".
-	Cooldown int64
+	// RetryBackoff counts rows in the same statuses whose next_attempt_at is still
+	// in the future -- rows not yet actionable because a retry delay has not
+	// elapsed. The empty state uses it to distinguish "nothing queued" from
+	// "everything waiting out a retry delay".
+	//
+	// NAMED FOR THE MECHANISM, NOT THE OLD LABEL. This count is governed by
+	// api.miss_backoff_base_hours, and is unrelated to every config key spelled
+	// "cooldown" (api.cooldown, providers.petitlyrics_cooldown_seconds,
+	// instrumental_detector.cooldown_seconds, and its backfill twin) -- all four
+	// of those are REQUEST PACING, the gap between outbound calls. Calling this
+	// "cooldown" sent an operator hunting for a pacing knob to shorten a retry
+	// delay, which no pacing key can do; the lever is `queue recheck --deferred`.
+	RetryBackoff int64
 	// Buffered counts the eligible rows currently stamped into the lookahead
 	// buffer (batch_seq IS NOT NULL) -- the TRUE size of the buffer, independent
 	// of any display cap on UpNext. The header uses this so a capped UpNext page
@@ -524,7 +533,7 @@ type QueueEligibility struct {
 	Buffered int64
 }
 
-// QueueEligibility returns the eligible, cooldown, and buffered counts for the
+// QueueEligibility returns the eligible, retry-backoff, and buffered counts for the
 // Up-next panel header and empty state, in one query so all three share a single
 // now and cannot skew against each other.
 //
@@ -535,7 +544,7 @@ type QueueEligibility struct {
 // total is scanned through sql.NullInt64 and defaults to 0.
 func (r *Repo) QueueEligibility(ctx context.Context) (QueueEligibility, error) {
 	now := time.Now().UTC().Format(timeFormat)
-	var eligible, cooldown, buffered sql.NullInt64
+	var eligible, retryBackoff, buffered sql.NullInt64
 	if err := r.db.QueryRowContext(ctx,
 		`SELECT
              SUM(CASE WHEN next_attempt_at <= ? THEN 1 ELSE 0 END),
@@ -544,12 +553,12 @@ func (r *Repo) QueueEligibility(ctx context.Context) (QueueEligibility, error) {
          FROM work_queue
          WHERE status IN ('pending', 'failed', 'deferred')`,
 		now, now, now,
-	).Scan(&eligible, &cooldown, &buffered); err != nil {
+	).Scan(&eligible, &retryBackoff, &buffered); err != nil {
 		return QueueEligibility{}, fmt.Errorf("reports: queue eligibility: %w", err)
 	}
 	return QueueEligibility{
-		Eligible: eligible.Int64,
-		Cooldown: cooldown.Int64,
-		Buffered: buffered.Int64,
+		Eligible:     eligible.Int64,
+		RetryBackoff: retryBackoff.Int64,
+		Buffered:     buffered.Int64,
 	}, nil
 }

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -698,13 +698,13 @@ func TestQueueEligibility(t *testing.T) {
 	if got.Eligible != 3 {
 		t.Errorf("Eligible = %d, want 3", got.Eligible)
 	}
-	if got.Cooldown != 2 {
-		t.Errorf("Cooldown = %d, want 2", got.Cooldown)
+	if got.RetryBackoff != 2 {
+		t.Errorf("RetryBackoff = %d, want 2", got.RetryBackoff)
 	}
-	// Buffered = the two eligible rows with a batch_seq; the buffered cooldown
-	// row is excluded because it is not eligible now.
+	// Buffered = the two eligible rows with a batch_seq; the buffered
+	// retry-backoff row is excluded because it is not eligible now.
 	if got.Buffered != 2 {
-		t.Errorf("Buffered = %d, want 2 (buffered cooldown row must not count)", got.Buffered)
+		t.Errorf("Buffered = %d, want 2 (buffered retry-backoff row must not count)", got.Buffered)
 	}
 }
 
@@ -718,7 +718,7 @@ func TestQueueEligibilityEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QueueEligibility: %v", err)
 	}
-	if got.Eligible != 0 || got.Cooldown != 0 {
+	if got.Eligible != 0 || got.RetryBackoff != 0 {
 		t.Errorf("empty queue = %+v, want {0 0}", got)
 	}
 }

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -43,7 +43,7 @@ type workItem struct {
 	// (priority 0, batch_seq NULL, next_attempt_at 1970 = eligible, created_at now).
 	priority      int    // 0 => default (PriorityScan); negative => miss tier
 	batchSeq      int    // 0 => NULL (unbuffered); >0 => buffered at this seq
-	nextAttemptAt string // "" => default (eligible); else RFC3339 (future => cooldown)
+	nextAttemptAt string // "" => default (eligible); else RFC3339 (future => retry backoff)
 	createdAt     string // "" => default (now); else RFC3339
 }
 
@@ -601,8 +601,9 @@ func mustParse(t *testing.T, s string) time.Time {
 }
 
 // TestUpNext verifies the buffered list is returned in batch_seq order and that
-// only eligible buffered rows appear (non-buffered, done, and future-cooldown
-// rows are excluded), matching the batched-claim predicate. Synthetic fixtures.
+// only eligible buffered rows appear (non-buffered, done, and rows still in
+// retry backoff are excluded), matching the batched-claim predicate. Synthetic
+// fixtures.
 func TestUpNext(t *testing.T) {
 	ctx := context.Background()
 	sqlDB := openTestDB(t)
@@ -618,8 +619,9 @@ func TestUpNext(t *testing.T) {
 	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist U", title: "Unbuffered", status: "pending"})
 	// Excluded: buffered but already done (fails the status predicate).
 	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist D", title: "Done", status: "done", batchSeq: 4})
-	// Excluded: buffered and pending but on cooldown (next_attempt_at in future).
-	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist C", title: "Cooldown", status: "deferred", batchSeq: 5, nextAttemptAt: "3000-01-01T00:00:00Z"})
+	// Excluded: buffered and pending but still in retry backoff (next_attempt_at
+	// in the future).
+	insertWorkItem(t, sqlDB, workItem{artist: "Test Artist C", title: "Backoff", status: "deferred", batchSeq: 5, nextAttemptAt: "3000-01-01T00:00:00Z"})
 
 	got, err := repo.UpNext(ctx, 10)
 	if err != nil {
@@ -671,7 +673,7 @@ func TestUpNextLimit(t *testing.T) {
 	}
 }
 
-// TestQueueEligibility checks the eligible/cooldown split and the exclusion of
+// TestQueueEligibility checks the eligible/retry-backoff split and the exclusion of
 // done/processing rows, all sharing one now so the two counts cannot skew.
 func TestQueueEligibility(t *testing.T) {
 	ctx := context.Background()
@@ -683,10 +685,10 @@ func TestQueueEligibility(t *testing.T) {
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-pending", status: "pending", batchSeq: 1})
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-failed", status: "failed", batchSeq: 2})
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "elig-deferred", status: "deferred"})
-	// Cooldown: same statuses but next_attempt_at in the future. One carries a
-	// batch_seq, which must NOT count as Buffered (it is not eligible now).
-	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-deferred", status: "deferred", nextAttemptAt: "3000-01-01T00:00:00Z", batchSeq: 3})
-	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "cool-failed", status: "failed", nextAttemptAt: "3000-01-01T00:00:00Z"})
+	// Retry backoff: same statuses but next_attempt_at in the future. One carries
+	// a batch_seq, which must NOT count as Buffered (it is not eligible now).
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "backoff-deferred", status: "deferred", nextAttemptAt: "3000-01-01T00:00:00Z", batchSeq: 3})
+	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "backoff-failed", status: "failed", nextAttemptAt: "3000-01-01T00:00:00Z"})
 	// Excluded from both: done and processing are not part of the backlog.
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "done", status: "done"})
 	insertWorkItem(t, sqlDB, workItem{artist: "A", title: "proc", status: "processing"})
@@ -718,8 +720,11 @@ func TestQueueEligibilityEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QueueEligibility: %v", err)
 	}
-	if got.Eligible != 0 || got.RetryBackoff != 0 {
-		t.Errorf("empty queue = %+v, want {0 0}", got)
+	// All THREE fields, not two: each is a separate SUM over zero rows, so each
+	// is a separate chance for the NULL to escape sql.NullInt64. Asserting only
+	// two left the third untested for exactly the condition this test names.
+	if got.Eligible != 0 || got.RetryBackoff != 0 || got.Buffered != 0 {
+		t.Errorf("empty queue = %+v, want all-zero", got)
 	}
 }
 

--- a/internal/web/dashboard.go
+++ b/internal/web/dashboard.go
@@ -102,8 +102,12 @@ func (u *UI) buildDashboardView(r *http.Request) (templates.DashboardView, error
 	// (queue.batch_size > cap) must still report its real size (#572 CR).
 	view.UpNextHeader = fmt.Sprintf("%d buffered of %s eligible",
 		elig.Buffered, groupThousands(elig.Eligible))
-	view.UpNextEmpty = fmt.Sprintf("Nothing buffered. %s eligible, %s waiting on cooldown.",
-		groupThousands(elig.Eligible), groupThousands(elig.Cooldown))
+	// "retry backoff", never "cooldown": this count is governed by
+	// api.miss_backoff_base_hours, while every config key spelled "cooldown" is
+	// request PACING. The old wording pointed an operator at a knob that cannot
+	// move this number; the lever is `queue recheck --deferred`.
+	view.UpNextEmpty = fmt.Sprintf("Nothing buffered. %s eligible, %s waiting on retry backoff.",
+		groupThousands(elig.Eligible), groupThousands(elig.RetryBackoff))
 
 	return view, nil
 }

--- a/web/templates/dashboard.templ
+++ b/web/templates/dashboard.templ
@@ -317,7 +317,7 @@ func dashQueueTileTooltip(label string) string {
 
 // iconDashboard is the grid glyph for the Dashboard sidebar nav item.
 templ iconDashboard() {
-	<svg class="mx-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+	<svg class="mx-nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 		<rect x="3" y="3" width="7" height="7"></rect>
 		<rect x="14" y="3" width="7" height="7"></rect>
 		<rect x="14" y="14" width="7" height="7"></rect>

--- a/web/templates/lanemark.templ
+++ b/web/templates/lanemark.templ
@@ -69,12 +69,22 @@ templ providerMark(src string) {
 // Integer coordinates so it stays sharp at 16px, and currentColor so it themes
 // for free in both light and dark rather than needing a second asset.
 //
+// width/height are set as attributes for the same reason providerMark sets them,
+// and the reason is sharper for an inline SVG than for an <img>. An inline SVG
+// has NO intrinsic pixel size, only an aspect ratio, and the base reset applies
+// `max-width:100%` to img/video but NOT to svg -- so a bare <svg> sized only by
+// CSS falls back to the replaced-element default (300x150, letterboxed by the
+// 1:1 viewBox to ~150px square) on any render where .mx-lane-mark is not in
+// effect at paint time. That is a real observed failure, not a hypothetical.
+// The attributes make 16px the floor; .mx-lane-mark still wins the cascade and
+// renders the intended 0.95em, so the styled result is byte-identical.
+//
 // If this is ever reported as confusing, the issue records the first swap to
 // reach for: `note-scan` (a musical note inside viewfinder corners), which
 // describes the lane's activity rather than its verdict and was truer on every
 // row, but measurably denser at 16px. Reach for that, not a redraw.
 templ iconInstrumentalDetector() {
-	<svg class="mx-lane-mark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+	<svg class="mx-lane-mark" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 		<rect x="9" y="3" width="6" height="10" rx="3"></rect>
 		<path d="M6 11v1a6 6 0 0 0 12 0v-1"></path>
 		<path d="M12 18v3"></path>

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -153,7 +153,7 @@ templ musixmatchCredit() {
 
 templ musixmatchBanner() {
 	<div class="mx-banner" role="status">
-		<svg class="mx-banner-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+		<svg class="mx-banner-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 			<path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
 			<line x1="12" y1="9" x2="12" y2="13"></line>
 			<line x1="12" y1="17" x2="12.01" y2="17"></line>

--- a/web/templates/sidebar.templ
+++ b/web/templates/sidebar.templ
@@ -109,7 +109,7 @@ templ navLink(href string, label string, active string) {
 
 // iconLogout: a door-with-arrow glyph for the Sign out control.
 templ iconLogout() {
-	<svg class="mx-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+	<svg class="mx-nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 		<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
 		<polyline points="16 17 21 12 16 7"></polyline>
 		<line x1="21" y1="12" x2="9" y2="12"></line>
@@ -118,7 +118,7 @@ templ iconLogout() {
 
 // iconSettings: a gear/cog glyph for the Settings page.
 templ iconSettings() {
-	<svg class="mx-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+	<svg class="mx-nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 		<circle cx="12" cy="12" r="3"></circle>
 		<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
 	</svg>


### PR DESCRIPTION
## Summary

- **Inline SVGs are sized by attribute, not CSS alone.** The instrumental-detector glyph rendered ~150px on any paint where `.mx-lane-mark` was not yet in effect, while the Musixmatch `<img>` beside it was correct. An inline SVG has no intrinsic pixel size, only an aspect ratio, and the base reset applies `max-width:100%` to img/video but NOT to svg -- so a CSS-only SVG falls back to the replaced-element default (300x150, letterboxed by the 1:1 viewBox). Fixed at all five inline-SVG sites, sized per class so each fallback matches its styled size.
- **`QueueEligibility.Cooldown` -> `RetryBackoff`**, and the Up-next empty state now reads "waiting on retry backoff". That count is governed by `api.miss_backoff_base_hours`, while every config key spelled "cooldown" is request PACING. The old wording pointed an operator at a knob that cannot move the number; the lever is `queue recheck --deferred`.
- **Reviewers look here first:** the icon half is justified structurally rather than by a before/after render (see Test plan). Config keys are untouched -- this renames one internal field and one display string, so there is no migration and no user-visible config change.

## Linked issue

Closes #776

The config-key half of the naming question is deliberately out of scope and tracked separately in #775.

## Pre-flight checklist

- [x] Pre-push gate green locally (`make gate`), run via `/prep-pr`. All twelve steps passed.
- [x] Code review pass complete; critical and important findings fixed before pushing.
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed for user-visible changes -- **not done, see Test plan.**
- [ ] Screenshot attached for any web-UI change -- **not attached, see Test plan.**
- [x] `make ui` re-run (`.templ` sources changed). Generated `*_templ.go` and `output.css` remain gitignored and uncommitted.
- [x] Migration -- N/A. No schema or data change; the rename is a Go field and a display string.

## Test plan

- [x] `make gate` passes locally: conflict markers, gofmt, `make ui`, `go build`, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, ci-shards, govulncheck. Zero test failures.
- [x] New assertion confirmed to fail against unfixed code. The `QueueEligibility` test was mutation-tested by swapping the two SQL `SUM` branches: it fails at the **assertion** with the exact swapped values (`Eligible = 2, want 3` / `RetryBackoff = 3, want 2`), not at the build, so it discriminates the two counts rather than merely compiling. The icon change has no new test -- it is a markup attribute, asserted only through the existing render tests.
- [x] Patch coverage meets the Codecov threshold (gate step passed).
- [x] **Surface stated explicitly.** Both changes are web-UI surface. The rename touches `internal/reports` (`QueueEligibility`) and its single consumer `internal/web/dashboard.go`; no metrics or DB-level surface is involved. Verified by building, regenerating templates, and running the `internal/web` and `internal/reports` suites.
- [ ] Manual UAT steps:
  - [ ] **Not performed.** The icon failure was transient and cleared on reload, so it was not reproduced on demand and a green render would not have proven the fix either. The attributes are justified as a structural floor: they dominate every hypothesis for why the rule was missing at paint time (stale CSS, slow CSS, failed CSS, FOUC), all of which then render 16px instead of ~150px. A CSS rule still beats a presentation attribute, so the styled render is unchanged.
- [ ] Reviewer follow-ups:
  - [ ] The per-class sizes assume the 14px root (`--mx-font-size-base`): `mx-lane-mark`/`mx-nav-icon` at `1.125rem` -> 16, `mx-banner-icon` at `1.25rem` -> 18. If that token changes, the attribute fallbacks drift from the styled sizes -- worth a second opinion on whether that coupling is acceptable or should be noted in the CSS.
  - [ ] `RetryBackoff` is my naming choice. If "deferred" or "miss backoff" reads better against `api.miss_backoff_base_hours`, say so -- it is a pre-release internal field with one consumer, so it is cheap to change now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified dashboard messaging for items waiting to retry, improving queue-status understanding.
  - Improved icon sizing and layout stability across dashboard navigation, banners, sidebar controls, and instrumental detection views.

- **UI Improvements**
  - Standardized fallback dimensions for interface icons while preserving existing styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->