### PR TITLE
fix(queue): record WHY a guard-rejected row settled, and surface it in the UI

### DIFF
--- a/internal/db/migrations/044_work_queue_outcome_detail.sql
+++ b/internal/db/migrations/044_work_queue_outcome_detail.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+-- +goose StatementBegin
+-- outcome_detail records WHY a row settled the way outcome_type says it did
+-- (issue #773). outcome_type names the CATEGORY; this names the reason within
+-- it. Today exactly one writer fills it: SettleGuardRejected, which stores the
+-- script guard's own verdict string (e.g. "foreign-script share 1.00 exceeds
+-- 0.05"). NULL everywhere else, and NULL is a legitimate value -- most outcomes
+-- need no detail beyond their type.
+--
+-- WHY A NEW COLUMN RATHER THAN last_error. A guard rejection is a POLICY
+-- outcome, not an error, and SettleGuardRejected deliberately CLEARS last_error
+-- so the row does not read as failed in the failure-analysis report. Writing the
+-- reason there would fight that clear and re-file a policy decision as a
+-- failure. It would also surface nowhere: FailureAnalysis selects
+-- status IN ('failed','deferred'), and a guard rejection settles as 'done'.
+--
+-- This is the same gap #655 closed one level up. #655 made a rejected row say
+-- WHICH category it landed in, ending the ambiguity where NULL outcome_type
+-- meant both "legacy row" and "deliberate policy decision". The reason itself
+-- was still discarded at every layer below the log line, so 'rejected' became a
+-- bucket with no detail and the web UI could say nothing about why a track
+-- produced no lyrics.
+--
+-- UNBOUNDED GROWTH IS NOT A RISK HERE, which is worth stating because #731 had
+-- to clean up exactly that in last_error (one row held 531,138 bytes of ffmpeg
+-- stderr). The only writer formats two floats into a fixed template, so the
+-- length is bounded by construction rather than by a cap that a future caller
+-- could forget to apply. A future writer storing unbounded external output must
+-- bound it at the capture site, as migration 043's accompanying fix did.
+--
+-- PRIVACY: the stored string carries no lyric text, artist, title, or path --
+-- only two ratios and a fixed phrase -- so it is safe to render in the UI and to
+-- include in a report without a redaction pass.
+ALTER TABLE work_queue ADD COLUMN outcome_detail TEXT;
+-- +goose StatementEnd
+-- +goose StatementBegin
+-- NO BACKFILL, deliberately. Rows already settled as 'rejected' never stored
+-- their reason anywhere -- it went to a log line that has long since rotated --
+-- so it is unrecoverable, and any value written here would be invented rather
+-- than recovered. Pre-existing rejections keep a NULL detail and read as
+-- "reason not recorded"; rows settled by a build carrying this column say why.
+--
+-- That is the same honest split #655 chose for legacy NULL outcome_type: a row
+-- that genuinely cannot be classified stays unclassified rather than being
+-- assigned a plausible-looking guess.
+SELECT 1;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE work_queue DROP COLUMN outcome_detail;
+-- +goose StatementEnd

--- a/internal/orchestrator/suitability.go
+++ b/internal/orchestrator/suitability.go
@@ -1,6 +1,10 @@
 package orchestrator
 
-import "github.com/sydlexius/canticle/internal/models"
+import (
+	"log/slog"
+
+	"github.com/sydlexius/canticle/internal/models"
+)
 
 // Quality ranks a lyric result by usefulness. A higher value is strictly
 // better: synced > unsynced > instrumental > none. The orchestrator uses it to
@@ -81,7 +85,21 @@ func IsSuitable(song models.Song, guard ScriptGuard) bool {
 		return false
 	}
 	if guard != nil && guard.Enabled() {
-		if ok, _ := guard.Accept(song); !ok {
+		// The reason is BOUND and logged, never discarded (#773). This site cannot
+		// persist it -- IsSuitable is a pure predicate scoring a candidate before
+		// any row is settled, so there is no row to write to, and the lane that
+		// ultimately settles records its own verdict via SettleGuardRejected.
+		//
+		// It is still worth emitting: previously this branch returned a bare false,
+		// so a candidate dropped HERE left no trace anywhere at any log level. That
+		// is the silent-failure shape -- a guard that computes a precise reason and
+		// then says nothing. Debug rather than Warn because rejecting one candidate
+		// is routine fall-through (the orchestrator advances to the next lane), not
+		// an incident; the terminal rejection is what warrants Warn, and the worker
+		// already logs that one.
+		if ok, reason := guard.Accept(song); !ok {
+			slog.Debug("lane candidate rejected by script guard; advancing",
+				"reason", reason, "quality", QualityOf(song))
 			return false
 		}
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -789,17 +789,17 @@ func (q *DBQueue) settleInstrumentalOnce(ctx context.Context, id int64, tel Inst
 // The guard is 'processing': only a worker holding the row reaches a guard
 // rejection, so unlike SettleInstrumental there is no backfill caller and no
 // RowOwnership parameter to get wrong.
-func (q *DBQueue) SettleGuardRejected(ctx context.Context, id int64) (SettleOutcome, error) {
+func (q *DBQueue) SettleGuardRejected(ctx context.Context, id int64, reason string) (SettleOutcome, error) {
 	var outcome SettleOutcome
 	err := db.RetryOnBusy(ctx, dequeueMaxAttempts, func() error {
 		var err error
-		outcome, err = q.settleGuardRejectedOnce(ctx, id)
+		outcome, err = q.settleGuardRejectedOnce(ctx, id, reason)
 		return err
 	})
 	return outcome, err
 }
 
-func (q *DBQueue) settleGuardRejectedOnce(ctx context.Context, id int64) (outcome SettleOutcome, retErr error) {
+func (q *DBQueue) settleGuardRejectedOnce(ctx context.Context, id int64, reason string) (outcome SettleOutcome, retErr error) {
 	now := formatTime(q.now())
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -810,15 +810,31 @@ func (q *DBQueue) settleGuardRejectedOnce(ctx context.Context, id int64) (outcom
 	// last_error is cleared deliberately: a guard rejection is a POLICY outcome,
 	// not an error. Leaving a stale error from an earlier attempt would make the
 	// row read as failed in the failure-analysis report.
+	//
+	// outcome_detail carries the reason IN THE SAME STATEMENT as the label (#773),
+	// for the same reason the label rides with the completion: a detail written
+	// separately and best-effort could be dropped while the row still settled,
+	// which is the #655 defect one level down -- a row that says it was rejected
+	// but not why. One UPDATE means the row can never hold one without the other.
+	//
+	// An empty reason stores NULL rather than '': "no reason recorded" gets ONE
+	// representation, so a reader cannot render a blank string as if it were a
+	// real verdict. Pre-#773 rows are NULL for the same reason and read the same
+	// way.
+	var detail any
+	if reason != "" {
+		detail = reason
+	}
 	res, err := tx.ExecContext(ctx,
 		`UPDATE work_queue
          SET outcome_type = 'rejected',
+             outcome_detail = ?,
              status = 'done',
              completed_at = ?,
              last_error = ''
          WHERE id = ?
            AND status = ?`,
-		now, id, StatusProcessing,
+		detail, now, id, StatusProcessing,
 	)
 	if err != nil {
 		return SettleFailed, fmt.Errorf("queue: settle guard-rejected: %w", err)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4988,7 +4988,7 @@ func TestDBQueue_SettleGuardRejectedAtomically(t *testing.T) {
 	t.Run("happy path: label and completion land together", func(t *testing.T) {
 		q, id := newProcessingRow(t)
 
-		outcome, err := q.SettleGuardRejected(ctx, id)
+		outcome, err := q.SettleGuardRejected(ctx, id, "")
 		if err != nil {
 			t.Fatalf("SettleGuardRejected: %v", err)
 		}
@@ -5037,7 +5037,7 @@ func TestDBQueue_SettleGuardRejectedAtomically(t *testing.T) {
 		}
 		// Deliberately NOT dequeued: the row is still 'pending'.
 
-		outcome, err := q.SettleGuardRejected(ctx, item.ID)
+		outcome, err := q.SettleGuardRejected(ctx, item.ID, "")
 		if err != nil {
 			t.Fatalf("SettleGuardRejected: %v", err)
 		}
@@ -5064,12 +5064,101 @@ func TestDBQueue_SettleGuardRejectedAtomically(t *testing.T) {
 
 	t.Run("missing row reports rather than erroring", func(t *testing.T) {
 		q := NewDBQueue(openQueueTestDB(t))
-		outcome, err := q.SettleGuardRejected(ctx, 424242)
+		outcome, err := q.SettleGuardRejected(ctx, 424242, "")
 		if err != nil {
 			t.Fatalf("SettleGuardRejected on a missing row: %v; want a reported outcome", err)
 		}
 		if outcome == Settled {
 			t.Error("a nonexistent row reported Settled")
+		}
+	})
+
+	// THE POINT OF #773: the row must record WHY, not only that it was rejected.
+	//
+	// The guard already computes a precise verdict -- mechanism, measurement and
+	// threshold -- and before this every layer below the log line discarded it, so
+	// 'rejected' was a bucket with no detail and the UI could say nothing about
+	// why a track produced no lyrics.
+	t.Run("the rejection reason is persisted alongside the label", func(t *testing.T) {
+		q, id := newProcessingRow(t)
+
+		const reason = "foreign-script share 1.00 exceeds 0.05"
+		outcome, err := q.SettleGuardRejected(ctx, id, reason)
+		if err != nil {
+			t.Fatalf("SettleGuardRejected: %v", err)
+		}
+		if outcome != Settled {
+			t.Fatalf("outcome = %v; want Settled", outcome)
+		}
+
+		var outcomeType, outcomeDetail *string
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT outcome_type, outcome_detail FROM work_queue WHERE id = ?`, id,
+		).Scan(&outcomeType, &outcomeDetail); err != nil {
+			t.Fatalf("read row: %v", err)
+		}
+		if outcomeDetail == nil {
+			t.Fatal("outcome_detail is NULL on a settled guard rejection; that is the #773 defect")
+		}
+		if *outcomeDetail != reason {
+			t.Errorf("outcome_detail = %q; want %q", *outcomeDetail, reason)
+		}
+		// The detail must accompany the label, never replace it: a detail on an
+		// unlabeled row would be the #655 defect wearing a new column.
+		if outcomeType == nil || *outcomeType != "rejected" {
+			t.Errorf("outcome_type = %v; want %q alongside the detail", outcomeType, "rejected")
+		}
+	})
+
+	// An empty reason stores NULL rather than an empty string, so "no reason
+	// recorded" has ONE representation in the column. Two spellings of absent
+	// would force every reader to test for both, and a reader that checked only
+	// one would silently render a blank detail as if it were a real verdict.
+	t.Run("an empty reason stores NULL, not an empty string", func(t *testing.T) {
+		q, id := newProcessingRow(t)
+
+		if _, err := q.SettleGuardRejected(ctx, id, ""); err != nil {
+			t.Fatalf("SettleGuardRejected: %v", err)
+		}
+
+		var outcomeDetail *string
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT outcome_detail FROM work_queue WHERE id = ?`, id,
+		).Scan(&outcomeDetail); err != nil {
+			t.Fatalf("read row: %v", err)
+		}
+		if outcomeDetail != nil {
+			t.Errorf("outcome_detail = %q; want NULL when no reason was supplied", *outcomeDetail)
+		}
+	})
+
+	// A refused settle writes NOTHING -- asserted for the detail specifically,
+	// because it is a second column that could leak past the processing guard
+	// independently of outcome_type.
+	t.Run("a refused settle writes no detail either", func(t *testing.T) {
+		q := NewDBQueue(openQueueTestDB(t))
+		item, err := q.Enqueue(ctx, models.Inputs{
+			Track:    models.Track{ArtistName: "Artist", TrackName: "Title"},
+			Outdir:   "out",
+			Filename: "a.lrc",
+		}, 1)
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		// Deliberately NOT dequeued: the row is still 'pending'.
+
+		if _, err := q.SettleGuardRejected(ctx, item.ID, "foreign-script share 1.00 exceeds 0.05"); err != nil {
+			t.Fatalf("SettleGuardRejected: %v", err)
+		}
+
+		var outcomeDetail *string
+		if err := q.db.QueryRowContext(ctx,
+			`SELECT outcome_detail FROM work_queue WHERE id = ?`, item.ID,
+		).Scan(&outcomeDetail); err != nil {
+			t.Fatalf("read row: %v", err)
+		}
+		if outcomeDetail != nil {
+			t.Errorf("outcome_detail = %q; a refused settle must write nothing at all", *outcomeDetail)
 		}
 	})
 }

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -135,6 +135,31 @@ type RecentOutcome struct {
 	// updated at completion, which is what made every completed row read as
 	// synced before #379.
 	Result ResultClass
+	// Detail is the recorded reason WITHIN the Result class (work_queue
+	// outcome_detail, #773) -- today the script guard's own verdict on a
+	// 'rejected' row, e.g. "foreign-script share 1.00 exceeds 0.05".
+	//
+	// It ALSO explains a NULL-outcome_type row the timing guard QUARANTINED
+	// ('categorical'), which renders as Result='unknown'. That reason
+	// is READ FROM timing_outcome rather than copied into outcome_detail: the
+	// column already records it, and writing it twice would create two sources of
+	// truth that can disagree. So Detail is a DISPLAY-LEVEL coalesce -- the stored
+	// detail when there is one, else the timing verdict -- not a second store.
+	//
+	// This matters because 'unknown' has always been documented as "a legacy row
+	// predating outcome_type", and that is now only half true: a timing-quarantined
+	// row settles as unknown TODAY, with the reason sitting one column over,
+	// unread. Those rows are the reason this coalesce exists.
+	//
+	// Empty means no reason was recorded, which is the honest state for three
+	// distinct populations: outcomes that need no detail beyond their class (a
+	// plain synced write), rejections settled before #773 shipped, whose reason
+	// went to a log line and is unrecoverable, and genuinely legacy NULL rows.
+	// None is rendered as a verdict.
+	//
+	// Carries no lyric text, artist, title, or path -- only ratios and a fixed
+	// phrase -- so it is safe to render without redaction.
+	Detail string
 }
 
 // RecentOutcomes returns the most recently completed (status='done') tracks,
@@ -159,6 +184,19 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
 	}
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT artist, title, album, completed_at, provider_lane,
+            COALESCE(
+                NULLIF(outcome_detail, ''),
+                -- outcome_type IS NULL is DEFENSIVE, not load-bearing: Categorical
+                -- always quarantines (nothing written), so such a row is already
+                -- NULL and no reachable state has both set. It states the intent --
+                -- explain the rows that render 'unknown' -- and would stop a future
+                -- writer that began stamping an outcome on a quarantined row from
+                -- silently relabeling a successful outcome. Removing it fails no
+                -- test, by construction rather than by omission.
+                CASE WHEN outcome_type IS NULL AND timing_outcome = 'categorical'
+                     THEN 'timing refused: categorical'
+                END
+            ) AS detail,
             CASE
                 WHEN last_error = 'miss limit reached' THEN 'miss'
                 WHEN outcome_type = 'synced' THEN 'synced'
@@ -184,9 +222,10 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
 			o            RecentOutcome
 			completedAt  sql.NullString
 			providerLane sql.NullString
+			detail       sql.NullString
 			result       string
 		)
-		if err := rows.Scan(&o.Artist, &o.Title, &o.Album, &completedAt, &providerLane, &result); err != nil {
+		if err := rows.Scan(&o.Artist, &o.Title, &o.Album, &completedAt, &providerLane, &detail, &result); err != nil {
 			return nil, fmt.Errorf("reports: scan recent outcome: %w", err)
 		}
 		if completedAt.Valid && completedAt.String != "" {
@@ -197,6 +236,7 @@ func (r *Repo) RecentOutcomes(ctx context.Context, limit int) ([]RecentOutcome, 
 			o.CompletedAt = t
 		}
 		o.ProviderLane = providerLane.String
+		o.Detail = detail.String
 		o.Result = ResultClass(result)
 		out = append(out, o)
 	}

--- a/internal/reports/reports_test.go
+++ b/internal/reports/reports_test.go
@@ -37,7 +37,13 @@ type workItem struct {
 	providerLane       any // string or nil
 	instrumentalResult any // int or nil
 	detectInstrumental any // int or nil
-	outcomeType        any // string ("synced"|"unsynced"|"instrumental") or nil
+	outcomeType        any // string ("synced"|"unsynced"|"instrumental"|"rejected") or nil
+	// outcomeDetail is the recorded reason within outcomeType (#773); nil => NULL.
+	outcomeDetail any // string or nil
+	// timingOutcome is the timing guard's verdict (#440); nil => NULL. A
+	// 'categorical'/'degenerate' value on a NULL outcomeType is the row that
+	// renders Result='unknown' with its reason one column over.
+	timingOutcome any // string or nil
 	// Buffered-panel columns (#572). These are applied as a post-insert UPDATE
 	// only when non-zero/non-empty, so existing callers keep the schema defaults
 	// (priority 0, batch_seq NULL, next_attempt_at 1970 = eligible, created_at now).
@@ -55,10 +61,12 @@ func insertWorkItem(t *testing.T, sqlDB *sql.DB, w workItem) int64 {
 	res, err := sqlDB.ExecContext(context.Background(),
 		`INSERT INTO work_queue
             (artist, title, artist_key, title_key, album, status, last_error, output_paths,
-             completed_at, provider_lane, instrumental_result, detect_instrumental, outcome_type)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             completed_at, provider_lane, instrumental_result, detect_instrumental, outcome_type,
+             outcome_detail, timing_outcome)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		w.artist, w.title, w.artist, w.title, w.album, w.status, w.lastError, w.outputPaths,
-		w.completedAt, w.providerLane, w.instrumentalResult, w.detectInstrumental, w.outcomeType)
+		w.completedAt, w.providerLane, w.instrumentalResult, w.detectInstrumental, w.outcomeType,
+		w.outcomeDetail, w.timingOutcome)
 	if err != nil {
 		t.Fatalf("insert work_queue: %v", err)
 	}
@@ -189,6 +197,91 @@ func TestQueueSummaryEmpty(t *testing.T) {
 	}
 	if (got != reports.QueueSummary{}) {
 		t.Errorf("QueueSummary on empty DB = %+v, want zero value", got)
+	}
+}
+
+// TestRecentOutcomesDetail covers the Detail column (#773): where the reason for
+// an outcome comes from, and which rows legitimately have none.
+//
+// Detail is a DISPLAY-LEVEL COALESCE over two stores, which is the part worth
+// testing: the stored outcome_detail when the row has one, else the timing
+// guard's verdict read from timing_outcome. The alternative -- copying the timing
+// verdict into outcome_detail at write time -- would put the same fact in two
+// columns that can drift apart.
+func TestRecentOutcomesDetail(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openTestDB(t)
+	repo := reports.New(sqlDB)
+
+	// A guard rejection: the reason is STORED, and is what Detail must show.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "A", title: "guard-rejected", status: "done",
+		completedAt: "2026-08-16T05:00:00Z", outcomeType: "rejected",
+		outcomeDetail: "foreign-script share 1.00 exceeds 0.05",
+	})
+	// A timing quarantine: outcome_type is NULL by design (nothing was written),
+	// so it renders Result='unknown' -- but the reason sits in timing_outcome and
+	// Detail must surface it. These rows are why the coalesce exists: 'unknown'
+	// is documented as "a legacy row predating outcome_type", which stopped being
+	// the whole truth once the timing guard began quarantining rows.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "A", title: "timing-quarantined", status: "done",
+		completedAt: "2026-08-16T04:00:00Z", timingOutcome: "categorical",
+	})
+	// A plain success needs no detail beyond its class.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "A", title: "plain-synced", status: "done",
+		completedAt: "2026-08-16T03:00:00Z", outcomeType: "synced", timingOutcome: "ok",
+	})
+	// DEGENERATE IS NOT A REFUSAL, and this row is why the CASE names 'categorical'
+	// alone. DecidePromotion maps Degenerate to DemoteToUnsynced (#673): the words
+	// ARE written, as .txt, so the row carries outcome_type='unsynced' and never
+	// reaches 'unknown'. Labeling it "timing refused" would be false -- it was
+	// demoted, not refused -- and timing_outcome already records the nuance for a
+	// reader who wants it. An earlier cut of this query listed both verdicts; a
+	// mutation that removed the NULL-outcome_type guard did not fail any test,
+	// which is what surfaced the mistake.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "A", title: "degenerate-demoted", status: "done",
+		completedAt: "2026-08-16T02:30:00Z", outcomeType: "unsynced", timingOutcome: "degenerate",
+	})
+	// A genuinely legacy row: no outcome, no timing verdict, no recoverable
+	// reason. It must stay blank rather than borrow one.
+	insertWorkItem(t, sqlDB, workItem{
+		artist: "A", title: "legacy-unknown", status: "done",
+		completedAt: "2026-08-16T02:00:00Z",
+	})
+
+	got, err := repo.RecentOutcomes(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentOutcomes: %v", err)
+	}
+	byTitle := make(map[string]reports.RecentOutcome, len(got))
+	for _, o := range got {
+		byTitle[o.Title] = o
+	}
+
+	for _, tc := range []struct {
+		title      string
+		wantResult reports.ResultClass
+		wantDetail string
+	}{
+		{"guard-rejected", reports.ResultRejected, "foreign-script share 1.00 exceeds 0.05"},
+		{"timing-quarantined", reports.ResultUnknown, "timing refused: categorical"},
+		{"plain-synced", reports.ResultSynced, ""},
+		{"degenerate-demoted", reports.ResultUnsynced, ""},
+		{"legacy-unknown", reports.ResultUnknown, ""},
+	} {
+		o, ok := byTitle[tc.title]
+		if !ok {
+			t.Fatalf("row %q missing from results", tc.title)
+		}
+		if o.Result != tc.wantResult {
+			t.Errorf("%s: Result = %q; want %q", tc.title, o.Result, tc.wantResult)
+		}
+		if o.Detail != tc.wantDetail {
+			t.Errorf("%s: Detail = %q; want %q", tc.title, o.Detail, tc.wantDetail)
+		}
 	}
 }
 

--- a/internal/web/ui.go
+++ b/internal/web/ui.go
@@ -458,6 +458,7 @@ func (u *UI) buildReportView(ctx context.Context, def reportDef) (templates.Repo
 				Title:       o.Title,
 				Album:       o.Album,
 				Result:      string(o.Result),
+				Detail:      detailOrDash(o.Detail),
 				Lane:        laneLabel(o.ProviderLane),
 				LaneMark:    laneMark(o.ProviderLane),
 				CompletedAt: formatReportTime(o.CompletedAt, serverLoc),
@@ -529,6 +530,20 @@ func formatReportTime(t time.Time, loc *time.Location) string {
 		return t.In(loc).Format(reportTimeFormat)
 	}
 	return t.UTC().Format(reportTimeFormat)
+}
+
+// detailOrDash renders a recorded outcome reason, or a hyphen when none was
+// recorded (#773), matching formatReportTime's treatment of a NULL timestamp so
+// an absent value reads as deliberate rather than as a rendering fault.
+//
+// An empty detail is the normal case, not an anomaly: most outcomes need no
+// reason beyond their class, and rejections settled before #773 shipped have
+// none to recover. Neither should look like a blank verdict.
+func detailOrDash(detail string) string {
+	if detail == "" {
+		return "-"
+	}
+	return detail
 }
 
 // detectRequestedLabel maps the per-item detect_instrumental request flag to a

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -77,7 +77,10 @@ type Queue interface {
 	// successful Complete would leave the row `done` with a NULL outcome_type,
 	// which IS the defect #655 exists to fix. A settle that can lose its own label
 	// is not a fix.
-	SettleGuardRejected(ctx context.Context, id int64) (queue.SettleOutcome, error)
+	// reason carries the guard's own verdict string, stored so the row records WHY
+	// it settled with nothing written (#773) rather than only that it was
+	// rejected. Empty means "no reason recorded" and stores NULL.
+	SettleGuardRejected(ctx context.Context, id int64, reason string) (queue.SettleOutcome, error)
 	// SetCompletionProvenance stamps the identifiers and writer version the row was
 	// settled with, so an outcome that writes no tag block -- an unsynced .txt above
 	// all -- still records what produced it (#620). Call before Complete while the
@@ -1438,7 +1441,7 @@ func (w *Worker) RunOnce(ctx context.Context) error {
 			// -- it fails and retries, and the guard will reject it again
 			// deterministically, so a retry costs one provider round-trip and
 			// cannot loop forever on a row that would otherwise settle unlabeled.
-			outcome, settleErr := w.queue.SettleGuardRejected(ctxNoCancel, item.ID)
+			outcome, settleErr := w.queue.SettleGuardRejected(ctxNoCancel, item.ID, reason)
 			if settleErr != nil {
 				return w.fail(ctx, item, fmt.Errorf("worker: settle guard-rejected item %d: %w", item.ID, settleErr))
 			}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -129,6 +129,11 @@ type fakeQueue struct {
 	// guardRejectOutcome overrides the returned SettleOutcome (default Settled),
 	// so the non-Settled branch can be exercised without contriving a race.
 	guardRejectOutcome *queue.SettleOutcome
+	// guardRejectReason records the reason the worker PASSED (#773), so a test can
+	// assert the CALL SITE forwards the guard's verdict rather than only that the
+	// seam stores what it is given. That distinction is load-bearing: a seam-tested
+	// but wiring-untested fix is exactly how #770's defect shipped.
+	guardRejectReason string
 	// settledLanes records ids settled through the shared settle transaction, so a
 	// test can distinguish a transactional settle from the old stamp-then-complete
 	// sequence.
@@ -328,7 +333,8 @@ func (q *fakeQueue) SettleInstrumental(_ context.Context, id int64, tel queue.In
 // It also honors the `WHERE status = 'processing'` guard: a row the fake is not
 // holding cannot be settled, matching the SQL rather than assuming the caller
 // passed a valid id.
-func (q *fakeQueue) SettleGuardRejected(_ context.Context, id int64) (queue.SettleOutcome, error) {
+func (q *fakeQueue) SettleGuardRejected(_ context.Context, id int64, reason string) (queue.SettleOutcome, error) {
+	q.guardRejectReason = reason
 	if q.guardRejectErr != nil {
 		return queue.SettleFailed, q.guardRejectErr
 	}
@@ -569,6 +575,15 @@ func TestRunOnceGuardRejectsTerminallyWithoutCacheOrWrite(t *testing.T) {
 	}
 	if w.consecutiveFailures != 0 {
 		t.Fatalf("consecutiveFailures = %d; want 0 (guard rejection must not trip backoff)", w.consecutiveFailures)
+	}
+	// WIRING, not the seam (#773). The queue test proves SettleGuardRejected
+	// STORES what it is handed; only this proves the worker HANDS IT the guard's
+	// actual verdict rather than an empty string. That distinction is exactly how
+	// #770's defect shipped -- the helper was tested directly, so reverting the
+	// call site left the suite green.
+	if q.guardRejectReason != guard.reason {
+		t.Errorf("forwarded reason = %q; want %q (the guard's verdict must reach the row)",
+			q.guardRejectReason, guard.reason)
 	}
 }
 

--- a/web/templates/reports.templ
+++ b/web/templates/reports.templ
@@ -141,6 +141,7 @@ templ tableRecentOutcomes(rows []RecentOutcomeRow) {
 						<th scope="col">Title</th>
 						<th scope="col">Album</th>
 						<th scope="col">Result</th>
+						<th scope="col">Detail</th>
 						<th scope="col">Source</th>
 						<th scope="col">Completed</th>
 					</tr>
@@ -152,6 +153,7 @@ templ tableRecentOutcomes(rows []RecentOutcomeRow) {
 							<td>{ r.Title }</td>
 							<td>{ r.Album }</td>
 							<td class="mx-cell-mono">{ r.Result }</td>
+							<td class="mx-cell-mono">{ r.Detail }</td>
 							<td class="mx-cell-mono">@laneCell(r.Lane, r.LaneMark)</td>
 							<td class="mx-cell-mono">{ r.CompletedAt }</td>
 						</tr>

--- a/web/templates/reports_view.go
+++ b/web/templates/reports_view.go
@@ -51,6 +51,11 @@ type RecentOutcomeRow struct {
 	Title  string
 	Album  string
 	Result string
+	// Detail is the recorded reason within Result (#773) -- today the script
+	// guard's verdict on a 'rejected' row. Empty renders an em dash rather than a
+	// blank cell, so "no reason recorded" reads as deliberate rather than as a
+	// rendering fault. Carries no lyric text, title, or path.
+	Detail string
 	Lane   string
 	// LaneMark is the mark token for Lane, empty when the lane has no mark (#601).
 	// Empty renders the name alone rather than a gap.


### PR DESCRIPTION
## Summary

- **The script guard's reason was computed and then discarded at every layer below the log line**, so `rejected` was a bucket with no detail and the web UI could say nothing about why a track produced no lyrics. Three loss points, each needing a different fix: `internal/queue` cleared `last_error` (correctly -- a policy outcome is not an error) leaving nowhere to put it; `internal/worker` had the reason and passed only the id; `internal/orchestrator` discarded it into `_` and returned a bare `false`, leaving no trace at any log level.
- **New `work_queue.outcome_detail`**, written in the SAME UPDATE as the label so a row can never hold one without the other. That atomicity is the #655 lesson one level down -- a best-effort detail plus an unconditional settle reproduces the original defect.
- **Recent Outcomes gains a Detail column**, which is the surface the issue was actually about.
- **Reviewers look here first:** the `Detail` value is a DISPLAY-LEVEL COALESCE over two stores, not a second store. See the second-producer note below -- that discovery changed the design mid-implementation.

## Linked issue

Closes #773

## Second producer, found while testing

A row the TIMING guard quarantined (`timing_outcome='categorical'`) writes nothing, so `outcome_type` stays NULL by design and it renders `Result='unknown'` -- with its reason already in the database, one column over, unread. `Detail` therefore reads the stored `outcome_detail` when present, else the timing verdict. Deliberately NOT copied into `outcome_detail` at write time: that would put one fact in two columns that can drift apart.

This narrows a doc claim that was no longer fully true. `ResultUnknown` is documented as "a legacy row predating the outcome_type column"; a timing-quarantined row lands there today.

## No backfill

Rows already settled as `rejected` never stored their reason anywhere recoverable -- it went to a log line. Any value written now would be invented rather than recovered, so pre-existing rejections keep a NULL detail and render `-`. Same honest split #655 chose for legacy NULL `outcome_type`.

## Pre-flight checklist

- [x] Pre-push gate green locally. All twelve steps passed via `gate-runner.py` in the worktree; patch coverage **95.74% (45/47 executable lines)**.
- [x] Code review pass complete; findings fixed before pushing (see mutation-testing note).
- [x] Commits squashed into one clean commit before the first push.
- [x] Label set on `gh pr create --label ...`.
- [ ] UAT performed -- **not done**, see Test plan.
- [ ] Screenshot attached for the web-UI change -- **not attached**, see Test plan.
- [x] `make ui` re-run (`.templ` changed). Generated `*_templ.go` and `output.css` remain gitignored and uncommitted.
- [x] Migration added under `internal/db/migrations/` (`044_work_queue_outcome_detail.sql`) -- goose gives run-once and transactionality; not hand-rolled in Go.

## Test plan

- [x] Full gate passes: conflict markers, gofmt, `make ui`, build, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, ci-shards, govulncheck. Zero test failures.
- [x] **New tests confirmed to fail against unfixed code.** The signature change was added WITHOUT the write first, so the red was an assertion failure (`outcome_detail is NULL on a settled guard rejection`), not a build error.
- [x] Mutation-tested in both directions:
  - dropping the detail write -> fails the persistence assertion
  - storing `''` instead of NULL -> fails the NULL-contract assertion
  - reverting the worker CALL SITE -> fails the wiring assertion (the seam-tested-but-wiring-untested gap that shipped #770's defect)
  - dropping the timing fallback -> fails the coalesce assertion
- [x] **One mutation PASSED when it should not have, and it found a real bug in this change.** The CASE originally listed `('categorical','degenerate')`, but `Degenerate` maps to `DemoteToUnsynced` (#673) -- those rows ARE written and carry `outcome_type='unsynced'`, so calling them "timing refused" was false. Fixed, with a fixture pinning it. Recorded because the passing mutation is what surfaced it.
- [x] Patch coverage meets the threshold (95.74%).
- [x] **Surface stated explicitly.** This changes the Recent Outcomes report surface (`internal/reports` -> `internal/web` -> `web/templates`). Verified the field reaches the GENERATED template, not just the source. `/metrics` is untouched.
- [ ] Manual UAT steps:
  - [ ] **Not performed.** Reproducing a guard rejection end-to-end needs a non-Latin-script lyric from a live provider against a configured allowlist. The path is covered by the queue round-trip test, the worker wiring test, and the reports coalesce test.
- [ ] Reviewer follow-ups:
  - [ ] The `outcome_type IS NULL` guard in the Detail CASE is **unreachable defensive code**: `Categorical` always quarantines, so such a row is already NULL. Removing it fails no test, by construction rather than omission. Documented inline; flagging in case you would rather it not exist.
  - [ ] `orchestrator.IsSuitable` logs at Debug rather than Warn -- rejecting one candidate is routine fall-through, and the worker already Warns on the terminal rejection. Second opinion welcome on the level.
  - [ ] **Size override:** 382 hand-written LOC across 11 files, one over the 10-file guideline. Not split because the migration, write path, and render path cannot be separated without shipping a broken intermediate (a column nobody writes, or a UI reading a column that does not exist). Four of the 11 are tests; two are the templ view/template pair for a single column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent outcomes now include a detail column showing rejection reasons and other relevant information.
  * Missing outcome details are displayed as a hyphen for clearer reporting.
  * Guard rejection reasons are preserved and surfaced in outcome records.

* **Bug Fixes**
  * Improved visibility into why candidates were rejected.
  * Ensured empty or unavailable details are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->