### PR TITLE
fix(gate,queue): stop two tools from reporting a false remedy

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1309,13 +1309,37 @@ func (q *DBQueue) RecheckDeferred(ctx context.Context, libraryID *int64) (int64,
 }
 
 // CountRecheckDeferred returns the number of 'deferred' rows that
-// RecheckDeferred would revive, without writing. Intended for dry-run output.
+// RecheckDeferred would actually CHANGE, without writing. Intended for dry-run
+// output.
+//
+// THE PREDICATE MUST MATCH THE APPLY'S EFFECT, not merely its WHERE clause
+// (#774). RecheckDeferred writes next_attempt_at and deliberately leaves status
+// alone, so counting on status alone described a set that a successful revive
+// could not shrink: re-running the dry run reported the identical number, which
+// is misleading at exactly the moment an operator re-runs it to confirm the apply
+// worked. Measured on a live instance: 18,651 revived, then 18,651 "would
+// revive". Adding the next_attempt_at bound makes the count a genuine preview --
+// it counts rows still waiting out a retry delay, which is what reviving them
+// changes.
+//
+// Note this deliberately does NOT match RecheckDeferred's own WHERE clause, which
+// stays broader: re-stamping an already-eligible row is harmless and idempotent,
+// so the apply has no reason to exclude it, while the COUNT must report only rows
+// whose state the apply would move. The two agree on the population that matters
+// and differ only on rows for which the write is a no-op.
+//
+// The 'now' here is q.now(), the same clock the apply stamps with, so a frozen
+// test clock keeps both sides consistent.
+//
+// The retired twin needs no equivalent: RecheckRetired's count and apply share
+// status='done' AND last_error=<sentinel>, and the apply MOVES status, so that
+// count already shrinks on a successful revive.
 func (q *DBQueue) CountRecheckDeferred(ctx context.Context, libraryID *int64) (int64, error) {
 	libClause, libArgs := recheckLibraryClause(libraryID)
-	args := append([]any(nil), libArgs...)
+	args := append([]any{formatTime(q.now())}, libArgs...)
 	var count int64
 	if err := q.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM work_queue WHERE status = 'deferred'`+libClause, //nolint:gosec // G202: libClause is a hardcoded constant from recheckLibraryClause, never user input
+		`SELECT COUNT(*) FROM work_queue WHERE status = 'deferred' AND next_attempt_at > ?`+libClause, //nolint:gosec // G202: libClause is a hardcoded constant from recheckLibraryClause, never user input
 		args...,
 	).Scan(&count); err != nil {
 		return 0, fmt.Errorf("queue: count recheck deferred: %w", err)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -2573,6 +2573,24 @@ func TestDBQueue_CountRecheckDeferred(t *testing.T) {
 	if n != count {
 		t.Fatalf("RecheckDeferred = %d; CountRecheckDeferred = %d; must agree", n, count)
 	}
+
+	// THE POINT OF #774: the count must be a PREVIEW of the apply, which means it
+	// has to MOVE once the apply succeeds. Asserting agreement BEFORE the apply
+	// (above) cannot catch this -- both sides read the same rows at that moment.
+	//
+	// Before the fix the count read only `status`, while the apply wrote
+	// `next_attempt_at` and deliberately left `status` alone, so a successful
+	// revive changed nothing the count could see. Re-running the dry run reported
+	// the identical number, which is misleading at exactly the moment an operator
+	// re-runs it to confirm the apply worked. Measured on a live instance: 18,651
+	// revived, then 18,651 "would revive".
+	after, err := q.CountRecheckDeferred(ctx, nil)
+	if err != nil {
+		t.Fatalf("CountRecheckDeferred after apply: %v", err)
+	}
+	if after != 0 {
+		t.Errorf("count after a successful revive = %d; want 0 (the dry run must reflect the apply)", after)
+	}
 }
 
 // TestDBQueue_RecheckRetired verifies that RecheckRetired revives

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -95,10 +95,52 @@ echo "==> patch coverage (Codecov parity, conservative lower bound)"
 # result; when absent it is SKIPPED, not failed. This gate is a dev-only
 # convenience -- CI enforces patch coverage via Codecov directly
 # (.github/workflows/ci.yml), so nothing is lost when the estimator is missing.
-HELPER="$HOME/.claude/scripts/patch-coverage.sh"
+# Overridable so the exit-code branches below can be exercised against a stub,
+# following the TAILWIND_BIN convention above. Unset -> the real estimator.
+HELPER="${PATCH_COVERAGE_HELPER:-$HOME/.claude/scripts/patch-coverage.sh}"
 if [ -x "$HELPER" ]; then
-  COVER_OUT="$COVER_OUT" \
-    bash "$HELPER" || fail "patch coverage below codecov.yml threshold (note: this gate is a conservative lower bound; Codecov typically reads a few points higher)"
+  # BRANCH ON THE EXIT CODE, never a bare `||` (#768). The estimator defines four
+  # codes whose remedies DIFFER, and two of them are OPPOSITE: exit 1 means write
+  # tests, exit 3 means commit what you already wrote. A bare `||` collapsed all of
+  # them into "below threshold", which is false for 2 and 3 and sends the reader to
+  # do work that cannot help. Observed three times in one session, costing a cycle
+  # each: the message is confident, plausible, and wrong.
+  #
+  # `rc=0; ... || rc=$?` rather than calling it bare: `set -e` is on, so an
+  # unguarded non-zero exit would kill the script before anything could read the
+  # code. The estimator prints its own detailed diagnosis to stderr on every path,
+  # so the job here is to stop MISLABELING it and name the right remedy -- not to
+  # restate what it already said.
+  rc=0
+  COVER_OUT="$COVER_OUT" bash "$HELPER" || rc=$?
+  case "$rc" in
+    0) ;;
+    1)
+      fail "patch coverage below codecov.yml threshold -- add tests for the uncovered lines.\n      (this gate is a conservative lower bound; Codecov typically reads a few points higher)"
+      ;;
+    2)
+      # Setup/config fault, NOT a coverage verdict: a missing profile, an
+      # unreadable codecov.yml, a malformed threshold. Nothing was measured.
+      fail "patch-coverage could not run (exit 2: setup/config). Read its stderr above -- no coverage figure was produced, so this is not a threshold failure."
+      ;;
+    3)
+      # REFUSED: the validity precondition failed, so the diff scope (committed
+      # HEAD) and the profile (working tree) would describe different versions of
+      # the same file. Deliberately NOT folded into 2 -- 2 legitimately routes to
+      # "this repo has no coverage tooling", and a refusal swallowed there is the
+      # silent skip the estimator's guard exists to end.
+      #
+      # TWO causes with DIFFERENT remedies; the estimator's stderr says which:
+      #   - uncommitted Go changes -> commit them, then re-run
+      #   - `git status` unreadable -> a repo-access fault; the tree state is
+      #     UNDETERMINED, committing fixes nothing, and PATCH_COVERAGE_ALLOW_DIRTY
+      #     does not apply (that branch exits before the override is consulted)
+      fail "patch-coverage REFUSED to measure (exit 3) -- no figure was produced, so this is NOT a threshold failure.\n      Read its stderr above for which precondition failed: commit your changes, or repair git access."
+      ;;
+    *)
+      fail "patch-coverage exited $rc, which this gate does not recognize. Read its stderr above; do not assume a coverage verdict."
+      ;;
+  esac
 else
   echo "    estimator not found at $HELPER"
   echo "    skipping local patch-coverage; Codecov enforces it in CI."


### PR DESCRIPTION
## Summary

Two tooling fixes, batched because they are the same defect class: **a tool reported something false and sent the reader to the wrong remedy.** Neither changes product behavior.

- **#768 -- the gate collapsed four patch-coverage exit codes into one message.** A bare `||` reported every non-zero exit as "patch coverage below codecov.yml threshold". That is true for exit 1 only. Exit 3 (REFUSED) fires on a dirty tree and produces *no figure at all*, so the printed message was confident, plausible, and wrong -- and it points at writing tests when the remedy is to commit. It misfired three times in a single session, costing a cycle each.
- **#774 -- the recheck dry-run count could not move.** `CountRecheckDeferred` counted on `status` while `RecheckDeferred` writes `next_attempt_at` and deliberately leaves `status` alone, so a successful revive changed nothing the count could see. Re-running the dry run reported the identical number, which is misleading at exactly the moment an operator re-runs it to confirm the apply worked. Measured live: "revived 18,651", then "would revive 18,651".
- **Reviewers look here first:** the `#774` count deliberately does NOT match the apply's own `WHERE` clause. Rationale is in the code comment and repeated below.

## Linked issues

Closes #768, closes #774

(Keyword repeated per number -- GitHub binds `Closes` to the one number that follows it. Each commit also carries its own `Closes #N`, which is what actually performs the close.)

## Design notes

**Why the #774 count and apply differ on purpose.** The apply's `WHERE` stays broader: re-stamping an already-eligible row is harmless and idempotent, so it has no reason to exclude one. The COUNT must report only rows whose state the apply would *move*. They agree on the population that matters and differ only where the write is a no-op.

**The retired twin needs no fix, verified rather than assumed.** `RecheckRetired`'s count and apply share `status='done' AND last_error=<sentinel>`, and the apply MOVES `status`, so that count already shrinks on a successful revive. All six recheck tests pass, including the retired ones.

**`PATCH_COVERAGE_HELPER` is new, and load-bearing for testability.** Without an override the exit-2 and exit-3 branches can only be observed by waiting for one to happen naturally. It follows the `TAILWIND_BIN` convention already in the script.

## Pre-flight checklist

- [x] Pre-push gate green locally: all twelve steps, zero test failures.
- [x] Code review pass complete.
- [x] Two commits, one per issue -- deliberately not squashed, so each fix is reviewable against its own issue.
- [x] Label set on `gh pr create --label ...`.
- [x] UAT: N/A -- no user-visible behavior change. Both fixes alter what a developer tool PRINTS and what a dry-run COUNTS.
- [x] Screenshot: N/A -- no web-UI change.
- [x] `make ui`: N/A -- no `.templ` or CSS change.
- [x] Migration: N/A -- no schema change.

## Test plan

- [x] `make gate` passes: conflict markers, gofmt, `make ui`, build, `go test -race` + coverage, patch coverage, coverage-floor ratchet, codecov validation, golangci-lint, actionlint, ci-shards, govulncheck.
- [x] Patch coverage **100.00% (2/2 executable lines)**. Small denominator is honest: the Go surface is a two-line SQL predicate. Patch coverage cannot see shell at all, which is why the gate script was verified separately (below).
- [x] **New assertion confirmed to fail against unfixed code.** #774's assertion re-reads the count AFTER a successful revive and requires 0. Mutation-tested: reverting the predicate to status-only fails at the assertion with the original defect (`count after a successful revive = 2; want 0`). The pre-existing assertion (`count == applied`, both read BEFORE the apply) could not catch this -- both sides read the same rows at that moment.
- [x] **All five gate branches driven against stub estimators**, since patch coverage cannot reach shell. Each exit code produces its own message and exit 0 falls through so the gate continues:
  - `0` -> continues
  - `1` -> "below threshold -- add tests"
  - `2` -> "could not run (setup/config) ... not a threshold failure"
  - `3` -> "REFUSED to measure ... NOT a threshold failure ... commit your changes, or repair git access"
  - unrecognized -> "does not recognize ... do not assume a coverage verdict"
- [x] `shellcheck scripts/pre-push-gate.sh` clean; `bash -n` parses.
- [x] **Surface stated explicitly.** #768 changes `scripts/pre-push-gate.sh` output only. #774 changes `internal/queue` read-path SQL; the write path is untouched, so no queue behavior changes -- only what the dry run reports.
- [ ] Reviewer follow-ups:
  - [ ] `set -e` forced `rc=0; ... || rc=$?` rather than a bare call -- an unguarded non-zero exit kills the script before anything can read the code. Worth a second pair of eyes on the capture pattern.
  - [ ] The exit-3 message names both causes (dirty tree / unreadable `git status`) rather than picking one, because the estimator's stderr distinguishes them and the remedies differ. Tell me if you would rather it stay terser and defer entirely to the stderr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred queue counts now accurately exclude items that are not yet eligible for rechecking.
  * Queue status correctly reports no remaining deferred items after successful reprocessing.

* **Chores**
  * Improved pre-push coverage checks with clearer handling for insufficient coverage, configuration issues, refused measurements, and unexpected failures.
  * Added support for overriding the coverage-check helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->